### PR TITLE
feat(skills): add miot-calendar agent skill

### DIFF
--- a/generative_ai/data/plans/miot-ai-first-tooling/02-agent-skill.md
+++ b/generative_ai/data/plans/miot-ai-first-tooling/02-agent-skill.md
@@ -8,24 +8,21 @@ Build an open Agent Skill (agentskills.io specification) that teaches any AI age
 
 ```bash
 # Install on any of 40+ supported platforms
-npx skills add microboxlabs/miot-cli
+npx skills add microboxlabs/modulariot --skill miot-calendar
 
 # Works on: Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, Cline, etc.
 ```
 
 ## Skill Location
 
-The skill lives inside the miot-cli package repository so it ships alongside the CLI:
+Skills live at the monorepo root so they are discoverable via the standard `npx skills add <owner>/<repo>` convention:
 
 ```
-packages/miot-cli/
-├── src/                          # CLI source (Phase 1)
-├── skills/
-│   └── miot-calendar/
-│       ├── SKILL.md              # Core skill definition
-│       └── reference.md          # Full API reference (loaded on demand)
-├── package.json
-└── ...
+skills/
+└── miot-calendar/
+    ├── SKILL.md                  # Core skill definition
+    └── references/
+        └── reference.md          # Full API reference (loaded on demand)
 ```
 
 ## SKILL.md Design
@@ -164,7 +161,7 @@ Agent parses JSON → presents formatted answer to user
 
 ### Step 3: Test with Claude Code
 
-- Install locally: `npx skills add ./packages/miot-cli`
+- Install locally: `npx skills add . --skill miot-calendar`
 - Verify skill triggers on relevant queries
 - Test each workflow recipe end-to-end
 - Verify progressive disclosure works (metadata → instructions → reference)
@@ -176,6 +173,6 @@ Agent parses JSON → presents formatted answer to user
 
 ### Step 5: Publish
 
-- Push to GitHub (skills/ directory in the miot-cli package)
+- Push to GitHub (skills/ directory at monorepo root)
 - Appears on skills.sh automatically
-- Users install: `npx skills add microboxlabs/miot-cli`
+- Users install: `npx skills add microboxlabs/modulariot --skill miot-calendar`

--- a/skills/miot-calendar/SKILL.md
+++ b/skills/miot-calendar/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: miot-calendar
+description: >
+  Query and manage ModularIoT Calendar services via the miot CLI. List calendars,
+  check slot availability, create bookings, manage time windows, and run slot
+  managers. Use when the user asks about schedules, appointments, bookings,
+  availability, calendar configuration, time slots, capacity, or calendar services
+  in their ModularIoT organization.
+---
+
+# ModularIoT Calendar Skill
+
+## Prerequisites
+
+The `miot` CLI must be available. Run commands via:
+- `npx @microboxlabs/miot-cli <command>` (no install needed), or
+- `miot <command>` (if globally installed)
+
+Configuration requires one of:
+1. `--base-url` and `--token` flags on every call
+2. `MIOT_BASE_URL` and `MIOT_TOKEN` environment variables
+3. A `~/.miotrc.json` profile (selected via `--profile <name>`)
+
+Always add `--output json` to CLI calls and parse the JSON result.
+
+## Domain Model
+
+```
+Organization
+ └── Groups          ← organize calendars by category
+      └── Calendars  ← represent a bookable resource (room, vehicle, service)
+           ├── Time Windows  ← define when slots are available (hours, days, capacity)
+           ├── Slots         ← generated from time windows; bookable time units
+           │    └── status: OPEN | CLOSED
+           ├── Bookings      ← consume a slot, linked to a resource (vehicle, room…)
+           └── Slot Managers ← automate slot generation on a rolling basis
+```
+
+Key relationships:
+- Time windows define the **rules**; slots are the **instances** generated from those rules.
+- A slot has `capacity` and `currentOccupancy`; `availableCapacity = capacity - currentOccupancy`.
+- A booking ties a resource to a specific slot. It requires the slot to be OPEN with remaining capacity.
+
+## Common Workflows
+
+### "What's available next week for X?"
+
+1. Find the calendar: `miot calendar list --output json`
+2. List available slots:
+   ```
+   miot calendar slots list --calendar <id> --from <monday> --to <friday> --available --output json
+   ```
+3. Present results grouped by date with times and remaining capacity.
+
+### "Book a slot for resource Y"
+
+1. Find available slots (workflow above).
+2. Present options to the user — let them choose.
+3. Create the booking:
+   ```
+   miot calendar bookings create --calendar <id> --resource-id <rid> --date <date> --hour <h> --minutes <m> --output json
+   ```
+
+### "How full is calendar X this month?"
+
+1. List all slots for the date range:
+   ```
+   miot calendar slots list --calendar <id> --from <start> --to <end> --output json
+   ```
+2. Compute: total slots, occupied (capacity - availableCapacity), available, occupancy %.
+
+### "Generate slots for the next 2 weeks"
+
+```
+miot calendar slots generate --calendar <id> --from <today> --to <today+14> --output json
+```
+
+### "What bookings does resource Z have?"
+
+```
+miot calendar bookings by-resource <resourceId> --output json
+```
+
+### "Run the slot managers"
+
+```
+miot calendar slot-managers run --output json
+```
+
+Run a specific one: `miot calendar slot-managers run <managerId> --output json`
+
+### "Show me the calendar setup"
+
+1. `miot calendar get <id> --output json`
+2. `miot calendar time-windows list --calendar <id> --output json`
+3. Summarize: calendar details + active time windows with their schedules.
+
+## Error Handling
+
+CLI errors return `{ "error": { "statusCode": N, "message": "..." } }`. Common codes:
+
+| Code | Meaning |
+|------|---------|
+| 400  | Invalid parameters (date range > 90 days, invalid hours, etc.) |
+| 404  | Resource not found |
+| 409  | Slot full / no capacity remaining |
+
+Explain the error in plain language to the user.
+
+## Business Rules
+
+- Slot generation is limited to **90-day** ranges.
+- Time window hours: `startHour < endHour`, both 0–23.
+- Days of week: `"1,2,3,4,5"` where 1 = Monday, 7 = Sunday.
+- Slot status: `OPEN` or `CLOSED`.
+- Booking requires an OPEN slot with `availableCapacity > 0`.
+- Hour: 0–23, Minutes: 0–59.
+
+## Full CLI Reference
+
+For the complete list of commands, flags, and JSON output shapes, read [references/reference.md](references/reference.md).

--- a/skills/miot-calendar/references/reference.md
+++ b/skills/miot-calendar/references/reference.md
@@ -1,0 +1,588 @@
+# miot-cli Calendar Module Reference
+
+## Table of Contents
+
+- [Global Options](#global-options)
+- [calendar list](#miot-calendar-list)
+- [calendar get](#miot-calendar-get)
+- [calendar create](#miot-calendar-create)
+- [calendar update](#miot-calendar-update)
+- [calendar deactivate](#miot-calendar-deactivate)
+- [slots list](#miot-calendar-slots-list)
+- [slots get](#miot-calendar-slots-get)
+- [slots generate](#miot-calendar-slots-generate)
+- [slots update-status](#miot-calendar-slots-update-status)
+- [bookings list](#miot-calendar-bookings-list)
+- [bookings get](#miot-calendar-bookings-get)
+- [bookings create](#miot-calendar-bookings-create)
+- [bookings cancel](#miot-calendar-bookings-cancel)
+- [bookings by-resource](#miot-calendar-bookings-by-resource)
+- [groups list](#miot-calendar-groups-list)
+- [groups get](#miot-calendar-groups-get)
+- [groups create](#miot-calendar-groups-create)
+- [groups update](#miot-calendar-groups-update)
+- [groups deactivate](#miot-calendar-groups-deactivate)
+- [time-windows list](#miot-calendar-time-windows-list)
+- [time-windows create](#miot-calendar-time-windows-create)
+- [time-windows update](#miot-calendar-time-windows-update)
+- [slot-managers list](#miot-calendar-slot-managers-list)
+- [slot-managers get](#miot-calendar-slot-managers-get)
+- [slot-managers create](#miot-calendar-slot-managers-create)
+- [slot-managers update](#miot-calendar-slot-managers-update)
+- [slot-managers deactivate](#miot-calendar-slot-managers-deactivate)
+- [slot-managers run](#miot-calendar-slot-managers-run)
+- [slot-managers runs](#miot-calendar-slot-managers-runs)
+
+---
+
+## Global Options
+
+These flags apply to every `miot` command:
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--base-url <url>` | string | API base URL (or `MIOT_BASE_URL` env) |
+| `--token <token>` | string | Auth token (or `MIOT_TOKEN` env) |
+| `--profile <name>` | string | Named profile from `~/.miotrc.json` |
+| `--output <mode>` | `json` \| `table` | Output format (default: `table` in TTY, `json` when piped) |
+
+---
+
+## miot calendar list
+
+List all calendars.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--group <code>` | string | Filter by group code |
+| `--active` | boolean | Show only active calendars |
+| `--inactive` | boolean | Show only inactive calendars |
+
+**JSON output:**
+
+```json
+[
+  {
+    "id": "cal_abc123",
+    "code": "vehicle-inspection",
+    "name": "Vehicle Inspection",
+    "timezone": "America/New_York",
+    "active": true
+  }
+]
+```
+
+---
+
+## miot calendar get
+
+`miot calendar get <id>`
+
+Get a single calendar by ID.
+
+**JSON output:**
+
+```json
+{
+  "id": "cal_abc123",
+  "code": "vehicle-inspection",
+  "name": "Vehicle Inspection",
+  "timezone": "America/New_York",
+  "active": true
+}
+```
+
+---
+
+## miot calendar create
+
+Create a new calendar.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--code <code>` | string | yes | Calendar code |
+| `--name <name>` | string | yes | Calendar name |
+| `--timezone <tz>` | string | no | Timezone |
+| `--description <desc>` | string | no | Description |
+
+**JSON output:** Same shape as `calendar get`.
+
+---
+
+## miot calendar update
+
+`miot calendar update <id>`
+
+Update an existing calendar.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--code <code>` | string | Update calendar code |
+| `--name <name>` | string | Update calendar name |
+| `--timezone <tz>` | string | Update timezone |
+| `--description <desc>` | string | Update description |
+
+**JSON output:** Same shape as `calendar get`.
+
+---
+
+## miot calendar deactivate
+
+`miot calendar deactivate <id>`
+
+Deactivate a calendar.
+
+**JSON output:**
+
+```json
+{ "success": true }
+```
+
+---
+
+## miot calendar slots list
+
+List slots for a calendar.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+| `--from <date>` | string | no | Start date (YYYY-MM-DD) |
+| `--to <date>` | string | no | End date (YYYY-MM-DD) |
+| `--available` | boolean | no | Show only available (OPEN with capacity) slots |
+
+**JSON output:**
+
+```json
+{
+  "data": [
+    {
+      "id": "slot_xyz",
+      "slotDate": "2025-06-15",
+      "slotHour": 9,
+      "slotMinutes": 0,
+      "capacity": 3,
+      "currentOccupancy": 1,
+      "availableCapacity": 2,
+      "status": "OPEN"
+    }
+  ]
+}
+```
+
+---
+
+## miot calendar slots get
+
+`miot calendar slots get <id>`
+
+Get a single slot by ID.
+
+**JSON output:** Same shape as a single slot object from `slots list`.
+
+---
+
+## miot calendar slots generate
+
+Generate slots from time windows.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+| `--from <date>` | string | yes | Start date (YYYY-MM-DD) |
+| `--to <date>` | string | yes | End date (YYYY-MM-DD) |
+
+**Note:** Date range limited to 90 days maximum.
+
+**JSON output:** Generation result object.
+
+---
+
+## miot calendar slots update-status
+
+`miot calendar slots update-status <id>`
+
+Change a slot's status.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--status <status>` | `OPEN` \| `CLOSED` | yes | New status |
+
+**JSON output:** Updated slot object.
+
+---
+
+## miot calendar bookings list
+
+List bookings.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | no | Filter by calendar ID |
+| `--from <date>` | string | no | Start date (YYYY-MM-DD) |
+| `--to <date>` | string | no | End date (YYYY-MM-DD) |
+
+**JSON output:**
+
+```json
+{
+  "data": [
+    {
+      "id": "bk_001",
+      "calendarId": "cal_abc123",
+      "resource": { "id": "vehicle-42" },
+      "slot": { "date": "2025-06-15", "hour": 9, "minutes": 0 },
+      "createdAt": "2025-06-10T14:30:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## miot calendar bookings get
+
+`miot calendar bookings get <id>`
+
+Get a single booking by ID.
+
+**JSON output:** Same shape as a single booking object from `bookings list`.
+
+---
+
+## miot calendar bookings create
+
+Create a new booking.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+| `--resource-id <id>` | string | yes | Resource ID |
+| `--date <date>` | string | yes | Slot date (YYYY-MM-DD) |
+| `--hour <hour>` | integer | yes | Slot hour (0–23) |
+| `--minutes <minutes>` | integer | yes | Slot minutes (0–59) |
+| `--resource-type <type>` | string | no | Resource type |
+| `--resource-label <label>` | string | no | Resource label |
+
+**JSON output:** Created booking object.
+
+---
+
+## miot calendar bookings cancel
+
+`miot calendar bookings cancel <id>`
+
+Cancel a booking.
+
+**JSON output:**
+
+```json
+{ "success": true }
+```
+
+---
+
+## miot calendar bookings by-resource
+
+`miot calendar bookings by-resource <resourceId>`
+
+List all bookings for a specific resource.
+
+**JSON output:**
+
+```json
+{
+  "data": [
+    {
+      "id": "bk_001",
+      "calendarId": "cal_abc123",
+      "slot": { "date": "2025-06-15", "hour": 9, "minutes": 0 },
+      "createdAt": "2025-06-10T14:30:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## miot calendar groups list
+
+List calendar groups.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--active` | boolean | Show only active groups |
+
+**JSON output:**
+
+```json
+[
+  {
+    "id": "grp_001",
+    "code": "inspections",
+    "name": "Inspections",
+    "active": true
+  }
+]
+```
+
+---
+
+## miot calendar groups get
+
+`miot calendar groups get <id>`
+
+Get a single group by ID.
+
+**JSON output:** Same shape as a single group object from `groups list`.
+
+---
+
+## miot calendar groups create
+
+Create a new group.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--code <code>` | string | yes | Group code |
+| `--name <name>` | string | yes | Group name |
+| `--description <desc>` | string | no | Description |
+
+**JSON output:** Created group object.
+
+---
+
+## miot calendar groups update
+
+`miot calendar groups update <id>`
+
+Update a group.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--code <code>` | string | Update group code |
+| `--name <name>` | string | Update group name |
+| `--description <desc>` | string | Update description |
+
+**JSON output:** Updated group object.
+
+---
+
+## miot calendar groups deactivate
+
+`miot calendar groups deactivate <id>`
+
+Deactivate a group.
+
+**JSON output:**
+
+```json
+{ "success": true }
+```
+
+---
+
+## miot calendar time-windows list
+
+List time windows for a calendar.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+
+**JSON output:**
+
+```json
+[
+  {
+    "id": "tw_001",
+    "name": "Morning Shift",
+    "startHour": 8,
+    "endHour": 12,
+    "slotDurationMinutes": 30,
+    "capacityPerSlot": 2,
+    "daysOfWeek": "1,2,3,4,5",
+    "validFrom": "2025-01-01",
+    "validTo": "2025-12-31",
+    "active": true
+  }
+]
+```
+
+---
+
+## miot calendar time-windows create
+
+Create a new time window.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+| `--name <name>` | string | yes | Time window name |
+| `--start-hour <hour>` | integer | yes | Start hour (0–23) |
+| `--end-hour <hour>` | integer | yes | End hour (0–23, must be > start-hour) |
+| `--valid-from <date>` | string | yes | Valid from date (YYYY-MM-DD) |
+| `--valid-to <date>` | string | no | Valid to date (YYYY-MM-DD) |
+| `--slot-duration <minutes>` | integer | no | Slot duration in minutes |
+| `--capacity <n>` | integer | no | Capacity per slot |
+| `--days-of-week <days>` | string | no | Days of week (e.g. `"1,2,3,4,5"`) |
+
+**JSON output:** Created time window object.
+
+---
+
+## miot calendar time-windows update
+
+`miot calendar time-windows update <calendarId> <timeWindowId>`
+
+Update an existing time window.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name <name>` | string | yes | Time window name |
+| `--start-hour <hour>` | integer | yes | Start hour (0–23) |
+| `--end-hour <hour>` | integer | yes | End hour (0–23) |
+| `--valid-from <date>` | string | yes | Valid from date (YYYY-MM-DD) |
+| `--valid-to <date>` | string | no | Valid to date (YYYY-MM-DD) |
+| `--slot-duration <minutes>` | integer | no | Slot duration in minutes |
+| `--capacity <n>` | integer | no | Capacity per slot |
+| `--days-of-week <days>` | string | no | Days of week |
+
+**JSON output:** Updated time window object.
+
+---
+
+## miot calendar slot-managers list
+
+List slot managers.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--active` | boolean | Show only active managers |
+
+**JSON output:**
+
+```json
+[
+  {
+    "id": "sm_001",
+    "calendarCode": "vehicle-inspection",
+    "active": true,
+    "daysInAdvance": 30,
+    "batchDays": 7,
+    "lastRunAt": "2025-06-10T02:00:00Z",
+    "lastRunStatus": "SUCCESS"
+  }
+]
+```
+
+---
+
+## miot calendar slot-managers get
+
+`miot calendar slot-managers get <id>`
+
+Get a single slot manager by ID.
+
+**JSON output:** Same shape as a single slot manager from `slot-managers list`.
+
+---
+
+## miot calendar slot-managers create
+
+Create a new slot manager.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--calendar <id>` | string | yes | Calendar ID |
+| `--days-in-advance <n>` | integer | no | Days in advance to generate |
+| `--batch-days <n>` | integer | no | Batch size in days |
+
+**JSON output:** Created slot manager object.
+
+---
+
+## miot calendar slot-managers update
+
+`miot calendar slot-managers update <id>`
+
+Update a slot manager.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--days-in-advance <n>` | integer | Days in advance |
+| `--batch-days <n>` | integer | Batch size in days |
+| `--active` | boolean | Activate the manager |
+| `--no-active` | boolean | Deactivate the manager |
+
+**JSON output:** Updated slot manager object.
+
+---
+
+## miot calendar slot-managers deactivate
+
+`miot calendar slot-managers deactivate <id>`
+
+Deactivate a slot manager.
+
+**JSON output:**
+
+```json
+{ "success": true }
+```
+
+---
+
+## miot calendar slot-managers run
+
+`miot calendar slot-managers run [id]`
+
+Run slot managers to generate slots.
+
+- Without `<id>`: run **all** active managers.
+- With `<id>`: run a **specific** manager.
+
+**JSON output (single):**
+
+```json
+{
+  "id": "run_001",
+  "managerId": "sm_001",
+  "status": "SUCCESS",
+  "slotsCreated": 42,
+  "slotsSkipped": 3
+}
+```
+
+**JSON output (all):** Array of run result objects.
+
+---
+
+## miot calendar slot-managers runs
+
+`miot calendar slot-managers runs [managerId]`
+
+List historical slot manager runs.
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--limit <n>` | integer | Limit number of results |
+
+- Without `[managerId]`: list runs for **all** managers.
+- With `[managerId]`: list runs for a **specific** manager.
+
+**JSON output:**
+
+```json
+[
+  {
+    "id": "run_001",
+    "managerId": "sm_001",
+    "status": "SUCCESS",
+    "startedAt": "2025-06-10T02:00:00Z",
+    "finishedAt": "2025-06-10T02:00:15Z",
+    "slotsCreated": 42,
+    "slotsSkipped": 3
+  }
+]
+```


### PR DESCRIPTION
## Summary
- Add `miot-calendar` agent skill (agentskills.io spec) at the monorepo root `skills/` directory for standard discoverability
- `SKILL.md` includes domain model, 7 workflow recipes, error handling, and business rules
- `references/reference.md` provides full CLI command reference (all 27 commands with flags and JSON output shapes)
- Update Phase 2 plan to reflect root-level skill location and correct install command

## Install

```bash
npx skills add microboxlabs/modulariot --skill miot-calendar
```

## Test plan
- [x] Install locally: `npx skills add . --skill miot-calendar`
- [x] Verify skill triggers on calendar-related queries
- [x] Test workflow recipes end-to-end against a live ModularIoT instance
- [x] Verify progressive disclosure (metadata → instructions → reference)
- [x] Test cross-platform (Cursor, Windsurf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the ModularIoT Calendar Skill, including configuration methods, workflows, and command examples.
  * Added CLI reference guide detailing calendar operations (listing, creating, updating calendars and slots), booking management, and group administration.
  * Updated installation and usage guidance for the Calendar Skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->