### PR TITLE
feat(miot-calendar-client): add CJS output and dev watch script

### DIFF
--- a/packages/miot-calendar-client/package.json
+++ b/packages/miot-calendar-client/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [
@@ -19,6 +20,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "lint": "eslint .",
     "check-types": "tsc --noEmit"

--- a/packages/miot-calendar-client/tsup.config.ts
+++ b/packages/miot-calendar-client/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm"],
+  format: ["esm", "cjs"],
   dts: true,
   outDir: "dist",
   clean: true,


### PR DESCRIPTION
## Summary

- Add `"cjs"` to tsup format array for dual ESM + CJS build output
- Add `"require": "./dist/index.cjs"` export condition so CommonJS consumers resolve the correct bundle
- Add `"dev": "tsup --watch"` script for local development

## Test plan

- [x] `npm run build` in `packages/miot-calendar-client` produces both `dist/index.js` (ESM) and `dist/index.cjs` (CJS)
- [x] Package can be `require()`d in a CJS context without error

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CommonJS module support alongside existing ES module support for broader compatibility across different project setups.
  * Introduced a development watch mode script to streamline local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->