### PR TITLE
feat(miot-cli): implement @microboxlabs/miot-cli package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,32 @@ env:
 
 jobs:
   # ===========================================================================
+  # Changed paths - Detect which areas of the monorepo changed
+  # ===========================================================================
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      apps: ${{ steps.filter.outputs.apps }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            apps:
+              - 'apps/**'
+              - 'packages/ui/**'
+              - 'packages/db/**'
+              - 'packages/typescript-config/**'
+              - 'packages/eslint-config/**'
+              - 'package-lock.json'
+              - 'docker/**'
+
+  # ===========================================================================
   # Install - Shared dependency installation with node_modules cache
   # ===========================================================================
   install:
@@ -148,7 +174,8 @@ jobs:
   build:
     name: Build Apps
     runs-on: ubuntu-latest
-    needs: install
+    needs: [install, changes]
+    if: needs.changes.outputs.apps == 'true'
     timeout-minutes: 15
 
     permissions:
@@ -223,7 +250,8 @@ jobs:
   publish-docker:
     name: Publish ${{ matrix.app }} Image
     runs-on: ubuntu-latest
-    needs: [lint, build]
+    needs: [lint, build, changes]
+    if: needs.changes.outputs.apps == 'true'
     timeout-minutes: 15
 
     strategy:
@@ -386,7 +414,7 @@ jobs:
   summary:
     name: Build Summary
     runs-on: ubuntu-latest
-    needs: [install, lint, build, publish-docker]
+    needs: [install, lint, build, publish-docker, changes]
     if: always()
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,10 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -159,7 +162,10 @@ jobs:
       - name: Restore node_modules cache
         uses: actions/cache/restore@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: Run linting
@@ -193,7 +199,10 @@ jobs:
       - name: Restore node_modules cache
         uses: actions/cache/restore@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: Build apps with Turbo

--- a/.github/workflows/publish-miot-cli.yaml
+++ b/.github/workflows/publish-miot-cli.yaml
@@ -40,7 +40,10 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies

--- a/.github/workflows/publish-miot-cli.yaml
+++ b/.github/workflows/publish-miot-cli.yaml
@@ -1,0 +1,63 @@
+name: Publish miot-cli
+
+on:
+  push:
+    tags:
+      - "miot-cli@v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. miot-cli@v0.1.0)"
+        required: true
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  publish:
+    name: Publish to npmjs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write          # OIDC for npm trusted publishers
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Upgrade npm for trusted publishing (requires >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Cache node_modules
+        id: cache-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build package
+        run: npx turbo run build --filter=@microboxlabs/miot-cli
+
+      - name: Run lint
+        run: npx turbo run lint --filter=@microboxlabs/miot-cli
+
+      - name: Run type check
+        run: npx turbo run check-types --filter=@microboxlabs/miot-cli
+
+      - name: Run tests
+        run: npx turbo run test --filter=@microboxlabs/miot-cli
+
+      - name: Publish to npm
+        run: npm publish --workspace=packages/miot-cli --access public

--- a/generative_ai/data/plans/miot-ai-first-tooling/00-overview.md
+++ b/generative_ai/data/plans/miot-ai-first-tooling/00-overview.md
@@ -1,0 +1,56 @@
+# ModularIoT AI-First Tooling — Strategy Overview
+
+## Vision
+
+Make ModularIoT services natively accessible to AI agents across all major platforms (Claude Code, ChatGPT, Gemini, Copilot, Cursor, Windsurf, and 40+ others) while remaining useful to humans, CI/CD, and scripts.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│  Layer 3: Agent Skill (open standard)            │
+│  Universal — 40+ platforms via npx skills        │
+│  SKILL.md teaches any agent the domain           │
+│  Calls CLI via bash for execution                │
+├──────────────────────────────────────────────────┤
+│  Layer 2: MCP Server (optional, later)           │
+│  For platforms that prefer native tool calls     │
+│  Thin wrapper over SDK                           │
+│  Claude Desktop, ChatGPT, Gemini, Copilot, etc. │
+├──────────────────────────────────────────────────┤
+│  Layer 1: CLI Tool (execution backbone)          │
+│  @microboxlabs/miot-cli                          │
+│  Humans, AI agents (via Bash), CI/CD, scripts    │
+├──────────────────────────────────────────────────┤
+│  Foundation: Existing TypeScript SDKs            │
+│  @microboxlabs/miot-calendar-client (v0.3.0)     │
+│  (future SDKs for other modules)                 │
+└──────────────────────────────────────────────────┘
+```
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Language | TypeScript | Team fluency, SDK reuse, monorepo integration, existing pattern (sonarcloud-tools) |
+| Location | `packages/miot-cli/` in monorepo | Turborepo integration, shared toolchain, workspace dependency on SDK |
+| CLI framework | Commander.js | Already used in sonarcloud-tools, lightweight, well-known |
+| Build tool | tsup | Existing pattern, ESM output with shebang for bin entry |
+| Distribution | npm (`@microboxlabs/miot-cli`) | `npx` for agents, `npm i -g` for humans |
+| Skill format | Open Agent Skills (agentskills.io) | Universal — 40+ platforms, not Claude-locked |
+| MCP | Deferred to Layer 2 | Build if/when cross-platform native tool calls are needed |
+
+## Build Order
+
+| Phase | Deliverable | Status |
+|---|---|---|
+| 1 | `@microboxlabs/miot-cli` — CLI with calendar module | Planned |
+| 2 | Agent Skill — open standard SKILL.md + reference docs | Planned |
+| 3 | MCP Server — optional native tool interface | Future |
+
+## Context
+
+- **Primary consumers:** AI agents (via Bash tool / npx), then humans
+- **MCP is industry standard** (Linux Foundation, adopted by OpenAI, Google, Microsoft) but pollutes agent context when always loaded
+- **Agent Skills load on demand** (~100 tokens at startup, full content only when triggered) — solves context pollution
+- **CLI is the universal backbone** — every layer above calls it or the SDK it wraps

--- a/generative_ai/data/plans/miot-ai-first-tooling/01-miot-cli.md
+++ b/generative_ai/data/plans/miot-ai-first-tooling/01-miot-cli.md
@@ -1,0 +1,247 @@
+# Phase 1: miot-cli — CLI Tool
+
+## Goal
+
+Build a modular CLI (`@microboxlabs/miot-cli`) that exposes ModularIoT services to humans and AI agents. Start with the calendar module; design for future modules (devices, alerts, etc.).
+
+## Package Location
+
+```
+packages/miot-cli/
+```
+
+## Project Structure
+
+```
+packages/miot-cli/
+├── src/
+│   ├── cli.ts                        # Entry point — Commander program, registers top-level commands
+│   ├── config.ts                     # Config resolution: env vars → dotfile → flags
+│   ├── output.ts                     # Output formatter: JSON (pipes/agents) or table (TTY/humans)
+│   ├── client-factory.ts             # Creates SDK clients from resolved config
+│   ├── commands/
+│   │   └── calendar/
+│   │       ├── index.ts              # Registers `miot calendar` and all subcommands
+│   │       ├── list.ts               # miot calendar list
+│   │       ├── get.ts                # miot calendar get <id>
+│   │       ├── create.ts             # miot calendar create
+│   │       ├── slots.ts              # miot calendar slots list|generate|update-status
+│   │       ├── bookings.ts           # miot calendar bookings list|create|cancel|by-resource
+│   │       ├── groups.ts             # miot calendar groups list|get|create
+│   │       ├── time-windows.ts       # miot calendar time-windows list|create|update
+│   │       └── slot-managers.ts      # miot calendar slot-managers list|get|run|runs
+│   └── utils/
+│       └── error.ts                  # Catches MiotCalendarApiError, formats for output
+├── package.json
+├── tsup.config.ts
+└── README.md
+```
+
+## Command Tree
+
+```
+miot
+├── calendar
+│   ├── list [--group <code>] [--active] [--inactive]
+│   ├── get <id>
+│   ├── create --code <code> --name <name> [--timezone <tz>] [--description <desc>]
+│   ├── update <id> --name <name> [--timezone <tz>] [--description <desc>]
+│   ├── deactivate <id>
+│   ├── slots
+│   │   ├── list --calendar <id> [--from <date>] [--to <date>] [--available]
+│   │   ├── get <id>
+│   │   ├── generate --calendar <id> --from <date> --to <date>
+│   │   └── update-status <id> --status <OPEN|CLOSED>
+│   ├── bookings
+│   │   ├── list [--calendar <id>] [--from <date>] [--to <date>]
+│   │   ├── get <id>
+│   │   ├── create --calendar <id> --resource-id <rid> [--resource-type <type>] [--resource-label <label>] --date <date> --hour <h> --minutes <m>
+│   │   ├── cancel <id>
+│   │   └── by-resource <resourceId>
+│   ├── groups
+│   │   ├── list [--active]
+│   │   ├── get <id>
+│   │   ├── create --code <code> --name <name> [--description <desc>]
+│   │   ├── update <id> --name <name> [--description <desc>]
+│   │   └── deactivate <id>
+│   ├── time-windows
+│   │   ├── list --calendar <id>
+│   │   ├── create --calendar <id> --name <name> --start-hour <h> --end-hour <h> --valid-from <date> [--valid-to <date>] [--slot-duration <min>] [--capacity <n>] [--days-of-week <1,2,3,4,5>]
+│   │   └── update <calendarId> <timeWindowId> [same flags as create]
+│   └── slot-managers
+│       ├── list [--active]
+│       ├── get <id>
+│       ├── create --calendar <id> [--days-in-advance <n>] [--batch-days <n>]
+│       ├── update <id> [--days-in-advance <n>] [--batch-days <n>] [--active]
+│       ├── deactivate <id>
+│       ├── run [<id>]                  # Run one or all
+│       └── runs [<managerId>] [--limit <n>]
+├── (future: devices, alerts, ...)
+└── Global flags:
+    --base-url <url>                    # or MIOT_BASE_URL env var
+    --token <token>                     # or MIOT_TOKEN env var
+    --profile <name>                    # Named profile from ~/.miotrc.json
+    --output json|table                 # Default: table on TTY, json on pipe
+    --help
+    --version
+```
+
+## Config Resolution (priority order)
+
+1. CLI flags (`--base-url`, `--token`)
+2. Environment variables (`MIOT_BASE_URL`, `MIOT_TOKEN`)
+3. Profile in dotfile (`~/.miotrc.json`)
+
+### Dotfile Format (`~/.miotrc.json`)
+
+```json
+{
+  "defaultProfile": "staging",
+  "profiles": {
+    "staging": {
+      "baseUrl": "https://staging-api.example.com",
+      "token": "eyJ..."
+    },
+    "production": {
+      "baseUrl": "https://api.example.com",
+      "token": "eyJ..."
+    }
+  }
+}
+```
+
+## Output Modes
+
+### Table (default on TTY — for humans)
+
+```
+ID                                   CODE              NAME                 TIMEZONE    ACTIVE
+550e8400-e29b-41d4-a716-446655440000 vehicle-inspection Vehicle Inspection   America/NY  true
+660e8400-e29b-41d4-a716-446655440001 room-booking       Room Booking        UTC         true
+```
+
+### JSON (default on pipe / --output json — for agents)
+
+```json
+[
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "code": "vehicle-inspection",
+    "name": "Vehicle Inspection",
+    "timezone": "America/New_York",
+    "active": true
+  }
+]
+```
+
+AI agents always get structured JSON. The skill or MCP server parses this output to reason over results.
+
+## Error Handling
+
+- Catch `MiotCalendarApiError` from the SDK
+- Exit code 0 for success, 1 for client errors (4xx), 2 for server errors (5xx), 3 for config errors
+- JSON mode: `{ "error": { "status": 404, "message": "Calendar not found" } }`
+- Table mode: human-readable error message to stderr
+
+## package.json
+
+```json
+{
+  "name": "@microboxlabs/miot-cli",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "miot": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@microboxlabs/miot-calendar-client": "workspace:*",
+    "commander": "^13.0.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  }
+}
+```
+
+## tsup.config.ts
+
+```ts
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    outDir: "dist",
+    clean: true,
+    banner: { js: "#!/usr/bin/env node" },
+  },
+  {
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    outDir: "dist",
+    dts: true,
+  },
+]);
+```
+
+## Implementation Steps
+
+### Step 1: Scaffold the package
+
+- Create `packages/miot-cli/` with package.json, tsup.config.ts, tsconfig.json
+- Wire into turborepo workspace
+- Verify `npm run build` works
+
+### Step 2: Core infrastructure
+
+- `config.ts` — env vars, dotfile, profile resolution
+- `output.ts` — TTY detection, JSON/table formatting
+- `client-factory.ts` — create SDK client from resolved config
+- `error.ts` — unified error handling with exit codes
+
+### Step 3: Calendar commands (iterative)
+
+Build in this order (each is independently testable):
+
+1. `calendar list` / `calendar get` — read-only, simple
+2. `calendar groups list` / `calendar groups get` — read-only, simple
+3. `calendar time-windows list` — read-only, depends on calendar
+4. `calendar slots list` — read-only, most useful for agents ("what's available?")
+5. `calendar bookings list` / `calendar bookings by-resource` — read-only
+6. `calendar slot-managers list` / `calendar slot-managers runs` — read-only
+7. `calendar create` / `calendar update` / `calendar deactivate` — write operations
+8. `calendar slots generate` / `calendar slots update-status` — write operations
+9. `calendar bookings create` / `calendar bookings cancel` — write operations
+10. `calendar time-windows create` / `calendar time-windows update` — write operations
+11. `calendar groups create` / `calendar groups update` / `calendar groups deactivate` — write
+12. `calendar slot-managers create` / `calendar slot-managers update` / `calendar slot-managers deactivate` / `calendar slot-managers run` — write
+
+### Step 4: Test coverage
+
+- Unit tests for config resolution, output formatting, error handling
+- Integration tests that mock the SDK client and verify CLI output
+- Test both JSON and table output modes
+
+### Step 5: Documentation and publish
+
+- README.md with usage examples
+- Add to monorepo's doc-sync workflow
+- First npm publish as `@microboxlabs/miot-cli@0.1.0`

--- a/generative_ai/data/plans/miot-ai-first-tooling/02-agent-skill.md
+++ b/generative_ai/data/plans/miot-ai-first-tooling/02-agent-skill.md
@@ -1,0 +1,181 @@
+# Phase 2: Agent Skill — Open Standard
+
+## Goal
+
+Build an open Agent Skill (agentskills.io specification) that teaches any AI agent how to interact with ModularIoT services via the CLI. The skill provides domain intelligence — the "brain" that knows when and how to compose CLI calls into meaningful workflows.
+
+## Distribution
+
+```bash
+# Install on any of 40+ supported platforms
+npx skills add microboxlabs/miot-cli
+
+# Works on: Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, Cline, etc.
+```
+
+## Skill Location
+
+The skill lives inside the miot-cli package repository so it ships alongside the CLI:
+
+```
+packages/miot-cli/
+├── src/                          # CLI source (Phase 1)
+├── skills/
+│   └── miot-calendar/
+│       ├── SKILL.md              # Core skill definition
+│       └── reference.md          # Full API reference (loaded on demand)
+├── package.json
+└── ...
+```
+
+## SKILL.md Design
+
+### Frontmatter (always loaded — ~100 tokens)
+
+```yaml
+---
+name: miot-calendar
+description: >
+  Query and manage ModularIoT Calendar services. List calendars, check slot
+  availability, create bookings, manage time windows, and run slot managers.
+  Use when the user asks about schedules, appointments, bookings, availability,
+  or calendar services in their ModularIoT organization.
+---
+```
+
+### Instructions Body (loaded when triggered)
+
+The SKILL.md body teaches the agent:
+
+1. **Prerequisites** — The CLI must be available (`npx @microboxlabs/miot-cli` or `miot` if globally installed). Config requires `MIOT_BASE_URL` and `MIOT_TOKEN` env vars or a `~/.miotrc.json` profile.
+
+2. **Domain Model** — Brief explanation of the calendar domain:
+   - Calendars contain time windows that define when slots are available
+   - Slots are generated from time windows and represent bookable time units
+   - Bookings consume slots and are linked to resources (vehicles, rooms, etc.)
+   - Slot managers automate slot generation on a rolling basis
+   - Groups organize calendars by category
+
+3. **Common Workflows** — Step-by-step recipes for natural language queries:
+
+   - **"What's available next week for X?"**
+     1. Find the calendar: `miot calendar list --output json`
+     2. List available slots: `miot calendar slots list --calendar <id> --from <monday> --to <friday> --available --output json`
+     3. Summarize: group by date, show times and remaining capacity
+
+   - **"Book a slot for resource Y"**
+     1. Find available slots (as above)
+     2. Present options to the user
+     3. Create booking: `miot calendar bookings create --calendar <id> --resource-id <rid> --date <date> --hour <h> --minutes <m> --output json`
+
+   - **"How full is calendar X this month?"**
+     1. List all slots for the date range: `miot calendar slots list --calendar <id> --from <start> --to <end> --output json`
+     2. Compute: total slots, occupied, available, percentage
+
+   - **"Generate slots for the next 2 weeks"**
+     1. `miot calendar slots generate --calendar <id> --from <today> --to <today+14> --output json`
+
+   - **"What bookings does resource Z have?"**
+     1. `miot calendar bookings by-resource <resourceId> --output json`
+
+   - **"Run the slot managers"**
+     1. `miot calendar slot-managers run --output json`
+
+   - **"Show me the calendar setup"**
+     1. `miot calendar get <id> --output json`
+     2. `miot calendar time-windows list --calendar <id> --output json`
+     3. Summarize: calendar details + active time windows with schedules
+
+4. **Output Handling** — Always use `--output json` when calling the CLI. Parse the JSON to extract relevant fields. Present results to the user in a readable format (tables, summaries, counts).
+
+5. **Error Handling** — If the CLI returns an error JSON (`{ "error": { ... } }`), explain the issue to the user in plain language. Common errors:
+   - 404: resource not found
+   - 409: slot is full / no capacity
+   - 400: invalid parameters (date range > 90 days, invalid hours, etc.)
+
+6. **Business Rules** — Constraints the agent should know:
+   - Slot generation is limited to 90-day ranges
+   - Time window hours: startHour < endHour, both 0-23
+   - Days of week: "1,2,3,4,5" where 1=Monday, 7=Sunday
+   - Slot status: OPEN, FULL, CLOSED
+   - Booking requires an available (OPEN) slot with remaining capacity
+
+## reference.md Design
+
+Full CLI command reference with all flags, loaded only when the agent needs specifics:
+
+```markdown
+# miot-cli Calendar Module Reference
+
+## miot calendar list
+List all calendars.
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| --group | string | | Filter by group code |
+| --active | boolean | | Only active calendars |
+| --output | json\|table | auto | Output format |
+
+Returns: Array of calendar objects with id, code, name, timezone, active, groups.
+
+## miot calendar slots list
+...
+(complete reference for every command)
+```
+
+## Progressive Disclosure Flow
+
+```
+Agent starts conversation
+  ↓
+System prompt includes: "miot-calendar — Query and manage ModularIoT Calendar services..."
+  (~100 tokens, always present)
+  ↓
+User asks: "What slots are available for vehicle inspection next week?"
+  ↓
+Agent recognizes intent → loads SKILL.md body
+  (~2-3k tokens, loaded once per conversation)
+  ↓
+Agent follows workflow recipe → calls CLI via Bash
+  miot calendar list --output json
+  miot calendar slots list --calendar <id> --from ... --to ... --available --output json
+  ↓
+Agent parses JSON → presents formatted answer to user
+  ↓
+(If agent needs exact flag details) → loads reference.md
+  (~5k tokens, loaded only if needed)
+```
+
+## Implementation Steps
+
+### Step 1: Write SKILL.md
+
+- Frontmatter with name, description
+- Domain model explanation
+- Workflow recipes for common queries
+- Output handling instructions
+- Error handling guidance
+- Business rules
+
+### Step 2: Write reference.md
+
+- Complete CLI command reference
+- Every command, every flag, every return type
+- Examples of JSON output for each command
+
+### Step 3: Test with Claude Code
+
+- Install locally: `npx skills add ./packages/miot-cli`
+- Verify skill triggers on relevant queries
+- Test each workflow recipe end-to-end
+- Verify progressive disclosure works (metadata → instructions → reference)
+
+### Step 4: Test cross-platform
+
+- Verify skill works on Cursor, Windsurf (at minimum)
+- Ensure CLI availability via npx works on each platform
+
+### Step 5: Publish
+
+- Push to GitHub (skills/ directory in the miot-cli package)
+- Appears on skills.sh automatically
+- Users install: `npx skills add microboxlabs/miot-cli`

--- a/generative_ai/data/plans/miot-ai-first-tooling/03-mcp-server.md
+++ b/generative_ai/data/plans/miot-ai-first-tooling/03-mcp-server.md
@@ -1,0 +1,186 @@
+# Phase 3: MCP Server (Optional, Future)
+
+## Goal
+
+Build a Model Context Protocol server that exposes ModularIoT calendar operations as native tools for MCP-compatible hosts. This is the optional layer for platforms where native tool calls are preferred over CLI invocation via Bash.
+
+## When to Build This
+
+Build this phase when ANY of these conditions are true:
+
+- Users want calendar access in **Claude Desktop** (chat, not coding)
+- Users want calendar access in **ChatGPT** (via MCP apps)
+- Users need **always-on** tool availability without skill activation
+- Third-party agents or integrations need a **programmatic tool interface**
+- The skill + CLI pattern proves insufficient for some workflow
+
+Do NOT build this preemptively. The Skill + CLI covers the primary use case (AI-assisted coding and operations). MCP adds value only when the consumption pattern is different.
+
+## Package Location
+
+```
+packages/miot-calendar-mcp/
+```
+
+## Architecture
+
+```
+┌─────────────────────────────┐
+│  MCP Host (Claude Desktop,  │
+│  ChatGPT, Copilot, etc.)    │
+│              │               │
+│         stdio transport      │
+│              │               │
+│  ┌───────────▼─────────────┐│
+│  │  miot-calendar-mcp      ││
+│  │  @modelcontextprotocol/ ││
+│  │  sdk                    ││
+│  │           │             ││
+│  │  @microboxlabs/         ││
+│  │  miot-calendar-client   ││
+│  └─────────────────────────┘│
+└─────────────────────────────┘
+```
+
+The MCP server imports the SDK directly — it does NOT shell out to the CLI. This keeps it fast and avoids Node startup overhead per tool call.
+
+## Tool Definitions
+
+### Read Operations
+
+| Tool | Input Schema | Description |
+|---|---|---|
+| `miot_calendar_list` | `{ group?: string, active?: boolean }` | List all calendars |
+| `miot_calendar_get` | `{ id: string }` | Get calendar details |
+| `miot_slots_list` | `{ calendarId: string, from?: string, to?: string, available?: boolean }` | List slots |
+| `miot_slots_get` | `{ id: string }` | Get slot details |
+| `miot_bookings_list` | `{ calendarId?: string, from?: string, to?: string }` | List bookings |
+| `miot_bookings_get` | `{ id: string }` | Get booking details |
+| `miot_bookings_by_resource` | `{ resourceId: string }` | Bookings for a resource |
+| `miot_groups_list` | `{ active?: boolean }` | List calendar groups |
+| `miot_groups_get` | `{ id: string }` | Get group details |
+| `miot_time_windows_list` | `{ calendarId: string }` | List time windows |
+| `miot_slot_managers_list` | `{ active?: boolean }` | List slot managers |
+| `miot_slot_managers_get` | `{ id: string }` | Get slot manager |
+| `miot_slot_managers_runs` | `{ managerId?: string, limit?: number }` | List run history |
+
+### Write Operations
+
+| Tool | Input Schema | Description |
+|---|---|---|
+| `miot_calendar_create` | `{ code, name, description?, timezone?, groups? }` | Create calendar |
+| `miot_calendar_update` | `{ id, name?, description?, timezone?, groups? }` | Update calendar |
+| `miot_calendar_deactivate` | `{ id: string }` | Deactivate calendar |
+| `miot_slots_generate` | `{ calendarId, from, to }` | Generate slots |
+| `miot_slots_update_status` | `{ id, status: "OPEN" \| "CLOSED" }` | Update slot status |
+| `miot_bookings_create` | `{ calendarId, resourceId, resourceType?, resourceLabel?, date, hour, minutes }` | Create booking |
+| `miot_bookings_cancel` | `{ id: string }` | Cancel booking |
+| `miot_groups_create` | `{ code, name, description? }` | Create group |
+| `miot_groups_update` | `{ id, name?, description? }` | Update group |
+| `miot_groups_deactivate` | `{ id: string }` | Deactivate group |
+| `miot_time_windows_create` | `{ calendarId, name, startHour, endHour, validFrom, validTo?, slotDurationMinutes?, capacityPerSlot?, daysOfWeek? }` | Create time window |
+| `miot_time_windows_update` | `{ calendarId, timeWindowId, ...same fields }` | Update time window |
+| `miot_slot_managers_create` | `{ calendarId, daysInAdvance?, batchDays? }` | Create slot manager |
+| `miot_slot_managers_update` | `{ id, daysInAdvance?, batchDays?, active? }` | Update slot manager |
+| `miot_slot_managers_deactivate` | `{ id: string }` | Deactivate slot manager |
+| `miot_slot_managers_run` | `{ id?: string }` | Run one or all managers |
+
+### MCP Resources (read-only context)
+
+| Resource URI | Description |
+|---|---|
+| `miot://calendar/{id}/summary` | Calendar + time windows + slot availability overview |
+| `miot://calendar/{id}/upcoming` | Next 20 available slots for a calendar |
+
+## Configuration
+
+### Claude Desktop / Claude Code
+
+```jsonc
+// settings or claude_desktop_config.json
+{
+  "mcpServers": {
+    "miot-calendar": {
+      "command": "npx",
+      "args": ["@microboxlabs/miot-calendar-mcp"],
+      "env": {
+        "MIOT_BASE_URL": "https://your-api.example.com",
+        "MIOT_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+### ChatGPT (remote MCP)
+
+ChatGPT requires remote (HTTP/SSE) MCP servers. This would need a hosted deployment of the MCP server, which is a separate consideration.
+
+## Project Structure
+
+```
+packages/miot-calendar-mcp/
+├── src/
+│   ├── index.ts              # MCP server setup, tool registration
+│   ├── tools/
+│   │   ├── calendars.ts      # Calendar tool handlers
+│   │   ├── slots.ts          # Slot tool handlers
+│   │   ├── bookings.ts       # Booking tool handlers
+│   │   ├── groups.ts         # Group tool handlers
+│   │   ├── time-windows.ts   # Time window tool handlers
+│   │   └── slot-managers.ts  # Slot manager tool handlers
+│   └── resources/
+│       └── calendar.ts       # Resource handlers (summary, upcoming)
+├── package.json
+├── tsup.config.ts
+└── README.md
+```
+
+## Dependencies
+
+```json
+{
+  "dependencies": {
+    "@microboxlabs/miot-calendar-client": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.x"
+  }
+}
+```
+
+## Context Pollution Consideration
+
+This MCP server registers ~30 tools. Each tool definition consumes tokens in the system prompt. Mitigation strategies:
+
+1. **Group into fewer, broader tools** — e.g., one `miot_calendar` tool with an `action` parameter instead of 30 separate tools. Trades discoverability for token efficiency.
+2. **Use MCP tool filtering** — some hosts allow selecting which tools to enable per conversation.
+3. **Accept the cost** — if the user has installed this MCP server, they want calendar access. ~30 tools at ~100 tokens each = ~3k tokens, which is acceptable for a dedicated integration.
+
+The Skill + CLI approach (Phase 1 + 2) avoids this entirely by loading on demand. The MCP server is for users who prefer native tools over CLI invocation.
+
+## Implementation Steps
+
+### Step 1: Scaffold
+
+- Create `packages/miot-calendar-mcp/`
+- Set up tsup, TypeScript, package.json
+- Install `@modelcontextprotocol/sdk`
+
+### Step 2: Read-only tools
+
+- Implement all list/get tools
+- Test with Claude Desktop or MCP Inspector
+
+### Step 3: Write tools
+
+- Implement create/update/delete/run tools
+- Add confirmation descriptions to destructive operations
+
+### Step 4: Resources
+
+- Implement summary and upcoming resources
+- Test resource loading in compatible hosts
+
+### Step 5: Publish
+
+- `@microboxlabs/miot-calendar-mcp` on npm
+- Document configuration for each supported host

--- a/package-lock.json
+++ b/package-lock.json
@@ -26197,7 +26197,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@microboxlabs/miot-calendar-client": "*",
-        "commander": "^7.2.0"
+        "commander": "^14.0.0"
       },
       "bin": {
         "miot": "dist/cli.js"
@@ -26340,12 +26340,12 @@
       }
     },
     "packages/miot-cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/miot-cli/node_modules/tinyexec": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@luma.gl/webgl": "9.2.6",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
-        "@microboxlabs/miot-calendar-client": "^0.2.0",
+        "@microboxlabs/miot-calendar-client": "*",
         "@next/mdx": "16.1.1",
         "@react-google-maps/api": "^2.20.3",
         "@tailwindcss/postcss": "^4.1.17",
@@ -4882,6 +4882,10 @@
     },
     "node_modules/@microboxlabs/miot-calendar-client": {
       "resolved": "packages/miot-calendar-client",
+      "link": true
+    },
+    "node_modules/@microboxlabs/miot-cli": {
+      "resolved": "packages/miot-cli",
       "link": true
     },
     "node_modules/@microboxlabs/sonarcloud-tools": {
@@ -10709,6 +10713,16 @@
       "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
       "license": "ISC"
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chevrotain": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
@@ -12003,6 +12017,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-equal": {
@@ -17252,6 +17276,13 @@
       "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -20273,6 +20304,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -23653,6 +23694,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -24113,6 +24174,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
@@ -24123,6 +24194,16 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25305,6 +25386,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -26078,7 +26182,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",
@@ -26086,6 +26190,279 @@
         "tsup": "^8.0.0",
         "typescript": "5.8.2",
         "vitest": "^4.0.18"
+      }
+    },
+    "packages/miot-cli": {
+      "name": "@microboxlabs/miot-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@microboxlabs/miot-calendar-client": "*",
+        "commander": "^13.0.0"
+      },
+      "bin": {
+        "miot": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@repo/eslint-config": "*",
+        "@repo/typescript-config": "*",
+        "tsup": "^8.0.0",
+        "typescript": "5.8.2",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/ui": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
+      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.4"
+      }
+    },
+    "packages/miot-cli/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/miot-cli/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/miot-cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/miot-cli/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/miot-cli/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/miot-cli/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/miot-cli/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/sonarcloud-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26197,7 +26197,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@microboxlabs/miot-calendar-client": "*",
-        "commander": "^13.0.0"
+        "commander": "^7.2.0"
       },
       "bin": {
         "miot": "dist/cli.js"

--- a/packages/miot-cli/eslint.config.mjs
+++ b/packages/miot-cli/eslint.config.mjs
@@ -1,0 +1,19 @@
+import { config as baseConfig } from "@repo/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...baseConfig,
+  {
+    rules: {
+      "turbo/no-undeclared-env-vars": [
+        "warn",
+        {
+          allowList: ["MIOT_BASE_URL", "MIOT_TOKEN"],
+        },
+      ],
+    },
+  },
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+];

--- a/packages/miot-cli/package.json
+++ b/packages/miot-cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@microboxlabs/miot-cli",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "miot": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@microboxlabs/miot-calendar-client": "*",
+    "commander": "^13.0.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "*",
+    "@repo/typescript-config": "*",
+    "tsup": "^8.0.0",
+    "typescript": "5.8.2",
+    "vitest": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/miot-cli/package.json
+++ b/packages/miot-cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@microboxlabs/miot-calendar-client": "*",
-    "commander": "^13.0.0"
+    "commander": "^7.2.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",

--- a/packages/miot-cli/package.json
+++ b/packages/miot-cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@microboxlabs/miot-calendar-client": "*",
-    "commander": "^7.2.0"
+    "commander": "^14.0.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",

--- a/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
+++ b/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerCalendarCommand } from "../../commands/calendar/index.js";
+
+vi.mock("../../action-context.js", () => ({
+  getActionContext: vi.fn(),
+}));
+
+import { getActionContext } from "../../action-context.js";
+
+const mockGetActionContext = vi.mocked(getActionContext);
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .name("miot")
+    .option("--base-url <url>")
+    .option("--token <token>")
+    .option("--profile <name>")
+    .option("--output <mode>");
+  registerCalendarCommand(program);
+  program.exitOverride();
+  return program;
+}
+
+describe("calendar list", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call calendars.list and print JSON", async () => {
+    const mockCalendars = [
+      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true },
+    ];
+    const mockClient = {
+      calendars: { list: vi.fn().mockResolvedValue(mockCalendars) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync(["node", "miot", "calendar", "list"]);
+
+    expect(mockClient.calendars.list).toHaveBeenCalledWith({
+      active: undefined,
+      groupCode: undefined,
+    });
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify(mockCalendars, null, 2),
+    );
+  });
+
+  it("should pass --group and --active filters", async () => {
+    const mockClient = {
+      calendars: { list: vi.fn().mockResolvedValue([]) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "miot",
+      "calendar",
+      "list",
+      "--group",
+      "vehicles",
+      "--active",
+    ]);
+
+    expect(mockClient.calendars.list).toHaveBeenCalledWith({
+      active: true,
+      groupCode: "vehicles",
+    });
+  });
+
+  it("should pass --inactive filter", async () => {
+    const mockClient = {
+      calendars: { list: vi.fn().mockResolvedValue([]) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "miot",
+      "calendar",
+      "list",
+      "--inactive",
+    ]);
+
+    expect(mockClient.calendars.list).toHaveBeenCalledWith({
+      active: false,
+      groupCode: undefined,
+    });
+  });
+
+  it("should print table output", async () => {
+    const mockCalendars = [
+      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true },
+    ];
+    const mockClient = {
+      calendars: { list: vi.fn().mockResolvedValue(mockCalendars) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "table",
+    });
+
+    const program = createProgram();
+    await program.parseAsync(["node", "miot", "calendar", "list"]);
+
+    // Should have header, separator, and row
+    expect(console.log).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("calendar get", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call calendars.get and print JSON", async () => {
+    const mockCalendar = {
+      id: "1",
+      code: "test",
+      name: "Test",
+      timezone: "UTC",
+      active: true,
+    };
+    const mockClient = {
+      calendars: { get: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync(["node", "miot", "calendar", "get", "1"]);
+
+    expect(mockClient.calendars.get).toHaveBeenCalledWith("1");
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify(mockCalendar, null, 2),
+    );
+  });
+});
+
+describe("calendar create", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call calendars.create with flags", async () => {
+    const mockCalendar = {
+      id: "1",
+      code: "new-cal",
+      name: "New Calendar",
+      timezone: "UTC",
+      active: true,
+    };
+    const mockClient = {
+      calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "miot",
+      "calendar",
+      "create",
+      "--code",
+      "new-cal",
+      "--name",
+      "New Calendar",
+      "--timezone",
+      "UTC",
+    ]);
+
+    expect(mockClient.calendars.create).toHaveBeenCalledWith({
+      code: "new-cal",
+      name: "New Calendar",
+      timezone: "UTC",
+      description: undefined,
+    });
+  });
+});
+
+describe("calendar deactivate", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call calendars.deactivate", async () => {
+    const mockClient = {
+      calendars: { deactivate: vi.fn().mockResolvedValue(undefined) },
+    };
+    mockGetActionContext.mockReturnValue({
+      client: mockClient as any,
+      outputMode: "json",
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "miot",
+      "calendar",
+      "deactivate",
+      "cal-1",
+    ]);
+
+    expect(mockClient.calendars.deactivate).toHaveBeenCalledWith("cal-1");
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify({ success: true }, null, 2),
+    );
+  });
+});

--- a/packages/miot-cli/src/__tests__/config.test.ts
+++ b/packages/miot-cli/src/__tests__/config.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveConfig, resolveOutputMode } from "../config.js";
+
+// Mock fs and os
+vi.mock("node:fs", () => ({
+  default: {
+    readFileSync: vi.fn(),
+  },
+}));
+
+vi.mock("node:os", () => ({
+  default: {
+    homedir: () => "/home/test",
+  },
+}));
+
+import fs from "node:fs";
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+describe("resolveConfig", () => {
+  const originalEnv = process.env;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["MIOT_BASE_URL"];
+    delete process.env["MIOT_TOKEN"];
+    mockReadFileSync.mockReset();
+    mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("should use CLI flags first", () => {
+    const config = resolveConfig({
+      baseUrl: "https://flag.example.com",
+      token: "flag-token",
+    });
+    expect(config).toEqual({
+      baseUrl: "https://flag.example.com",
+      token: "flag-token",
+    });
+  });
+
+  it("should fall back to env vars", () => {
+    process.env["MIOT_BASE_URL"] = "https://env.example.com";
+    process.env["MIOT_TOKEN"] = "env-token";
+
+    const config = resolveConfig({});
+    expect(config).toEqual({
+      baseUrl: "https://env.example.com",
+      token: "env-token",
+    });
+  });
+
+  it("should fall back to dotfile", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        defaultProfile: "staging",
+        profiles: {
+          staging: {
+            baseUrl: "https://staging.example.com",
+            token: "staging-token",
+          },
+        },
+      }),
+    );
+
+    const config = resolveConfig({});
+    expect(config).toEqual({
+      baseUrl: "https://staging.example.com",
+      token: "staging-token",
+    });
+  });
+
+  it("should use named profile from dotfile", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        defaultProfile: "staging",
+        profiles: {
+          staging: {
+            baseUrl: "https://staging.example.com",
+            token: "staging-token",
+          },
+          production: {
+            baseUrl: "https://prod.example.com",
+            token: "prod-token",
+          },
+        },
+      }),
+    );
+
+    const config = resolveConfig({ profile: "production" });
+    expect(config).toEqual({
+      baseUrl: "https://prod.example.com",
+      token: "prod-token",
+    });
+  });
+
+  it("should exit with code 3 when baseUrl is missing", () => {
+    process.env["MIOT_TOKEN"] = "token";
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    resolveConfig({});
+    expect(mockExit).toHaveBeenCalledWith(3);
+  });
+
+  it("should exit with code 3 when token is missing", () => {
+    process.env["MIOT_BASE_URL"] = "https://example.com";
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    resolveConfig({});
+    expect(mockExit).toHaveBeenCalledWith(3);
+  });
+
+  it("should handle missing dotfile gracefully", () => {
+    process.env["MIOT_BASE_URL"] = "https://example.com";
+    process.env["MIOT_TOKEN"] = "token";
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const config = resolveConfig({});
+    expect(config).toEqual({
+      baseUrl: "https://example.com",
+      token: "token",
+    });
+  });
+
+  it("should prioritize flags over env and dotfile", () => {
+    process.env["MIOT_BASE_URL"] = "https://env.example.com";
+    process.env["MIOT_TOKEN"] = "env-token";
+
+    const config = resolveConfig({
+      baseUrl: "https://flag.example.com",
+      token: "flag-token",
+    });
+    expect(config).toEqual({
+      baseUrl: "https://flag.example.com",
+      token: "flag-token",
+    });
+  });
+});
+
+describe("resolveOutputMode", () => {
+  it("should return json when explicitly set", () => {
+    expect(resolveOutputMode({ output: "json" })).toBe("json");
+  });
+
+  it("should return table when explicitly set", () => {
+    expect(resolveOutputMode({ output: "table" })).toBe("table");
+  });
+
+  it("should return json when stdout is not a TTY", () => {
+    const original = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+
+    expect(resolveOutputMode({})).toBe("json");
+
+    Object.defineProperty(process.stdout, "isTTY", { value: original, configurable: true });
+  });
+
+  it("should return table when stdout is a TTY", () => {
+    const original = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+
+    expect(resolveOutputMode({})).toBe("table");
+
+    Object.defineProperty(process.stdout, "isTTY", { value: original, configurable: true });
+  });
+});

--- a/packages/miot-cli/src/__tests__/config.test.ts
+++ b/packages/miot-cli/src/__tests__/config.test.ts
@@ -20,16 +20,12 @@ const mockReadFileSync = vi.mocked(fs.readFileSync);
 
 describe("resolveConfig", () => {
   const originalEnv = process.env;
-  let mockExit: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env["MIOT_BASE_URL"];
     delete process.env["MIOT_TOKEN"];
     mockReadFileSync.mockReset();
-    mockExit = vi
-      .spyOn(process, "exit")
-      .mockImplementation(() => undefined as never);
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -111,7 +107,7 @@ describe("resolveConfig", () => {
     });
 
     resolveConfig({});
-    expect(mockExit).toHaveBeenCalledWith(3);
+    expect(process.exit).toHaveBeenCalledWith(3);
   });
 
   it("should exit with code 3 when token is missing", () => {
@@ -121,7 +117,7 @@ describe("resolveConfig", () => {
     });
 
     resolveConfig({});
-    expect(mockExit).toHaveBeenCalledWith(3);
+    expect(process.exit).toHaveBeenCalledWith(3);
   });
 
   it("should handle missing dotfile gracefully", () => {

--- a/packages/miot-cli/src/__tests__/error.test.ts
+++ b/packages/miot-cli/src/__tests__/error.test.ts
@@ -3,12 +3,8 @@ import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
 import { handleError } from "../utils/error.js";
 
 describe("handleError", () => {
-  let mockExit: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
-    mockExit = vi
-      .spyOn(process, "exit")
-      .mockImplementation(() => undefined as never);
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -30,7 +26,7 @@ describe("handleError", () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining('"status": 404'),
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should handle API 5xx error in json mode", () => {
@@ -43,7 +39,7 @@ describe("handleError", () => {
 
     handleError(err, "json");
 
-    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(process.exit).toHaveBeenCalledWith(2);
   });
 
   it("should handle API error in table mode", () => {
@@ -57,7 +53,7 @@ describe("handleError", () => {
     handleError(err, "table");
 
     expect(console.error).toHaveBeenCalledWith("Error (400): Invalid input");
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should handle API error with string body", () => {
@@ -68,7 +64,7 @@ describe("handleError", () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("Bad Gateway"),
     );
-    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(process.exit).toHaveBeenCalledWith(2);
   });
 
   it("should handle generic Error in json mode", () => {
@@ -79,7 +75,7 @@ describe("handleError", () => {
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining("Network failure"),
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should handle generic Error in table mode", () => {
@@ -88,13 +84,13 @@ describe("handleError", () => {
     handleError(err, "table");
 
     expect(console.error).toHaveBeenCalledWith("Error: Network failure");
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should handle non-Error values", () => {
     handleError("string error", "table");
 
     expect(console.error).toHaveBeenCalledWith("Error: string error");
-    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/miot-cli/src/__tests__/error.test.ts
+++ b/packages/miot-cli/src/__tests__/error.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import { handleError } from "../utils/error.js";
+
+describe("handleError", () => {
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockExit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should handle API 4xx error in json mode", () => {
+    const err = new MiotCalendarApiError(404, {
+      error: "Not Found",
+      message: "Calendar not found",
+      status: 404,
+      timestamp: "2025-01-01T00:00:00Z",
+    });
+
+    handleError(err, "json");
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('"status": 404'),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle API 5xx error in json mode", () => {
+    const err = new MiotCalendarApiError(500, {
+      error: "Internal Server Error",
+      message: "Something went wrong",
+      status: 500,
+      timestamp: "2025-01-01T00:00:00Z",
+    });
+
+    handleError(err, "json");
+
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("should handle API error in table mode", () => {
+    const err = new MiotCalendarApiError(400, {
+      error: "Bad Request",
+      message: "Invalid input",
+      status: 400,
+      timestamp: "2025-01-01T00:00:00Z",
+    });
+
+    handleError(err, "table");
+
+    expect(console.error).toHaveBeenCalledWith("Error (400): Invalid input");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle API error with string body", () => {
+    const err = new MiotCalendarApiError(502, "Bad Gateway");
+
+    handleError(err, "json");
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("Bad Gateway"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("should handle generic Error in json mode", () => {
+    const err = new Error("Network failure");
+
+    handleError(err, "json");
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("Network failure"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle generic Error in table mode", () => {
+    const err = new Error("Network failure");
+
+    handleError(err, "table");
+
+    expect(console.error).toHaveBeenCalledWith("Error: Network failure");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle non-Error values", () => {
+    handleError("string error", "table");
+
+    expect(console.error).toHaveBeenCalledWith("Error: string error");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/miot-cli/src/__tests__/output.test.ts
+++ b/packages/miot-cli/src/__tests__/output.test.ts
@@ -59,7 +59,7 @@ describe("printTable", () => {
       { header: "DATE", key: "slot.date" },
     ];
 
-    printTable(rows as unknown as Record<string, unknown>[], columns);
+    printTable(rows, columns);
 
     const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
     expect(calls[2]).toContain("r1");

--- a/packages/miot-cli/src/__tests__/output.test.ts
+++ b/packages/miot-cli/src/__tests__/output.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { printJson, printTable, printDetail, printSuccess } from "../output.js";
+
+describe("printJson", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should print formatted JSON", () => {
+    printJson({ id: "123", name: "test" });
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify({ id: "123", name: "test" }, null, 2),
+    );
+  });
+
+  it("should handle arrays", () => {
+    printJson([1, 2, 3]);
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify([1, 2, 3], null, 2),
+    );
+  });
+
+  it("should handle null", () => {
+    printJson(null);
+    expect(console.log).toHaveBeenCalledWith("null");
+  });
+});
+
+describe("printTable", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should print aligned columns", () => {
+    const rows = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ];
+    const columns = [
+      { header: "ID", key: "id" },
+      { header: "NAME", key: "name" },
+    ];
+
+    printTable(rows, columns);
+
+    const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
+    expect(calls[0]).toBe("ID  NAME ");
+    expect(calls[1]).toBe("--  -----");
+    expect(calls[2]).toBe("1   Alice");
+    expect(calls[3]).toBe("2   Bob  ");
+  });
+
+  it("should handle dot-path columns", () => {
+    const rows = [
+      { resource: { id: "r1" }, slot: { date: "2025-01-01" } },
+    ];
+    const columns = [
+      { header: "RESOURCE", key: "resource.id" },
+      { header: "DATE", key: "slot.date" },
+    ];
+
+    printTable(rows as unknown as Record<string, unknown>[], columns);
+
+    const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
+    expect(calls[2]).toContain("r1");
+    expect(calls[2]).toContain("2025-01-01");
+  });
+
+  it("should print message for empty data", () => {
+    printTable([], [{ header: "ID", key: "id" }]);
+    expect(console.log).toHaveBeenCalledWith("No results found.");
+  });
+});
+
+describe("printDetail", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should print key-value pairs", () => {
+    printDetail({ id: "123", name: "test" });
+
+    const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
+    expect(calls[0]).toContain("id");
+    expect(calls[0]).toContain("123");
+    expect(calls[1]).toContain("name");
+    expect(calls[1]).toContain("test");
+  });
+
+  it("should JSON-stringify nested objects", () => {
+    printDetail({ resource: { id: "r1", type: "vehicle" } });
+
+    const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
+    expect(calls[0]).toContain(JSON.stringify({ id: "r1", type: "vehicle" }));
+  });
+
+  it("should handle empty object", () => {
+    printDetail({});
+    expect(console.log).not.toHaveBeenCalled();
+  });
+});
+
+describe("printSuccess", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should print success message", () => {
+    printSuccess("Done!");
+    expect(console.log).toHaveBeenCalledWith("Done!");
+  });
+});

--- a/packages/miot-cli/src/action-context.ts
+++ b/packages/miot-cli/src/action-context.ts
@@ -7,28 +7,13 @@ export interface ActionContext {
   outputMode: OutputMode;
 }
 
-function collectGlobalOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  const merged: Record<string, unknown> = {};
-  while (current) {
-    const localOpts = current.opts();
-    for (const [key, value] of Object.entries(localOpts)) {
-      if (!(key in merged)) {
-        merged[key] = value;
-      }
-    }
-    current = current.parent;
-  }
-  return merged;
-}
-
 export function getActionContext(cmd: Command): ActionContext {
-  const globals = collectGlobalOpts(cmd) as {
+  const globals = cmd.optsWithGlobals<{
     baseUrl?: string;
     token?: string;
     profile?: string;
     output?: string;
-  };
+  }>();
 
   const config = resolveConfig(globals);
   const client = createClient(config);

--- a/packages/miot-cli/src/action-context.ts
+++ b/packages/miot-cli/src/action-context.ts
@@ -7,13 +7,28 @@ export interface ActionContext {
   outputMode: OutputMode;
 }
 
+function collectGlobalOpts(cmd: Command): Record<string, unknown> {
+  let current: Command | null = cmd;
+  const merged: Record<string, unknown> = {};
+  while (current) {
+    const localOpts = current.opts();
+    for (const [key, value] of Object.entries(localOpts)) {
+      if (!(key in merged)) {
+        merged[key] = value;
+      }
+    }
+    current = current.parent;
+  }
+  return merged;
+}
+
 export function getActionContext(cmd: Command): ActionContext {
-  const globals = cmd.optsWithGlobals<{
+  const globals = collectGlobalOpts(cmd) as {
     baseUrl?: string;
     token?: string;
     profile?: string;
     output?: string;
-  }>();
+  };
 
   const config = resolveConfig(globals);
   const client = createClient(config);

--- a/packages/miot-cli/src/action-context.ts
+++ b/packages/miot-cli/src/action-context.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+import { resolveConfig, resolveOutputMode, type OutputMode } from "./config.js";
+import { createClient, type MiotClient } from "./client-factory.js";
+
+export interface ActionContext {
+  client: MiotClient;
+  outputMode: OutputMode;
+}
+
+export function getActionContext(cmd: Command): ActionContext {
+  const globals = cmd.optsWithGlobals<{
+    baseUrl?: string;
+    token?: string;
+    profile?: string;
+    output?: string;
+  }>();
+
+  const config = resolveConfig(globals);
+  const client = createClient(config);
+  const outputMode = resolveOutputMode(globals);
+
+  return { client, outputMode };
+}

--- a/packages/miot-cli/src/cli.ts
+++ b/packages/miot-cli/src/cli.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { registerCalendarCommand } from "./commands/calendar/index.js";
+
+const program = new Command();
+
+program
+  .name("miot")
+  .description("ModularIoT CLI — manage calendars, bookings, slots, and more")
+  .version("0.1.0")
+  .option("--base-url <url>", "API base URL (or MIOT_BASE_URL env)")
+  .option("--token <token>", "Auth token (or MIOT_TOKEN env)")
+  .option("--profile <name>", "Named profile from ~/.miotrc.json")
+  .option("--output <mode>", "Output mode: json or table");
+
+registerCalendarCommand(program);
+
+program.parse();

--- a/packages/miot-cli/src/client-factory.ts
+++ b/packages/miot-cli/src/client-factory.ts
@@ -1,0 +1,11 @@
+import { createMiotCalendarClient } from "@microboxlabs/miot-calendar-client";
+import type { ResolvedConfig } from "./config.js";
+
+export type MiotClient = ReturnType<typeof createMiotCalendarClient>;
+
+export function createClient(config: ResolvedConfig): MiotClient {
+  return createMiotCalendarClient({
+    baseUrl: config.baseUrl,
+    headers: { Authorization: `Bearer ${config.token}` },
+  });
+}

--- a/packages/miot-cli/src/commands/calendar/bookings.ts
+++ b/packages/miot-cli/src/commands/calendar/bookings.ts
@@ -1,0 +1,157 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable, printDetail, printSuccess } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerBookingsCommand(parent: Command): void {
+  const bookings = parent
+    .command("bookings")
+    .description("Manage calendar bookings");
+
+  bookings
+    .command("list")
+    .description("List bookings")
+    .option("--calendar <id>", "Calendar ID")
+    .option("--from <date>", "Start date (YYYY-MM-DD)")
+    .option("--to <date>", "End date (YYYY-MM-DD)")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar?: string;
+          from?: string;
+          to?: string;
+        };
+
+        const result = await client.bookings.list({
+          calendarId: opts.calendar,
+          startDate: opts.from,
+          endDate: opts.to,
+        });
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result.data as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "CALENDAR", key: "calendarId" },
+            { header: "RESOURCE", key: "resource.id" },
+            { header: "DATE", key: "slot.date" },
+            { header: "HOUR", key: "slot.hour" },
+            { header: "MIN", key: "slot.minutes" },
+            { header: "CREATED", key: "createdAt" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  bookings
+    .command("get <id>")
+    .description("Get a booking by ID")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const booking = await client.bookings.get(id);
+
+        if (outputMode === "json") {
+          printJson(booking);
+        } else {
+          printDetail(booking as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  bookings
+    .command("create")
+    .description("Create a booking")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .requiredOption("--resource-id <id>", "Resource ID")
+    .option("--resource-type <type>", "Resource type")
+    .option("--resource-label <label>", "Resource label")
+    .requiredOption("--date <date>", "Slot date (YYYY-MM-DD)")
+    .requiredOption("--hour <hour>", "Slot hour")
+    .requiredOption("--minutes <minutes>", "Slot minutes")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar: string;
+          resourceId: string;
+          resourceType?: string;
+          resourceLabel?: string;
+          date: string;
+          hour: string;
+          minutes: string;
+        };
+
+        const booking = await client.bookings.create({
+          calendarId: opts.calendar,
+          resource: {
+            id: opts.resourceId,
+            type: opts.resourceType,
+            label: opts.resourceLabel,
+          },
+          slot: {
+            date: opts.date,
+            hour: parseInt(opts.hour, 10),
+            minutes: parseInt(opts.minutes, 10),
+          },
+        });
+
+        if (outputMode === "json") {
+          printJson(booking);
+        } else {
+          printDetail(booking as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  bookings
+    .command("cancel <id>")
+    .description("Cancel a booking")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        await client.bookings.cancel(id);
+
+        if (outputMode === "json") {
+          printJson({ success: true });
+        } else {
+          printSuccess(`Booking ${id} cancelled.`);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  bookings
+    .command("by-resource <resourceId>")
+    .description("List bookings by resource ID")
+    .action(async (resourceId: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const result = await client.bookings.listByResource(resourceId);
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result.data as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "CALENDAR", key: "calendarId" },
+            { header: "DATE", key: "slot.date" },
+            { header: "HOUR", key: "slot.hour" },
+            { header: "MIN", key: "slot.minutes" },
+            { header: "CREATED", key: "createdAt" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/bookings.ts
+++ b/packages/miot-cli/src/commands/calendar/bookings.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { getActionContext } from "../../action-context.js";
 import { printJson, printTable, printDetail, printSuccess } from "../../output.js";
 import { handleError } from "../../utils/error.js";
+import { parseIntOrThrow } from "../../utils/parse.js";
 
 export function registerBookingsCommand(parent: Command): void {
   const bookings = parent
@@ -32,7 +33,7 @@ export function registerBookingsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result.data as unknown as Record<string, unknown>[], [
+          printTable(result.data, [
             { header: "ID", key: "id" },
             { header: "CALENDAR", key: "calendarId" },
             { header: "RESOURCE", key: "resource.id" },
@@ -58,7 +59,7 @@ export function registerBookingsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(booking);
         } else {
-          printDetail(booking as unknown as Record<string, unknown>);
+          printDetail(booking);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -73,8 +74,8 @@ export function registerBookingsCommand(parent: Command): void {
     .option("--resource-type <type>", "Resource type")
     .option("--resource-label <label>", "Resource label")
     .requiredOption("--date <date>", "Slot date (YYYY-MM-DD)")
-    .requiredOption("--hour <hour>", "Slot hour")
-    .requiredOption("--minutes <minutes>", "Slot minutes")
+    .requiredOption("--hour <hour>", "Slot hour (0-23)")
+    .requiredOption("--minutes <minutes>", "Slot minutes (0-59)")
     .action(async (_opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -88,6 +89,16 @@ export function registerBookingsCommand(parent: Command): void {
           minutes: string;
         };
 
+        const hour = parseIntOrThrow(opts.hour, "--hour");
+        const minutes = parseIntOrThrow(opts.minutes, "--minutes");
+
+        if (hour < 0 || hour > 23) {
+          throw new Error(`Invalid --hour: ${hour}. Must be 0-23.`);
+        }
+        if (minutes < 0 || minutes > 59) {
+          throw new Error(`Invalid --minutes: ${minutes}. Must be 0-59.`);
+        }
+
         const booking = await client.bookings.create({
           calendarId: opts.calendar,
           resource: {
@@ -97,15 +108,15 @@ export function registerBookingsCommand(parent: Command): void {
           },
           slot: {
             date: opts.date,
-            hour: parseInt(opts.hour, 10),
-            minutes: parseInt(opts.minutes, 10),
+            hour,
+            minutes,
           },
         });
 
         if (outputMode === "json") {
           printJson(booking);
         } else {
-          printDetail(booking as unknown as Record<string, unknown>);
+          printDetail(booking);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -141,7 +152,7 @@ export function registerBookingsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result.data as unknown as Record<string, unknown>[], [
+          printTable(result.data, [
             { header: "ID", key: "id" },
             { header: "CALENDAR", key: "calendarId" },
             { header: "DATE", key: "slot.date" },

--- a/packages/miot-cli/src/commands/calendar/create.ts
+++ b/packages/miot-cli/src/commands/calendar/create.ts
@@ -1,0 +1,96 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printDetail, printSuccess } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerCreateCommand(parent: Command): void {
+  parent
+    .command("create")
+    .description("Create a new calendar")
+    .requiredOption("--code <code>", "Calendar code")
+    .requiredOption("--name <name>", "Calendar name")
+    .option("--timezone <tz>", "Timezone")
+    .option("--description <desc>", "Description")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          code: string;
+          name: string;
+          timezone?: string;
+          description?: string;
+        };
+
+        const calendar = await client.calendars.create({
+          code: opts.code,
+          name: opts.name,
+          timezone: opts.timezone,
+          description: opts.description,
+        });
+
+        if (outputMode === "json") {
+          printJson(calendar);
+        } else {
+          printDetail(calendar as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}
+
+export function registerUpdateCommand(parent: Command): void {
+  parent
+    .command("update <id>")
+    .description("Update a calendar")
+    .option("--code <code>", "Calendar code")
+    .option("--name <name>", "Calendar name")
+    .option("--timezone <tz>", "Timezone")
+    .option("--description <desc>", "Description")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          code?: string;
+          name?: string;
+          timezone?: string;
+          description?: string;
+        };
+
+        const calendar = await client.calendars.update(id, {
+          code: opts.code!,
+          name: opts.name!,
+          timezone: opts.timezone,
+          description: opts.description,
+        });
+
+        if (outputMode === "json") {
+          printJson(calendar);
+        } else {
+          printDetail(calendar as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}
+
+export function registerDeactivateCommand(parent: Command): void {
+  parent
+    .command("deactivate <id>")
+    .description("Deactivate a calendar")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        await client.calendars.deactivate(id);
+
+        if (outputMode === "json") {
+          printJson({ success: true });
+        } else {
+          printSuccess(`Calendar ${id} deactivated.`);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/create.ts
+++ b/packages/miot-cli/src/commands/calendar/create.ts
@@ -31,7 +31,7 @@ export function registerCreateCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(calendar);
         } else {
-          printDetail(calendar as unknown as Record<string, unknown>);
+          printDetail(calendar);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -57,17 +57,21 @@ export function registerUpdateCommand(parent: Command): void {
           description?: string;
         };
 
-        const calendar = await client.calendars.update(id, {
-          code: opts.code!,
-          name: opts.name!,
-          timezone: opts.timezone,
-          description: opts.description,
-        });
+        const body = {
+          ...(opts.code !== undefined && { code: opts.code }),
+          ...(opts.name !== undefined && { name: opts.name }),
+          ...(opts.timezone !== undefined && { timezone: opts.timezone }),
+          ...(opts.description !== undefined && {
+            description: opts.description,
+          }),
+        };
+
+        const calendar = await client.calendars.update(id, body as Parameters<typeof client.calendars.update>[1]);
 
         if (outputMode === "json") {
           printJson(calendar);
         } else {
-          printDetail(calendar as unknown as Record<string, unknown>);
+          printDetail(calendar);
         }
       } catch (err) {
         handleError(err, outputMode);

--- a/packages/miot-cli/src/commands/calendar/get.ts
+++ b/packages/miot-cli/src/commands/calendar/get.ts
@@ -15,7 +15,7 @@ export function registerGetCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(calendar);
         } else {
-          printDetail(calendar as unknown as Record<string, unknown>);
+          printDetail(calendar);
         }
       } catch (err) {
         handleError(err, outputMode);

--- a/packages/miot-cli/src/commands/calendar/get.ts
+++ b/packages/miot-cli/src/commands/calendar/get.ts
@@ -1,0 +1,24 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printDetail } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerGetCommand(parent: Command): void {
+  parent
+    .command("get <id>")
+    .description("Get a calendar by ID")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const calendar = await client.calendars.get(id);
+
+        if (outputMode === "json") {
+          printJson(calendar);
+        } else {
+          printDetail(calendar as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/groups.ts
+++ b/packages/miot-cli/src/commands/calendar/groups.ts
@@ -24,7 +24,7 @@ export function registerGroupsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result as unknown as Record<string, unknown>[], [
+          printTable(result, [
             { header: "ID", key: "id" },
             { header: "CODE", key: "code" },
             { header: "NAME", key: "name" },
@@ -47,7 +47,7 @@ export function registerGroupsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(group);
         } else {
-          printDetail(group as unknown as Record<string, unknown>);
+          printDetail(group);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -78,7 +78,7 @@ export function registerGroupsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(group);
         } else {
-          printDetail(group as unknown as Record<string, unknown>);
+          printDetail(group);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -100,16 +100,20 @@ export function registerGroupsCommand(parent: Command): void {
           description?: string;
         };
 
-        const group = await client.groups.update(id, {
-          code: opts.code!,
-          name: opts.name!,
-          description: opts.description,
-        });
+        const body = {
+          ...(opts.code !== undefined && { code: opts.code }),
+          ...(opts.name !== undefined && { name: opts.name }),
+          ...(opts.description !== undefined && {
+            description: opts.description,
+          }),
+        };
+
+        const group = await client.groups.update(id, body as Parameters<typeof client.groups.update>[1]);
 
         if (outputMode === "json") {
           printJson(group);
         } else {
-          printDetail(group as unknown as Record<string, unknown>);
+          printDetail(group);
         }
       } catch (err) {
         handleError(err, outputMode);

--- a/packages/miot-cli/src/commands/calendar/groups.ts
+++ b/packages/miot-cli/src/commands/calendar/groups.ts
@@ -1,0 +1,136 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable, printDetail, printSuccess } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerGroupsCommand(parent: Command): void {
+  const groups = parent
+    .command("groups")
+    .description("Manage calendar groups");
+
+  groups
+    .command("list")
+    .description("List calendar groups")
+    .option("--active", "Show only active groups")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as { active?: boolean };
+
+        const result = await client.groups.list({
+          active: opts.active,
+        });
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "CODE", key: "code" },
+            { header: "NAME", key: "name" },
+            { header: "ACTIVE", key: "active" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  groups
+    .command("get <id>")
+    .description("Get a group by ID")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const group = await client.groups.get(id);
+
+        if (outputMode === "json") {
+          printJson(group);
+        } else {
+          printDetail(group as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  groups
+    .command("create")
+    .description("Create a calendar group")
+    .requiredOption("--code <code>", "Group code")
+    .requiredOption("--name <name>", "Group name")
+    .option("--description <desc>", "Description")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          code: string;
+          name: string;
+          description?: string;
+        };
+
+        const group = await client.groups.create({
+          code: opts.code,
+          name: opts.name,
+          description: opts.description,
+        });
+
+        if (outputMode === "json") {
+          printJson(group);
+        } else {
+          printDetail(group as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  groups
+    .command("update <id>")
+    .description("Update a calendar group")
+    .option("--code <code>", "Group code")
+    .option("--name <name>", "Group name")
+    .option("--description <desc>", "Description")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          code?: string;
+          name?: string;
+          description?: string;
+        };
+
+        const group = await client.groups.update(id, {
+          code: opts.code!,
+          name: opts.name!,
+          description: opts.description,
+        });
+
+        if (outputMode === "json") {
+          printJson(group);
+        } else {
+          printDetail(group as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  groups
+    .command("deactivate <id>")
+    .description("Deactivate a calendar group")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        await client.groups.deactivate(id);
+
+        if (outputMode === "json") {
+          printJson({ success: true });
+        } else {
+          printSuccess(`Group ${id} deactivated.`);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/index.ts
+++ b/packages/miot-cli/src/commands/calendar/index.ts
@@ -1,0 +1,30 @@
+import type { Command } from "commander";
+import { registerListCommand } from "./list.js";
+import { registerGetCommand } from "./get.js";
+import {
+  registerCreateCommand,
+  registerUpdateCommand,
+  registerDeactivateCommand,
+} from "./create.js";
+import { registerSlotsCommand } from "./slots.js";
+import { registerBookingsCommand } from "./bookings.js";
+import { registerGroupsCommand } from "./groups.js";
+import { registerTimeWindowsCommand } from "./time-windows.js";
+import { registerSlotManagersCommand } from "./slot-managers.js";
+
+export function registerCalendarCommand(program: Command): void {
+  const calendar = program
+    .command("calendar")
+    .description("Manage calendars");
+
+  registerListCommand(calendar);
+  registerGetCommand(calendar);
+  registerCreateCommand(calendar);
+  registerUpdateCommand(calendar);
+  registerDeactivateCommand(calendar);
+  registerSlotsCommand(calendar);
+  registerBookingsCommand(calendar);
+  registerGroupsCommand(calendar);
+  registerTimeWindowsCommand(calendar);
+  registerSlotManagersCommand(calendar);
+}

--- a/packages/miot-cli/src/commands/calendar/list.ts
+++ b/packages/miot-cli/src/commands/calendar/list.ts
@@ -1,0 +1,44 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("List calendars")
+    .option("--group <code>", "Filter by group code")
+    .option("--active", "Show only active calendars")
+    .option("--inactive", "Show only inactive calendars")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          group?: string;
+          active?: boolean;
+          inactive?: boolean;
+        };
+
+        const active = opts.active ? true : opts.inactive ? false : undefined;
+
+        const calendars = await client.calendars.list({
+          active,
+          groupCode: opts.group,
+        });
+
+        if (outputMode === "json") {
+          printJson(calendars);
+        } else {
+          printTable(calendars as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "CODE", key: "code" },
+            { header: "NAME", key: "name" },
+            { header: "TIMEZONE", key: "timezone" },
+            { header: "ACTIVE", key: "active" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/list.ts
+++ b/packages/miot-cli/src/commands/calendar/list.ts
@@ -29,7 +29,7 @@ export function registerListCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(calendars);
         } else {
-          printTable(calendars as unknown as Record<string, unknown>[], [
+          printTable(calendars, [
             { header: "ID", key: "id" },
             { header: "CODE", key: "code" },
             { header: "NAME", key: "name" },

--- a/packages/miot-cli/src/commands/calendar/slot-managers.ts
+++ b/packages/miot-cli/src/commands/calendar/slot-managers.ts
@@ -1,0 +1,208 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable, printDetail, printSuccess } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerSlotManagersCommand(parent: Command): void {
+  const sm = parent
+    .command("slot-managers")
+    .description("Manage slot managers");
+
+  sm.command("list")
+    .description("List slot managers")
+    .option("--active", "Show only active managers")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as { active?: boolean };
+
+        const result = await client.slotManagers.list({
+          active: opts.active,
+        });
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "CALENDAR", key: "calendarCode" },
+            { header: "ACTIVE", key: "active" },
+            { header: "DAYS AHEAD", key: "daysInAdvance" },
+            { header: "BATCH", key: "batchDays" },
+            { header: "LAST RUN", key: "lastRunAt" },
+            { header: "STATUS", key: "lastRunStatus" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("get <id>")
+    .description("Get a slot manager by ID")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const manager = await client.slotManagers.get(id);
+
+        if (outputMode === "json") {
+          printJson(manager);
+        } else {
+          printDetail(manager as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("create")
+    .description("Create a slot manager")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .option("--days-in-advance <n>", "Days in advance")
+    .option("--batch-days <n>", "Batch days")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar: string;
+          daysInAdvance?: string;
+          batchDays?: string;
+        };
+
+        const manager = await client.slotManagers.create({
+          calendarId: opts.calendar,
+          daysInAdvance: opts.daysInAdvance
+            ? parseInt(opts.daysInAdvance, 10)
+            : undefined,
+          batchDays: opts.batchDays
+            ? parseInt(opts.batchDays, 10)
+            : undefined,
+        });
+
+        if (outputMode === "json") {
+          printJson(manager);
+        } else {
+          printDetail(manager as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("update <id>")
+    .description("Update a slot manager")
+    .option("--days-in-advance <n>", "Days in advance")
+    .option("--batch-days <n>", "Batch days")
+    .option("--active", "Set active")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          daysInAdvance?: string;
+          batchDays?: string;
+          active?: boolean;
+        };
+
+        const manager = await client.slotManagers.update(id, {
+          calendarId: "", // required by SDK, server ignores on update
+          daysInAdvance: opts.daysInAdvance
+            ? parseInt(opts.daysInAdvance, 10)
+            : undefined,
+          batchDays: opts.batchDays
+            ? parseInt(opts.batchDays, 10)
+            : undefined,
+          active: opts.active,
+        });
+
+        if (outputMode === "json") {
+          printJson(manager);
+        } else {
+          printDetail(manager as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("deactivate <id>")
+    .description("Deactivate a slot manager")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        await client.slotManagers.deactivate(id);
+
+        if (outputMode === "json") {
+          printJson({ success: true });
+        } else {
+          printSuccess(`Slot manager ${id} deactivated.`);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("run [id]")
+    .description("Run slot manager(s). If no ID, runs all.")
+    .action(async (id: string | undefined, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        if (id) {
+          const result = await client.slotManagers.run(id);
+          if (outputMode === "json") {
+            printJson(result);
+          } else {
+            printDetail(result as unknown as Record<string, unknown>);
+          }
+        } else {
+          const results = await client.slotManagers.runAll();
+          if (outputMode === "json") {
+            printJson(results);
+          } else {
+            printTable(results as unknown as Record<string, unknown>[], [
+              { header: "ID", key: "id" },
+              { header: "MANAGER", key: "managerId" },
+              { header: "STATUS", key: "status" },
+              { header: "CREATED", key: "slotsCreated" },
+              { header: "SKIPPED", key: "slotsSkipped" },
+            ]);
+          }
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  sm.command("runs [managerId]")
+    .description("List slot manager runs. If no ID, lists all.")
+    .option("--limit <n>", "Limit results")
+    .action(async (managerId: string | undefined, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as { limit?: string };
+        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+
+        let results;
+        if (managerId) {
+          results = await client.slotManagers.listRuns(managerId, { limit });
+        } else {
+          results = await client.slotManagers.listAllRuns({ limit });
+        }
+
+        if (outputMode === "json") {
+          printJson(results);
+        } else {
+          printTable(results as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "MANAGER", key: "managerId" },
+            { header: "STATUS", key: "status" },
+            { header: "STARTED", key: "startedAt" },
+            { header: "FINISHED", key: "finishedAt" },
+            { header: "CREATED", key: "slotsCreated" },
+            { header: "SKIPPED", key: "slotsSkipped" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/slot-managers.ts
+++ b/packages/miot-cli/src/commands/calendar/slot-managers.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { getActionContext } from "../../action-context.js";
 import { printJson, printTable, printDetail, printSuccess } from "../../output.js";
 import { handleError } from "../../utils/error.js";
+import { parseOptionalInt } from "../../utils/parse.js";
 
 export function registerSlotManagersCommand(parent: Command): void {
   const sm = parent
@@ -23,7 +24,7 @@ export function registerSlotManagersCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result as unknown as Record<string, unknown>[], [
+          printTable(result, [
             { header: "ID", key: "id" },
             { header: "CALENDAR", key: "calendarCode" },
             { header: "ACTIVE", key: "active" },
@@ -48,7 +49,7 @@ export function registerSlotManagersCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(manager);
         } else {
-          printDetail(manager as unknown as Record<string, unknown>);
+          printDetail(manager);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -71,18 +72,14 @@ export function registerSlotManagersCommand(parent: Command): void {
 
         const manager = await client.slotManagers.create({
           calendarId: opts.calendar,
-          daysInAdvance: opts.daysInAdvance
-            ? parseInt(opts.daysInAdvance, 10)
-            : undefined,
-          batchDays: opts.batchDays
-            ? parseInt(opts.batchDays, 10)
-            : undefined,
+          daysInAdvance: parseOptionalInt(opts.daysInAdvance, "--days-in-advance"),
+          batchDays: parseOptionalInt(opts.batchDays, "--batch-days"),
         });
 
         if (outputMode === "json") {
           printJson(manager);
         } else {
-          printDetail(manager as unknown as Record<string, unknown>);
+          printDetail(manager);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -93,7 +90,8 @@ export function registerSlotManagersCommand(parent: Command): void {
     .description("Update a slot manager")
     .option("--days-in-advance <n>", "Days in advance")
     .option("--batch-days <n>", "Batch days")
-    .option("--active", "Set active")
+    .option("--active", "Activate the manager")
+    .option("--no-active", "Deactivate the manager")
     .action(async (id: string, _opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -105,19 +103,15 @@ export function registerSlotManagersCommand(parent: Command): void {
 
         const manager = await client.slotManagers.update(id, {
           calendarId: "", // required by SDK, server ignores on update
-          daysInAdvance: opts.daysInAdvance
-            ? parseInt(opts.daysInAdvance, 10)
-            : undefined,
-          batchDays: opts.batchDays
-            ? parseInt(opts.batchDays, 10)
-            : undefined,
+          daysInAdvance: parseOptionalInt(opts.daysInAdvance, "--days-in-advance"),
+          batchDays: parseOptionalInt(opts.batchDays, "--batch-days"),
           active: opts.active,
         });
 
         if (outputMode === "json") {
           printJson(manager);
         } else {
-          printDetail(manager as unknown as Record<string, unknown>);
+          printDetail(manager);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -151,14 +145,14 @@ export function registerSlotManagersCommand(parent: Command): void {
           if (outputMode === "json") {
             printJson(result);
           } else {
-            printDetail(result as unknown as Record<string, unknown>);
+            printDetail(result);
           }
         } else {
           const results = await client.slotManagers.runAll();
           if (outputMode === "json") {
             printJson(results);
           } else {
-            printTable(results as unknown as Record<string, unknown>[], [
+            printTable(results, [
               { header: "ID", key: "id" },
               { header: "MANAGER", key: "managerId" },
               { header: "STATUS", key: "status" },
@@ -179,7 +173,7 @@ export function registerSlotManagersCommand(parent: Command): void {
       const { client, outputMode } = getActionContext(cmd);
       try {
         const opts = cmd.opts() as { limit?: string };
-        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+        const limit = parseOptionalInt(opts.limit, "--limit");
 
         let results;
         if (managerId) {
@@ -191,7 +185,7 @@ export function registerSlotManagersCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(results);
         } else {
-          printTable(results as unknown as Record<string, unknown>[], [
+          printTable(results, [
             { header: "ID", key: "id" },
             { header: "MANAGER", key: "managerId" },
             { header: "STATUS", key: "status" },

--- a/packages/miot-cli/src/commands/calendar/slots.ts
+++ b/packages/miot-cli/src/commands/calendar/slots.ts
@@ -1,0 +1,125 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable, printDetail } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerSlotsCommand(parent: Command): void {
+  const slots = parent
+    .command("slots")
+    .description("Manage calendar slots");
+
+  slots
+    .command("list")
+    .description("List slots for a calendar")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .option("--from <date>", "Start date (YYYY-MM-DD)")
+    .option("--to <date>", "End date (YYYY-MM-DD)")
+    .option("--available", "Show only available slots")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar: string;
+          from?: string;
+          to?: string;
+          available?: boolean;
+        };
+
+        const result = await client.slots.list({
+          calendarId: opts.calendar,
+          startDate: opts.from,
+          endDate: opts.to,
+          available: opts.available,
+        });
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result.data as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "DATE", key: "slotDate" },
+            { header: "HOUR", key: "slotHour" },
+            { header: "MIN", key: "slotMinutes" },
+            { header: "CAPACITY", key: "capacity" },
+            { header: "OCCUPIED", key: "currentOccupancy" },
+            { header: "AVAILABLE", key: "availableCapacity" },
+            { header: "STATUS", key: "status" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  slots
+    .command("get <id>")
+    .description("Get a slot by ID")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const slot = await client.slots.get(id);
+
+        if (outputMode === "json") {
+          printJson(slot);
+        } else {
+          printDetail(slot as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  slots
+    .command("generate")
+    .description("Generate slots for a calendar")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .requiredOption("--from <date>", "Start date (YYYY-MM-DD)")
+    .requiredOption("--to <date>", "End date (YYYY-MM-DD)")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar: string;
+          from: string;
+          to: string;
+        };
+
+        const result = await client.slots.generate({
+          calendarId: opts.calendar,
+          startDate: opts.from,
+          endDate: opts.to,
+        });
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printDetail(result as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  slots
+    .command("update-status <id>")
+    .description("Update slot status")
+    .requiredOption("--status <status>", "New status (OPEN or CLOSED)")
+    .action(async (id: string, _opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as { status: string };
+
+        const slot = await client.slots.updateStatus(id, {
+          status: opts.status as "OPEN" | "CLOSED",
+        });
+
+        if (outputMode === "json") {
+          printJson(slot);
+        } else {
+          printDetail(slot as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/packages/miot-cli/src/commands/calendar/slots.ts
+++ b/packages/miot-cli/src/commands/calendar/slots.ts
@@ -1,7 +1,10 @@
 import type { Command } from "commander";
+import type { SlotStatus } from "@microboxlabs/miot-calendar-client";
 import { getActionContext } from "../../action-context.js";
 import { printJson, printTable, printDetail } from "../../output.js";
 import { handleError } from "../../utils/error.js";
+
+const VALID_SLOT_STATUSES: SlotStatus[] = ["OPEN", "CLOSED"];
 
 export function registerSlotsCommand(parent: Command): void {
   const slots = parent
@@ -35,7 +38,7 @@ export function registerSlotsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result.data as unknown as Record<string, unknown>[], [
+          printTable(result.data, [
             { header: "ID", key: "id" },
             { header: "DATE", key: "slotDate" },
             { header: "HOUR", key: "slotHour" },
@@ -62,7 +65,7 @@ export function registerSlotsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(slot);
         } else {
-          printDetail(slot as unknown as Record<string, unknown>);
+          printDetail(slot);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -93,7 +96,7 @@ export function registerSlotsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printDetail(result as unknown as Record<string, unknown>);
+          printDetail(result);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -109,14 +112,20 @@ export function registerSlotsCommand(parent: Command): void {
       try {
         const opts = cmd.opts() as { status: string };
 
+        if (!VALID_SLOT_STATUSES.includes(opts.status as SlotStatus)) {
+          throw new Error(
+            `Invalid status "${opts.status}". Must be one of: ${VALID_SLOT_STATUSES.join(", ")}`,
+          );
+        }
+
         const slot = await client.slots.updateStatus(id, {
-          status: opts.status as "OPEN" | "CLOSED",
+          status: opts.status as SlotStatus,
         });
 
         if (outputMode === "json") {
           printJson(slot);
         } else {
-          printDetail(slot as unknown as Record<string, unknown>);
+          printDetail(slot);
         }
       } catch (err) {
         handleError(err, outputMode);

--- a/packages/miot-cli/src/commands/calendar/time-windows.ts
+++ b/packages/miot-cli/src/commands/calendar/time-windows.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { getActionContext } from "../../action-context.js";
 import { printJson, printTable, printDetail } from "../../output.js";
 import { handleError } from "../../utils/error.js";
+import { parseIntOrThrow, parseOptionalInt } from "../../utils/parse.js";
 
 export function registerTimeWindowsCommand(parent: Command): void {
   const tw = parent
@@ -21,7 +22,7 @@ export function registerTimeWindowsCommand(parent: Command): void {
         if (outputMode === "json") {
           printJson(result);
         } else {
-          printTable(result as unknown as Record<string, unknown>[], [
+          printTable(result, [
             { header: "ID", key: "id" },
             { header: "NAME", key: "name" },
             { header: "START", key: "startHour" },
@@ -65,25 +66,21 @@ export function registerTimeWindowsCommand(parent: Command): void {
           daysOfWeek?: string;
         };
 
-        const tw = await client.calendars.createTimeWindow(opts.calendar, {
+        const result = await client.calendars.createTimeWindow(opts.calendar, {
           name: opts.name,
-          startHour: parseInt(opts.startHour, 10),
-          endHour: parseInt(opts.endHour, 10),
+          startHour: parseIntOrThrow(opts.startHour, "--start-hour"),
+          endHour: parseIntOrThrow(opts.endHour, "--end-hour"),
           validFrom: opts.validFrom,
           validTo: opts.validTo,
-          slotDurationMinutes: opts.slotDuration
-            ? parseInt(opts.slotDuration, 10)
-            : undefined,
-          capacityPerSlot: opts.capacity
-            ? parseInt(opts.capacity, 10)
-            : undefined,
+          slotDurationMinutes: parseOptionalInt(opts.slotDuration, "--slot-duration"),
+          capacityPerSlot: parseOptionalInt(opts.capacity, "--capacity"),
           daysOfWeek: opts.daysOfWeek,
         });
 
         if (outputMode === "json") {
-          printJson(tw);
+          printJson(result);
         } else {
-          printDetail(tw as unknown as Record<string, unknown>);
+          printDetail(result);
         }
       } catch (err) {
         handleError(err, outputMode);
@@ -115,29 +112,25 @@ export function registerTimeWindowsCommand(parent: Command): void {
             daysOfWeek?: string;
           };
 
-          const tw = await client.calendars.updateTimeWindow(
+          const result = await client.calendars.updateTimeWindow(
             calendarId,
             timeWindowId,
             {
               name: opts.name,
-              startHour: parseInt(opts.startHour, 10),
-              endHour: parseInt(opts.endHour, 10),
+              startHour: parseIntOrThrow(opts.startHour, "--start-hour"),
+              endHour: parseIntOrThrow(opts.endHour, "--end-hour"),
               validFrom: opts.validFrom,
               validTo: opts.validTo,
-              slotDurationMinutes: opts.slotDuration
-                ? parseInt(opts.slotDuration, 10)
-                : undefined,
-              capacityPerSlot: opts.capacity
-                ? parseInt(opts.capacity, 10)
-                : undefined,
+              slotDurationMinutes: parseOptionalInt(opts.slotDuration, "--slot-duration"),
+              capacityPerSlot: parseOptionalInt(opts.capacity, "--capacity"),
               daysOfWeek: opts.daysOfWeek,
             },
           );
 
           if (outputMode === "json") {
-            printJson(tw);
+            printJson(result);
           } else {
-            printDetail(tw as unknown as Record<string, unknown>);
+            printDetail(result);
           }
         } catch (err) {
           handleError(err, outputMode);

--- a/packages/miot-cli/src/commands/calendar/time-windows.ts
+++ b/packages/miot-cli/src/commands/calendar/time-windows.ts
@@ -1,0 +1,147 @@
+import type { Command } from "commander";
+import { getActionContext } from "../../action-context.js";
+import { printJson, printTable, printDetail } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+export function registerTimeWindowsCommand(parent: Command): void {
+  const tw = parent
+    .command("time-windows")
+    .description("Manage calendar time windows");
+
+  tw.command("list")
+    .description("List time windows for a calendar")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as { calendar: string };
+
+        const result = await client.calendars.listTimeWindows(opts.calendar);
+
+        if (outputMode === "json") {
+          printJson(result);
+        } else {
+          printTable(result as unknown as Record<string, unknown>[], [
+            { header: "ID", key: "id" },
+            { header: "NAME", key: "name" },
+            { header: "START", key: "startHour" },
+            { header: "END", key: "endHour" },
+            { header: "DURATION", key: "slotDurationMinutes" },
+            { header: "CAPACITY", key: "capacityPerSlot" },
+            { header: "DAYS", key: "daysOfWeek" },
+            { header: "VALID FROM", key: "validFrom" },
+            { header: "VALID TO", key: "validTo" },
+            { header: "ACTIVE", key: "active" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  tw.command("create")
+    .description("Create a time window")
+    .requiredOption("--calendar <id>", "Calendar ID")
+    .requiredOption("--name <name>", "Time window name")
+    .requiredOption("--start-hour <hour>", "Start hour")
+    .requiredOption("--end-hour <hour>", "End hour")
+    .requiredOption("--valid-from <date>", "Valid from date (YYYY-MM-DD)")
+    .option("--valid-to <date>", "Valid to date (YYYY-MM-DD)")
+    .option("--slot-duration <minutes>", "Slot duration in minutes")
+    .option("--capacity <n>", "Capacity per slot")
+    .option("--days-of-week <days>", "Days of week (e.g. 1,2,3,4,5)")
+    .action(async (_opts, cmd) => {
+      const { client, outputMode } = getActionContext(cmd);
+      try {
+        const opts = cmd.opts() as {
+          calendar: string;
+          name: string;
+          startHour: string;
+          endHour: string;
+          validFrom: string;
+          validTo?: string;
+          slotDuration?: string;
+          capacity?: string;
+          daysOfWeek?: string;
+        };
+
+        const tw = await client.calendars.createTimeWindow(opts.calendar, {
+          name: opts.name,
+          startHour: parseInt(opts.startHour, 10),
+          endHour: parseInt(opts.endHour, 10),
+          validFrom: opts.validFrom,
+          validTo: opts.validTo,
+          slotDurationMinutes: opts.slotDuration
+            ? parseInt(opts.slotDuration, 10)
+            : undefined,
+          capacityPerSlot: opts.capacity
+            ? parseInt(opts.capacity, 10)
+            : undefined,
+          daysOfWeek: opts.daysOfWeek,
+        });
+
+        if (outputMode === "json") {
+          printJson(tw);
+        } else {
+          printDetail(tw as unknown as Record<string, unknown>);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+
+  tw.command("update <calendarId> <timeWindowId>")
+    .description("Update a time window")
+    .requiredOption("--name <name>", "Time window name")
+    .requiredOption("--start-hour <hour>", "Start hour")
+    .requiredOption("--end-hour <hour>", "End hour")
+    .requiredOption("--valid-from <date>", "Valid from date (YYYY-MM-DD)")
+    .option("--valid-to <date>", "Valid to date (YYYY-MM-DD)")
+    .option("--slot-duration <minutes>", "Slot duration in minutes")
+    .option("--capacity <n>", "Capacity per slot")
+    .option("--days-of-week <days>", "Days of week (e.g. 1,2,3,4,5)")
+    .action(
+      async (calendarId: string, timeWindowId: string, _opts, cmd) => {
+        const { client, outputMode } = getActionContext(cmd);
+        try {
+          const opts = cmd.opts() as {
+            name: string;
+            startHour: string;
+            endHour: string;
+            validFrom: string;
+            validTo?: string;
+            slotDuration?: string;
+            capacity?: string;
+            daysOfWeek?: string;
+          };
+
+          const tw = await client.calendars.updateTimeWindow(
+            calendarId,
+            timeWindowId,
+            {
+              name: opts.name,
+              startHour: parseInt(opts.startHour, 10),
+              endHour: parseInt(opts.endHour, 10),
+              validFrom: opts.validFrom,
+              validTo: opts.validTo,
+              slotDurationMinutes: opts.slotDuration
+                ? parseInt(opts.slotDuration, 10)
+                : undefined,
+              capacityPerSlot: opts.capacity
+                ? parseInt(opts.capacity, 10)
+                : undefined,
+              daysOfWeek: opts.daysOfWeek,
+            },
+          );
+
+          if (outputMode === "json") {
+            printJson(tw);
+          } else {
+            printDetail(tw as unknown as Record<string, unknown>);
+          }
+        } catch (err) {
+          handleError(err, outputMode);
+        }
+      },
+    );
+}

--- a/packages/miot-cli/src/config.ts
+++ b/packages/miot-cli/src/config.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface ResolvedConfig {
+  baseUrl: string;
+  token: string;
+}
+
+interface DotfileProfile {
+  baseUrl: string;
+  token: string;
+}
+
+interface Dotfile {
+  defaultProfile?: string;
+  profiles: Record<string, DotfileProfile>;
+}
+
+function readDotfile(): Dotfile | undefined {
+  const filePath = path.join(os.homedir(), ".miotrc.json");
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as Dotfile;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveConfig(opts: {
+  baseUrl?: string;
+  token?: string;
+  profile?: string;
+}): ResolvedConfig {
+  let baseUrl = opts.baseUrl ?? process.env["MIOT_BASE_URL"];
+  let token = opts.token ?? process.env["MIOT_TOKEN"];
+
+  if (!baseUrl || !token) {
+    const dotfile = readDotfile();
+    if (dotfile) {
+      const profileName = opts.profile ?? dotfile.defaultProfile;
+      const profile = profileName ? dotfile.profiles[profileName] : undefined;
+      if (profile) {
+        baseUrl ??= profile.baseUrl;
+        token ??= profile.token;
+      }
+    }
+  }
+
+  if (!baseUrl) {
+    console.error(
+      "Error: missing base URL. Use --base-url, MIOT_BASE_URL env, or ~/.miotrc.json",
+    );
+    process.exit(3);
+  }
+
+  if (!token) {
+    console.error(
+      "Error: missing token. Use --token, MIOT_TOKEN env, or ~/.miotrc.json",
+    );
+    process.exit(3);
+  }
+
+  return { baseUrl, token };
+}
+
+export type OutputMode = "json" | "table";
+
+export function resolveOutputMode(opts: { output?: string }): OutputMode {
+  if (opts.output === "json" || opts.output === "table") {
+    return opts.output;
+  }
+  return process.stdout.isTTY ? "table" : "json";
+}

--- a/packages/miot-cli/src/index.ts
+++ b/packages/miot-cli/src/index.ts
@@ -5,3 +5,4 @@ export type { MiotClient } from "./client-factory.js";
 export { printJson, printTable, printDetail, printSuccess } from "./output.js";
 export type { Column } from "./output.js";
 export { handleError } from "./utils/error.js";
+export { parseIntOrThrow, parseOptionalInt } from "./utils/parse.js";

--- a/packages/miot-cli/src/index.ts
+++ b/packages/miot-cli/src/index.ts
@@ -1,0 +1,7 @@
+export { resolveConfig, resolveOutputMode } from "./config.js";
+export type { ResolvedConfig, OutputMode } from "./config.js";
+export { createClient } from "./client-factory.js";
+export type { MiotClient } from "./client-factory.js";
+export { printJson, printTable, printDetail, printSuccess } from "./output.js";
+export type { Column } from "./output.js";
+export { handleError } from "./utils/error.js";

--- a/packages/miot-cli/src/output.ts
+++ b/packages/miot-cli/src/output.ts
@@ -1,0 +1,70 @@
+export function printJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function getNestedValue(obj: Record<string, unknown>, dotPath: string): unknown {
+  let current: unknown = obj;
+  for (const key of dotPath.split(".")) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+export interface Column {
+  header: string;
+  key: string;
+}
+
+export function printTable(
+  rows: Record<string, unknown>[],
+  columns: Column[],
+): void {
+  if (rows.length === 0) {
+    console.log("No results found.");
+    return;
+  }
+
+  const widths = columns.map((col) => {
+    const values = rows.map((row) =>
+      String(getNestedValue(row, col.key) ?? ""),
+    );
+    return Math.max(col.header.length, ...values.map((v) => v.length));
+  });
+
+  const header = columns
+    .map((col, i) => col.header.padEnd(widths[i]!))
+    .join("  ");
+  const separator = widths.map((w) => "-".repeat(w)).join("  ");
+
+  console.log(header);
+  console.log(separator);
+
+  for (const row of rows) {
+    const line = columns
+      .map((col, i) =>
+        String(getNestedValue(row, col.key) ?? "").padEnd(widths[i]!),
+      )
+      .join("  ");
+    console.log(line);
+  }
+}
+
+export function printDetail(obj: Record<string, unknown>): void {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return;
+
+  const maxKeyLen = Math.max(...entries.map(([k]) => k.length));
+
+  for (const [key, value] of entries) {
+    const displayValue =
+      typeof value === "object" && value !== null
+        ? JSON.stringify(value)
+        : String(value ?? "");
+    console.log(`${key.padEnd(maxKeyLen)}  ${displayValue}`);
+  }
+}
+
+export function printSuccess(message: string): void {
+  console.log(message);
+}

--- a/packages/miot-cli/src/output.ts
+++ b/packages/miot-cli/src/output.ts
@@ -2,7 +2,7 @@ export function printJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
 }
 
-function getNestedValue(obj: Record<string, unknown>, dotPath: string): unknown {
+function getNestedValue(obj: object, dotPath: string): unknown {
   let current: unknown = obj;
   for (const key of dotPath.split(".")) {
     if (current === null || current === undefined) return undefined;
@@ -16,10 +16,7 @@ export interface Column {
   key: string;
 }
 
-export function printTable(
-  rows: Record<string, unknown>[],
-  columns: Column[],
-): void {
+export function printTable(rows: object[], columns: Column[]): void {
   if (rows.length === 0) {
     console.log("No results found.");
     return;
@@ -50,17 +47,23 @@ export function printTable(
   }
 }
 
-export function printDetail(obj: Record<string, unknown>): void {
+export function printDetail(obj: object): void {
   const entries = Object.entries(obj);
   if (entries.length === 0) return;
 
   const maxKeyLen = Math.max(...entries.map(([k]) => k.length));
 
   for (const [key, value] of entries) {
-    const displayValue =
-      typeof value === "object" && value !== null
-        ? JSON.stringify(value)
-        : String(value ?? "");
+    let displayValue: string;
+    if (typeof value === "object" && value !== null) {
+      try {
+        displayValue = JSON.stringify(value);
+      } catch {
+        displayValue = "[Circular]";
+      }
+    } else {
+      displayValue = String(value ?? "");
+    }
     console.log(`${key.padEnd(maxKeyLen)}  ${displayValue}`);
   }
 }

--- a/packages/miot-cli/src/utils/error.ts
+++ b/packages/miot-cli/src/utils/error.ts
@@ -4,7 +4,9 @@ import type { OutputMode } from "../config.js";
 export function handleError(err: unknown, outputMode: OutputMode): never {
   if (err instanceof MiotCalendarApiError) {
     const message =
-      typeof err.body === "string" ? err.body : err.body.message;
+      typeof err.body === "string"
+        ? err.body
+        : err.body.message ?? "Unknown error";
 
     if (outputMode === "json") {
       console.log(

--- a/packages/miot-cli/src/utils/error.ts
+++ b/packages/miot-cli/src/utils/error.ts
@@ -1,0 +1,33 @@
+import { MiotCalendarApiError } from "@microboxlabs/miot-calendar-client";
+import type { OutputMode } from "../config.js";
+
+export function handleError(err: unknown, outputMode: OutputMode): never {
+  if (err instanceof MiotCalendarApiError) {
+    const message =
+      typeof err.body === "string" ? err.body : err.body.message;
+
+    if (outputMode === "json") {
+      console.log(
+        JSON.stringify(
+          { error: { status: err.status, message } },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.error(`Error (${err.status}): ${message}`);
+    }
+
+    process.exit(err.status >= 500 ? 2 : 1);
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (outputMode === "json") {
+    console.log(JSON.stringify({ error: { message } }, null, 2));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+
+  process.exit(1);
+}

--- a/packages/miot-cli/src/utils/parse.ts
+++ b/packages/miot-cli/src/utils/parse.ts
@@ -1,0 +1,15 @@
+export function parseIntOrThrow(value: string, fieldName: string): number {
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid number for ${fieldName}: "${value}"`);
+  }
+  return parsed;
+}
+
+export function parseOptionalInt(
+  value: string | undefined,
+  fieldName: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  return parseIntOrThrow(value, fieldName);
+}

--- a/packages/miot-cli/tsconfig.json
+++ b/packages/miot-cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/miot-cli/tsconfig.json
+++ b/packages/miot-cli/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "@repo/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
-    "module": "Node16",
-    "moduleResolution": "Node16"
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/miot-cli/tsconfig.json
+++ b/packages/miot-cli/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "module": "ESNext",
-    "moduleResolution": "bundler"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/miot-cli/tsup.config.ts
+++ b/packages/miot-cli/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    outDir: "dist",
+    clean: true,
+    banner: { js: "#!/usr/bin/env node" },
+  },
+  {
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    outDir: "dist",
+    dts: true,
+  },
+]);


### PR DESCRIPTION
## Summary

- Implement `@microboxlabs/miot-cli` — a Commander.js CLI wrapping the `@microboxlabs/miot-calendar-client` SDK
- Support table output on TTY (humans) and JSON on pipe (AI agents), with config via flags/env/dotfile
- Cover all calendar subcommands: calendars, slots, bookings, groups, time-windows, slot-managers
- Include input validation (numeric parsing, enum checks, range validation) and structured error handling with exit codes

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run check-types` passes (0 errors)
- [x] `npm run lint` passes (0 errors, 7 warnings in test mocks)
- [x] `npm run test` passes (36/36 tests)
- [x] `miot --help` and `miot calendar --help` display correct command tree
- [x] Manual smoke test: `miot calendar list` against a running API instance

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishable MIOT CLI exposing full calendar domain: bookings, slots, slot managers, groups, time‑windows with create/read/update/deactivate/run/cancel and JSON/table outputs.
* **Configuration**
  * Robust resolution: CLI flags > env > dotfile; TTY-aware output mode and clear exit codes for missing credentials.
* **Documentation**
  * Multi‑phase AI‑first tooling overview, CLI & agent skill design, and roadmap.
* **Tests**
  * Extensive tests for commands, config, output formatting, and error handling.
* **Chores**
  * Build, lint, packaging, publish workflows and CI change-detection added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->