### PR TITLE
feat(calendar): add Overview landing page as section entry point

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "coderabbit@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/doc-sync-package/SKILL.md
+++ b/.claude/skills/doc-sync-package/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: doc-sync-package
+description: Sync documentation after changes to a publishable package under packages/. Use when the user says "update the docs", "document this", "sync the docs", or "reflect these changes in the docs" after modifying a package. Updates the package README, the EN and ES SDK reference pages, and the EN and ES changelogs.
+---
+
+# doc-sync-package
+
+Keep all documentation in sync after changes to a publishable package in this monorepo.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- Sync docs after modifying a package (new features, changed types, new API methods)
+- Update the docs to reflect a new package version
+- Find and fill documentation gaps after a package change
+
+Do NOT use this skill for `apps/app` changes, architectural decisions, or backend API changes — those affect different doc sections and require a different approach.
+
+## Doc Structure Overview
+
+Every package change potentially touches **five files**. Always treat all five as candidates and verify each one:
+
+| File | Purpose | Depth |
+|---|---|---|
+| `packages/<name>/README.md` | npm-facing full API reference | Full method tables, full type blocks |
+| `apps/docs/content/en/reference/sdks/<name>.mdx` | Docs site summary page (EN) | Feature bullets + link to README |
+| `apps/docs/content/es/reference/sdks/<name>.mdx` | Docs site summary page (ES) | Same as EN, in Spanish |
+| `apps/docs/content/en/reference/changelog.mdx` | Changelog (EN) | One entry per release |
+| `apps/docs/content/es/reference/changelog.mdx` | Changelog (ES) | Same as EN, in Spanish |
+
+**Critical rule:** The docs site pages are **summary-level only** — they describe capabilities in plain language and link to the README for method-level details. Never duplicate full API tables or type blocks into the MDX pages.
+
+## Instructions
+
+### Step 1: Understand the Changes
+
+Run a diff against the base branch to understand exactly what changed in the package:
+
+```bash
+git diff trunk -- packages/<name>/
+```
+
+If the package has an `openapi.json`, diff it too — it's the most reliable source of truth for API changes:
+
+```bash
+git diff trunk -- packages/<name>/openapi.json
+```
+
+From the diff, identify:
+- **New resource namespaces** (e.g. a new `groups` property on the client)
+- **New or changed methods** within existing namespaces
+- **New or changed query params** on existing methods
+- **New, removed, or changed fields** on request/response types
+- **New types** added to `src/types.ts` and exported from `src/index.ts`
+- **Version bump** in `package.json`
+
+### Step 2: Read All Five Doc Files
+
+Read all five files in parallel before making any edits:
+
+```
+packages/<name>/README.md
+apps/docs/content/en/reference/sdks/<name>.mdx
+apps/docs/content/es/reference/sdks/<name>.mdx
+apps/docs/content/en/reference/changelog.mdx
+apps/docs/content/es/reference/changelog.mdx
+```
+
+If a docs site MDX page does not yet exist for the package, create it following the template in the **SDK Page Structure** section below.
+
+### Step 3: Identify Gaps
+
+For each file, verify whether a gap actually exists before planning an edit. Do not edit files where the content is already accurate.
+
+**README gaps to check:**
+- Method param tables missing new query params
+- `create()` / `update()` body tables missing new fields
+- New resource namespace entirely absent (no section for it)
+- Type blocks (`interface Foo`) stale — missing new fields or new types not yet added
+- Install/Quick Start example still references old version behavior
+
+**SDK docs page gaps to check:**
+- Features section missing a bullet for a new capability
+- Existing feature bullet describes a capability that has changed meaningfully
+- Overview paragraph still accurate
+
+**Changelog gaps to check:**
+- No entry for the new version
+- Entry exists but is missing key changes
+
+### Step 4: Update the README
+
+The README is the authoritative reference for all method signatures and types. Apply the following rules:
+
+**Methods:**
+- Each namespace gets its own `### <Namespace>` section
+- Each method gets its own `#### <namespace>.<method>(params)` subsection
+- New params go in the param table with their type, Required column, and description
+- Preserve existing methods — only add or update, never remove unless something was actually deleted
+
+**Types section:**
+- Each exported interface/type gets its own `### <TypeName>` subsection with a fenced `ts` code block
+- New fields go inside the existing code block with inline comments
+- New types get their own new subsection, inserted in a logical place (request types before response types; group-related types together)
+
+**Ordering for new namespace sections:**
+Insert new sections in an order that reflects conceptual grouping — organizational/grouping resources before the items they contain (e.g. Groups before Calendars, not after Bookings).
+
+### Step 5: Update the EN SDK Docs Page
+
+The EN MDX page lives at `apps/docs/content/en/reference/sdks/<name>.mdx`.
+
+**Features section:** Add one short paragraph per new top-level capability. Write in plain language, no method signatures. Reference the client namespace (e.g. `client.groups`) so readers know where to look, but don't list individual methods.
+
+**Do not add:**
+- Full method param tables
+- Type code blocks
+- Error code tables
+
+These all belong in the README. The MDX page ends with a link to the README on npm — that is intentional.
+
+### Step 6: Update the ES SDK Docs Page
+
+Apply the exact same changes as Step 5, translated into Spanish.
+
+Keep technical identifiers (method names, interface names, field names) in their original form — only translate the surrounding prose.
+
+### Step 7: Update the EN Changelog
+
+The changelog lives at `apps/docs/content/en/reference/changelog.mdx`.
+
+Insert a new entry **at the top of the `## Recent Releases` section**, above all existing entries. Use this format:
+
+```markdown
+### `<package-name>` v<version> — <Short Title> (<YYYY-MM-DD>)
+
+**`@microboxlabs/<package-name>`** — [npm](...) | [GitHub](...)
+
+One-sentence summary of what this release adds.
+
+**New — `client.<namespace>` namespace:**
+- `<namespace>.<method>(params)` — brief description
+- ...
+
+**Updated — `client.<existing-namespace>`:**
+- `<method>()` accepts new `<param>` param — description
+- `<TypeName>.<field>?: type` — description
+
+**New types exported:** `TypeA`, `TypeB`
+
+---
+```
+
+Only include sections that actually apply. If nothing was updated (pure addition), omit the "Updated" block.
+
+### Step 8: Update the ES Changelog
+
+Apply the exact same entry as Step 7, translated into Spanish, in `apps/docs/content/es/reference/changelog.mdx`.
+
+Insert above the existing entries under `## Lanzamientos Recientes`.
+
+---
+
+## SDK Page Structure
+
+If a docs page does not yet exist for a package, create it using this template.
+
+**EN (`apps/docs/content/en/reference/sdks/<name>.mdx`):**
+
+```markdown
+# <Human Name>
+
+<One-sentence description>.
+
+**Status:** Available — [npm](<npm-url>) | [GitHub](<github-url>)
+
+## Overview
+
+`@microboxlabs/<package-name>` <paragraph describing what it does, what runtimes it supports, key design decisions>.
+
+## Installation
+
+\```bash
+npm install @microboxlabs/<package-name>
+\```
+
+## Quick Start
+
+\```ts
+<minimal working example — create client, do one meaningful operation>
+\```
+
+## Features
+
+### <Feature 1>
+<One paragraph.>
+
+### <Feature 2>
+<One paragraph.>
+
+## Configuration
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `baseUrl` | `string` | Yes | Base URL of the API |
+| `headers` | `Record<string, string>` | No | Default headers for every request |
+| `fetch` | `typeof fetch` | No | Custom fetch implementation |
+
+## Full API Reference
+
+For complete method documentation, parameter tables, type definitions, and error code reference, see the [package README on npm](<npm-url>).
+```
+
+**ES:** same structure, all prose translated, identifiers (types, method names, field names) left as-is.
+
+---
+
+## Changelog Entry Date
+
+Always use today's date in `YYYY-MM-DD` format. Do not use relative dates like "today" or "recently".
+
+---
+
+## Publishable Packages
+
+| Directory | npm Name | README | SDK docs page |
+|---|---|---|---|
+| `miot-calendar-client` | `@microboxlabs/miot-calendar-client` | `packages/miot-calendar-client/README.md` | `sdks/miot-calendar-client.mdx` |
+
+As new publishable packages are added, extend this table.
+
+---
+
+## Common Mistakes to Avoid
+
+- **Editing without reading first.** Always read the current file content before writing. The gap may already be filled.
+- **Duplicating the full API into the MDX pages.** The MDX pages are summaries. Full tables belong in the README.
+- **Updating only one language.** EN and ES must always be updated together in the same session.
+- **Inserting changelog entries at the bottom.** Always insert newest-first, at the top of the releases section.
+- **Touching `sdks/index.mdx`.** This file only lists available SDKs and does not need updating unless a brand new package is being added for the first time.
+- **Inferring paths without verifying.** The docs content root is `apps/docs/content/`, not `apps/docs/src/content/docs/` — always verify with a glob if unsure.

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -40,7 +40,7 @@ USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0"
 STREAMHUB_CLIENT_ID=your_client_id
 STREAMHUB_CLIENT_SECRET=your_client_secret
 STREAMHUB_AUDIENCE=your_audience
-STREAMHUB_URL=https://pgrest.streamhub.cl:443
+STREAMHUB_URL=https://pgrest.streamhub.cl
 STREAMHUB_IOT_URL=https://iot.streamhub.cl
 
 # ─── Mapbox ──────────────────────────────────────────────────────
@@ -52,5 +52,8 @@ NEXT_PUBLIC_SKIP_DRIVER_VERIFICATION=true
 NEXT_PUBLIC_ENABLE_HOME_DASHBOARDS=false
 
 # ─── OpenAPI ─────────────────────────────────────────────────────
-OPENAPI_URL=https://coordinador-dev.mintral.cl
+OPENAPI_URL=https://your-openapi-host.com
 OPENAPI_TOKEN=your_api_token_here
+
+# ─── Calendar ────────────────────────────────────────────────────
+MIOT_CALENDAR_URL=https://your-calendar-host.com

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -20,7 +20,10 @@ const nextConfig = {
       },
     ],
   },
+  // ESM-only packages that Node.js loads natively on the server (no bundling)
   serverExternalPackages: ["pino", "pino-pretty"],
+  // ESM-only packages that Turbopack must transpile for client bundles
+  transpilePackages: ["@microboxlabs/miot-calendar-client"],
 };
 
 const mdxConfig = withMDX({

--- a/apps/app/sonar-project.properties
+++ b/apps/app/sonar-project.properties
@@ -1,6 +1,6 @@
 # SonarQube Configuration
 sonar.projectKey=microboxlabs_modulariot
-sonar.projectName=Coordinador WebClient
+sonar.projectName=Modulariot
 sonar.organization=microboxlabs
 sonar.projectVersion=1.0
 

--- a/apps/app/sonar-project.properties
+++ b/apps/app/sonar-project.properties
@@ -18,8 +18,8 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,public/autentia/**,**/*.config.*,**/*.setup.*,**/*.d.ts
 
 # Test coverage report paths (LCOV format from Vitest)
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+# sonar.javascript.lcov.reportPaths=coverage/lcov.info
+# sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
 # Encoding
 sonar.sourceEncoding=UTF-8 

--- a/apps/app/src/app/[lang]/(secured)/calendar/[calendarId]/planning/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/calendar/[calendarId]/planning/page.tsx
@@ -1,0 +1,20 @@
+import { ParamsWithLang } from "@/features/i18n/i18n.service.types";
+import { getDictionary } from "@/features/i18n/i18n.service";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import Planning from "@/features/calendar/components/planning/planning";
+
+export default async function CalendarIdPlanningPage(
+  props: ParamsWithLang<{ calendarId: string }>
+) {
+  const { lang, calendarId } = await props.params;
+  const session = await auth();
+  if (!session) redirect(`/${lang}/sign-in`);
+  const [, dictionary] = await getDictionary(lang);
+
+  return (
+    <div className="h-full overflow-hidden">
+      <Planning lang={lang} dict={dictionary} calendarId={calendarId} />
+    </div>
+  );
+}

--- a/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
@@ -1,0 +1,37 @@
+import { ParamsWithLang, I18nRecord } from "@/features/i18n/i18n.service.types";
+import { getDictionary } from "@/features/i18n/i18n.service";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { Breadcrumb } from "@/features/common/components/Breadcrumb/Breadcrumb";
+import { HiCalendar } from "react-icons/hi";
+import { CalendarLanding } from "@/features/calendar/components/calendar-landing/calendar-landing";
+
+export default async function CalendarPage(props: ParamsWithLang) {
+  const { lang } = await props.params;
+
+  const session = await auth();
+  if (!session) {
+    redirect(`/${lang}/sign-in`);
+  }
+
+  const [, dict] = await getDictionary(lang);
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      <div className="p-5 flex items-center justify-between sticky top-0 bg-white dark:bg-gray-900 dark:text-white w-full">
+        <Breadcrumb
+          path={["calendar"]}
+          lang={lang}
+          rootIcon={<HiCalendar className="mr-2 h-4 w-4" />}
+          dict={dict["layout"]["secured"]["sidebar"] as I18nRecord}
+        />
+      </div>
+      <div className="flex-1 overflow-auto">
+        <CalendarLanding
+          dict={dict["calendar"] as I18nRecord}
+          lang={lang}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
@@ -1,4 +1,4 @@
-import { ParamsWithLang, I18nRecord } from "@/features/i18n/i18n.service.types";
+import { ParamsWithLang } from "@/features/i18n/i18n.service.types";
 import { getDictionary } from "@/features/i18n/i18n.service";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
@@ -23,7 +23,7 @@ export default async function CalendarPage(props: ParamsWithLang) {
           path={["calendar"]}
           lang={lang}
           rootIcon={<HiCalendar className="mr-2 h-4 w-4" />}
-          dict={dict["layout"]["secured"]["sidebar"] as I18nRecord}
+          dict={dict.layout.secured.sidebar}
         />
       </div>
       <div className="flex-1 overflow-auto">

--- a/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/calendar/page.tsx
@@ -27,10 +27,7 @@ export default async function CalendarPage(props: ParamsWithLang) {
         />
       </div>
       <div className="flex-1 overflow-auto">
-        <CalendarLanding
-          dict={dict["calendar"] as I18nRecord}
-          lang={lang}
-        />
+        <CalendarLanding lang={lang} />
       </div>
     </div>
   );

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
@@ -1,0 +1,41 @@
+import {
+  createMiotCalendarClient,
+  MiotCalendarApiError,
+} from "@microboxlabs/miot-calendar-client";
+import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
+import { requireAuth } from "../../../../utils/alfresco-crud-client";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ calendarId: string; timeWindowId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { calendarId, timeWindowId } = await params;
+  const body: TimeWindowRequest = await request.json();
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const timeWindow = await client.calendars.updateTimeWindow(
+      calendarId,
+      timeWindowId,
+      body
+    );
+    return NextResponse.json(timeWindow);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error }, "Failed to update time window");
+    return NextResponse.json({ error: "Failed to update time window" }, { status });
+  }
+}

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
@@ -1,13 +1,21 @@
-import {
-  createMiotCalendarClient,
-  MiotCalendarApiError,
-} from "@microboxlabs/miot-calendar-client";
-import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
+import { createCalendarClient } from "../../../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 
-const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+const TimeWindowRequestSchema = z.object({
+  name: z.string(),
+  startHour: z.number(),
+  endHour: z.number(),
+  validFrom: z.string(),
+  slotDurationMinutes: z.number().optional(),
+  capacityPerSlot: z.number().optional(),
+  daysOfWeek: z.string().optional(),
+  validTo: z.string().optional(),
+  active: z.boolean().optional(),
+});
 
 export async function PUT(
   request: Request,
@@ -16,21 +24,18 @@ export async function PUT(
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const { calendarId, timeWindowId } = await params;
-  const body: TimeWindowRequest = await request.json();
-
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
-
   try {
+    const { calendarId, timeWindowId } = await params;
+    const parsed = TimeWindowRequestSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+    }
+
+    const client = createCalendarClient(authResult.session);
     const timeWindow = await client.calendars.updateTimeWindow(
       calendarId,
       timeWindowId,
-      body
+      parsed.data
     );
     return NextResponse.json(timeWindow);
   } catch (error) {

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/[timeWindowId]/route.ts
@@ -1,21 +1,9 @@
 import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
-import { z } from "zod";
 import { createCalendarClient } from "../../../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../../../utils/alfresco-crud-client";
+import { TimeWindowRequestSchema } from "../time-window.schema";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
-
-const TimeWindowRequestSchema = z.object({
-  name: z.string(),
-  startHour: z.number(),
-  endHour: z.number(),
-  validFrom: z.string(),
-  slotDurationMinutes: z.number().optional(),
-  capacityPerSlot: z.number().optional(),
-  daysOfWeek: z.string().optional(),
-  validTo: z.string().optional(),
-  active: z.boolean().optional(),
-});
 
 export async function PUT(
   request: Request,

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
@@ -2,10 +2,22 @@ import {
   createMiotCalendarClient,
   MiotCalendarApiError,
 } from "@microboxlabs/miot-calendar-client";
-import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
 import { requireAuth } from "../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+
+const TimeWindowRequestSchema = z.object({
+  name: z.string(),
+  startHour: z.number(),
+  endHour: z.number(),
+  validFrom: z.string(),
+  slotDurationMinutes: z.number().optional(),
+  capacityPerSlot: z.number().optional(),
+  daysOfWeek: z.string().optional(),
+  validTo: z.string().optional(),
+  active: z.boolean().optional(),
+});
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -42,9 +54,6 @@ export async function POST(
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const { calendarId } = await params;
-  const body: TimeWindowRequest = await request.json();
-
   const client = createMiotCalendarClient({
     baseUrl: MIOT_CALENDAR_URL,
     headers: {
@@ -53,7 +62,12 @@ export async function POST(
   });
 
   try {
-    const timeWindow = await client.calendars.createTimeWindow(calendarId, body);
+    const { calendarId } = await params;
+    const parsed = TimeWindowRequestSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+    }
+    const timeWindow = await client.calendars.createTimeWindow(calendarId, parsed.data);
     return NextResponse.json(timeWindow, { status: 201 });
   } catch (error) {
     const status = error instanceof MiotCalendarApiError ? error.status : 500;

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
@@ -1,0 +1,63 @@
+import {
+  createMiotCalendarClient,
+  MiotCalendarApiError,
+} from "@microboxlabs/miot-calendar-client";
+import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
+import { requireAuth } from "../../../utils/alfresco-crud-client";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ calendarId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { calendarId } = await params;
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const timeWindows = await client.calendars.listTimeWindows(calendarId);
+    return NextResponse.json(timeWindows);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error }, "Failed to fetch time windows");
+    return NextResponse.json({ error: "Failed to fetch time windows" }, { status });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ calendarId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { calendarId } = await params;
+  const body: TimeWindowRequest = await request.json();
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const timeWindow = await client.calendars.createTimeWindow(calendarId, body);
+    return NextResponse.json(timeWindow, { status: 201 });
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error }, "Failed to create time window");
+    return NextResponse.json({ error: "Failed to create time window" }, { status });
+  }
+}

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
@@ -1,8 +1,6 @@
-import {
-  createMiotCalendarClient,
-  MiotCalendarApiError,
-} from "@microboxlabs/miot-calendar-client";
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
+import { createCalendarClient } from "../../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
@@ -19,8 +17,6 @@ const TimeWindowRequestSchema = z.object({
   active: z.boolean().optional(),
 });
 
-const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
-
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ calendarId: string }> }
@@ -29,13 +25,7 @@ export async function GET(
   if (!authResult.authenticated) return authResult.response;
 
   const { calendarId } = await params;
-
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
+  const client = createCalendarClient(authResult.session);
 
   try {
     const timeWindows = await client.calendars.listTimeWindows(calendarId);
@@ -54,19 +44,21 @@ export async function POST(
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
-
   try {
     const { calendarId } = await params;
-    const parsed = TimeWindowRequestSchema.safeParse(await request.json());
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+    const parsed = TimeWindowRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error.message }, { status: 400 });
     }
+
+    const client = createCalendarClient(authResult.session);
     const timeWindow = await client.calendars.createTimeWindow(calendarId, parsed.data);
     return NextResponse.json(timeWindow, { status: 201 });
   } catch (error) {

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/route.ts
@@ -1,21 +1,9 @@
 import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
-import { z } from "zod";
 import { createCalendarClient } from "../../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../../utils/alfresco-crud-client";
+import { TimeWindowRequestSchema } from "./time-window.schema";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
-
-const TimeWindowRequestSchema = z.object({
-  name: z.string(),
-  startHour: z.number(),
-  endHour: z.number(),
-  validFrom: z.string(),
-  slotDurationMinutes: z.number().optional(),
-  capacityPerSlot: z.number().optional(),
-  daysOfWeek: z.string().optional(),
-  validTo: z.string().optional(),
-  active: z.boolean().optional(),
-});
 
 export async function GET(
   _request: Request,

--- a/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
+++ b/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const TimeWindowRequestSchema = z.object({
+  name: z.string(),
+  startHour: z.number(),
+  endHour: z.number(),
+  validFrom: z.string(),
+  slotDurationMinutes: z.number().optional(),
+  capacityPerSlot: z.number().optional(),
+  daysOfWeek: z.string().optional(),
+  validTo: z.string().optional(),
+  active: z.boolean().optional(),
+});

--- a/apps/app/src/app/api/calendar/groups/route.ts
+++ b/apps/app/src/app/api/calendar/groups/route.ts
@@ -1,8 +1,15 @@
 import { createMiotCalendarClient, MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
-import type { CalendarGroupRequest } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+
+const CalendarGroupSchema = z.object({
+  code: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  active: z.boolean().optional(),
+}).strict();
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -31,7 +38,17 @@ export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const body: CalendarGroupRequest = await request.json();
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CalendarGroupSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
   const client = createMiotCalendarClient({
     baseUrl: MIOT_CALENDAR_URL,
     headers: {
@@ -40,7 +57,7 @@ export async function POST(request: Request) {
   });
 
   try {
-    const group = await client.groups.create(body);
+    const group = await client.groups.create(parsed.data);
     return NextResponse.json(group, { status: 201 });
   } catch (error) {
     const status = error instanceof MiotCalendarApiError ? error.status : 500;

--- a/apps/app/src/app/api/calendar/groups/route.ts
+++ b/apps/app/src/app/api/calendar/groups/route.ts
@@ -1,5 +1,6 @@
-import { createMiotCalendarClient, MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
+import { createCalendarClient } from "../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
@@ -11,18 +12,11 @@ const CalendarGroupSchema = z.object({
   active: z.boolean().optional(),
 }).strict();
 
-const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
-
 export async function GET() {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
+  const client = createCalendarClient(authResult.session);
 
   try {
     const groups = await client.groups.list({ active: true });
@@ -49,12 +43,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: parsed.error.message }, { status: 400 });
   }
 
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
+  const client = createCalendarClient(authResult.session);
 
   try {
     const group = await client.groups.create(parsed.data);

--- a/apps/app/src/app/api/calendar/groups/route.ts
+++ b/apps/app/src/app/api/calendar/groups/route.ts
@@ -1,9 +1,11 @@
-import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
 import { createCalendarClient } from "../../utils/miot-calendar-api-client";
 import { requireAuth } from "../../utils/alfresco-crud-client";
+import {
+  handleMiotCalendarApiError,
+  parseJsonBody,
+} from "../../utils/calendar-route-utils";
 import { NextResponse } from "next/server";
-import { logger } from "@/lib/logger";
 
 const CalendarGroupSchema = z.object({
   code: z.string(),
@@ -22,9 +24,11 @@ export async function GET() {
     const groups = await client.groups.list({ active: true });
     return NextResponse.json(groups);
   } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to fetch calendar groups");
-    return NextResponse.json({ error: "Failed to fetch calendar groups" }, { status });
+    return handleMiotCalendarApiError(
+      error,
+      "Failed to fetch calendar groups",
+      "Failed to fetch calendar groups"
+    );
   }
 }
 
@@ -32,13 +36,9 @@ export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-  const parsed = CalendarGroupSchema.safeParse(rawBody);
+  const bodyResult = await parseJsonBody(request);
+  if ("error" in bodyResult) return bodyResult.error;
+  const parsed = CalendarGroupSchema.safeParse(bodyResult.data);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.message }, { status: 400 });
   }
@@ -49,8 +49,10 @@ export async function POST(request: Request) {
     const group = await client.groups.create(parsed.data);
     return NextResponse.json(group, { status: 201 });
   } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to create calendar group");
-    return NextResponse.json({ error: "Failed to create calendar group" }, { status });
+    return handleMiotCalendarApiError(
+      error,
+      "Failed to create calendar group",
+      "Failed to create calendar group"
+    );
   }
 }

--- a/apps/app/src/app/api/calendar/groups/route.ts
+++ b/apps/app/src/app/api/calendar/groups/route.ts
@@ -1,6 +1,6 @@
 import { createMiotCalendarClient, MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
-import type { CalendarRequest } from "@microboxlabs/miot-calendar-client";
-import { requireAuth } from "../utils/alfresco-crud-client";
+import type { CalendarGroupRequest } from "@microboxlabs/miot-calendar-client";
+import { requireAuth } from "../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 
@@ -18,12 +18,12 @@ export async function GET() {
   });
 
   try {
-    const calendars = await client.calendars.list({ active: true });
-    return NextResponse.json(calendars);
+    const groups = await client.groups.list({ active: true });
+    return NextResponse.json(groups);
   } catch (error) {
     const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to fetch calendars");
-    return NextResponse.json({ error: "Failed to fetch calendars" }, { status });
+    logger.error({ err: error }, "Failed to fetch calendar groups");
+    return NextResponse.json({ error: "Failed to fetch calendar groups" }, { status });
   }
 }
 
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const body: CalendarRequest = await request.json();
+  const body: CalendarGroupRequest = await request.json();
   const client = createMiotCalendarClient({
     baseUrl: MIOT_CALENDAR_URL,
     headers: {
@@ -40,11 +40,11 @@ export async function POST(request: Request) {
   });
 
   try {
-    const calendar = await client.calendars.create(body);
-    return NextResponse.json(calendar, { status: 201 });
+    const group = await client.groups.create(body);
+    return NextResponse.json(group, { status: 201 });
   } catch (error) {
     const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to create calendar");
-    return NextResponse.json({ error: "Failed to create calendar" }, { status });
+    logger.error({ err: error }, "Failed to create calendar group");
+    return NextResponse.json({ error: "Failed to create calendar group" }, { status });
   }
 }

--- a/apps/app/src/app/api/calendar/route.ts
+++ b/apps/app/src/app/api/calendar/route.ts
@@ -1,0 +1,27 @@
+import { createMiotCalendarClient, MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { requireAuth } from "../utils/alfresco-crud-client";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+
+export async function GET() {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const calendars = await client.calendars.list({ active: true });
+    return NextResponse.json(calendars);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error }, "Failed to fetch calendars");
+    return NextResponse.json({ error: "Failed to fetch calendars" }, { status });
+  }
+}

--- a/apps/app/src/app/api/calendar/route.ts
+++ b/apps/app/src/app/api/calendar/route.ts
@@ -1,21 +1,24 @@
-import { createMiotCalendarClient, MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
-import type { CalendarRequest } from "@microboxlabs/miot-calendar-client";
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
+import { createCalendarClient } from "../utils/miot-calendar-api-client";
 import { requireAuth } from "../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 
-const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+const CalendarRequestSchema = z.object({
+  code: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  timezone: z.string().optional(),
+  active: z.boolean().optional(),
+  groups: z.array(z.string()).optional(),
+});
 
 export async function GET() {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
+  const client = createCalendarClient(authResult.session);
 
   try {
     const calendars = await client.calendars.list({ active: true });
@@ -31,16 +34,21 @@ export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  const body: CalendarRequest = await request.json();
-  const client = createMiotCalendarClient({
-    baseUrl: MIOT_CALENDAR_URL,
-    headers: {
-      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
-    },
-  });
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CalendarRequestSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const client = createCalendarClient(authResult.session);
 
   try {
-    const calendar = await client.calendars.create(body);
+    const calendar = await client.calendars.create(parsed.data);
     return NextResponse.json(calendar, { status: 201 });
   } catch (error) {
     const status = error instanceof MiotCalendarApiError ? error.status : 500;

--- a/apps/app/src/app/api/calendar/route.ts
+++ b/apps/app/src/app/api/calendar/route.ts
@@ -1,9 +1,11 @@
-import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
 import { createCalendarClient } from "../utils/miot-calendar-api-client";
 import { requireAuth } from "../utils/alfresco-crud-client";
+import {
+  handleMiotCalendarApiError,
+  parseJsonBody,
+} from "../utils/calendar-route-utils";
 import { NextResponse } from "next/server";
-import { logger } from "@/lib/logger";
 
 const CalendarRequestSchema = z.object({
   code: z.string(),
@@ -24,9 +26,11 @@ export async function GET() {
     const calendars = await client.calendars.list({ active: true });
     return NextResponse.json(calendars);
   } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to fetch calendars");
-    return NextResponse.json({ error: "Failed to fetch calendars" }, { status });
+    return handleMiotCalendarApiError(
+      error,
+      "Failed to fetch calendars",
+      "Failed to fetch calendars"
+    );
   }
 }
 
@@ -34,13 +38,9 @@ export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-  const parsed = CalendarRequestSchema.safeParse(rawBody);
+  const bodyResult = await parseJsonBody(request);
+  if ("error" in bodyResult) return bodyResult.error;
+  const parsed = CalendarRequestSchema.safeParse(bodyResult.data);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.message }, { status: 400 });
   }
@@ -51,8 +51,10 @@ export async function POST(request: Request) {
     const calendar = await client.calendars.create(parsed.data);
     return NextResponse.json(calendar, { status: 201 });
   } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error }, "Failed to create calendar");
-    return NextResponse.json({ error: "Failed to create calendar" }, { status });
+    return handleMiotCalendarApiError(
+      error,
+      "Failed to create calendar",
+      "Failed to create calendar"
+    );
   }
 }

--- a/apps/app/src/app/api/utils/calendar-route-utils.ts
+++ b/apps/app/src/app/api/utils/calendar-route-utils.ts
@@ -1,0 +1,24 @@
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+export function handleMiotCalendarApiError(
+  error: unknown,
+  logMessage: string,
+  userMessage: string
+): NextResponse {
+  const status = error instanceof MiotCalendarApiError ? error.status : 500;
+  logger.error({ err: error }, logMessage);
+  return NextResponse.json({ error: userMessage }, { status });
+}
+
+export async function parseJsonBody(
+  request: Request
+): Promise<{ data: unknown } | { error: NextResponse }> {
+  try {
+    const data = await request.json();
+    return { data };
+  } catch {
+    return { error: NextResponse.json({ error: "Invalid JSON" }, { status: 400 }) };
+  }
+}

--- a/apps/app/src/app/api/utils/miot-calendar-api-client.ts
+++ b/apps/app/src/app/api/utils/miot-calendar-api-client.ts
@@ -1,0 +1,11 @@
+import { createMiotCalendarClient } from "@microboxlabs/miot-calendar-client";
+import type { Session } from "next-auth";
+
+export function createCalendarClient(session: Session) {
+  return createMiotCalendarClient({
+    baseUrl: process.env.MIOT_CALENDAR_URL ?? "",
+    headers: {
+      Authorization: `Bearer ${session.user?.rawJWT ?? session.user?.ticket ?? ""}`,
+    },
+  });
+}

--- a/apps/app/src/app/api/utils/miot-calendar-api-client.ts
+++ b/apps/app/src/app/api/utils/miot-calendar-api-client.ts
@@ -1,9 +1,17 @@
 import { createMiotCalendarClient } from "@microboxlabs/miot-calendar-client";
 import type { Session } from "next-auth";
 
+const baseUrl = process.env.MIOT_CALENDAR_URL;
+if (!baseUrl) {
+  throw new Error(
+    "MIOT_CALENDAR_URL environment variable is not set. " +
+      "Ensure it is defined before starting the server."
+  );
+}
+
 export function createCalendarClient(session: Session) {
   return createMiotCalendarClient({
-    baseUrl: process.env.MIOT_CALENDAR_URL ?? "",
+    baseUrl: baseUrl!,
     headers: {
       Authorization: `Bearer ${session.user?.rawJWT ?? session.user?.ticket ?? ""}`,
     },

--- a/apps/app/src/app/api/utils/miot-calendar-api-client.ts
+++ b/apps/app/src/app/api/utils/miot-calendar-api-client.ts
@@ -10,10 +10,14 @@ if (!baseUrl) {
 }
 
 export function createCalendarClient(session: Session) {
+  const token = session.user?.rawJWT ?? session.user?.ticket;
+  if (!token) {
+    throw new Error("No authentication token found in session.");
+  }
   return createMiotCalendarClient({
     baseUrl: baseUrl!,
     headers: {
-      Authorization: `Bearer ${session.user?.rawJWT ?? session.user?.ticket ?? ""}`,
+      Authorization: `Bearer ${token}`,
     },
   });
 }

--- a/apps/app/src/app/api/utils/miot-calendar-api-client.ts
+++ b/apps/app/src/app/api/utils/miot-calendar-api-client.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createMiotCalendarClient } from "@microboxlabs/miot-calendar-client";
 import type { Session } from "next-auth";
 

--- a/apps/app/src/app/api/utils/miot-calendar-api-client.ts
+++ b/apps/app/src/app/api/utils/miot-calendar-api-client.ts
@@ -1,21 +1,20 @@
 import { createMiotCalendarClient } from "@microboxlabs/miot-calendar-client";
 import type { Session } from "next-auth";
 
-const baseUrl = process.env.MIOT_CALENDAR_URL;
-if (!baseUrl) {
-  throw new Error(
-    "MIOT_CALENDAR_URL environment variable is not set. " +
-      "Ensure it is defined before starting the server."
-  );
-}
-
 export function createCalendarClient(session: Session) {
+  const baseUrl = process.env.MIOT_CALENDAR_URL;
+  if (!baseUrl) {
+    throw new Error(
+      "MIOT_CALENDAR_URL environment variable is not set. " +
+        "Ensure it is defined before starting the server."
+    );
+  }
   const token = session.user?.rawJWT ?? session.user?.ticket;
   if (!token) {
     throw new Error("No authentication token found in session.");
   }
   return createMiotCalendarClient({
-    baseUrl: baseUrl!,
+    baseUrl,
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/apps/app/src/features/calendar/components/calendar-landing/calendar-feature-card.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/calendar-feature-card.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+
+interface CalendarFeatureCardProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+export function CalendarFeatureCard({
+  icon,
+  title,
+  description,
+}: Readonly<CalendarFeatureCardProps>) {
+  return (
+    <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/20">
+        {icon}
+      </div>
+      <h3 className="mb-2 text-base font-semibold text-gray-900 dark:text-white">
+        {title}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400">{description}</p>
+    </div>
+  );
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
@@ -1,18 +1,15 @@
-import Link from "next/link";
-import { HiCalendar, HiCog, HiCollection, HiPlus } from "react-icons/hi";
+import { HiCalendar, HiCog, HiCollection } from "react-icons/hi";
 import { tr } from "@/features/i18n/tr.service";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { CalendarFeatureCard } from "./calendar-feature-card";
+import { CreateCalendarButton } from "./create-calendar-button";
 
 interface CalendarLandingProps {
   dict: I18nRecord;
   lang: string;
 }
 
-export function CalendarLanding({
-  dict,
-  lang,
-}: Readonly<CalendarLandingProps>) {
+export function CalendarLanding({ dict }: Readonly<CalendarLandingProps>) {
   const landing = dict.landing as I18nRecord;
 
   return (
@@ -47,13 +44,7 @@ export function CalendarLanding({
         />
       </div>
 
-      <Link
-        href={`/${lang}/calendar/planning`}
-        className="inline-flex items-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800"
-      >
-        <HiPlus className="mr-2 h-4 w-4" />
-        {tr("cta", landing)}
-      </Link>
+      <CreateCalendarButton dict={dict} ctaLabel={tr("cta", landing)} />
     </div>
   );
 }

--- a/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { HiCalendar, HiCog, HiCollection, HiPlus } from "react-icons/hi";
+import { tr } from "@/features/i18n/tr.service";
+import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { CalendarFeatureCard } from "./calendar-feature-card";
+
+interface CalendarLandingProps {
+  dict: I18nRecord;
+  lang: string;
+}
+
+export function CalendarLanding({
+  dict,
+  lang,
+}: Readonly<CalendarLandingProps>) {
+  const landing = dict.landing as I18nRecord;
+
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-16">
+      <div className="mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-900/20">
+        <HiCalendar className="h-12 w-12 text-blue-500" />
+      </div>
+
+      <h1 className="mb-3 text-3xl font-bold text-gray-900 dark:text-white">
+        {tr("title", landing)}
+      </h1>
+
+      <p className="mb-12 max-w-lg text-center text-gray-500 dark:text-gray-400">
+        {tr("subtitle", landing)}
+      </p>
+
+      <div className="mb-12 grid w-full max-w-3xl grid-cols-1 gap-6 sm:grid-cols-3">
+        <CalendarFeatureCard
+          icon={<HiCalendar className="h-6 w-6 text-blue-500" />}
+          title={tr("planning_title", landing)}
+          description={tr("planning_description", landing)}
+        />
+        <CalendarFeatureCard
+          icon={<HiCog className="h-6 w-6 text-blue-500" />}
+          title={tr("rules_title", landing)}
+          description={tr("rules_description", landing)}
+        />
+        <CalendarFeatureCard
+          icon={<HiCollection className="h-6 w-6 text-blue-500" />}
+          title={tr("multi_calendar_title", landing)}
+          description={tr("multi_calendar_description", landing)}
+        />
+      </div>
+
+      <Link
+        href={`/${lang}/calendar/planning`}
+        className="inline-flex items-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800"
+      >
+        <HiPlus className="mr-2 h-4 w-4" />
+        {tr("cta", landing)}
+      </Link>
+    </div>
+  );
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/calendar-landing.tsx
@@ -1,16 +1,17 @@
 import { HiCalendar, HiCog, HiCollection } from "react-icons/hi";
+import { getDictionary } from "@/features/i18n/i18n.service";
 import { tr } from "@/features/i18n/tr.service";
-import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { CalendarFeatureCard } from "./calendar-feature-card";
 import { CreateCalendarButton } from "./create-calendar-button";
 
 interface CalendarLandingProps {
-  dict: I18nRecord;
   lang: string;
 }
 
-export function CalendarLanding({ dict }: Readonly<CalendarLandingProps>) {
-  const landing = dict.landing as I18nRecord;
+export async function CalendarLanding({ lang }: Readonly<CalendarLandingProps>) {
+  const [, dict] = await getDictionary(lang);
+  const { calendar } = dict;
+  const { landing } = calendar;
 
   return (
     <div className="flex flex-col items-center justify-center px-4 py-16">
@@ -44,7 +45,7 @@ export function CalendarLanding({ dict }: Readonly<CalendarLandingProps>) {
         />
       </div>
 
-      <CreateCalendarButton dict={dict} ctaLabel={tr("cta", landing)} />
+      <CreateCalendarButton dict={calendar} ctaLabel={tr("cta", landing)} />
     </div>
   );
 }

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-button.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { HiPlus } from "react-icons/hi";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { CreateCalendarModal } from "./create-calendar-modal";
+
+interface CreateCalendarButtonProps {
+  dict: I18nRecord;
+  ctaLabel: string;
+}
+
+export function CreateCalendarButton({
+  dict,
+  ctaLabel,
+}: Readonly<CreateCalendarButtonProps>) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="inline-flex items-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800"
+      >
+        <HiPlus className="mr-2 h-4 w-4" />
+        {ctaLabel}
+      </button>
+      <CreateCalendarModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        dict={dict}
+      />
+    </>
+  );
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
@@ -1,0 +1,72 @@
+import type { DynamicFormConfig } from "@/features/dynamic-forms";
+
+// Curated IANA timezone list (Latin America–focused + UTC + common EU/US)
+export const TIMEZONE_OPTIONS = [
+  { value: "UTC", labelKey: "UTC" },
+  { value: "America/Santiago", labelKey: "America/Santiago" },
+  { value: "America/Argentina/Buenos_Aires", labelKey: "America/Argentina/Buenos_Aires" },
+  { value: "America/Bogota", labelKey: "America/Bogota" },
+  { value: "America/Lima", labelKey: "America/Lima" },
+  { value: "America/Sao_Paulo", labelKey: "America/Sao_Paulo" },
+  { value: "America/Mexico_City", labelKey: "America/Mexico_City" },
+  { value: "America/New_York", labelKey: "America/New_York" },
+  { value: "America/Los_Angeles", labelKey: "America/Los_Angeles" },
+  { value: "Europe/London", labelKey: "Europe/London" },
+  { value: "Europe/Madrid", labelKey: "Europe/Madrid" },
+];
+
+/**
+ * Form config for creating a calendar.
+ * labelKeys are relative to the full calendar dict (e.g. tr("create.nameLabel", calendarDict)).
+ * The "groups" field is rendered as a custom GroupAutocompleteField in the modal.
+ */
+export const CREATE_CALENDAR_FORM_CONFIG: DynamicFormConfig = {
+  fields: [
+    {
+      name: "name",
+      labelKey: "create.nameLabel",
+      type: "text",
+      required: true,
+      placeholder: "Loading Dock South",
+    },
+    {
+      name: "code",
+      labelKey: "create.codeLabel",
+      type: "text",
+      required: true,
+      placeholder: "loadingdocksouth",
+      readonly: true,
+    },
+    {
+      name: "description",
+      labelKey: "create.descriptionLabel",
+      type: "textarea",
+      placeholder: "Scheduling calendar for Loading Dock South",
+    },
+    {
+      name: "timezone",
+      labelKey: "create.timezoneLabel",
+      type: "select",
+      required: true,
+      defaultValue: "America/Santiago",
+      options: TIMEZONE_OPTIONS,
+    },
+    {
+      name: "active",
+      labelKey: "create.activeLabel",
+      type: "checkbox",
+      defaultValue: true,
+    },
+  ],
+};
+
+/**
+ * Normalize a name to a valid calendar/group code:
+ * lowercase, alphanumeric only, max 15 chars.
+ */
+export function normalizeCode(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .substring(0, 15);
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
@@ -67,6 +67,6 @@ export const CREATE_CALENDAR_FORM_CONFIG: DynamicFormConfig = {
 export function normalizeCode(name: string): string {
   return name
     .toLowerCase()
-    .replace(/[^a-z0-9]/g, "")
+    .replaceAll(/[^a-z0-9]/g, "")
     .substring(0, 15);
 }

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
@@ -4,8 +4,7 @@ import { useState, useCallback, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useSWRConfig } from "swr";
 import FormModal from "@/features/common/components/form-modal/form-modal";
-import { DynamicFormField } from "@/features/dynamic-forms";
-import { useDynamicFormState } from "@/features/dynamic-forms";
+import { DynamicFormField, useDynamicFormState } from "@/features/dynamic-forms";
 import {
   useCalendarGroups,
   createCalendar,

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { useSWRConfig } from "swr";
+import FormModal from "@/features/common/components/form-modal/form-modal";
+import { DynamicFormField } from "@/features/dynamic-forms";
+import { useDynamicFormState } from "@/features/dynamic-forms";
+import {
+  useCalendarGroups,
+  createCalendar,
+} from "@/features/common/providers/client-api.provider";
+import type { CalendarGroupResponse, CalendarRequest } from "@microboxlabs/miot-calendar-client";
+
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { ShowNotification } from "@/features/notifications/notification";
+import { CREATE_CALENDAR_FORM_CONFIG, normalizeCode } from "./create-calendar-modal.config";
+import { GroupAutocompleteField } from "./group-autocomplete-field";
+
+interface CreateCalendarModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Full calendar i18n dict (dict["calendar"]) */
+  dict: I18nRecord;
+  onCreated?: () => void;
+}
+
+export function CreateCalendarModal({
+  isOpen,
+  onClose,
+  dict,
+  onCreated,
+}: Readonly<CreateCalendarModalProps>) {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [selectedGroupCode, setSelectedGroupCode] = useState("");
+  const { mutate } = useSWRConfig();
+  const { groups } = useCalendarGroups();
+  const router = useRouter();
+  const params = useParams<{ lang: string }>();
+
+  const { formValues, setFormValue, resetFormValues, isFieldVisible } =
+    useDynamicFormState(isOpen, CREATE_CALENDAR_FORM_CONFIG);
+
+  // Auto-derive code from name
+  useEffect(() => {
+    const name = formValues.name as string | undefined;
+    if (name !== undefined) {
+      setFormValue("code", normalizeCode(name));
+    }
+  }, [formValues.name, setFormValue]);
+
+  const handleClose = useCallback(() => {
+    resetFormValues();
+    setSelectedGroupCode("");
+    onClose();
+  }, [resetFormValues, onClose]);
+
+  const handleGroupCreated = useCallback(
+    (group: CalendarGroupResponse) => {
+      // Refresh the groups SWR cache so the new group appears immediately
+      void mutate("/app/api/calendar/groups");
+      setSelectedGroupCode(group.code);
+    },
+    [mutate]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setIsProcessing(true);
+
+    try {
+      const body: CalendarRequest = {
+        name: formValues.name as string,
+        code: formValues.code as string,
+        description: (formValues.description as string) || undefined,
+        timezone: (formValues.timezone as string) || "UTC",
+        active: (formValues.active as boolean) ?? true,
+        groups: selectedGroupCode ? [selectedGroupCode] : [],
+      };
+
+      const calendar = await createCalendar(body);
+      await mutate("/app/api/calendar");
+      ShowNotification({
+        type: "success",
+        message: tr("create.successNotification", dict),
+      });
+      handleClose();
+      onCreated?.();
+      const groupQuery = selectedGroupCode ? `?groupCode=${selectedGroupCode}` : "";
+      router.push(`/${params.lang}/calendar/${calendar.id}/planning${groupQuery}`);
+    } catch (err) {
+      ShowNotification({
+        type: "error",
+        message: err instanceof Error ? err.message : tr("create.errorNotification", dict),
+      });
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [formValues, selectedGroupCode, mutate, dict, handleClose, onCreated, router, params.lang]);
+
+  // Fields rendered via DynamicFormField (all except "groups" handled by GroupAutocompleteField)
+  const standardFields = CREATE_CALENDAR_FORM_CONFIG.fields;
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={tr("create.title", dict)}
+      subtitle={tr("create.subtitle", dict)}
+      submitLabel={tr("create.submit", dict)}
+      isProcessing={isProcessing}
+      onSubmit={handleSubmit}
+      size="2xl"
+    >
+      <div className="flex flex-col gap-4">
+        {/* name, code, description, timezone */}
+        {standardFields
+          .filter((f) => f.name !== "active")
+          .map((field) => (
+            <DynamicFormField
+              key={field.name}
+              field={field}
+              value={formValues[field.name] ?? field.defaultValue ?? ""}
+              onChange={(value) => setFormValue(field.name, value)}
+              isVisible={isFieldVisible(field)}
+              translate={(key) => tr(key, dict)}
+            />
+          ))}
+
+        {/* Group autocomplete/autocreate */}
+        <GroupAutocompleteField
+          groups={groups}
+          value={selectedGroupCode}
+          onChange={setSelectedGroupCode}
+          onGroupCreated={handleGroupCreated}
+          dict={dict}
+        />
+
+        {/* active checkbox */}
+        {standardFields
+          .filter((f) => f.name === "active")
+          .map((field) => (
+            <DynamicFormField
+              key={field.name}
+              field={field}
+              value={formValues[field.name] ?? field.defaultValue ?? ""}
+              onChange={(value) => setFormValue(field.name, value)}
+              isVisible={isFieldVisible(field)}
+              translate={(key) => tr(key, dict)}
+            />
+          ))}
+      </div>
+    </FormModal>
+  );
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/group-autocomplete-field.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/group-autocomplete-field.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { HiSearch, HiPlus } from "react-icons/hi";
+import { twMerge } from "tailwind-merge";
+import { Label } from "flowbite-react";
+import type { CalendarGroupResponse } from "@microboxlabs/miot-calendar-client";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { createCalendarGroup } from "@/features/common/providers/client-api.provider";
+import { ShowNotification } from "@/features/notifications/notification";
+import { normalizeCode } from "./create-calendar-modal.config";
+
+interface GroupAutocompleteFieldProps {
+  groups: CalendarGroupResponse[];
+  value: string; // selected group code
+  onChange: (code: string) => void;
+  onGroupCreated: (group: CalendarGroupResponse) => void;
+  dict: I18nRecord; // full calendar dict
+}
+
+const MIN_CHARACTERS = 1;
+
+export function GroupAutocompleteField({
+  groups,
+  value,
+  onChange,
+  onGroupCreated,
+  dict,
+}: Readonly<GroupAutocompleteFieldProps>) {
+  // Display the name of the selected group (or empty if none selected)
+  const selectedGroup = groups.find((g) => g.code === value);
+  const [query, setQuery] = useState(selectedGroup?.name ?? "");
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sync display when external value changes
+  useEffect(() => {
+    const group = groups.find((g) => g.code === value);
+    setQuery(group?.name ?? "");
+  }, [value, groups]);
+
+  // Filter groups by query
+  const filteredGroups = useMemo(() => {
+    if (query.length < MIN_CHARACTERS) return groups;
+    const lower = query.toLowerCase();
+    return groups.filter(
+      (g) =>
+        g.name.toLowerCase().includes(lower) ||
+        g.code.toLowerCase().includes(lower)
+    );
+  }, [query, groups]);
+
+  const hasExactMatch = useMemo(
+    () => groups.some((g) => g.name.toLowerCase() === query.toLowerCase()),
+    [query, groups]
+  );
+
+  const showCreateOption = query.length >= MIN_CHARACTERS && !hasExactMatch;
+
+  // Total items in dropdown: filtered groups + optional create option
+  const totalItems = filteredGroups.length + (showCreateOption ? 1 : 0);
+
+  // Handle click outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+        // Restore display name if user left without selecting
+        const group = groups.find((g) => g.code === value);
+        setQuery(group?.name ?? "");
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen, value, groups]);
+
+  const handleSelect = useCallback(
+    (group: CalendarGroupResponse) => {
+      onChange(group.code);
+      setQuery(group.name);
+      setIsOpen(false);
+    },
+    [onChange]
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (!query.trim() || isCreating) return;
+    setIsCreating(true);
+    try {
+      const newGroup = await createCalendarGroup({
+        code: normalizeCode(query.trim()),
+        name: query.trim(),
+        active: true,
+      });
+      ShowNotification({
+        type: "success",
+        message: tr("create.group.successNotification", dict),
+      });
+      onGroupCreated(newGroup);
+      onChange(newGroup.code);
+      setQuery(newGroup.name);
+      setIsOpen(false);
+    } catch (err) {
+      ShowNotification({
+        type: "error",
+        message: err instanceof Error ? err.message : tr("create.group.errorNotification", dict),
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  }, [query, isCreating, dict, onChange, onGroupCreated]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!isOpen) {
+        if (e.key === "ArrowDown" || e.key === "Enter") {
+          setIsOpen(true);
+          setSelectedIndex(0);
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < totalItems - 1 ? prev + 1 : prev
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (selectedIndex < filteredGroups.length) {
+            handleSelect(filteredGroups[selectedIndex]);
+          } else if (showCreateOption) {
+            void handleCreate();
+          }
+          break;
+        case "Escape": {
+          e.preventDefault();
+          setIsOpen(false);
+          const escGroup = groups.find((g) => g.code === value);
+          setQuery(escGroup?.name ?? "");
+          break;
+        }
+        case "Tab":
+          if (selectedIndex < filteredGroups.length) {
+            handleSelect(filteredGroups[selectedIndex]);
+          }
+          break;
+      }
+    },
+    [
+      isOpen,
+      totalItems,
+      filteredGroups,
+      selectedIndex,
+      showCreateOption,
+      handleSelect,
+      handleCreate,
+      groups,
+      value,
+    ]
+  );
+
+  const createLabel = tr("create.group.create", dict).replace(
+    "{name}",
+    query.trim()
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="group-autocomplete">
+        {tr("create.groupLabel", dict)}
+      </Label>
+      <div ref={containerRef} className="relative">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+            <HiSearch className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+          </div>
+          <input
+            ref={inputRef}
+            id="group-autocomplete"
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setIsOpen(true);
+              setSelectedIndex(0);
+            }}
+            onFocus={() => {
+              setIsOpen(true);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder={tr("create.group.searchPlaceholder", dict)}
+            autoComplete="off"
+            className={twMerge(
+              "block w-full pl-10 pr-4 py-2 text-sm",
+              "border border-gray-300 dark:border-gray-600",
+              "rounded-lg",
+              "bg-white dark:bg-gray-700",
+              "text-gray-900 dark:text-white",
+              "placeholder-gray-400 dark:placeholder-gray-500",
+              "focus:border-blue-500 dark:focus:border-blue-400",
+              "focus:outline-none",
+              "transition-colors"
+            )}
+          />
+        </div>
+
+        {isOpen && (
+          <div
+            className={twMerge(
+              "absolute z-50 w-full mt-1",
+              "bg-white dark:bg-gray-800",
+              "border border-gray-200 dark:border-gray-700",
+              "rounded-lg shadow-lg",
+              "max-h-[220px] overflow-y-auto"
+            )}
+          >
+            <ul className="py-1" role="listbox">
+              {filteredGroups.map((group, index) => (
+                <li key={group.code}>
+                  <button
+                    type="button"
+                    tabIndex={index === selectedIndex ? 0 : -1}
+                    onClick={() => handleSelect(group)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={twMerge(
+                      "w-full text-left px-4 py-2 cursor-pointer",
+                      "transition-colors border-0 bg-transparent",
+                      "text-sm text-gray-900 dark:text-white",
+                      index === selectedIndex
+                        ? "bg-blue-50 dark:bg-blue-900/30"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700"
+                    )}
+                  >
+                    {group.name}
+                    <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                      {group.code}
+                    </span>
+                  </button>
+                </li>
+              ))}
+
+              {filteredGroups.length === 0 && !showCreateOption && (
+                <li className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 text-center">
+                  {tr("create.group.noResults", dict)}
+                </li>
+              )}
+
+              {showCreateOption && (
+                <li>
+                  <button
+                    type="button"
+                    tabIndex={selectedIndex === filteredGroups.length ? 0 : -1}
+                    onClick={() => void handleCreate()}
+                    onMouseEnter={() => setSelectedIndex(filteredGroups.length)}
+                    disabled={isCreating}
+                    className={twMerge(
+                      "w-full text-left px-4 py-2 cursor-pointer",
+                      "transition-colors border-0 bg-transparent",
+                      "text-sm font-medium text-blue-600 dark:text-blue-400",
+                      "flex items-center gap-2",
+                      selectedIndex === filteredGroups.length
+                        ? "bg-blue-50 dark:bg-blue-900/30"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700",
+                      isCreating && "opacity-50 cursor-not-allowed"
+                    )}
+                  >
+                    <HiPlus className="w-4 h-4 shrink-0" />
+                    {isCreating ? "..." : createLabel}
+                  </button>
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/features/calendar/components/calendar-landing/group-autocomplete-field.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/group-autocomplete-field.tsx
@@ -233,7 +233,7 @@ export function GroupAutocompleteField({
               "max-h-[220px] overflow-y-auto"
             )}
           >
-            <ul className="py-1" role="listbox">
+            <ul className="py-1">
               {filteredGroups.map((group, index) => (
                 <li key={group.code}>
                   <button

--- a/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
+++ b/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
@@ -22,9 +22,12 @@ export function CalendarGroupSelector({
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedId = e.target.value;
     if (selectedId === calendarId) return;
-    const newPath = pathname.replace(calendarId, selectedId);
-    const params = new URLSearchParams(searchParams.toString());
-    router.push(`${newPath}?${params.toString()}`);
+    const newPath = pathname
+      .split("/")
+      .map((seg) => (seg === calendarId ? selectedId : seg))
+      .join("/");
+    const query = searchParams.toString();
+    router.push(query ? `${newPath}?${query}` : newPath);
   };
 
   return (

--- a/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
+++ b/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useCalendarsInGroup } from "@/features/common/providers/client-api.provider";
+
+interface CalendarGroupSelectorProps {
+  calendarId: string;
+  groupCode: string;
+}
+
+export function CalendarGroupSelector({
+  calendarId,
+  groupCode,
+}: Readonly<CalendarGroupSelectorProps>) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { calendars, isLoading } = useCalendarsInGroup(groupCode);
+
+  if (isLoading || calendars.length <= 1) return null;
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedId = e.target.value;
+    if (selectedId === calendarId) return;
+    const newPath = pathname.replace(calendarId, selectedId);
+    const params = new URLSearchParams(searchParams.toString());
+    router.push(`${newPath}?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor="calendar-group-selector"
+        className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap"
+      >
+        Calendar
+      </label>
+      <select
+        id="calendar-group-selector"
+        value={calendarId}
+        onChange={handleChange}
+        className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+      >
+        {calendars.map((cal) => (
+          <option key={cal.id} value={cal.id}>
+            {cal.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
+++ b/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
@@ -17,7 +17,7 @@ export function CalendarGroupSelector({
   const searchParams = useSearchParams();
   const { calendars, isLoading } = useCalendarsInGroup(groupCode);
 
-  if (isLoading || calendars.length === 0) return null;
+  if (isLoading || calendars.length <= 1) return null;
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedId = e.target.value;

--- a/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
+++ b/apps/app/src/features/calendar/components/planning/calendar-group-selector.tsx
@@ -17,7 +17,7 @@ export function CalendarGroupSelector({
   const searchParams = useSearchParams();
   const { calendars, isLoading } = useCalendarsInGroup(groupCode);
 
-  if (isLoading || calendars.length <= 1) return null;
+  if (isLoading || calendars.length === 0) return null;
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedId = e.target.value;

--- a/apps/app/src/features/calendar/components/planning/calendar-rules/quota-manager.tsx
+++ b/apps/app/src/features/calendar/components/planning/calendar-rules/quota-manager.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Datepicker, Select } from "flowbite-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ShowNotification } from "@/features/notifications/notification";
 import { createPortal } from "react-dom";
 import { HiPlus, HiTrash, HiCheck, HiClock, HiCalendar } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
@@ -242,6 +243,8 @@ export interface QuotaManagerMessages {
   apply: string;
   today: string;
   clear: string;
+  applySuccess: string;
+  applyError: string;
   colors: {
     emerald: string;
     blue: string;
@@ -277,6 +280,8 @@ export function getQuotaManagerMessages(
     apply: tr(`${QUOTA_MANAGER_BASE}.apply`, dict),
     today: tr(`${QUOTA_MANAGER_BASE}.today`, dict),
     clear: tr(`${QUOTA_MANAGER_BASE}.clear`, dict),
+    applySuccess: tr(`${QUOTA_MANAGER_BASE}.applySuccess`, dict),
+    applyError: tr(`${QUOTA_MANAGER_BASE}.applyError`, dict),
     colors: {
       emerald: tr(`${QUOTA_MANAGER_BASE}.colors.emerald`, dict),
       blue: tr(`${QUOTA_MANAGER_BASE}.colors.blue`, dict),
@@ -554,16 +559,16 @@ export default function QuotaManager({
 
   const handleApply = useCallback(async () => {
     try {
-      // Sync current time windows to API
       await syncTimeSlotsToAPI();
-      // Call the parent callback (closes modal, etc.)
+      ShowNotification({ type: "success", message: messages.applySuccess });
       onRulesChange?.(timeWindows, formatString);
     } catch (error) {
-      console.error("Error syncing time windows to API:", error);
-      // Still call the callback to close modal even if API sync fails
-      onRulesChange?.(timeWindows, formatString);
+      ShowNotification({
+        type: "error",
+        message: error instanceof Error ? error.message : messages.applyError,
+      });
     }
-  }, [timeWindows, formatString, onRulesChange, syncTimeSlotsToAPI]);
+  }, [timeWindows, formatString, messages, onRulesChange, syncTimeSlotsToAPI]);
 
   return (
     <div className="z-50 min-w-[320px]">

--- a/apps/app/src/features/calendar/components/planning/planning-header.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-header.tsx
@@ -133,7 +133,7 @@ export default function PlanningHeader({
 
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-      <PlanningTitle dict={dict} />
+      <PlanningTitle dict={dict} calendarId={calendarId} />
 
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-4">

--- a/apps/app/src/features/calendar/components/planning/planning-header.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-header.tsx
@@ -22,6 +22,7 @@ import CalendarRules, {
 } from "./calendar-rules/calendar-rules";
 import PlanningTitle from "./planning-title";
 import { usePlanningSelection } from "./planning-selection-context";
+import { CalendarGroupSelector } from "./calendar-group-selector";
 
 dayjs.extend(weekOfYear);
 
@@ -66,6 +67,7 @@ function navigateDate(
 export default function PlanningHeader({
   lang,
   dict,
+  calendarId,
   initialDate = new Date(),
   initialViewMode = "week",
   onDateChange,
@@ -75,6 +77,7 @@ export default function PlanningHeader({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { setAndenesCount } = usePlanningSelection();
+  const groupCode = searchParams.get("groupCode");
 
   // Read state from URL, fallback to props/defaults
   const currentDate = useMemo(() => {
@@ -180,6 +183,12 @@ export default function PlanningHeader({
             setAndenesCount(config.count);
           }}
         />
+        {groupCode && calendarId && (
+          <CalendarGroupSelector
+            calendarId={calendarId}
+            groupCode={groupCode}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/app/src/features/calendar/components/planning/planning-header.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-header.tsx
@@ -22,7 +22,6 @@ import CalendarRules, {
 } from "./calendar-rules/calendar-rules";
 import PlanningTitle from "./planning-title";
 import { usePlanningSelection } from "./planning-selection-context";
-import { CalendarGroupSelector } from "./calendar-group-selector";
 
 dayjs.extend(weekOfYear);
 
@@ -133,7 +132,7 @@ export default function PlanningHeader({
 
   return (
     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-      <PlanningTitle dict={dict} calendarId={calendarId} />
+      <PlanningTitle dict={dict} calendarId={calendarId} groupCode={groupCode} />
 
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-4">
@@ -183,12 +182,6 @@ export default function PlanningHeader({
             setAndenesCount(config.count);
           }}
         />
-        {groupCode && calendarId && (
-          <CalendarGroupSelector
-            calendarId={calendarId}
-            groupCode={groupCode}
-          />
-        )}
       </div>
     </div>
   );

--- a/apps/app/src/features/calendar/components/planning/planning-header.types.ts
+++ b/apps/app/src/features/calendar/components/planning/planning-header.types.ts
@@ -4,6 +4,7 @@ import type { ViewMode } from "@/features/calendar/services/calendar.service.typ
 export interface PlanningHeaderProps {
   lang: string;
   dict: I18nDictionary;
+  calendarId?: string;
   initialDate?: Date;
   initialViewMode?: ViewMode;
   onDateChange?: (date: Date) => void;

--- a/apps/app/src/features/calendar/components/planning/planning-layout-client.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-layout-client.tsx
@@ -13,6 +13,7 @@ interface PlanningLayoutClientProps {
   readonly dict: I18nDictionary;
   readonly header: ReactNode;
   readonly calendar: ReactNode;
+  readonly calendarId?: string;
 }
 
 /**
@@ -61,9 +62,10 @@ export function PlanningLayoutClient({
   dict,
   header,
   calendar,
+  calendarId,
 }: PlanningLayoutClientProps) {
   return (
-    <PlanningSelectionProvider>
+    <PlanningSelectionProvider calendarId={calendarId}>
       <PlanningLayoutInner dict={dict} header={header} calendar={calendar} />
     </PlanningSelectionProvider>
   );

--- a/apps/app/src/features/calendar/components/planning/planning-layout.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-layout.tsx
@@ -8,16 +8,18 @@ import { PlanningLayoutClient } from "./planning-layout-client";
 interface PlanningLayoutProps {
   lang: string;
   dict: I18nDictionary;
+  calendarId?: string;
 }
 
 export default function PlanningLayout({
   lang,
   dict,
+  calendarId,
 }: Readonly<PlanningLayoutProps>) {
   return (
     <PlanningLayoutClient
       dict={dict}
-      header={<PlanningHeader lang={lang} dict={dict} />}
+      header={<PlanningHeader lang={lang} dict={dict} calendarId={calendarId} />}
       calendar={<PlanningCalendar lang={lang} dict={dict} />}
     />
   );

--- a/apps/app/src/features/calendar/components/planning/planning-layout.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-layout.tsx
@@ -19,6 +19,7 @@ export default function PlanningLayout({
   return (
     <PlanningLayoutClient
       dict={dict}
+      calendarId={calendarId}
       header={<PlanningHeader lang={lang} dict={dict} calendarId={calendarId} />}
       calendar={<PlanningCalendar lang={lang} dict={dict} />}
     />

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -17,15 +17,19 @@ import {
   createPlannedService,
   updatePlannedService,
   deletePlannedService,
-  useTimeSlots,
-  createTimeSlot,
-  updateTimeSlot,
-  deleteTimeSlot,
+  useCalendarTimeWindows,
+  createCalendarTimeWindow,
+  updateCalendarTimeWindow,
+  deactivateCalendarTimeWindow,
 } from "@/features/common/providers/client-api.provider";
 import {
   apiToLocalPlannedService,
   localToApiPlannedService,
 } from "@/features/calendar/services/planned-service.service";
+import {
+  apiToLocalTimeWindow,
+  localToApiTimeWindow,
+} from "@/features/calendar/services/time-window.service";
 import type { CreatePlannedServiceRequest } from "@/features/calendar/types/planned-service.types";
 
 dayjs.extend(isoWeek);
@@ -635,6 +639,7 @@ const PlanningSelectionContext =
 
 interface PlanningSelectionProviderProps {
   readonly children: ReactNode;
+  readonly calendarId?: string;
 }
 
 /**
@@ -659,6 +664,7 @@ function getWeekOfMonth(date: dayjs.Dayjs): number {
 
 export function PlanningSelectionProvider({
   children,
+  calendarId,
 }: PlanningSelectionProviderProps) {
   const [selectedSlot, setSelectedSlot] = useState<SelectedSlot | null>(null);
   const [selectedService, setSelectedService] =
@@ -682,12 +688,12 @@ export function PlanningSelectionProvider({
     refresh: refreshPlannedServices,
   } = usePlannedServices();
 
-  // Load time slots (windows and blocks) from API
+  // Load time windows from the miot-calendar-client backend
   const {
-    timeSlots: apiTimeSlots,
+    timeWindows: apiTimeWindows,
     error: timeSlotsError,
-    refresh: refreshTimeSlots,
-  } = useTimeSlots();
+    refresh: refreshTimeWindows,
+  } = useCalendarTimeWindows(calendarId ?? null);
 
   // Sync API data to local state (only when there's no error and data has actually changed)
   useEffect(() => {
@@ -713,19 +719,16 @@ export function PlanningSelectionProvider({
     }
   }, [apiPlannedServices, plannedServicesError]);
 
-  // Sync time slots from API to local state (only when there's no error)
+  // Sync time windows from API to local state (only when there's no error)
   useEffect(() => {
-    // Skip if there's an error - don't update state based on error responses
     if (timeSlotsError) return;
 
-    if (apiTimeSlots?.length > 0) {
-      // API TimeSlotResponse matches our TimeSlot interface, so we can use directly
-      setTimeSlots(apiTimeSlots as TimeSlot[]);
-    } else if (apiTimeSlots?.length === 0) {
-      // Clear local state if API returns empty array
+    if (apiTimeWindows.length > 0) {
+      setTimeSlots(apiTimeWindows.map(apiToLocalTimeWindow));
+    } else if (apiTimeWindows.length === 0 && !timeSlotsError) {
       setTimeSlots([]);
     }
-  }, [apiTimeSlots, timeSlotsError]);
+  }, [apiTimeWindows, timeSlotsError]);
 
   // Derived arrays from unified state (memoized for performance)
   const timeWindows = useMemo(
@@ -749,66 +752,55 @@ export function PlanningSelectionProvider({
       // Update local state immediately (optimistic update)
       setTimeSlots(slots);
 
-      // Sync to API - save all slots
-      try {
-        // Get current API slots to determine what to create/update/delete
-        const currentApiSlots = apiTimeSlots || [];
-        const currentIds = new Set(currentApiSlots.map((s) => s.id));
-        const newIds = new Set(slots.map((s) => s.id));
+      // Skip API sync when there is no calendarId (generic planning page)
+      if (!calendarId) return;
 
-        // Delete slots that are no longer in the new array
-        for (const currentSlot of currentApiSlots) {
-          if (!newIds.has(currentSlot.id)) {
-            try {
-              await deleteTimeSlot(currentSlot.id);
-            } catch (error) {
-              console.error("Error deleting time slot:", error);
-            }
-          }
-        }
+      const currentApiWindows = apiTimeWindows;
+      const currentIds = new Set(currentApiWindows.map((w) => w.id));
+      const newWindowIds = new Set(
+        slots.filter((s) => s.kind === "window").map((s) => s.id)
+      );
 
-        // Create or update slots
-        for (const slot of slots) {
+      const errors: string[] = [];
+
+      // Deactivate windows removed from local state
+      for (const apiWindow of currentApiWindows) {
+        if (!newWindowIds.has(apiWindow.id)) {
           try {
-            if (currentIds.has(slot.id)) {
-              // Update existing
-              await updateTimeSlot(slot.id, {
-                id: slot.id,
-                name: slot.name,
-                kind: slot.kind,
-                type: slot.type,
-                weeklyPattern: slot.weeklyPattern,
-                startTimestamp: slot.startTimestamp,
-                endTimestamp: slot.endTimestamp,
-                quota: slot.quota,
-                color: slot.color,
-              });
-            } else {
-              // Create new
-              await createTimeSlot({
-                name: slot.name,
-                kind: slot.kind,
-                type: slot.type,
-                weeklyPattern: slot.weeklyPattern,
-                startTimestamp: slot.startTimestamp,
-                endTimestamp: slot.endTimestamp,
-                quota: slot.quota,
-                color: slot.color,
-              });
-            }
-          } catch (error) {
-            console.error("Error saving time slot:", error);
+            await deactivateCalendarTimeWindow(calendarId, apiWindow);
+          } catch (err) {
+            errors.push(
+              `Failed to deactivate "${apiWindow.name}": ${err instanceof Error ? err.message : "unknown error"}`
+            );
           }
         }
+      }
 
-        // Refresh from API to ensure consistency
-        await refreshTimeSlots();
-      } catch (error) {
-        console.error("Error syncing time slots to API:", error);
-        // State was already updated optimistically, so we continue
+      // Create or update local windows
+      for (const slot of slots) {
+        if (slot.kind !== "window") continue; // blocks are local-only
+        try {
+          const body = localToApiTimeWindow(slot);
+          if (currentIds.has(slot.id)) {
+            await updateCalendarTimeWindow(calendarId, slot.id, body);
+          } else {
+            await createCalendarTimeWindow(calendarId, body);
+          }
+        } catch (err) {
+          errors.push(
+            `Failed to save "${slot.name}": ${err instanceof Error ? err.message : "unknown error"}`
+          );
+        }
+      }
+
+      // Reload from API to replace temp IDs with real server IDs
+      await refreshTimeWindows();
+
+      if (errors.length > 0) {
+        throw new Error(errors.join("; "));
       }
     },
-    [apiTimeSlots, refreshTimeSlots]
+    [calendarId, apiTimeWindows, refreshTimeWindows]
   );
 
   // Convenience setter: updates only windows, preserves blocks (local state only, no API sync)

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -29,6 +29,7 @@ import {
 import {
   apiToLocalTimeWindow,
   localToApiTimeWindow,
+  TimeWindowResponseSchema,
 } from "@/features/calendar/services/time-window.service";
 import type { CreatePlannedServiceRequest } from "@/features/calendar/types/planned-service.types";
 
@@ -724,7 +725,16 @@ export function PlanningSelectionProvider({
     if (timeSlotsError) return;
 
     if (apiTimeWindows.length > 0) {
-      setTimeSlots(apiTimeWindows.map(apiToLocalTimeWindow));
+      setTimeSlots(
+        apiTimeWindows.flatMap((tw) => {
+          const result = TimeWindowResponseSchema.safeParse(tw);
+          if (!result.success) {
+            console.warn("Skipping invalid time window response", tw, result.error.message);
+            return [];
+          }
+          return [apiToLocalTimeWindow(result.data)];
+        })
+      );
     } else if (apiTimeWindows.length === 0 && !timeSlotsError) {
       setTimeSlots([]);
     }

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -746,6 +746,53 @@ export function PlanningSelectionProvider({
     setSelectedService(service);
   }, []);
 
+  /** Deactivate API windows that were removed from local state; returns error strings. */
+  const deactivateRemovedWindows = useCallback(
+    async (
+      currentApiWindows: typeof apiTimeWindows,
+      newWindowIds: Set<string>
+    ): Promise<string[]> => {
+      const errors: string[] = [];
+      for (const apiWindow of currentApiWindows) {
+        if (!newWindowIds.has(apiWindow.id)) {
+          try {
+            await deactivateCalendarTimeWindow(calendarId!, apiWindow);
+          } catch (err) {
+            errors.push(
+              `Failed to deactivate "${apiWindow.name}": ${err instanceof Error ? err.message : "unknown error"}`
+            );
+          }
+        }
+      }
+      return errors;
+    },
+    [calendarId]
+  );
+
+  /** Create or update local window slots against the API; returns error strings. */
+  const saveLocalWindows = useCallback(
+    async (slots: TimeSlot[], currentIds: Set<string>): Promise<string[]> => {
+      const errors: string[] = [];
+      for (const slot of slots) {
+        if (slot.kind !== "window") continue; // blocks are local-only
+        try {
+          const body = localToApiTimeWindow(slot);
+          if (currentIds.has(slot.id)) {
+            await updateCalendarTimeWindow(calendarId!, slot.id, body);
+          } else {
+            await createCalendarTimeWindow(calendarId!, body);
+          }
+        } catch (err) {
+          errors.push(
+            `Failed to save "${slot.name}": ${err instanceof Error ? err.message : "unknown error"}`
+          );
+        }
+      }
+      return errors;
+    },
+    [calendarId]
+  );
+
   // Primary setter: replaces entire unified array and syncs to API
   const setTimeSlotsAndSync = useCallback(
     async (slots: TimeSlot[]) => {
@@ -761,46 +808,20 @@ export function PlanningSelectionProvider({
         slots.filter((s) => s.kind === "window").map((s) => s.id)
       );
 
-      const errors: string[] = [];
-
-      // Deactivate windows removed from local state
-      for (const apiWindow of currentApiWindows) {
-        if (!newWindowIds.has(apiWindow.id)) {
-          try {
-            await deactivateCalendarTimeWindow(calendarId, apiWindow);
-          } catch (err) {
-            errors.push(
-              `Failed to deactivate "${apiWindow.name}": ${err instanceof Error ? err.message : "unknown error"}`
-            );
-          }
-        }
-      }
-
-      // Create or update local windows
-      for (const slot of slots) {
-        if (slot.kind !== "window") continue; // blocks are local-only
-        try {
-          const body = localToApiTimeWindow(slot);
-          if (currentIds.has(slot.id)) {
-            await updateCalendarTimeWindow(calendarId, slot.id, body);
-          } else {
-            await createCalendarTimeWindow(calendarId, body);
-          }
-        } catch (err) {
-          errors.push(
-            `Failed to save "${slot.name}": ${err instanceof Error ? err.message : "unknown error"}`
-          );
-        }
-      }
+      const [deactivateErrors, saveErrors] = await Promise.all([
+        deactivateRemovedWindows(currentApiWindows, newWindowIds),
+        saveLocalWindows(slots, currentIds),
+      ]);
 
       // Reload from API to replace temp IDs with real server IDs
       await refreshTimeWindows();
 
+      const errors = [...deactivateErrors, ...saveErrors];
       if (errors.length > 0) {
         throw new Error(errors.join("; "));
       }
     },
-    [calendarId, apiTimeWindows, refreshTimeWindows]
+    [calendarId, apiTimeWindows, refreshTimeWindows, deactivateRemovedWindows, saveLocalWindows]
   );
 
   // Convenience setter: updates only windows, preserves blocks (local state only, no API sync)

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -762,11 +762,12 @@ export function PlanningSelectionProvider({
       currentApiWindows: typeof apiTimeWindows,
       newWindowIds: Set<string>
     ): Promise<string[]> => {
+      if (!calendarId) return [];
       const errors: string[] = [];
       for (const apiWindow of currentApiWindows) {
         if (!newWindowIds.has(apiWindow.id)) {
           try {
-            await deactivateCalendarTimeWindow(calendarId!, apiWindow);
+            await deactivateCalendarTimeWindow(calendarId, apiWindow);
           } catch (err) {
             errors.push(
               `Failed to deactivate "${apiWindow.name}": ${err instanceof Error ? err.message : "unknown error"}`
@@ -782,15 +783,16 @@ export function PlanningSelectionProvider({
   /** Create or update local window slots against the API; returns error strings. */
   const saveLocalWindows = useCallback(
     async (slots: TimeSlot[], currentIds: Set<string>): Promise<string[]> => {
+      if (!calendarId) return [];
       const errors: string[] = [];
       for (const slot of slots) {
         if (slot.kind !== "window") continue; // blocks are local-only
         try {
           const body = localToApiTimeWindow(slot);
           if (currentIds.has(slot.id)) {
-            await updateCalendarTimeWindow(calendarId!, slot.id, body);
+            await updateCalendarTimeWindow(calendarId, slot.id, body);
           } else {
-            await createCalendarTimeWindow(calendarId!, body);
+            await createCalendarTimeWindow(calendarId, body);
           }
         } catch (err) {
           errors.push(

--- a/apps/app/src/features/calendar/components/planning/planning-title.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-title.tsx
@@ -36,9 +36,12 @@ export default function PlanningTitle({
 
   const handleSelect = (id: string) => {
     if (!calendarId || id === calendarId) return;
-    const newPath = pathname.replace(calendarId, id);
-    const params = new URLSearchParams(searchParams.toString());
-    router.push(`${newPath}?${params.toString()}`);
+    const newPath = pathname
+      .split("/")
+      .map((seg) => (seg === calendarId ? id : seg))
+      .join("/");
+    const query = searchParams.toString();
+    router.push(query ? `${newPath}?${query}` : newPath);
   };
 
   const showPicker = groupCalendars.length > 1;

--- a/apps/app/src/features/calendar/components/planning/planning-title.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-title.tsx
@@ -1,59 +1,79 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import { Dropdown, DropdownItem, Button } from "flowbite-react";
 import { ChevronDown } from "flowbite-react-icons/outline";
-import { useState } from "react";
-import { useCalendars } from "@/features/common/providers/client-api.provider";
+import {
+  useCalendars,
+  useCalendarsInGroup,
+} from "@/features/common/providers/client-api.provider";
+
+interface PlanningTitleProps {
+  dict: I18nRecord;
+  calendarId?: string;
+  groupCode?: string | null;
+}
 
 export default function PlanningTitle({
   dict,
   calendarId,
-}: Readonly<{ dict: I18nRecord; calendarId?: string }>) {
-  const [type, setType] = useState<"dispatch" | "reception">("dispatch");
-  const { calendars } = useCalendars();
+  groupCode,
+}: Readonly<PlanningTitleProps>) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // All calendars for name resolution; group calendars for the picker
+  const { calendars: allCalendars } = useCalendars();
+  const { calendars: groupCalendars } = useCalendarsInGroup(groupCode ?? null);
+
   const calendarName = calendarId
-    ? (calendars.find((c) => c.id === calendarId)?.name ?? tr("layout.secured.sidebar.planning", dict))
+    ? (allCalendars.find((c) => c.id === calendarId)?.name ??
+       tr("layout.secured.sidebar.planning", dict))
     : tr("layout.secured.sidebar.planning", dict);
 
+  const handleSelect = (id: string) => {
+    if (!calendarId || id === calendarId) return;
+    const newPath = pathname.replace(calendarId, id);
+    const params = new URLSearchParams(searchParams.toString());
+    router.push(`${newPath}?${params.toString()}`);
+  };
+
+  const showPicker = groupCalendars.length > 1;
+
   return (
-    <div className="flex flex-row gap-2 items-center">
-      {/* Title */}
-      <h1 className="text-xl font-semibold text-gray-700 dark:text-white">
-        {calendarName}
-      </h1>
-      <Dropdown
-        label=""
-        dismissOnClick={false}
-        className="z-50"
-        renderTrigger={() => (
-          <Button
-            color="alternative"
-            className="text-lg font-normal text-gray-500 dark:text-white bg-white px-2 py-1 h-8 rounded-lg flex items-center"
-          >
-            {type === "dispatch"
-              ? tr("layout.planning.dispatch", dict)
-              : tr("layout.planning.reception", dict)}
-            <ChevronDown
-              className={`inline transition-transform duration-200`}
-            />
-          </Button>
-        )}
-      >
-        <DropdownItem
-          onClick={() => {
-            setType("dispatch");
-          }}
+    <div className="flex flex-row items-center">
+      {showPicker ? (
+        <Dropdown
+          label=""
+          dismissOnClick
+          className="z-50"
+          renderTrigger={() => (
+            <Button
+              color="alternative"
+              className="text-xl font-semibold text-gray-700 dark:text-white bg-transparent border-0 shadow-none px-0 flex items-center gap-1 hover:bg-transparent focus:ring-0"
+            >
+              {calendarName}
+              <ChevronDown className="inline h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform duration-200" />
+            </Button>
+          )}
         >
-          {tr("layout.planning.dispatch", dict)}
-        </DropdownItem>
-        <DropdownItem
-          onClick={() => {
-            setType("reception");
-          }}
-        >
-          {tr("layout.planning.reception", dict)}
-        </DropdownItem>
-      </Dropdown>
+          {groupCalendars.map((cal) => (
+            <DropdownItem
+              key={cal.id}
+              onClick={() => handleSelect(cal.id)}
+            >
+              {cal.name}
+            </DropdownItem>
+          ))}
+        </Dropdown>
+      ) : (
+        <h1 className="text-xl font-semibold text-gray-700 dark:text-white">
+          {calendarName}
+        </h1>
+      )}
     </div>
   );
 }

--- a/apps/app/src/features/calendar/components/planning/planning-title.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-title.tsx
@@ -3,17 +3,23 @@ import { tr } from "@/features/i18n/tr.service";
 import { Dropdown, DropdownItem, Button } from "flowbite-react";
 import { ChevronDown } from "flowbite-react-icons/outline";
 import { useState } from "react";
+import { useCalendars } from "@/features/common/providers/client-api.provider";
 
 export default function PlanningTitle({
   dict,
-}: Readonly<{ dict: I18nRecord }>) {
+  calendarId,
+}: Readonly<{ dict: I18nRecord; calendarId?: string }>) {
   const [type, setType] = useState<"dispatch" | "reception">("dispatch");
+  const { calendars } = useCalendars();
+  const calendarName = calendarId
+    ? (calendars.find((c) => c.id === calendarId)?.name ?? tr("layout.secured.sidebar.planning", dict))
+    : tr("layout.secured.sidebar.planning", dict);
 
   return (
     <div className="flex flex-row gap-2 items-center">
       {/* Title */}
       <h1 className="text-xl font-semibold text-gray-700 dark:text-white">
-        {tr("layout.secured.sidebar.planning", dict)}
+        {calendarName}
       </h1>
       <Dropdown
         label=""

--- a/apps/app/src/features/calendar/components/planning/planning.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning.tsx
@@ -6,8 +6,9 @@ import PlanningLayout from "./planning-layout";
 interface PlanningProps {
   lang: string;
   dict: I18nDictionary;
+  calendarId?: string;
 }
 
-export default function Planning({ lang, dict }: Readonly<PlanningProps>) {
-  return <PlanningLayout lang={lang} dict={dict} />;
+export default function Planning({ lang, dict, calendarId }: Readonly<PlanningProps>) {
+  return <PlanningLayout lang={lang} dict={dict} calendarId={calendarId} />;
 }

--- a/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/apps/app/src/features/calendar/services/time-window.service.ts
@@ -12,8 +12,8 @@ export const TimeWindowResponseSchema = z.object({
   slotDurationMinutes: z.number(),
   capacityPerSlot: z.number(),
   daysOfWeek: z.string().min(1).nullish(),
-  validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
-  validTo: z.string().regex(/^\d{4}-\d{2}-\d{2}/).nullish(),
+  validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  validTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullish(),
   active: z.boolean(),
 });
 

--- a/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/apps/app/src/features/calendar/services/time-window.service.ts
@@ -11,7 +11,7 @@ export const TimeWindowResponseSchema = z.object({
   endHour: z.number().int().min(0).max(23),
   slotDurationMinutes: z.number(),
   capacityPerSlot: z.number(),
-  daysOfWeek: z.string().min(1).nullish(),
+  daysOfWeek: z.string().regex(/^[\d,\-]+$/).min(1).nullish(),
   validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   validTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullish(),
   active: z.boolean(),
@@ -28,9 +28,12 @@ function parseDaysString(daysStr: string): number[] {
     const trimmed = part.trim();
     if (trimmed.includes("-")) {
       const [start, end] = trimmed.split("-").map(Number);
-      for (let i = start; i <= end; i++) result.push(i);
+      if (Number.isInteger(start) && Number.isInteger(end) && start <= end) {
+        for (let i = start; i <= end; i++) result.push(i);
+      }
     } else {
-      result.push(Number(trimmed));
+      const n = Number(trimmed);
+      if (Number.isInteger(n)) result.push(n);
     }
   }
   return result;

--- a/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/apps/app/src/features/calendar/services/time-window.service.ts
@@ -1,0 +1,149 @@
+import type {
+  TimeWindowRequest,
+  TimeWindowResponse,
+} from "@microboxlabs/miot-calendar-client";
+import type { TimeSlot } from "../components/planning/planning-selection-context";
+import dayjs from "dayjs";
+
+/**
+ * Parse a comma-or-range string like "1,2,3,4,5" or "1-5" into a number array.
+ */
+function parseDaysString(daysStr: string): number[] {
+  const result: number[] = [];
+  for (const part of daysStr.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.includes("-")) {
+      const [start, end] = trimmed.split("-").map(Number);
+      for (let i = start; i <= end; i++) result.push(i);
+    } else {
+      result.push(Number(trimmed));
+    }
+  }
+  return result;
+}
+
+/**
+ * Format a sorted number array as a compact range string.
+ * e.g. [1,2,3,4,5] → "1-5",  [1,3,5] → "1,3,5"
+ */
+function formatDaysRangeString(nums: number[]): string {
+  if (nums.length === 0) return "";
+  const sorted = [...nums].sort((a, b) => a - b);
+  const isRange =
+    sorted.length > 1 && sorted.every((n, i) => i === 0 || n === sorted[i - 1] + 1);
+  return isRange ? `${sorted[0]}-${sorted.at(-1)}` : sorted.join(",");
+}
+
+/** Format an integer hour as a HHMM string (e.g. 9 → "0900", 17 → "1700"). */
+function hourToHHMM(hour: number): string {
+  return `${hour.toString().padStart(2, "0")}00`;
+}
+
+/**
+ * Convert an API TimeWindowResponse to the app's local TimeSlot format.
+ *
+ * Convention:
+ *  - If validFrom === validTo → "daily-override" (specific-date window)
+ *  - Otherwise              → "weekly" (recurring weekly pattern)
+ */
+export function apiToLocalTimeWindow(response: TimeWindowResponse): TimeSlot {
+  const isDailyOverride =
+    Boolean(response.validTo) && response.validFrom === response.validTo;
+
+  if (isDailyOverride) {
+    const startTs = `${response.validFrom}T${response.startHour.toString().padStart(2, "0")}:00:00`;
+    const endTs = `${response.validTo ?? response.validFrom}T${response.endHour.toString().padStart(2, "0")}:00:00`;
+    return {
+      id: response.id,
+      name: response.name,
+      kind: "window",
+      type: "daily-override",
+      startTimestamp: startTs,
+      endTimestamp: endTs,
+      quota: response.capacityPerSlot,
+      color: "emerald",
+    };
+  }
+
+  // Weekly window: build pattern string "W* <days> <startHHMM>-<endHHMM>"
+  const days = response.daysOfWeek
+    ? parseDaysString(response.daysOfWeek)
+    : [1, 2, 3, 4, 5];
+  const daysStr = formatDaysRangeString(days);
+  const weeklyPattern = `W* ${daysStr} ${hourToHHMM(response.startHour)}-${hourToHHMM(response.endHour)}`;
+
+  return {
+    id: response.id,
+    name: response.name,
+    kind: "window",
+    type: "weekly",
+    weeklyPattern,
+    quota: response.capacityPerSlot,
+    color: "emerald",
+  };
+}
+
+/**
+ * Convert the app's local TimeSlot to an API TimeWindowRequest.
+ *
+ * @param slot      - The local time slot to convert.
+ * @param validFrom - Optional override for the effective-from date (YYYY-MM-DD).
+ *                    Defaults to today for weekly windows.
+ */
+export function localToApiTimeWindow(
+  slot: TimeSlot,
+  validFrom?: string
+): TimeWindowRequest {
+  if (slot.type === "daily-override") {
+    const start = slot.startTimestamp ? dayjs(slot.startTimestamp) : dayjs();
+    const end = slot.endTimestamp ? dayjs(slot.endTimestamp) : dayjs().add(1, "hour");
+    const dateStr = start.format("YYYY-MM-DD");
+    // Day of week: JS 0=Sunday → format 1=Monday…7=Sunday
+    const jsDay = start.day();
+    const formatDay = jsDay === 0 ? 7 : jsDay;
+    return {
+      name: slot.name || "Time Window",
+      startHour: start.hour(),
+      endHour: end.hour(),
+      validFrom: dateStr,
+      validTo: dateStr,
+      daysOfWeek: String(formatDay),
+      capacityPerSlot: slot.quota ?? 1,
+      slotDurationMinutes: 60,
+      active: true,
+    };
+  }
+
+  // Weekly type: parse weeklyPattern "W* 1-5 0900-1700"
+  const pattern = slot.weeklyPattern ?? "W* 1-5 0900-1700";
+  const match = /^W(?:\*|[\d,-]+)\s+([\d,-]+)\s+(\d{4})-(\d{4})$/.exec(pattern);
+
+  if (!match) {
+    return {
+      name: slot.name || "Time Window",
+      startHour: 9,
+      endHour: 17,
+      validFrom: validFrom ?? dayjs().format("YYYY-MM-DD"),
+      daysOfWeek: "1,2,3,4,5",
+      capacityPerSlot: slot.quota ?? 1,
+      slotDurationMinutes: 60,
+      active: true,
+    };
+  }
+
+  const [, daysStr, startTime, endTime] = match;
+  const days = parseDaysString(daysStr);
+  const startHour = Number.parseInt(startTime.slice(0, 2), 10);
+  const endHour = Number.parseInt(endTime.slice(0, 2), 10);
+
+  return {
+    name: slot.name || "Time Window",
+    startHour,
+    endHour,
+    validFrom: validFrom ?? dayjs().format("YYYY-MM-DD"),
+    daysOfWeek: days.join(","),
+    capacityPerSlot: slot.quota ?? 1,
+    slotDurationMinutes: 60,
+    active: true,
+  };
+}

--- a/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/apps/app/src/features/calendar/services/time-window.service.ts
@@ -11,7 +11,7 @@ export const TimeWindowResponseSchema = z.object({
   endHour: z.number().int().min(0).max(23),
   slotDurationMinutes: z.number(),
   capacityPerSlot: z.number(),
-  daysOfWeek: z.string().regex(/^[\d,\-]+$/).min(1).nullish(),
+  daysOfWeek: z.string().regex(/^[\d,-]+$/).min(1).nullish(),
   validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   validTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullish(),
   active: z.boolean(),

--- a/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/apps/app/src/features/calendar/services/time-window.service.ts
@@ -1,9 +1,23 @@
-import type {
-  TimeWindowRequest,
-  TimeWindowResponse,
-} from "@microboxlabs/miot-calendar-client";
+import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
 import type { TimeSlot } from "../components/planning/planning-selection-context";
 import dayjs from "dayjs";
+
+export const TimeWindowResponseSchema = z.object({
+  id: z.string(),
+  calendarId: z.string(),
+  name: z.string(),
+  startHour: z.number().int().min(0).max(23),
+  endHour: z.number().int().min(0).max(23),
+  slotDurationMinutes: z.number(),
+  capacityPerSlot: z.number(),
+  daysOfWeek: z.string().min(1).nullish(),
+  validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
+  validTo: z.string().regex(/^\d{4}-\d{2}-\d{2}/).nullish(),
+  active: z.boolean(),
+});
+
+type ValidatedTimeWindowResponse = z.infer<typeof TimeWindowResponseSchema>;
 
 /**
  * Parse a comma-or-range string like "1,2,3,4,5" or "1-5" into a number array.
@@ -46,7 +60,7 @@ function hourToHHMM(hour: number): string {
  *  - If validFrom === validTo → "daily-override" (specific-date window)
  *  - Otherwise              → "weekly" (recurring weekly pattern)
  */
-export function apiToLocalTimeWindow(response: TimeWindowResponse): TimeSlot {
+export function apiToLocalTimeWindow(response: ValidatedTimeWindowResponse): TimeSlot {
   const isDailyOverride =
     Boolean(response.validTo) && response.validFrom === response.validTo;
 

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1500,7 +1500,7 @@ export function useCalendars() {
  * Filters cached calendar data by group code — no extra network request
  */
 export function useCalendarsInGroup(groupCode: string | null) {
-  const { calendars, isLoading, refresh } = useCalendars();
+  const { calendars, isLoading, refresh, error } = useCalendars();
   const filtered = useMemo(
     () =>
       groupCode
@@ -1508,7 +1508,7 @@ export function useCalendarsInGroup(groupCode: string | null) {
         : EMPTY_CALENDARS,
     [calendars, groupCode]
   );
-  return { calendars: filtered, isLoading, refresh };
+  return { calendars: filtered, isLoading, refresh, error };
 }
 
 const EMPTY_GROUPS: CalendarGroupResponse[] = [];
@@ -1526,11 +1526,11 @@ export function useCalendarGroups() {
 }
 
 async function parseErrorBody(response: Response, fallback: string): Promise<string> {
+  const text = await response.text().catch(() => "");
   try {
-    const json = (await response.json()) as { error?: string };
+    const json = JSON.parse(text) as { error?: string };
     return `[${response.status}] ${json.error ?? fallback}`;
   } catch {
-    const text = await response.text().catch(() => "");
     return `[${response.status}] ${text || fallback}`;
   }
 }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1488,12 +1488,12 @@ const EMPTY_CALENDARS: CalendarResponse[] = [];
  * Hook to fetch all active calendars (with their groups)
  */
 export function useCalendars() {
-  const { data, error, isLoading } = useSWR<CalendarResponse[], FetcherError>(
+  const { data, error, isLoading, mutate } = useSWR<CalendarResponse[], FetcherError>(
     "/app/api/calendar",
     fetcher,
     { errorRetryCount: 3, errorRetryInterval: 5000 }
   );
-  return { calendars: data ?? EMPTY_CALENDARS, error, isLoading };
+  return { calendars: data ?? EMPTY_CALENDARS, error, isLoading, refresh: mutate };
 }
 
 /**
@@ -1517,12 +1517,22 @@ const EMPTY_GROUPS: CalendarGroupResponse[] = [];
  * Hook to fetch all active calendar groups
  */
 export function useCalendarGroups() {
-  const { data, error, isLoading } = useSWR<CalendarGroupResponse[], FetcherError>(
+  const { data, error, isLoading, mutate } = useSWR<CalendarGroupResponse[], FetcherError>(
     "/app/api/calendar/groups",
     fetcher,
     { errorRetryCount: 3, errorRetryInterval: 5000 }
   );
-  return { groups: data ?? EMPTY_GROUPS, error, isLoading };
+  return { groups: data ?? EMPTY_GROUPS, error, isLoading, refresh: mutate };
+}
+
+async function parseErrorBody(response: Response, fallback: string): Promise<string> {
+  try {
+    const json = (await response.json()) as { error?: string };
+    return `[${response.status}] ${json.error ?? fallback}`;
+  } catch {
+    const text = await response.text().catch(() => "");
+    return `[${response.status}] ${text || fallback}`;
+  }
 }
 
 /**
@@ -1535,8 +1545,7 @@ export async function createCalendarGroup(body: CalendarGroupRequest): Promise<C
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    const err = await response.json();
-    throw new Error(err.error ?? "Failed to create calendar group");
+    throw new Error(await parseErrorBody(response, "Failed to create calendar group"));
   }
   return response.json();
 }
@@ -1551,8 +1560,7 @@ export async function createCalendar(body: CalendarRequest): Promise<CalendarRes
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    const err = await response.json();
-    throw new Error(err.error ?? "Failed to create calendar");
+    throw new Error(await parseErrorBody(response, "Failed to create calendar"));
   }
   return response.json();
 }
@@ -1601,8 +1609,7 @@ export async function createCalendarTimeWindow(
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    const err = await response.json();
-    throw new Error(err.error ?? "Failed to create time window");
+    throw new Error(await parseErrorBody(response, "Failed to create time window"));
   }
   return response.json();
 }
@@ -1624,8 +1631,7 @@ export async function updateCalendarTimeWindow(
     }
   );
   if (!response.ok) {
-    const err = await response.json();
-    throw new Error(err.error ?? "Failed to update time window");
+    throw new Error(await parseErrorBody(response, "Failed to update time window"));
   }
   return response.json();
 }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1500,7 +1500,7 @@ export function useCalendars() {
  * Filters cached calendar data by group code — no extra network request
  */
 export function useCalendarsInGroup(groupCode: string | null) {
-  const { calendars, isLoading } = useCalendars();
+  const { calendars, isLoading, refresh } = useCalendars();
   const filtered = useMemo(
     () =>
       groupCode
@@ -1508,7 +1508,7 @@ export function useCalendarsInGroup(groupCode: string | null) {
         : EMPTY_CALENDARS,
     [calendars, groupCode]
   );
-  return { calendars: filtered, isLoading };
+  return { calendars: filtered, isLoading, refresh };
 }
 
 const EMPTY_GROUPS: CalendarGroupResponse[] = [];

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -51,7 +51,12 @@ import type {
   CreateTimeSlotRequest,
   UpdateTimeSlotRequest,
 } from "@/features/calendar/types/time-slot.types";
-import type { CalendarResponse } from "@microboxlabs/miot-calendar-client";
+import type {
+  CalendarResponse,
+  CalendarGroupResponse,
+  CalendarRequest,
+  CalendarGroupRequest,
+} from "@microboxlabs/miot-calendar-client";
 
 
 
@@ -1502,4 +1507,50 @@ export function useCalendarsInGroup(groupCode: string | null) {
     [calendars, groupCode]
   );
   return { calendars: filtered, isLoading };
+}
+
+const EMPTY_GROUPS: CalendarGroupResponse[] = [];
+
+/**
+ * Hook to fetch all active calendar groups
+ */
+export function useCalendarGroups() {
+  const { data, error, isLoading } = useSWR<CalendarGroupResponse[], FetcherError>(
+    "/app/api/calendar/groups",
+    fetcher,
+    { errorRetryCount: 3, errorRetryInterval: 5000 }
+  );
+  return { groups: data ?? EMPTY_GROUPS, error, isLoading };
+}
+
+/**
+ * Create a new calendar group
+ */
+export async function createCalendarGroup(body: CalendarGroupRequest): Promise<CalendarGroupResponse> {
+  const response = await fetch("/app/api/calendar/groups", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.error ?? "Failed to create calendar group");
+  }
+  return response.json();
+}
+
+/**
+ * Create a new calendar
+ */
+export async function createCalendar(body: CalendarRequest): Promise<CalendarResponse> {
+  const response = await fetch("/app/api/calendar", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.error ?? "Failed to create calendar");
+  }
+  return response.json();
 }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -56,6 +56,8 @@ import type {
   CalendarGroupResponse,
   CalendarRequest,
   CalendarGroupRequest,
+  TimeWindowResponse,
+  TimeWindowRequest,
 } from "@microboxlabs/miot-calendar-client";
 
 
@@ -1553,4 +1555,98 @@ export async function createCalendar(body: CalendarRequest): Promise<CalendarRes
     throw new Error(err.error ?? "Failed to create calendar");
   }
   return response.json();
+}
+
+// ============================================================================
+// Calendar Time Windows Hooks
+// ============================================================================
+
+const EMPTY_TIME_WINDOWS: TimeWindowResponse[] = [];
+
+/**
+ * Fetch time windows for a specific calendar from the miot-calendar-client backend.
+ * Returns null SWR key (no fetch) when calendarId is null/undefined.
+ */
+export function useCalendarTimeWindows(calendarId: string | null) {
+  const url = calendarId
+    ? `/app/api/calendar/${calendarId}/time-windows`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<
+    TimeWindowResponse[],
+    FetcherError
+  >(url, fetcher, {
+    errorRetryCount: 3,
+    errorRetryInterval: 5000,
+  });
+
+  return {
+    timeWindows: data ?? EMPTY_TIME_WINDOWS,
+    error,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+/**
+ * Create a new time window for the given calendar.
+ */
+export async function createCalendarTimeWindow(
+  calendarId: string,
+  body: TimeWindowRequest
+): Promise<TimeWindowResponse> {
+  const response = await fetch(`/app/api/calendar/${calendarId}/time-windows`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.error ?? "Failed to create time window");
+  }
+  return response.json();
+}
+
+/**
+ * Update an existing time window.
+ */
+export async function updateCalendarTimeWindow(
+  calendarId: string,
+  timeWindowId: string,
+  body: TimeWindowRequest
+): Promise<TimeWindowResponse> {
+  const response = await fetch(
+    `/app/api/calendar/${calendarId}/time-windows/${timeWindowId}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.error ?? "Failed to update time window");
+  }
+  return response.json();
+}
+
+/**
+ * Deactivate (soft-delete) a time window by setting active=false.
+ * Requires the existing window data to satisfy required API fields.
+ */
+export async function deactivateCalendarTimeWindow(
+  calendarId: string,
+  window: TimeWindowResponse
+): Promise<void> {
+  await updateCalendarTimeWindow(calendarId, window.id, {
+    name: window.name,
+    startHour: window.startHour,
+    endHour: window.endHour,
+    validFrom: window.validFrom,
+    validTo: window.validTo,
+    daysOfWeek: window.daysOfWeek,
+    capacityPerSlot: window.capacityPerSlot,
+    slotDurationMinutes: window.slotDurationMinutes,
+    active: false,
+  });
 }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1,6 +1,6 @@
 "use client";
 import useSWR from "swr";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { usePathname } from "next/navigation";
 import fetcher from "./fetcher";
 import { safeJsonParse } from "./safe-json";
@@ -51,15 +51,9 @@ import type {
   CreateTimeSlotRequest,
   UpdateTimeSlotRequest,
 } from "@/features/calendar/types/time-slot.types";
+import type { CalendarResponse } from "@microboxlabs/miot-calendar-client";
 
-// export function useI8n(lang: string) {
-//   const { data, error, isLoading } = useSWR(`/api/i18n/${lang}`, fetcher);
-//   return {
-//     dict: data,
-//     error,
-//     isLoading,
-//   };
-// }
+
 
 export function useMyTasks(
   columns: string[],
@@ -1475,4 +1469,37 @@ export async function deleteTimeSlot(id: string): Promise<void> {
     const error = await response.json();
     throw new Error(error.error || "Failed to delete time slot");
   }
+}
+
+// ============================================================================
+// Calendar Hooks
+// ============================================================================
+
+const EMPTY_CALENDARS: CalendarResponse[] = [];
+
+/**
+ * Hook to fetch all active calendars (with their groups)
+ */
+export function useCalendars() {
+  const { data, error, isLoading } = useSWR<CalendarResponse[], FetcherError>(
+    "/app/api/calendar",
+    fetcher,
+    { errorRetryCount: 3, errorRetryInterval: 5000 }
+  );
+  return { calendars: data ?? EMPTY_CALENDARS, error, isLoading };
+}
+
+/**
+ * Filters cached calendar data by group code — no extra network request
+ */
+export function useCalendarsInGroup(groupCode: string | null) {
+  const { calendars, isLoading } = useCalendars();
+  const filtered = useMemo(
+    () =>
+      groupCode
+        ? calendars.filter((cal) => cal.groups?.some((g) => g.code === groupCode))
+        : EMPTY_CALENDARS,
+    [calendars, groupCode]
+  );
+  return { calendars: filtered, isLoading };
 }

--- a/apps/app/src/features/i18n/i18n.service.ts
+++ b/apps/app/src/features/i18n/i18n.service.ts
@@ -10,7 +10,7 @@ import type { NextRequest } from "next/server";
 import { defaultLocale, locales, tr } from "./tr.service";
 
 const dictionaries: I18nDictionries<I18nDictionary> = {
-  en: () => import("@/lang/en.json").then((m) => m.default as I18nDictionary),
+  en: () => import("@/lang/en.json").then((m) => m.default),
   es: () => import("@/lang/es.json").then((m) => m.default as unknown as I18nDictionary),
 };
 

--- a/apps/app/src/features/i18n/i18n.service.ts
+++ b/apps/app/src/features/i18n/i18n.service.ts
@@ -2,7 +2,6 @@ import "server-only";
 import {
   I18nDictionries,
   I18nDictionary,
-  I18nRecord,
 } from "./i18n.service.types";
 import Negotiator from "negotiator";
 import { match } from "@formatjs/intl-localematcher";
@@ -11,15 +10,14 @@ import { defaultLocale, locales, tr } from "./tr.service";
 
 const dictionaries: I18nDictionries<I18nDictionary> = {
   en: () => import("@/lang/en.json").then((m) => m.default),
-  es: () => import("@/lang/es.json").then((m) => m.default as unknown as I18nDictionary),
+  es: () => import("@/lang/es.json").then((m) => m.default),
 };
 
 export async function getDictionary(locale: string) {
-  const localeDictionary = dictionaries[locale];
-  if (!locale) {
+  if (!locale || !dictionaries[locale]) {
     throw new Error(`Locale ${locale} not found`);
   }
-  const dictionary = await localeDictionary();
+  const dictionary = await dictionaries[locale]();
   const memoized = new Map<string, string>();
   return [
     function _tr(path: string, params?: Record<string, string>): string {

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -13,7 +13,6 @@ import { useSearchParams } from "next/navigation";
 
 export default function SidebarItem({
   href,
-  target,
   icon,
   label,
   items,
@@ -50,7 +49,7 @@ export default function SidebarItem({
         open={isOpen}
         theme={{ list: "space-y-2 py-2 [&>li>div]:w-full" }}
       >
-        {items.map((item, index) => {
+        {items.map((item) => {
           // Check if user has any blocked groups for this sub-item
           const hasSubItemBlockedGroup = (item.blockedGroups || []).some(
             (group) => userGroups.includes(group)
@@ -71,14 +70,14 @@ export default function SidebarItem({
             );
             return (
               <SidebarCollapse
-                key={index}
+                key={item.label}
                 label={tr(item.label, dict)}
                 open={isGroupOpen}
                 theme={{ list: "space-y-2 py-2 [&>li>div]:w-full" }}
               >
-                {item.items.map((child, childIndex) => (
+                {item.items.map((child) => (
                   <FlowbiteSidebarItem
-                    key={childIndex}
+                    key={child.href ?? child.label}
                     href={child.href}
                     as={Link}
                     className={twMerge(
@@ -107,7 +106,7 @@ export default function SidebarItem({
 
           return (
             <FlowbiteSidebarItem
-              key={index}
+              key={item.href ?? item.label}
               href={item.href}
               as={Link}
               icon={item.icon}

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -66,7 +66,7 @@ export default function SidebarItem({
           // Render nested group as second-level SidebarCollapse
           if (item.items) {
             const isGroupOpen = item.items.some(
-              (child) => child.href && pathname === child.href.split("?")[0]
+              (child) => pathname === child.href?.split("?")[0]
             );
             return (
               <SidebarCollapse

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -83,7 +83,8 @@ export default function SidebarItem({
                     className={twMerge(
                       "justify-center [&>*]:font-normal",
                       (pathname === child.href?.split("?")[0] ||
-                        child.href === pathname + "?" + searchParams.toString()) &&
+                        (searchParams.toString() &&
+                          child.href === pathname + "?" + searchParams.toString())) &&
                         "bg-gray-100 dark:bg-gray-700"
                     )}
                   >
@@ -115,7 +116,8 @@ export default function SidebarItem({
                 isHomeSection &&
                   "[&>span]:min-w-0 [&>span]:overflow-hidden [&>span]:text-ellipsis",
                 (pathname === item.href ||
-                  item.href === pathname + "?" + searchParams.toString()) &&
+                  (searchParams.toString() &&
+                    item.href === pathname + "?" + searchParams.toString())) &&
                   "bg-gray-100 dark:bg-gray-700"
               )}
               {...badgeProps}
@@ -136,7 +138,8 @@ export default function SidebarItem({
       label={badge}
       className={twMerge(
         (pathname === href ||
-          href === pathname + "?" + searchParams.toString()) &&
+          (searchParams.toString() &&
+            href === pathname + "?" + searchParams.toString())) &&
           "bg-gray-100 dark:bg-gray-700",
         "[&_svg]:!w-6 [&_svg]:!h-6 [&_svg]:!min-w-6 [&_svg]:!min-h-6"
       )}

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -64,6 +64,37 @@ export default function SidebarItem({
             return null;
           }
 
+          // Render nested group as second-level SidebarCollapse
+          if (item.items) {
+            const isGroupOpen = item.items.some(
+              (child) => child.href && pathname === child.href.split("?")[0]
+            );
+            return (
+              <SidebarCollapse
+                key={index}
+                label={tr(item.label, dict)}
+                open={isGroupOpen}
+                theme={{ list: "space-y-2 py-2 [&>li>div]:w-full" }}
+              >
+                {item.items.map((child, childIndex) => (
+                  <FlowbiteSidebarItem
+                    key={childIndex}
+                    href={child.href}
+                    as={Link}
+                    className={twMerge(
+                      "justify-center [&>*]:font-normal",
+                      (pathname === child.href?.split("?")[0] ||
+                        child.href === pathname + "?" + searchParams.toString()) &&
+                        "bg-gray-100 dark:bg-gray-700"
+                    )}
+                  >
+                    {tr(child.label, dict)}
+                  </FlowbiteSidebarItem>
+                ))}
+              </SidebarCollapse>
+            );
+          }
+
           const itemTotal = totals?.[item.label];
           const badgeProps =
             isHomeSection || itemTotal === undefined || typeof itemTotal === "string"

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -64,13 +64,12 @@ export default function SidebarItem({
             return null;
           }
 
+          const itemTotal = totals?.[item.label];
           const badgeProps =
-            isHomeSection || typeof totals[item.label] === "string"
+            isHomeSection || itemTotal === undefined || typeof itemTotal === "string"
               ? {}
               : (() => {
-                  const count = getTotalCountBadges(
-                    totals[item.label] as number
-                  );
+                  const count = getTotalCountBadges(itemTotal);
                   const labelColor = getLabelColor(count);
                   return { label: `${count}`, labelColor };
                 })();

--- a/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
+++ b/apps/app/src/features/layout/components/sidebar-item/sidebar-item.tsx
@@ -94,7 +94,7 @@ export default function SidebarItem({
             );
           }
 
-          const itemTotal = totals?.[item.label];
+          const itemTotal = item.totals?.[item.label] ?? totals?.[item.label];
           const badgeProps =
             isHomeSection || itemTotal === undefined || typeof itemTotal === "string"
               ? {}

--- a/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
+++ b/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
@@ -108,7 +108,7 @@ function useCalendarDynamicItems(): SidebarItem[] {
 
     const groupMap = new Map<string, { group: CalendarGroupResponse; firstCalId: string }>();
 
-    for (const cal of calendars) {
+    for (const cal of calendars.slice().sort((a, b) => a.id.localeCompare(b.id))) {
       const group = cal.groups?.[0];
       if (group && !groupMap.has(group.code)) {
         groupMap.set(group.code, { group, firstCalId: cal.id });
@@ -116,7 +116,7 @@ function useCalendarDynamicItems(): SidebarItem[] {
     }
 
     return Array.from(groupMap.values()).map(({ group, firstCalId }) => ({
-      href: `/calendar/${firstCalId}/planning?groupCode=${group.code}`,
+      href: `/calendar/${firstCalId}/planning?groupCode=${encodeURIComponent(group.code)}`,
       label: group.name,
     }));
   }, [calendars]);

--- a/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
+++ b/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
@@ -12,12 +12,14 @@ import { pages } from "../models/pages";
 import { SidebarItem } from "../types/common.types";
 import {
   getMyTasks,
+  useCalendars,
   useHistoricInstancesCount,
   useMapPositions,
   useMyTasksCount,
   useSymptoms,
   useUserFilters,
 } from "@/features/common/providers/client-api.provider";
+import type { CalendarGroupResponse, CalendarResponse } from "@microboxlabs/miot-calendar-client";
 import {
   DELIVERY_COORDINATOR_PROCESS_TASKS,
   PLANNING_COORDINATOR_PROCESS_TASKS,
@@ -98,6 +100,45 @@ function useTaskDynamicItems(): SidebarItem[] {
   );
 }
 
+function useCalendarDynamicItems(): SidebarItem[] {
+  const { calendars } = useCalendars();
+
+  return useMemo(() => {
+    if (calendars.length === 0) return [];
+
+    const groupMap = new Map<string, { group: CalendarGroupResponse; items: CalendarResponse[] }>();
+    const ungrouped: CalendarResponse[] = [];
+
+    for (const cal of calendars) {
+      const group = cal.groups?.[0];
+      if (group) {
+        if (!groupMap.has(group.code)) groupMap.set(group.code, { group, items: [] });
+        groupMap.get(group.code)!.items.push(cal);
+      } else {
+        ungrouped.push(cal);
+      }
+    }
+
+    const result: SidebarItem[] = [];
+
+    for (const { group, items } of groupMap.values()) {
+      result.push({
+        label: group.name,
+        items: items.map((cal) => ({
+          href: `/calendar/${cal.id}/planning?groupCode=${group.code}`,
+          label: cal.name,
+        })),
+      });
+    }
+
+    for (const cal of ungrouped) {
+      result.push({ href: `/calendar/${cal.id}/planning`, label: cal.name });
+    }
+
+    return result;
+  }, [calendars]);
+}
+
 export function SidebarNavigationProvider({ children }: Readonly<PropsWithChildren>) {
   const router = useRouter();
   const { data, error } = useMyTasksCount();
@@ -105,6 +146,7 @@ export function SidebarNavigationProvider({ children }: Readonly<PropsWithChildr
   const { count: mapCount } = useMapPositions();
   const { count: symptomsCount } = useSymptoms();
   const taskDynamicItems = useTaskDynamicItems();
+  const calendarDynamicItems = useCalendarDynamicItems();
 
   useEffect(() => {
     if (error && (error.status === 401 || error.status === 403)) {
@@ -158,6 +200,7 @@ export function SidebarNavigationProvider({ children }: Readonly<PropsWithChildr
 
     const dynamicMap: Record<string, SidebarItem[]> = {
       tasks: taskDynamicItems,
+      calendars: calendarDynamicItems,
     };
 
     const resolvedItems = pages.map((page) => {
@@ -167,7 +210,7 @@ export function SidebarNavigationProvider({ children }: Readonly<PropsWithChildr
     });
 
     return { items: resolvedItems, totals, isLoading: false };
-  }, [taskDynamicItems, data, historicInstances, mapCount, symptomsCount, error]);
+  }, [taskDynamicItems, calendarDynamicItems, data, historicInstances, mapCount, symptomsCount, error]);
 
   return (
     <SidebarNavigationContext.Provider

--- a/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
+++ b/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
@@ -106,36 +106,19 @@ function useCalendarDynamicItems(): SidebarItem[] {
   return useMemo(() => {
     if (calendars.length === 0) return [];
 
-    const groupMap = new Map<string, { group: CalendarGroupResponse; items: CalendarResponse[] }>();
-    const ungrouped: CalendarResponse[] = [];
+    const groupMap = new Map<string, { group: CalendarGroupResponse; firstCalId: string }>();
 
     for (const cal of calendars) {
       const group = cal.groups?.[0];
-      if (group) {
-        if (!groupMap.has(group.code)) groupMap.set(group.code, { group, items: [] });
-        groupMap.get(group.code)!.items.push(cal);
-      } else {
-        ungrouped.push(cal);
+      if (group && !groupMap.has(group.code)) {
+        groupMap.set(group.code, { group, firstCalId: cal.id });
       }
     }
 
-    const result: SidebarItem[] = [];
-
-    for (const { group, items } of groupMap.values()) {
-      result.push({
-        label: group.name,
-        items: items.map((cal) => ({
-          href: `/calendar/${cal.id}/planning?groupCode=${group.code}`,
-          label: cal.name,
-        })),
-      });
-    }
-
-    for (const cal of ungrouped) {
-      result.push({ href: `/calendar/${cal.id}/planning`, label: cal.name });
-    }
-
-    return result;
+    return Array.from(groupMap.values()).map(({ group, firstCalId }) => ({
+      href: `/calendar/${firstCalId}/planning?groupCode=${group.code}`,
+      label: group.name,
+    }));
   }, [calendars]);
 }
 

--- a/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
+++ b/apps/app/src/features/layout/context/sidebar-navigation-context.tsx
@@ -19,7 +19,7 @@ import {
   useSymptoms,
   useUserFilters,
 } from "@/features/common/providers/client-api.provider";
-import type { CalendarGroupResponse, CalendarResponse } from "@microboxlabs/miot-calendar-client";
+import type { CalendarGroupResponse } from "@microboxlabs/miot-calendar-client";
 import {
   DELIVERY_COORDINATOR_PROCESS_TASKS,
   PLANNING_COORDINATOR_PROCESS_TASKS,

--- a/apps/app/src/features/layout/models/pages.ts
+++ b/apps/app/src/features/layout/models/pages.ts
@@ -80,11 +80,6 @@ export const pages: SidebarItem[] = [
         href: "/calendar",
         label: "calendarOverview",
       },
-      {
-        href: "/calendar/planning",
-        label: "calendarPlanning",
-        totals: {},
-      },
     ],
     totals: {},
     requiredGroups: ["GROUP_ALFRESCO_ADMINISTRATORS"],

--- a/apps/app/src/features/layout/models/pages.ts
+++ b/apps/app/src/features/layout/models/pages.ts
@@ -74,6 +74,7 @@ export const pages: SidebarItem[] = [
   {
     icon: CalendarIcon,
     label: "calendar",
+    dynamicItemsSource: "calendars",
     items: [
       {
         href: "/calendar",

--- a/apps/app/src/features/layout/models/pages.ts
+++ b/apps/app/src/features/layout/models/pages.ts
@@ -76,6 +76,10 @@ export const pages: SidebarItem[] = [
     label: "calendar",
     items: [
       {
+        href: "/calendar",
+        label: "calendarOverview",
+      },
+      {
         href: "/calendar/planning",
         label: "calendarPlanning",
         totals: {},

--- a/apps/app/src/features/layout/types/common.types.ts
+++ b/apps/app/src/features/layout/types/common.types.ts
@@ -7,7 +7,7 @@ export type SidebarItem = {
   label: string;
   items?: SidebarItem[];
   badge?: string;
-  totals: Record<string, number | string>;
+  totals?: Record<string, number | string>;
   requiredGroups?: string[];
   blockedGroups?: string[];
   dynamicItemsSource?: string;

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -2011,6 +2011,26 @@
       "multi_calendar_title": "Multiple Calendars",
       "multi_calendar_description": "Manage independent calendars for different operations, locations, or teams.",
       "cta": "Get Started"
+    },
+    "create": {
+      "title": "New Calendar",
+      "subtitle": "Create a calendar to manage scheduling and time windows.",
+      "nameLabel": "Name",
+      "codeLabel": "Code",
+      "descriptionLabel": "Description",
+      "timezoneLabel": "Timezone",
+      "groupLabel": "Group",
+      "activeLabel": "Active",
+      "submit": "Create Calendar",
+      "group": {
+        "searchPlaceholder": "Search or create a group...",
+        "noResults": "No groups found",
+        "create": "Create group \"{name}\"",
+        "successNotification": "Group created successfully",
+        "errorNotification": "Failed to create group"
+      },
+      "successNotification": "Calendar created successfully",
+      "errorNotification": "Failed to create calendar"
     }
   }
 }

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -1064,6 +1064,7 @@
         "werehouse": "Werehouse",
         "logistics": "Logistics",
         "planning": "Planning",
+        "calendarOverview": "Overview",
         "calendarPlanning": "Planning",
         "shipping": "Shipping",
         "shippingv1": "Shipping V1",
@@ -1997,6 +1998,19 @@
       "test_pulse_historic_feature": "Test the new Pulse Historic feature!!!",
       "description": "Filter pulses by license plate and date range to get a downloadable report based by past positions of the vehicles.",
       "learn_more": "Learn more about what was changed in this update."
+    }
+  },
+  "calendar": {
+    "landing": {
+      "title": "Calendar",
+      "subtitle": "Organize your operations, schedule services and manage time windows across multiple calendars.",
+      "planning_title": "Planning",
+      "planning_description": "Schedule and assign services to specific time windows with full day, week, and month views.",
+      "rules_title": "Rules & Quotas",
+      "rules_description": "Define time blocks, configure quotas, and control the workload for each calendar.",
+      "multi_calendar_title": "Multiple Calendars",
+      "multi_calendar_description": "Manage independent calendars for different operations, locations, or teams.",
+      "cta": "Get Started"
     }
   }
 }

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -1125,6 +1125,8 @@
           "apply": "Apply",
           "today": "Today",
           "clear": "Clear",
+          "applySuccess": "Time windows saved successfully",
+          "applyError": "Failed to save time windows",
           "colors": {
             "emerald": "Green",
             "blue": "Blue",

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -2030,6 +2030,26 @@
       "multi_calendar_title": "Múltiples Calendarios",
       "multi_calendar_description": "Administra calendarios independientes para distintas operaciones, ubicaciones o equipos.",
       "cta": "Comenzar"
+    },
+    "create": {
+      "title": "Nuevo Calendario",
+      "subtitle": "Crea un calendario para gestionar la programación y las ventanas de tiempo.",
+      "nameLabel": "Nombre",
+      "codeLabel": "Código",
+      "descriptionLabel": "Descripción",
+      "timezoneLabel": "Zona Horaria",
+      "groupLabel": "Grupo",
+      "activeLabel": "Activo",
+      "submit": "Crear Calendario",
+      "group": {
+        "searchPlaceholder": "Buscar o crear un grupo...",
+        "noResults": "No se encontraron grupos",
+        "create": "Crear grupo \"{name}\"",
+        "successNotification": "Grupo creado correctamente",
+        "errorNotification": "Error al crear el grupo"
+      },
+      "successNotification": "Calendario creado correctamente",
+      "errorNotification": "Error al crear el calendario"
     }
   }
 }

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -1074,6 +1074,7 @@
         "werehouse": "Bodega",
         "logistics": "Logística",
         "planning": "Planificación",
+        "calendarOverview": "Inicio",
         "calendarPlanning": "Planificación",
         "shipping": "Despachos",
         "shippingv1": "Despachos V1",
@@ -2016,6 +2017,19 @@
       "test_pulse_historic_feature": "¡Prueba el nuevo Histórico de pulsos!",
       "description": "Filtra pulsos por patente y rango de fechas para obtener un reporte descargable basado en posiciones pasadas de los vehículos.",
       "learn_more": "Aprende más sobre lo que se cambió en esta última actualización."
+    }
+  },
+  "calendar": {
+    "landing": {
+      "title": "Calendarios",
+      "subtitle": "Organiza tus operaciones, agenda servicios y administra ventanas de tiempo en múltiples calendarios.",
+      "planning_title": "Planificación",
+      "planning_description": "Agenda y asigna servicios a ventanas de tiempo específicas con vistas de día, semana y mes.",
+      "rules_title": "Reglas y Cupos",
+      "rules_description": "Define bloques de tiempo, configura cupos y controla la carga de trabajo de cada calendario.",
+      "multi_calendar_title": "Múltiples Calendarios",
+      "multi_calendar_description": "Administra calendarios independientes para distintas operaciones, ubicaciones o equipos.",
+      "cta": "Comenzar"
     }
   }
 }

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -1139,6 +1139,8 @@
           "apply": "Aplicar",
           "today": "Hoy",
           "clear": "Limpiar",
+          "applySuccess": "Ventanas de tiempo guardadas correctamente",
+          "applyError": "Error al guardar las ventanas de tiempo",
           "colors": {
             "emerald": "Verde",
             "blue": "Azul",

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -678,7 +678,17 @@
         "Consolidar Carga": "Consolidar Carga",
         "Separar Documentos": "Separar Documentos",
         "Planificar Servicio": "Planificar Servicio",
-        "Asignar Conductor": "Asignar Conductor"
+        "Asignar Conductor": "Asignar Conductor",
+        "redirectToMissionControl": "Devolver a Torre de Control",
+        "Asignar Conductor/Transporte": "Asignar Conductor/Transporte",
+        "Presentar Conductor": "Presentar Conductor",
+        "Preparar Servicio": "Controlar Servicio",
+        "Torre de Control: Iniciar Viaje": "Iniciar Viaje",
+        "Torre de Control: Iniciar Viaje sin firma": "Iniciar Viaje sin firma",
+        "Viaje Cancelado": "Viaje Cancelado",
+        "Viaje Anulado": "Viaje Anulado",
+        "Monitorear viaje en curso": "Monitorear viaje en curso",
+        "Confirmar Arribo": "Confirmar Arribo"
       },
       "modal": {
         "title": "Estás intentando mover la tarea a otro estado del proceso",
@@ -798,7 +808,8 @@
         "Consolidar Carga": "Consolidar Carga",
         "Separar Documentos": "Separar Documentos",
         "Planificar Servicio": "Planificar Servicio",
-        "Asignar Conductor": "Asignar Conductor"
+        "Asignar Conductor": "Asignar Conductor",
+        "Confirmar Arribo a Destino": "Confirmar Arribo a Destino"
       },
       "modal": {
         "title": "Estás intentando mover la tarea a otro estado del proceso",
@@ -1495,6 +1506,7 @@
     "normal_speed": "Velocidad normal",
     "high_speed": "Velocidad grave",
     "very_high_speed": "Velocidad gravísima",
+    "speed_limit": "Exceso de límite de velocidad",
     "speed limit": "Exceso límite de velocidad",
     "Lost Signal": "Perdida de reportabilidad GPS",
     "Speed Limit": "Exceso límite de velocidad",
@@ -1977,6 +1989,7 @@
     "duration": "Duración",
     "selected_range": "Rango Seleccionado",
     "assetid": "ID del Activo",
+    "asset_id": "ID del Activo",
     "tripid": "ID del Viaje",
     "timestamp": "Marca de Tiempo",
     "speed": "Velocidad",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@luma.gl/webgl": "9.2.6",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
-        "@microboxlabs/miot-calendar-client": "^0.1.3",
+        "@microboxlabs/miot-calendar-client": "^0.2.0",
         "@next/mdx": "16.1.1",
         "@react-google-maps/api": "^2.20.3",
         "@tailwindcss/postcss": "^4.1.17",
@@ -26078,7 +26078,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",

--- a/packages/miot-calendar-client/package.json
+++ b/packages/miot-calendar-client/package.json
@@ -7,12 +7,16 @@
     "url": "https://github.com/microboxlabs/modulariot",
     "directory": "packages/miot-calendar-client"
   },
-  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [

--- a/packages/miot-calendar-client/tsup.config.ts
+++ b/packages/miot-calendar-client/tsup.config.ts
@@ -6,4 +6,6 @@ export default defineConfig({
   dts: true,
   outDir: "dist",
   clean: true,
+  // Explicit .mjs/.cjs extensions so "type":"module" is not needed in package.json
+  outExtension: ({ format }) => ({ js: format === "esm" ? ".mjs" : ".cjs" }),
 });

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,7 @@
       "dependsOn": ["^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build"]
     },
     "dev": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,8 @@
     "STREAMHUB_CLIENT_SECRET",
     "STREAMHUB_AUDIENCE",
     "STREAMHUB_URL",
-    "STREAMHUB_IOT_URL"
+    "STREAMHUB_IOT_URL",
+    "MIOT_CALENDAR_URL"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Adds a `/calendar` onboarding page that orients users before they navigate into a specific calendar, displaying a hero section, three feature-highlight cards (Planning, Rules & Quotas, Multiple Calendars), and a CTA to the planning calendar
- Introduces a static **Overview / Inicio** sub-item in the Calendar sidebar group as the section entry point — no counter badge since no count applies here
- Fixes phantom "0" badges on sidebar items not backed by a counter by making `totals` optional on `SidebarItem` and skipping badge rendering when no total is defined

## Test plan

- [x] Navigate to `/calendar` — Overview landing page renders with breadcrumb, hero, feature cards, and CTA
- [x] CTA "Get Started" navigates to `/calendar/planning`
- [x] Sidebar Calendar group expands and shows two sub-items: **Overview** (EN) / **Inicio** (ES) and **Planning** / **Planificación**
- [x] Overview sidebar item shows no badge
- [x] Other sidebar items with defined counts still show their badges correctly
- [x] Existing `/calendar/planning` route is unaffected
- [x] Both Spanish and English dictionaries render correctly on each locale

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar landing and secured planning pages; calendar creation flow with modal, group autocomplete, and calendar/group management APIs; time-window lifecycle (create/update/deactivate) and calendar group listing.

* **Improvements**
  * Sidebar shows an "Overview" entry and dynamically lists calendars; planning UI supports group-aware calendar selection and shows success/error notifications for rule/time-window actions.

* **Documentation**
  * Added English and Spanish calendar translations.

* **Chores**
  * Environment, packaging, and build config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->