### PR TITLE
fix(calendar): load existing bookings in planning view on mount

### DIFF
--- a/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/apps/app/src/app/api/calendar/bookings/route.ts
@@ -9,6 +9,32 @@ import { logger } from "@/lib/logger";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
+export async function GET(request: Request) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { searchParams } = new URL(request.url);
+  const calendarId = searchParams.get("calendarId") ?? undefined;
+  const startDate = searchParams.get("startDate") ?? undefined;
+  const endDate = searchParams.get("endDate") ?? undefined;
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const bookings = await client.bookings.list({ calendarId, startDate, endDate });
+    return NextResponse.json(bookings);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error }, "Failed to list bookings");
+    return NextResponse.json({ error: "Failed to list bookings" }, { status });
+  }
+}
+
 export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -729,7 +729,7 @@ export function PlanningSelectionProvider({
           incidencias: [],
           observaciones: "",
           prioridad: 0,
-          ...(stored ?? {}),
+          ...stored,
           // Canonical booking fields always win over stored data
           id: booking.resource.id,
           cliente: booking.resource.label ?? booking.resource.id,

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -19,6 +19,7 @@ import {
   deactivateCalendarTimeWindow,
   createBooking,
   cancelBooking,
+  listBookings,
 } from "@/features/common/providers/client-api.provider";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
 import {
@@ -702,6 +703,56 @@ export function PlanningSelectionProvider({
     }
   }, [apiTimeWindows, timeSlotsError]);
 
+  // Load existing bookings from the backend when a calendar is selected
+  useEffect(() => {
+    if (!calendarId) return;
+
+    listBookings({ calendarId }).then((result) => {
+      const loaded: PlannedService[] = [];
+      const ids = new Map<string, string>();
+
+      for (const booking of result.data) {
+        const stored = booking.resource.data as Partial<SelectedService> | undefined;
+        const service: SelectedService = {
+          origen: "",
+          lugarCarguio: "",
+          destino: "",
+          tipoViaje: "Sider",
+          ocupacion: 0,
+          permanencia: "",
+          leadTime: {
+            total_lineasoc_cumplen: 0,
+            total_lineasoc_incumplen: 0,
+            lineasoc_pctn_cumplimiento: 0,
+          },
+          eta: "",
+          incidencias: [],
+          observaciones: "",
+          prioridad: 0,
+          ...(stored ?? {}),
+          // Canonical booking fields always win over stored data
+          id: booking.resource.id,
+          cliente: booking.resource.label ?? booking.resource.id,
+        };
+
+        loaded.push({
+          service,
+          slot: {
+            date: new Date(booking.slot.date),
+            hour: booking.slot.hour,
+            minutes: booking.slot.minutes,
+          },
+        });
+        ids.set(booking.resource.id, booking.id);
+      }
+
+      setPlannedServices(loaded);
+      setBookingIds(ids);
+    }).catch((err) => {
+      console.warn("Failed to load existing bookings:", err);
+    });
+  }, [calendarId]);
+
   // Derived arrays from unified state (memoized for performance)
   const timeWindows = useMemo(
     () => timeSlots.filter(isTimeWindow),
@@ -1067,6 +1118,7 @@ export function PlanningSelectionProvider({
                 id: selectedService.id,
                 type: "service",
                 label: selectedService.cliente,
+                data: selectedService as unknown as Record<string, unknown>,
               },
               slot: {
                 date: dayjs(slotToUse.date).format("YYYY-MM-DD"),

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -703,11 +703,18 @@ export function PlanningSelectionProvider({
     }
   }, [apiTimeWindows, timeSlotsError]);
 
-  // Load existing bookings from the backend when a calendar is selected
+  // Load existing bookings from the backend when a calendar is selected.
+  // An AbortController cancels the in-flight request when calendarId changes
+  // or the component unmounts, preventing stale responses from overwriting state.
   useEffect(() => {
     if (!calendarId) return;
 
-    listBookings({ calendarId }).then((result) => {
+    const controller = new AbortController();
+
+    listBookings({ calendarId }, controller.signal).then((result) => {
+      // Discard the response if the effect was cleaned up before it resolved.
+      if (controller.signal.aborted) return;
+
       const loaded: PlannedService[] = [];
       const ids = new Map<string, string>();
 
@@ -749,8 +756,13 @@ export function PlanningSelectionProvider({
       setPlannedServices(loaded);
       setBookingIds(ids);
     }).catch((err) => {
+      if (controller.signal.aborted) return;
       console.warn("Failed to load existing bookings:", err);
     });
+
+    return () => {
+      controller.abort();
+    };
   }, [calendarId]);
 
   // Derived arrays from unified state (memoized for performance)

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/features/common/providers/client-api.provider";
 import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
+import { ShowNotification } from "@/features/notifications/notification";
 import {
   apiToLocalTimeWindow,
   localToApiTimeWindow,
@@ -627,6 +628,8 @@ interface PlanningSelectionContextType {
   removeService: (serviceId: string) => Promise<void>;
   startReassignment: (plannedService: PlannedService) => void;
   cancelReassignment: () => void;
+  /** Non-null when the initial bookings fetch failed; null while loading or after a successful load */
+  bookingsLoadError: string | null;
 }
 
 const MAX_SERVICES_PER_SLOT = 99;
@@ -711,6 +714,7 @@ export function PlanningSelectionProvider({
   const [bookingIds, setBookingIds] = useState<Map<string, string>>(
     new Map()
   ); // Map of service.id -> booking.id from calendar backend
+  const [bookingsLoadError, setBookingsLoadError] = useState<string | null>(null);
 
   // Load time windows from the miot-calendar-client backend
   const {
@@ -800,9 +804,12 @@ export function PlanningSelectionProvider({
 
       setPlannedServices(loaded);
       setBookingIds(ids);
+      setBookingsLoadError(null);
     }).catch((err) => {
       if (controller.signal.aborted) return;
-      console.warn("Failed to load existing bookings:", err);
+      const message = "No se pudieron cargar las reservas existentes del calendario.";
+      setBookingsLoadError(message);
+      ShowNotification({ type: "error", message });
     });
 
     return () => {
@@ -1336,6 +1343,7 @@ export function PlanningSelectionProvider({
       removeService,
       startReassignment,
       cancelReassignment,
+      bookingsLoadError,
     }),
     [
       selectedSlot,
@@ -1369,6 +1377,7 @@ export function PlanningSelectionProvider({
       removeService,
       startReassignment,
       cancelReassignment,
+      bookingsLoadError,
     ]
   );
 

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -1183,7 +1183,7 @@ export function PlanningSelectionProvider({
                 type: "service",
                 label: selectedService.cliente,
                 data: {
-                  ...(selectedService as unknown as Record<string, unknown>),
+                  ...selectedService,
                   ...(slotToUse.anden !== undefined ? { _anden: slotToUse.anden } : {}),
                 },
               },

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -796,7 +796,7 @@ export function PlanningSelectionProvider({
             date: new Date(booking.slot.date),
             hour: booking.slot.hour,
             minutes: booking.slot.minutes,
-            ...(_anden !== undefined ? { anden: _anden } : {}),
+            ...(_anden === undefined ? {} : { anden: _anden }),
           },
         });
         ids.set(booking.resource.id, booking.id);
@@ -1144,85 +1144,84 @@ export function PlanningSelectionProvider({
       // Use finalSlot if provided, otherwise fall back to selectedSlot
       const slotToUse = finalSlot ?? selectedSlot;
 
-      if (slotToUse && selectedService) {
-        // Check if slot has room (unless re-planning same service)
-        const existingInSlot = getServicesForSlot(slotToUse);
-        const isReplanning = existingInSlot.some(
-          (ps) => ps.service.id === selectedService.id
-        );
+      if (!slotToUse || !selectedService) return false;
 
-        if (!isReplanning && existingInSlot.length >= MAX_SERVICES_PER_SLOT) {
-          // Slot is full, cannot add more
-          return false;
-        }
+      // Check if slot has room (unless re-planning same service)
+      const existingInSlot = getServicesForSlot(slotToUse);
+      const isReplanning = existingInSlot.some(
+        (ps) => ps.service.id === selectedService.id
+      );
 
-        // Check if this is a reassignment completion
-        const wasReassigning = reassigningService !== null;
-
-        // Create the new planned service with the final slot (including time and andén)
-        const newPlannedService: PlannedService = {
-          service: selectedService,
-          slot: slotToUse,
-        };
-
-        // Update local state
-        setPlannedServices((prev) => {
-          const filtered = prev.filter(
-            (p) => p.service.id !== selectedService.id
-          );
-          return [...filtered, newPlannedService];
-        });
-
-        // Create / reassign booking in the calendar backend
-        if (calendarId) {
-          try {
-            const bookingBody: BookingRequest = {
-              calendarId,
-              resource: {
-                id: selectedService.id,
-                type: "service",
-                label: selectedService.cliente,
-                data: {
-                  ...selectedService,
-                  ...(slotToUse.anden !== undefined ? { _anden: slotToUse.anden } : {}),
-                },
-              },
-              slot: {
-                date: dayjs(slotToUse.date).format("YYYY-MM-DD"),
-                hour: slotToUse.hour,
-                minutes: slotToUse.minutes,
-              },
-            };
-
-            // Cancel old booking on reassignment
-            const oldBookingId = bookingIds.get(selectedService.id);
-            if (oldBookingId) {
-              await cancelBooking(oldBookingId).catch((err) =>
-                console.warn("Failed to cancel old booking:", err)
-              );
-            }
-
-            const booking = await createBooking(bookingBody);
-            setBookingIds((prev) => {
-              const next = new Map(prev);
-              next.set(selectedService.id, booking.id);
-              return next;
-            });
-          } catch (err) {
-            console.warn("Failed to create booking:", err);
-          }
-        }
-
-        // Always clear reassigning state after confirmation
-        setReassigningService(null);
-
-        // Clear selection after confirming
-        setSelectedSlot(null);
-        setSelectedService(null);
-
-        return wasReassigning;
+      if (!isReplanning && existingInSlot.length >= MAX_SERVICES_PER_SLOT) {
+        // Slot is full, cannot add more
+        return false;
       }
-      return false;
+
+      // Check if this is a reassignment completion
+      const wasReassigning = reassigningService !== null;
+
+      // Create the new planned service with the final slot (including time and andén)
+      const newPlannedService: PlannedService = {
+        service: selectedService,
+        slot: slotToUse,
+      };
+
+      // Update local state
+      setPlannedServices((prev) => {
+        const filtered = prev.filter(
+          (p) => p.service.id !== selectedService.id
+        );
+        return [...filtered, newPlannedService];
+      });
+
+      // Create / reassign booking in the calendar backend
+      if (calendarId) {
+        try {
+          const bookingBody: BookingRequest = {
+            calendarId,
+            resource: {
+              id: selectedService.id,
+              type: "service",
+              label: selectedService.cliente,
+              data: {
+                ...selectedService,
+                ...(slotToUse.anden === undefined ? {} : { _anden: slotToUse.anden }),
+              },
+            },
+            slot: {
+              date: dayjs(slotToUse.date).format("YYYY-MM-DD"),
+              hour: slotToUse.hour,
+              minutes: slotToUse.minutes,
+            },
+          };
+
+          // Cancel old booking on reassignment
+          const oldBookingId = bookingIds.get(selectedService.id);
+          if (oldBookingId) {
+            await cancelBooking(oldBookingId).catch((err) =>
+              console.warn("Failed to cancel old booking:", err)
+            );
+          }
+
+          const booking = await createBooking(bookingBody);
+          setBookingIds((prev) => {
+            const next = new Map(prev);
+            next.set(selectedService.id, booking.id);
+            return next;
+          });
+        } catch (err) {
+          console.warn("Failed to create booking:", err);
+        }
+      }
+
+      // Always clear reassigning state after confirmation
+      setReassigningService(null);
+
+      // Clear selection after confirming
+      setSelectedSlot(null);
+      setSelectedService(null);
+
+      return wasReassigning;
     },
     [
       selectedSlot,

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -21,6 +21,7 @@ import {
   cancelBooking,
   listBookings,
 } from "@/features/common/providers/client-api.provider";
+import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
 import {
   apiToLocalTimeWindow,
@@ -630,6 +631,41 @@ interface PlanningSelectionContextType {
 
 const MAX_SERVICES_PER_SLOT = 99;
 
+/**
+ * Zod schema for data stored inside booking.resource.data.
+ * All SelectedService fields are optional (defaults are applied on merge).
+ * _anden is stored here because SlotData has no anden field.
+ */
+const StoredServiceSchema = z
+  .object({
+    origen: z.string().optional(),
+    lugarCarguio: z.string().optional(),
+    destino: z.string().optional(),
+    tipoViaje: z.enum(["Sider", "Doble Sider", "Rampla"]).optional(),
+    ocupacion: z.number().optional(),
+    permanencia: z.string().optional(),
+    leadTime: z
+      .object({
+        total_lineasoc_cumplen: z.number(),
+        total_lineasoc_incumplen: z.number(),
+        lineasoc_pctn_cumplimiento: z.number(),
+      })
+      .optional(),
+    eta: z.string().optional(),
+    incidencias: z.array(z.string()).optional(),
+    mintral_incidents: z.array(z.tuple([z.string(), z.string()])).optional(),
+    observaciones: z.string().optional(),
+    prioridad: z.number().optional(),
+    cm_created: z.string().optional(),
+    loadConstraint: z.string().optional(),
+    loadMaxUtilization: z.number().optional(),
+    loadWeightUtilization: z.number().optional(),
+    loadPalletUtilization: z.number().optional(),
+    loadVolumeUtilization: z.number().optional(),
+    _anden: z.number().optional(),
+  })
+  .optional();
+
 const PlanningSelectionContext =
   createContext<PlanningSelectionContextType | null>(null);
 
@@ -719,7 +755,15 @@ export function PlanningSelectionProvider({
       const ids = new Map<string, string>();
 
       for (const booking of result.data) {
-        const stored = booking.resource.data as Partial<SelectedService> | undefined;
+        // Skip entries whose slot is missing — nothing to place on the grid.
+        if (!booking.slot) continue;
+
+        // Validate stored payload; malformed shapes are silently dropped.
+        const storedParse = StoredServiceSchema.safeParse(booking.resource.data);
+        const stored = storedParse.success ? storedParse.data : undefined;
+        // Keep _anden separate so it is not spread into SelectedService.
+        const { _anden, ...storedService } = stored ?? {};
+
         const service: SelectedService = {
           origen: "",
           lugarCarguio: "",
@@ -736,7 +780,7 @@ export function PlanningSelectionProvider({
           incidencias: [],
           observaciones: "",
           prioridad: 0,
-          ...stored,
+          ...storedService,
           // Canonical booking fields always win over stored data
           id: booking.resource.id,
           cliente: booking.resource.label ?? booking.resource.id,
@@ -748,6 +792,7 @@ export function PlanningSelectionProvider({
             date: new Date(booking.slot.date),
             hour: booking.slot.hour,
             minutes: booking.slot.minutes,
+            ...(_anden !== undefined ? { anden: _anden } : {}),
           },
         });
         ids.set(booking.resource.id, booking.id);
@@ -1130,7 +1175,10 @@ export function PlanningSelectionProvider({
                 id: selectedService.id,
                 type: "service",
                 label: selectedService.cliente,
-                data: selectedService as unknown as Record<string, unknown>,
+                data: {
+                  ...(selectedService as unknown as Record<string, unknown>),
+                  ...(slotToUse.anden !== undefined ? { _anden: slotToUse.anden } : {}),
+                },
               },
               slot: {
                 date: dayjs(slotToUse.date).format("YYYY-MM-DD"),

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1592,10 +1592,8 @@ export async function listBookings(params?: {
   if (params?.startDate) searchParams.set("startDate", params.startDate);
   if (params?.endDate) searchParams.set("endDate", params.endDate);
   const query = searchParams.toString();
-  const response = await fetch(
-    `/app/api/calendar/bookings${query ? `?${query}` : ""}`,
-    { method: "GET" }
-  );
+  const url = query ? `/app/api/calendar/bookings?${query}` : "/app/api/calendar/bookings";
+  const response = await fetch(url, { method: "GET" });
   if (!response.ok) {
     const err = await response.json();
     throw new Error(err.error ?? "Failed to list bookings");

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1,4 +1,5 @@
 "use client";
+import { z } from "zod";
 import useSWR from "swr";
 import { useEffect, useMemo } from "react";
 import { usePathname } from "next/navigation";
@@ -1579,6 +1580,29 @@ export async function cancelBooking(bookingId: string): Promise<void> {
   }
 }
 
+const BookingListResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      calendarId: z.string(),
+      resource: z.object({
+        id: z.string(),
+        type: z.string().optional(),
+        label: z.string().optional(),
+        data: z.record(z.string(), z.unknown()).optional(),
+      }),
+      slot: z.object({
+        date: z.string(),
+        hour: z.number(),
+        minutes: z.number(),
+      }),
+      createdAt: z.string(),
+      createdBy: z.string().optional(),
+    }),
+  ),
+  total: z.number(),
+});
+
 /**
  * List bookings for a calendar, optionally filtered by date range.
  */
@@ -1597,5 +1621,6 @@ export async function listBookings(
     const err = await response.json();
     throw new Error(err.error ?? "Failed to list bookings");
   }
-  return response.json();
+  const json = await response.json();
+  return BookingListResponseSchema.parse(json);
 }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1582,18 +1582,17 @@ export async function cancelBooking(bookingId: string): Promise<void> {
 /**
  * List bookings for a calendar, optionally filtered by date range.
  */
-export async function listBookings(params?: {
-  calendarId?: string;
-  startDate?: string;
-  endDate?: string;
-}): Promise<BookingListResponse> {
+export async function listBookings(
+  params?: { calendarId?: string; startDate?: string; endDate?: string },
+  signal?: AbortSignal,
+): Promise<BookingListResponse> {
   const searchParams = new URLSearchParams();
   if (params?.calendarId) searchParams.set("calendarId", params.calendarId);
   if (params?.startDate) searchParams.set("startDate", params.startDate);
   if (params?.endDate) searchParams.set("endDate", params.endDate);
   const query = searchParams.toString();
   const url = query ? `/app/api/calendar/bookings?${query}` : "/app/api/calendar/bookings";
-  const response = await fetch(url, { method: "GET" });
+  const response = await fetch(url, { method: "GET", signal });
   if (!response.ok) {
     const err = await response.json();
     throw new Error(err.error ?? "Failed to list bookings");

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -54,6 +54,7 @@ import type {
   TimeWindowRequest,
   BookingRequest,
   BookingResponse,
+  BookingListResponse,
 } from "@microboxlabs/miot-calendar-client";
 
 
@@ -1576,4 +1577,28 @@ export async function cancelBooking(bookingId: string): Promise<void> {
     const err = await response.json();
     throw new Error(err.error ?? "Failed to cancel booking");
   }
+}
+
+/**
+ * List bookings for a calendar, optionally filtered by date range.
+ */
+export async function listBookings(params?: {
+  calendarId?: string;
+  startDate?: string;
+  endDate?: string;
+}): Promise<BookingListResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.calendarId) searchParams.set("calendarId", params.calendarId);
+  if (params?.startDate) searchParams.set("startDate", params.startDate);
+  if (params?.endDate) searchParams.set("endDate", params.endDate);
+  const query = searchParams.toString();
+  const response = await fetch(
+    `/app/api/calendar/bookings${query ? `?${query}` : ""}`,
+    { method: "GET" }
+  );
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.error ?? "Failed to list bookings");
+  }
+  return response.json();
 }


### PR DESCRIPTION
Closes #49

## Summary

- **Missing GET route**: `/api/calendar/bookings` only had a `POST` handler; added `GET` to proxy `client.bookings.list()` with `calendarId`, `startDate`, `endDate` query params
- **Missing client function**: added `listBookings()` to `client-api.provider.ts` so the frontend can call the new route
- **Context never hydrated**: `PlanningSelectionProvider` initialized `plannedServices` as `[]` and never populated it from the backend; added a `useEffect` that fetches bookings when `calendarId` changes and sets both `plannedServices` and `bookingIds`
- **Data persistence**: `confirmService` now stores the full `SelectedService` in `resource.data` so bookings can be fully reconstructed on page reload (legacy bookings without stored data fall back to safe defaults)

## Test plan

- [x] Open the calendar planning view for a calendar that has existing bookings
- [x] Verify booked resources appear on the grid on initial load (without manually re-booking them)
- [x] Create a new booking, reload the page, verify it persists on the grid
- [x] Reassign a booking, reload, verify new slot is shown
- [x] Open a calendar with no bookings — grid should remain empty with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View and retrieve existing calendar bookings, including optional date-range filtering.
  * Bookings automatically load when a calendar is selected.
  * Booking records now retain enriched service data for improved visibility.
  * Backend API added to support bookings retrieval.
  * Booking creation now persists comprehensive service details for accurate round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->