### PR TITLE
fix(planning/calendar): correct KPI data, booking reliability, and calendar setup

### DIFF
--- a/apps/app/src/app/api/calendar/route.ts
+++ b/apps/app/src/app/api/calendar/route.ts
@@ -14,6 +14,7 @@ const CalendarRequestSchema = z.object({
   timezone: z.string().optional(),
   active: z.boolean().optional(),
   groups: z.array(z.string()).optional(),
+  autoSlotManager: z.boolean().optional(),
 });
 
 export async function GET() {

--- a/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
+++ b/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
@@ -75,6 +75,7 @@ export function CreateCalendarModal({
         timezone: (formValues.timezone as string) || "UTC",
         active: (formValues.active as boolean) ?? true,
         groups: selectedGroupCode ? [selectedGroupCode] : [],
+        autoSlotManager: true,
       };
 
       const calendar = await createCalendar(body);

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -1212,6 +1212,11 @@ export function PlanningSelectionProvider({
           });
         } catch (err) {
           console.warn("Failed to create booking:", err);
+          // Rollback local state — the booking was rejected by the backend
+          setPlannedServices((prev) =>
+            prev.filter((p) => p.service.id !== selectedService.id)
+          );
+          throw err;
         }
       }
 

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -793,7 +793,7 @@ export function PlanningSelectionProvider({
         loaded.push({
           service,
           slot: {
-            date: new Date(booking.slot.date),
+            date: dayjs(booking.slot.date).toDate(),
             hour: booking.slot.hour,
             minutes: booking.slot.minutes,
             ...(_anden === undefined ? {} : { anden: _anden }),

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -1161,13 +1161,17 @@ export function PlanningSelectionProvider({
       // Check if this is a reassignment completion
       const wasReassigning = reassigningService !== null;
 
+      // Capture the original PlannedService before the optimistic update so we
+      // can restore it if the backend call fails (reassignment case).
+      const originalPlannedService = reassigningService?.service ?? null;
+
       // Create the new planned service with the final slot (including time and andén)
       const newPlannedService: PlannedService = {
         service: selectedService,
         slot: slotToUse,
       };
 
-      // Update local state
+      // Optimistic update: replace the existing entry with the new slot
       setPlannedServices((prev) => {
         const filtered = prev.filter(
           (p) => p.service.id !== selectedService.id
@@ -1177,6 +1181,9 @@ export function PlanningSelectionProvider({
 
       // Create / reassign booking in the calendar backend
       if (calendarId) {
+        // Capture the old booking ID before any state updates.
+        const oldBookingId = bookingIds.get(selectedService.id);
+
         try {
           const bookingBody: BookingRequest = {
             calendarId,
@@ -1196,26 +1203,33 @@ export function PlanningSelectionProvider({
             },
           };
 
-          // Cancel old booking on reassignment
-          const oldBookingId = bookingIds.get(selectedService.id);
-          if (oldBookingId) {
-            await cancelBooking(oldBookingId).catch((err) =>
-              console.warn("Failed to cancel old booking:", err)
-            );
-          }
-
+          // Create the new booking BEFORE cancelling the old one so that a
+          // creation failure leaves the original backend booking intact.
           const booking = await createBooking(bookingBody);
           setBookingIds((prev) => {
             const next = new Map(prev);
             next.set(selectedService.id, booking.id);
             return next;
           });
+
+          // Cancel the previous booking only after the new one is confirmed.
+          if (oldBookingId) {
+            await cancelBooking(oldBookingId).catch((err) =>
+              console.warn("Failed to cancel old booking:", err)
+            );
+          }
         } catch (err) {
           console.warn("Failed to create booking:", err);
-          // Rollback local state — the booking was rejected by the backend
-          setPlannedServices((prev) =>
-            prev.filter((p) => p.service.id !== selectedService.id)
-          );
+          // Rollback local state: restore the original PlannedService on
+          // reassignment, or simply remove the new entry on a fresh assignment.
+          setPlannedServices((prev) => {
+            const withoutNew = prev.filter(
+              (p) => p.service.id !== selectedService.id
+            );
+            return originalPlannedService
+              ? [...withoutNew, originalPlannedService]
+              : withoutNew;
+          });
           throw err;
         }
       }

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -14,6 +14,7 @@ import {
   getLeadTimeStatus,
   DEBUG_SHOW_TEST_SERVICE,
   TEST_SERVICES,
+  TimeWindowUtils,
 } from "./planning-selection-context";
 import { PlanningSidebarForm } from "./planning-sidebar-form";
 import { ServiceEvent } from "./service-event";
@@ -267,13 +268,30 @@ export function PlanningSidebarClient({
     return Math.max(1, Math.floor(totalMinutes / SLOT_DURATION_MINUTES));
   }, [selectedTimeWindow]);
 
-  // Format the selected slot for display with start and end times
+  // Format the selected slot for display with start and end times.
+  // When a matching time window is available, use its actual boundaries so
+  // that slotStartTime/slotEndTime reflect the window's configured time
+  // (e.g. 08:30) rather than the raw grid-cell click time (e.g. 08:00).
   const formattedSlot = useMemo(() => {
     if (!selectedSlot) return undefined;
-    const startDate = dayjs(selectedSlot.date)
-      .hour(selectedSlot.hour)
-      .minute(selectedSlot.minutes);
-    const endDate = startDate.add(SLOT_DURATION_MINUTES, "minute");
+
+    const windowRange = selectedTimeWindow
+      ? TimeWindowUtils.getTimeRange(selectedTimeWindow)
+      : null;
+
+    const startDate = windowRange
+      ? dayjs(selectedSlot.date)
+          .hour(windowRange.startHour)
+          .minute(windowRange.startMinutes)
+      : dayjs(selectedSlot.date)
+          .hour(selectedSlot.hour)
+          .minute(selectedSlot.minutes);
+
+    const endDate = windowRange
+      ? dayjs(selectedSlot.date)
+          .hour(windowRange.endHour)
+          .minute(windowRange.endMinutes)
+      : startDate.add(SLOT_DURATION_MINUTES, "minute");
 
     const dateStr = formatDateString(startDate.toDate(), "date");
     const startTime = formatDateString(startDate.toDate(), "time");
@@ -285,7 +303,7 @@ export function PlanningSidebarClient({
       endTime,
       full: `${dateStr}, ${startTime} - ${endTime}`,
     };
-  }, [selectedSlot]);
+  }, [selectedSlot, selectedTimeWindow]);
 
   type MatchType =
     | "id"

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -38,29 +38,6 @@ type PlanningSearchMatchType =
   | "permanencia"
   | "tipoViaje";
 
-/**
- * Calculate occupation percentage based on load constraint type.
- * Uses the appropriate utilization value depending on the constraint
- * reported by the backend (descriptiva_utilizacion_maxima):
- * - "VOLUMEN" → mintral_loadVolumeUtilization
- * - "PESO"    → mintral_loadWeightUtilization
- * - "PALLETS" → mintral_loadPalletUtilization
- * - Default: mintral_loadMaxUtilization (overall max)
- */
-function calculateOccupation(task: KanbanBoardTask): number {
-  const constraint = task.mintral_loadConstraint;
-
-  switch (constraint) {
-    case "VOLUMEN":
-      return task.mintral_loadVolumeUtilization ?? 0;
-    case "PESO":
-      return task.mintral_loadWeightUtilization ?? 0;
-    case "PALLETS":
-      return task.mintral_loadPalletUtilization ?? 0;
-    default:
-      return task.mintral_loadMaxUtilization ?? 0;
-  }
-}
 
 /**
  * Determine trip type from serviceKind or executionType
@@ -145,7 +122,7 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     lugarCarguio: "", // Not available in KanbanBoardTask
     destino: task.destination || "",
     tipoViaje,
-    ocupacion: calculateOccupation(task),
+    ocupacion: task.mintral_loadMaxUtilization ?? 0,
     permanencia,
     leadTime: {
       total_lineasoc_cumplen: task.mintral_compliantOrderLines ?? 0,

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -40,28 +40,25 @@ type PlanningSearchMatchType =
 
 /**
  * Calculate occupation percentage based on load constraint type.
- * Uses the appropriate utilization value depending on the constraint:
- * - "Volumen" → mintral_loadVolumeUtilization
- * - "Weight" → mintral_loadWeightUtilization
- * - "Pallet" → mintral_loadPalletUtilization
- * - Default: 0
+ * Uses the appropriate utilization value depending on the constraint
+ * reported by the backend (descriptiva_utilizacion_maxima):
+ * - "VOLUMEN" → mintral_loadVolumeUtilization
+ * - "PESO"    → mintral_loadWeightUtilization
+ * - "PALLETS" → mintral_loadPalletUtilization
+ * - Default: mintral_loadMaxUtilization (overall max)
  */
 function calculateOccupation(task: KanbanBoardTask): number {
   const constraint = task.mintral_loadConstraint;
 
-  if (!constraint) {
-    return 0;
-  }
-
   switch (constraint) {
-    case "Volumen":
+    case "VOLUMEN":
       return task.mintral_loadVolumeUtilization ?? 0;
-    case "Weight":
+    case "PESO":
       return task.mintral_loadWeightUtilization ?? 0;
-    case "Pallet":
+    case "PALLETS":
       return task.mintral_loadPalletUtilization ?? 0;
     default:
-      return 0;
+      return task.mintral_loadMaxUtilization ?? 0;
   }
 }
 
@@ -96,24 +93,6 @@ function calculatePermanencia(task: KanbanBoardTask): string {
   return `${hours}h`;
 }
 
-/**
- * Calculate lead time compliance metrics from ICU condition
- */
-function calculateLeadTimeCompliance(icuCondition: number): {
-  compliantLines: number;
-  nonCompliantLines: number;
-  compliancePercentage: number;
-} {
-  const totalLines = 4; // Default total lines for calculation
-  const compliantLines =
-    icuCondition >= 0
-      ? Math.min(totalLines, Math.abs(icuCondition) + 2)
-      : Math.max(0, totalLines - Math.abs(icuCondition));
-  const nonCompliantLines = totalLines - compliantLines;
-  const compliancePercentage = Math.round((compliantLines / totalLines) * 100);
-
-  return { compliantLines, nonCompliantLines, compliancePercentage };
-}
 
 /**
  * Extract incidencias from task fields
@@ -158,9 +137,6 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
   const serviceId = task.name || task.id;
   const tipoViaje = determineTripType(task);
   const permanencia = calculatePermanencia(task);
-  const icuCondition = task.mintral_icuCondition ?? 0;
-  const { compliantLines, nonCompliantLines, compliancePercentage } =
-    calculateLeadTimeCompliance(icuCondition);
 
   return {
     id: serviceId,
@@ -172,12 +148,12 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     ocupacion: calculateOccupation(task),
     permanencia,
     leadTime: {
-      total_lineasoc_cumplen: compliantLines,
-      total_lineasoc_incumplen: nonCompliantLines,
-      lineasoc_pctn_cumplimiento: compliancePercentage,
+      total_lineasoc_cumplen: task.mintral_compliantOrderLines ?? 0,
+      total_lineasoc_incumplen: task.mintral_nonCompliantOrderLines ?? 0,
+      lineasoc_pctn_cumplimiento: task.mintral_deliveryComplianceRate ?? 0,
     },
     eta: task.estimatedArrivalDate || task.arrivalDate || "",
-    incidencias: extractIncidencias(task, compliancePercentage),
+    incidencias: extractIncidencias(task, task.mintral_deliveryComplianceRate ?? 0),
     mintral_incidents: extractMintralIncidents(task.mintral_incidents),
     observaciones: task.description || "",
     prioridad: task.mintral_icuCondition ?? 0,

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -292,19 +292,25 @@ export function PlanningSidebarForm({
 
     const wasReassigning = reassigningService !== null;
     // Pass the final slot directly to confirmService
-    const result = await confirmService(finalSlot);
-    if (wasReassigning || result) {
-      ShowNotification({
-        type: "success",
-        message: "Servicio reasignado exitosamente",
-      });
-    } else {
-      ShowNotification({
-        type: "success",
-        message: "Servicio asignado exitosamente",
-      });
+    try {
+      const result = await confirmService(finalSlot);
+      if (wasReassigning || result) {
+        ShowNotification({
+          type: "success",
+          message: "Servicio reasignado exitosamente",
+        });
+      } else {
+        ShowNotification({
+          type: "success",
+          message: "Servicio asignado exitosamente",
+        });
+      }
+      onSubmit?.({});
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Error al asignar el servicio";
+      ShowNotification({ type: "error", message });
     }
-    onSubmit?.({});
   };
 
   // Check if the selected time has available andenes

--- a/apps/app/src/features/shipping/types/common.types.ts
+++ b/apps/app/src/features/shipping/types/common.types.ts
@@ -53,6 +53,9 @@ export type KanbanBoardTask = {
   mintral_loadWeightUtilization?: number;
   mintral_loadPalletUtilization?: number;
   mintral_loadMaxUtilization?: number;
+  mintral_deliveryComplianceRate?: number;
+  mintral_compliantOrderLines?: number;
+  mintral_nonCompliantOrderLines?: number;
 };
 
 export type KanbanBoardTaskMember = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26182,7 +26182,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",
@@ -26194,7 +26194,8 @@
     },
     "packages/miot-cli": {
       "name": "@microboxlabs/miot-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@microboxlabs/miot-calendar-client": "*",
         "commander": "^14.0.0"


### PR DESCRIPTION
## Summary

### Planning card KPI fixes
- **Fix fake lead time %**: replaced invented `calculateLeadTimeCompliance(icuCondition)` formula (hardcoded `totalLines=4`) with real backend variables `mintral_deliveryComplianceRate`, `mintral_compliantOrderLines`, `mintral_nonCompliantOrderLines`
- **Fix occupation always 0**: removed `calculateOccupation()` whose switch statement used mismatched case labels (`"Volumen"/"Weight"/"Pallet"` vs backend `"VOLUMEN"/"PESO"/"PALLETS"`); reads `mintral_loadMaxUtilization` directly (backend already computes the max)
- **Add missing type fields**: added `mintral_deliveryComplianceRate`, `mintral_compliantOrderLines`, `mintral_nonCompliantOrderLines` to `KanbanBoardTask`

### Booking reliability fixes
- **Fix silent 409**: `confirmService` was swallowing booking errors with `console.warn` and never rolling back optimistic state; now rethrows so callers surface the failure
- **Fix slot time offset**: `formattedSlot` was using raw grid-click time (e.g. `08:00`) instead of the configured time window boundary (e.g. `08:30`); now uses `TimeWindowUtils.getTimeRange(selectedTimeWindow)` when a window is matched

### Calendar setup fix
- **Fix `autoSlotManager` never sent**: `CalendarRequestSchema` in the API route was missing the field, causing it to be stripped by `safeParse` before reaching the miot-calendar-client; the modal also never included it in the request body — both are now fixed so the backend provisions a SlotManager on every new calendar

### Calendar week view fix
- **Fix booking rendered in wrong day column**: `new Date("YYYY-MM-DD")` treats date-only strings as UTC midnight, which in timezones behind UTC (e.g. America/Santiago, UTC-3) shifts the date to the previous day — Monday bookings appeared in the Sunday column; replaced with `dayjs("YYYY-MM-DD").toDate()` which parses as local midnight

## Test plan

- [x] Open the planning sidebar — verify lead time % and occupation values match the kanban API response
- [x] Attempt to book a slot the backend rejects (no configured time window) — verify an error notification appears and the service is NOT placed on the grid
- [x] Book a valid slot — verify the `hour`/`minutes` in the POST body match the time window boundary, not the raw grid-click time
- [x] Create a new calendar — confirm `autoSlotManager: true` is present in the request payload and slots are generated immediately after setup
- [x] Load a calendar with existing bookings in a UTC-behind timezone — verify each booking renders in the correct day column

Closes #50
Related: #53 (backend slot generation trigger — fixed server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)