### PR TITLE
feat(miot-calendar-client): add Calendar Groups support (v0.2.0)

### DIFF
--- a/apps/docs/content/en/reference/changelog.mdx
+++ b/apps/docs/content/en/reference/changelog.mdx
@@ -21,6 +21,28 @@ Features and improvements in development:
 
 ## Recent Releases
 
+### `miot-calendar-client` v0.2.0 — Calendar Groups (2026-02-19)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Adds a new Calendar Groups resource that lets you organize calendars into named collections and filter or query them by group.
+
+**New — `client.groups` namespace:**
+- `groups.list({ active? })` — list all groups
+- `groups.get(id)` — get a group by ID
+- `groups.create(body)` — create a group
+- `groups.update(id, body)` — update a group
+- `groups.deactivate(id)` — soft-delete a group
+
+**Updated — `client.calendars`:**
+- `calendars.list()` accepts a new `groupCode` query param to filter calendars by group membership
+- `CalendarRequest.groups?: string[]` — assign groups on create/update (`null` = no change, `[]` = remove all, `["code"]` = replace all)
+- `CalendarResponse.groups?: CalendarGroupResponse[]` — groups the calendar belongs to are now included in the response
+
+**New types exported:** `CalendarGroupRequest`, `CalendarGroupResponse`
+
+---
+
 ### Architecture: Centralized Sidebar Navigation (2026-02-19)
 
 **`apps/app` — internal change, no API impact**

--- a/apps/docs/content/en/reference/sdks/miot-calendar-client.mdx
+++ b/apps/docs/content/en/reference/sdks/miot-calendar-client.mdx
@@ -61,7 +61,10 @@ const booking = await client.bookings.create({
 ## Features
 
 ### Calendars
-Create and manage calendars with timezone support. Each calendar groups time windows, slots, and bookings.
+Create and manage calendars with timezone support. Each calendar groups time windows, slots, and bookings. Optionally assign calendars to one or more groups via the `groups` field on create or update.
+
+### Calendar Groups
+Organize calendars into named groups with `client.groups`. Filter calendar lists by `groupCode`, and read which groups a calendar belongs to from `CalendarResponse.groups`.
 
 ### Time Windows
 Define recurring availability windows — specify hours, days of week, slot duration, and capacity per slot.

--- a/apps/docs/content/es/reference/changelog.mdx
+++ b/apps/docs/content/es/reference/changelog.mdx
@@ -21,6 +21,28 @@ Features and improvements in development:
 
 ## Lanzamientos Recientes
 
+### `miot-calendar-client` v0.2.0 — Grupos de Calendarios (2026-02-19)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Agrega un nuevo recurso de Grupos de Calendarios que permite organizar calendarios en colecciones con nombre y filtrarlos o consultarlos por grupo.
+
+**Nuevo — namespace `client.groups`:**
+- `groups.list({ active? })` — listar todos los grupos
+- `groups.get(id)` — obtener un grupo por ID
+- `groups.create(body)` — crear un grupo
+- `groups.update(id, body)` — actualizar un grupo
+- `groups.deactivate(id)` — desactivar un grupo (eliminación lógica)
+
+**Actualizado — `client.calendars`:**
+- `calendars.list()` acepta el nuevo parámetro `groupCode` para filtrar calendarios por pertenencia a un grupo
+- `CalendarRequest.groups?: string[]` — asigna grupos al crear o actualizar (`null` = sin cambios, `[]` = eliminar todos, `["code"]` = reemplazar todos)
+- `CalendarResponse.groups?: CalendarGroupResponse[]` — los grupos a los que pertenece el calendario ahora se incluyen en la respuesta
+
+**Nuevos tipos exportados:** `CalendarGroupRequest`, `CalendarGroupResponse`
+
+---
+
 ### Arquitectura: Navegación Lateral Centralizada (2026-02-19)
 
 **`apps/app` — cambio interno, sin impacto en la API**

--- a/apps/docs/content/es/reference/sdks/miot-calendar-client.mdx
+++ b/apps/docs/content/es/reference/sdks/miot-calendar-client.mdx
@@ -61,7 +61,10 @@ const booking = await client.bookings.create({
 ## Funcionalidades
 
 ### Calendarios
-Crea y gestiona calendarios con soporte de zona horaria. Cada calendario agrupa ventanas horarias, slots y reservas.
+Crea y gestiona calendarios con soporte de zona horaria. Cada calendario agrupa ventanas horarias, slots y reservas. Opcionalmente, asigna calendarios a uno o más grupos mediante el campo `groups` al crear o actualizar.
+
+### Grupos de calendarios
+Organiza calendarios en grupos con nombre mediante `client.groups`. Filtra listas de calendarios por `groupCode`, y consulta a qué grupos pertenece un calendario desde `CalendarResponse.groups`.
 
 ### Ventanas horarias
 Define ventanas de disponibilidad recurrentes — especifica horas, días de la semana, duración del slot y capacidad por slot.

--- a/packages/miot-calendar-client/README.md
+++ b/packages/miot-calendar-client/README.md
@@ -89,11 +89,12 @@ const client = createMiotCalendarClient({
 
 #### `calendars.list(params?)`
 
-List all calendars, optionally filtered by active status.
+List all calendars, optionally filtered by active status or group membership.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `active` | `boolean` | No | Filter by active status |
+| `groupCode` | `string` | No | Filter calendars belonging to this group code |
 
 **Returns:** `CalendarResponse[]`
 
@@ -120,6 +121,7 @@ Create a new calendar.
 | `description` | `string` | No | — | Optional description |
 | `timezone` | `string` | No | `"UTC"` | IANA timezone |
 | `active` | `boolean` | No | `true` | Whether the calendar is active |
+| `groups` | `string[]` | No | — | Group codes to assign. `null` = no change; `[]` = remove all; `["code"]` = replace all |
 
 **Returns:** `CalendarResponse`
 
@@ -130,7 +132,7 @@ Replace a calendar's fields. Takes the same body as `create`.
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | `string` | Yes | Calendar ID |
-| `body` | `CalendarRequest` | Yes | Updated calendar data |
+| `body` | `CalendarRequest` | Yes | Updated calendar data (include `groups` to reassign group membership) |
 
 **Returns:** `CalendarResponse`
 
@@ -189,6 +191,70 @@ Update a time window. Takes the same body as `createTimeWindow`.
 | `body` | `TimeWindowRequest` | Yes | Updated time window data |
 
 **Returns:** `TimeWindowResponse`
+
+---
+
+### Groups
+
+Calendar groups let you organize calendars into named collections. Calendars can belong to multiple groups; use `CalendarRequest.groups` on create or update to manage membership.
+
+#### `groups.list(params?)`
+
+List all calendar groups, optionally filtered by active status.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `active` | `boolean` | No | Filter by active status |
+
+**Returns:** `CalendarGroupResponse[]`
+
+#### `groups.get(id)`
+
+Get a single calendar group by ID.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Group ID |
+
+**Returns:** `CalendarGroupResponse`
+
+**Throws:** `MiotCalendarApiError` with status `404` if not found.
+
+#### `groups.create(body)`
+
+Create a new calendar group.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `code` | `string` | Yes | — | Unique code identifier (max 50 chars) |
+| `name` | `string` | Yes | — | Display name (max 255 chars) |
+| `description` | `string` | No | — | Optional description |
+| `active` | `boolean` | No | `true` | Whether the group is active |
+
+**Returns:** `CalendarGroupResponse`
+
+**Throws:** `MiotCalendarApiError` with status `400` if the code is already taken.
+
+#### `groups.update(id, body)`
+
+Replace a calendar group's fields. Takes the same body as `create`.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Group ID |
+| `body` | `CalendarGroupRequest` | Yes | Updated group data |
+
+**Returns:** `CalendarGroupResponse`
+
+#### `groups.deactivate(id)`
+
+Deactivate a calendar group (soft delete). Calendars in the group are not affected.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Group ID |
+
+**Returns:** `void` (HTTP 204 — no content)
 
 ---
 
@@ -321,6 +387,31 @@ List all bookings for a specific resource.
 
 ## Types
 
+### `CalendarGroupRequest`
+
+```ts
+interface CalendarGroupRequest {
+  code: string;           // Unique code identifier (max 50 chars)
+  name: string;           // Display name (max 255 chars)
+  description?: string;   // Optional description
+  active?: boolean;       // Active status (default: true)
+}
+```
+
+### `CalendarGroupResponse`
+
+```ts
+interface CalendarGroupResponse {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  active: boolean;
+  createdAt: string;      // ISO 8601
+  updatedAt: string;      // ISO 8601
+}
+```
+
 ### `CalendarRequest`
 
 ```ts
@@ -330,6 +421,7 @@ interface CalendarRequest {
   description?: string;   // Optional description
   timezone?: string;      // IANA timezone (default: "UTC")
   active?: boolean;       // Active status (default: true)
+  groups?: string[];      // Group codes to assign. null = no change; [] = remove all; ["code"] = replace all
 }
 ```
 
@@ -341,10 +433,11 @@ interface CalendarResponse {
   code: string;
   name: string;
   description?: string;
-  timezone: string;       // Always present (default: "UTC")
-  active: boolean;        // Always present (default: true)
-  createdAt: string;      // ISO 8601
-  updatedAt: string;      // ISO 8601
+  timezone: string;                    // Always present (default: "UTC")
+  active: boolean;                     // Always present (default: true)
+  createdAt: string;                   // ISO 8601
+  updatedAt: string;                   // ISO 8601
+  groups?: CalendarGroupResponse[];    // Groups this calendar belongs to
 }
 ```
 

--- a/packages/miot-calendar-client/openapi.json
+++ b/packages/miot-calendar-client/openapi.json
@@ -80,6 +80,75 @@
           }
         }
       },
+      "CalendarGroupRequest" : {
+        "type" : "object",
+        "required" : [ "code", "name" ],
+        "description" : "Request payload to create or update a calendar group",
+        "properties" : {
+          "code" : {
+            "type" : "string",
+            "examples" : [ "warehouse-south" ],
+            "maxLength" : 50,
+            "description" : "Unique code identifying the group"
+          },
+          "name" : {
+            "type" : "string",
+            "examples" : [ "Warehouse South" ],
+            "maxLength" : 255,
+            "description" : "Display name of the group"
+          },
+          "description" : {
+            "type" : "string",
+            "examples" : [ "Group for all calendars in Warehouse South" ],
+            "description" : "Detailed description of the group purpose"
+          },
+          "active" : {
+            "type" : "boolean",
+            "description" : "Whether the group is active",
+            "default" : true
+          }
+        }
+      },
+      "CalendarGroupResponse" : {
+        "type" : "object",
+        "required" : [ "id", "code", "name", "active", "createdAt", "updatedAt" ],
+        "description" : "Calendar group data returned by the API",
+        "properties" : {
+          "id" : {
+            "$ref" : "#/components/schemas/UUID",
+            "type" : "string",
+            "description" : "Unique identifier of the group"
+          },
+          "code" : {
+            "type" : "string",
+            "examples" : [ "warehouse-south" ],
+            "description" : "Unique code identifying the group"
+          },
+          "name" : {
+            "type" : "string",
+            "examples" : [ "Warehouse South" ],
+            "description" : "Display name of the group"
+          },
+          "description" : {
+            "type" : "string",
+            "description" : "Detailed description of the group purpose"
+          },
+          "active" : {
+            "type" : "boolean",
+            "description" : "Whether the group is active"
+          },
+          "createdAt" : {
+            "$ref" : "#/components/schemas/ZonedDateTime",
+            "type" : "string",
+            "description" : "Timestamp when the group was created"
+          },
+          "updatedAt" : {
+            "$ref" : "#/components/schemas/ZonedDateTime",
+            "type" : "string",
+            "description" : "Timestamp when the group was last updated"
+          }
+        }
+      },
       "CalendarRequest" : {
         "type" : "object",
         "required" : [ "code", "name" ],
@@ -112,6 +181,13 @@
             "type" : "boolean",
             "description" : "Whether the calendar is active and accepting bookings",
             "default" : true
+          },
+          "groups" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "description" : "List of group codes to assign. null = no change; [] = remove all; [\"code1\"] = replace all"
           }
         }
       },
@@ -157,6 +233,13 @@
             "$ref" : "#/components/schemas/ZonedDateTime",
             "type" : "string",
             "description" : "Timestamp when the calendar was last updated"
+          },
+          "groups" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CalendarGroupResponse"
+            },
+            "description" : "Groups this calendar belongs to"
           }
         }
       },
@@ -574,6 +657,9 @@
     "name" : "Bookings",
     "description" : "Booking creation, cancellation, and query operations"
   }, {
+    "name" : "Calendar Groups",
+    "description" : "Calendar group management operations"
+  }, {
     "name" : "Calendars",
     "description" : "Calendar and time window management operations"
   }, {
@@ -780,7 +866,7 @@
     "/api/v1/miot-calendar/calendars" : {
       "get" : {
         "summary" : "List calendars",
-        "description" : "Retrieve all calendars, optionally filtered by active status",
+        "description" : "Retrieve all calendars, optionally filtered by active status or group code",
         "operationId" : "listCalendars",
         "tags" : [ "Calendars" ],
         "parameters" : [ {
@@ -789,6 +875,13 @@
           "in" : "query",
           "schema" : {
             "type" : "boolean"
+          }
+        }, {
+          "description" : "Filter calendars belonging to this group code",
+          "name" : "groupCode",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
           }
         } ],
         "responses" : {
@@ -1128,6 +1221,201 @@
         }
       }
     },
+    "/api/v1/miot-calendar/groups" : {
+      "get" : {
+        "summary" : "List calendar groups",
+        "description" : "Retrieve all calendar groups, optionally filtered by active status",
+        "operationId" : "listGroups",
+        "tags" : [ "Calendar Groups" ],
+        "parameters" : [ {
+          "description" : "When true, return only active groups",
+          "name" : "active",
+          "in" : "query",
+          "schema" : {
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "List of calendar groups",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/CalendarGroupResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post" : {
+        "summary" : "Create calendar group",
+        "description" : "Create a new calendar group",
+        "operationId" : "createGroup",
+        "tags" : [ "Calendar Groups" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CalendarGroupRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Group created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CalendarGroupResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request or duplicate code",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/miot-calendar/groups/{id}" : {
+      "put" : {
+        "summary" : "Update calendar group",
+        "description" : "Update an existing calendar group",
+        "operationId" : "updateGroup",
+        "tags" : [ "Calendar Groups" ],
+        "parameters" : [ {
+          "description" : "Unique identifier of the group to update",
+          "required" : true,
+          "name" : "id",
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CalendarGroupRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Group updated",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CalendarGroupResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Group not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Get group by ID",
+        "description" : "Retrieve a specific calendar group by its unique identifier",
+        "operationId" : "getGroup",
+        "tags" : [ "Calendar Groups" ],
+        "parameters" : [ {
+          "description" : "Unique identifier of the group",
+          "required" : true,
+          "name" : "id",
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Group found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CalendarGroupResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Group not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deactivate calendar group",
+        "description" : "Soft-delete a calendar group by setting it as inactive",
+        "operationId" : "deactivateGroup",
+        "tags" : [ "Calendar Groups" ],
+        "parameters" : [ {
+          "description" : "Unique identifier of the group to deactivate",
+          "required" : true,
+          "name" : "id",
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Group deactivated"
+          },
+          "404" : {
+            "description" : "Group not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/miot-calendar/slots" : {
       "get" : {
         "summary" : "List slots",
@@ -1329,7 +1617,7 @@
   },
   "info" : {
     "title" : "MIOT Calendar API",
-    "version" : "0.1.1",
+    "version" : "0.2.0",
     "description" : "Calendar booking microservice for resource scheduling. Provides calendar management, time window configuration, slot generation, and booking operations.",
     "contact" : {
       "name" : "MicroBoxLabs",

--- a/packages/miot-calendar-client/package.json
+++ b/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/miot-calendar-client/src/__tests__/groups.test.ts
+++ b/packages/miot-calendar-client/src/__tests__/groups.test.ts
@@ -38,6 +38,16 @@ describe("groups", () => {
       expect(url.searchParams.get("active")).toBe("true");
     });
 
+    it("passes active: false as query param", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.list({ active: false });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("active")).toBe("false");
+    });
+
     it("returns group array", async () => {
       const { fn } = createMockFetch([sampleGroup]);
       const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });

--- a/packages/miot-calendar-client/src/__tests__/groups.test.ts
+++ b/packages/miot-calendar-client/src/__tests__/groups.test.ts
@@ -112,6 +112,15 @@ describe("groups", () => {
       expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}/grp-1`);
       expect(call.init.body).toBe(JSON.stringify(groupRequest));
     });
+
+    it("returns updated group", async () => {
+      const { fn } = createMockFetch(sampleGroup);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.groups.update("grp-1", groupRequest);
+
+      expect(result).toEqual(sampleGroup);
+    });
   });
 
   describe("deactivate", () => {

--- a/packages/miot-calendar-client/src/__tests__/groups.test.ts
+++ b/packages/miot-calendar-client/src/__tests__/groups.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { createMiotCalendarClient } from "../index.js";
+import type { CalendarGroupRequest, CalendarGroupResponse } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+const BASE_URL = "https://api.example.com";
+const GROUPS_PATH = "/api/v1/miot-calendar/groups";
+
+const sampleGroup: CalendarGroupResponse = {
+  id: "grp-1",
+  code: "warehouse-south",
+  name: "Warehouse South",
+  description: "Group for all calendars in Warehouse South",
+  active: true,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+describe("groups", () => {
+  describe("list", () => {
+    it("sends GET to groups endpoint", async () => {
+      const { fn, call } = createMockFetch([sampleGroup]);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.list();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}`);
+    });
+
+    it("passes active filter as query param", async () => {
+      const { fn, call } = createMockFetch([sampleGroup]);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.list({ active: true });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("active")).toBe("true");
+    });
+
+    it("returns group array", async () => {
+      const { fn } = createMockFetch([sampleGroup]);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.groups.list();
+
+      expect(result).toEqual([sampleGroup]);
+    });
+  });
+
+  describe("get", () => {
+    it("sends GET to groups/:id", async () => {
+      const { fn, call } = createMockFetch(sampleGroup);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.get("grp-1");
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}/grp-1`);
+    });
+
+    it("returns the group", async () => {
+      const { fn } = createMockFetch(sampleGroup);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.groups.get("grp-1");
+
+      expect(result).toEqual(sampleGroup);
+    });
+  });
+
+  describe("create", () => {
+    const groupRequest: CalendarGroupRequest = {
+      code: "warehouse-south",
+      name: "Warehouse South",
+    };
+
+    it("sends POST with body", async () => {
+      const { fn, call } = createMockFetch(sampleGroup, 201);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.create(groupRequest);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}`);
+      expect(call.init.body).toBe(JSON.stringify(groupRequest));
+    });
+
+    it("returns created group", async () => {
+      const { fn } = createMockFetch(sampleGroup, 201);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.groups.create(groupRequest);
+
+      expect(result).toEqual(sampleGroup);
+    });
+  });
+
+  describe("update", () => {
+    const groupRequest: CalendarGroupRequest = {
+      code: "warehouse-south",
+      name: "Warehouse South Updated",
+    };
+
+    it("sends PUT to groups/:id with body", async () => {
+      const { fn, call } = createMockFetch(sampleGroup);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.update("grp-1", groupRequest);
+
+      expect(call.init.method).toBe("PUT");
+      expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}/grp-1`);
+      expect(call.init.body).toBe(JSON.stringify(groupRequest));
+    });
+  });
+
+  describe("deactivate", () => {
+    it("sends DELETE to groups/:id", async () => {
+      const { fn, call } = createMockFetch(undefined, 204);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.groups.deactivate("grp-1");
+
+      expect(call.init.method).toBe("DELETE");
+      expect(call.url).toBe(`${BASE_URL}${GROUPS_PATH}/grp-1`);
+    });
+
+    it("returns undefined", async () => {
+      const { fn } = createMockFetch(undefined, 204);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.groups.deactivate("grp-1");
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/miot-calendar-client/src/client.ts
+++ b/packages/miot-calendar-client/src/client.ts
@@ -2,6 +2,7 @@ import type { ClientConfig } from "./types.js";
 import { MiotCalendarApiError } from "./errors.js";
 import { createBookingsApi } from "./resources/bookings.js";
 import { createCalendarsApi } from "./resources/calendars.js";
+import { createGroupsApi } from "./resources/groups.js";
 import { createSlotsApi } from "./resources/slots.js";
 
 export interface FetchOptions<TBody = unknown> {
@@ -77,6 +78,7 @@ export function createMiotCalendarClient(config: ClientConfig) {
   return {
     bookings: createBookingsApi(fetcher),
     calendars: createCalendarsApi(fetcher),
+    groups: createGroupsApi(fetcher),
     slots: createSlotsApi(fetcher),
   };
 }

--- a/packages/miot-calendar-client/src/index.ts
+++ b/packages/miot-calendar-client/src/index.ts
@@ -7,6 +7,8 @@ export type {
   BookingRequest,
   BookingResponse,
   BookingListResponse,
+  CalendarGroupRequest,
+  CalendarGroupResponse,
   CalendarRequest,
   CalendarResponse,
   TimeWindowRequest,

--- a/packages/miot-calendar-client/src/resources/calendars.ts
+++ b/packages/miot-calendar-client/src/resources/calendars.ts
@@ -10,7 +10,7 @@ const BASE = "/api/v1/miot-calendar/calendars";
 
 export function createCalendarsApi(fetcher: Fetcher) {
   return {
-    list(params?: { active?: boolean }): Promise<CalendarResponse[]> {
+    list(params?: { active?: boolean; groupCode?: string }): Promise<CalendarResponse[]> {
       return fetcher("GET", BASE, { query: params });
     },
 

--- a/packages/miot-calendar-client/src/resources/groups.ts
+++ b/packages/miot-calendar-client/src/resources/groups.ts
@@ -1,0 +1,28 @@
+import type { Fetcher } from "../client.js";
+import type { CalendarGroupRequest, CalendarGroupResponse } from "../types.js";
+
+const BASE = "/api/v1/miot-calendar/groups";
+
+export function createGroupsApi(fetcher: Fetcher) {
+  return {
+    list(params?: { active?: boolean }): Promise<CalendarGroupResponse[]> {
+      return fetcher("GET", BASE, { query: params });
+    },
+
+    get(id: string): Promise<CalendarGroupResponse> {
+      return fetcher("GET", `${BASE}/${id}`);
+    },
+
+    create(body: CalendarGroupRequest): Promise<CalendarGroupResponse> {
+      return fetcher("POST", BASE, { body });
+    },
+
+    update(id: string, body: CalendarGroupRequest): Promise<CalendarGroupResponse> {
+      return fetcher("PUT", `${BASE}/${id}`, { body });
+    },
+
+    deactivate(id: string): Promise<void> {
+      return fetcher("DELETE", `${BASE}/${id}`);
+    },
+  };
+}

--- a/packages/miot-calendar-client/src/types.ts
+++ b/packages/miot-calendar-client/src/types.ts
@@ -39,6 +39,25 @@ export interface BookingListResponse {
   total: number;
 }
 
+// --- Calendar Groups ---
+
+export interface CalendarGroupRequest {
+  code: string;
+  name: string;
+  description?: string;
+  active?: boolean;
+}
+
+export interface CalendarGroupResponse {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // --- Calendars ---
 
 export interface CalendarRequest {
@@ -47,6 +66,7 @@ export interface CalendarRequest {
   description?: string;
   timezone?: string;
   active?: boolean;
+  groups?: string[];
 }
 
 export interface CalendarResponse {
@@ -58,6 +78,7 @@ export interface CalendarResponse {
   active: boolean;
   createdAt: string;
   updatedAt: string;
+  groups?: CalendarGroupResponse[];
 }
 
 // --- Time Windows ---


### PR DESCRIPTION
## Summary

- Add `CalendarGroupRequest` and `CalendarGroupResponse` types
- Extend `CalendarRequest` with `groups?: string[]` and `CalendarResponse` with `groups?: CalendarGroupResponse[]`
- New `groups` resource with `list`, `get`, `create`, `update`, `deactivate` methods against `/api/v1/miot-calendar/groups`
- Wire `groups` namespace into `createMiotCalendarClient`
- Add `groupCode?: string` filter to `calendars.list()`
- Export new group types from package index
- Bump package version `0.1.3` → `0.2.0`

## Test plan

- [x] All 54 tests pass (`vitest run`)
- [x] 10 new tests in `groups.test.ts` cover all 5 group operations
- [x] Pre-commit hooks pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar groups management: create, read, update, deactivate calendar groups
  * Assign calendars to multiple groups and show group details in calendar responses
  * Filter calendar listings by group code

* **Chores**
  * Package and API version bumped to 0.2.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->