### PR TITLE
fix(calendar): prevent spurious error toast on bookings load

### DIFF
--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -807,6 +807,7 @@ export function PlanningSelectionProvider({
       setBookingsLoadError(null);
     }).catch((err) => {
       if (controller.signal.aborted) return;
+      if (err instanceof Error && err.name === "AbortError") return;
       const message = "No se pudieron cargar las reservas existentes del calendario.";
       setBookingsLoadError(message);
       ShowNotification({ type: "error", message });

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1626,7 +1626,7 @@ export async function listBookings(
   if (!parsed.success) {
     console.error("BookingListResponse validation warning:", parsed.error.issues);
     if (!Array.isArray((json as BookingListResponse).data)) {
-      throw new Error("Invalid booking list response format");
+      throw new TypeError("Invalid booking list response format");
     }
     return json as BookingListResponse;
   }

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1595,7 +1595,7 @@ const BookingListResponseSchema = z.object({
         date: z.string(),
         hour: z.number(),
         minutes: z.number(),
-      }),
+      }).nullable(),
       createdAt: z.string(),
       createdBy: z.string().optional(),
     }),
@@ -1622,5 +1622,13 @@ export async function listBookings(
     throw new Error(err.error ?? "Failed to list bookings");
   }
   const json = await response.json();
-  return BookingListResponseSchema.parse(json);
+  const parsed = BookingListResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    console.error("BookingListResponse validation warning:", parsed.error.issues);
+    if (!Array.isArray((json as BookingListResponse).data)) {
+      throw new Error("Invalid booking list response format");
+    }
+    return json as BookingListResponse;
+  }
+  return parsed.data as BookingListResponse;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26182,7 +26182,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",
@@ -26194,7 +26194,8 @@
     },
     "packages/miot-cli": {
       "name": "@microboxlabs/miot-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@microboxlabs/miot-calendar-client": "*",
         "commander": "^14.0.0"


### PR DESCRIPTION
Closes #49

## Summary

- **Nullable slot in Zod schema**: `BookingListResponseSchema` required `slot` to be non-null. A server response with `slot: null` would throw a `ZodError` before the per-booking null-guard (`!booking.slot`) in the loop could skip it — surfacing an error toast for what should be a silent skip. Fixed by marking `slot` as `.nullable()` and switching from `.parse()` to `.safeParse()`. Schema mismatches now log a `console.error` with the Zod issue details (for easy diagnosis) and fall back to returning the raw response as long as `data` is an array.

- **Explicit AbortError guard**: The catch handler only checked `controller.signal.aborted`. In React Strict Mode, effects mount/unmount/remount in quick succession; an `AbortError` can arrive in the `.catch` before `signal.aborted` is observable in the closure. Added `err instanceof Error && err.name === "AbortError"` as a belt-and-suspenders guard.

## Test plan

- [x] Open the calendar planning view — no error toast should appear on load
- [x] Open browser console and verify no `BookingListResponse validation warning` message appears for valid responses
- [x] Rapidly switch between calendars — no spurious error toasts
- [x] Kill the miot-calendar backend mid-load — error toast should still appear for genuine failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed error notifications for canceled booking requests so aborted fetches no longer trigger user-facing errors.
  * Strengthened handling of booking list responses: added safer validation and a fallback path to gracefully handle unexpected or malformed API data without crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->