### PR TITLE
fix(kpi-display): update terminology from "OC" to "LOC" 

### DIFF
--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -463,7 +463,7 @@ export function PlanningSidebarForm({
 
       {/* KPIs Section */}
       <FormSection title={tr("pages.planning.sidebar.form.kpis", dict)}>
-        <LeadTimeDisplay leadTime={selectedService.leadTime} />
+        <LeadTimeDisplay leadTime={selectedService.leadTime} dict={dict} />
         <KpiRow label="ETA" value={eta} />
         <ProgressBar
           label={tr("pages.planning.sidebar.form.occupancy", dict)}

--- a/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
+++ b/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
@@ -149,7 +149,7 @@ export function LeadTimeDisplay({ leadTime, compact }: LeadTimeDisplayProps) {
             Lead Time
           </span>
           <span className="text-xs text-gray-400 dark:text-gray-500">
-            ({totalLines} OC)
+            ({totalLines} LOC)
           </span>
         </div>
         {/* Column 2: Progress bar + percentage + metadata */}
@@ -194,7 +194,7 @@ export function LeadTimeDisplay({ leadTime, compact }: LeadTimeDisplayProps) {
             Lead Time
           </span>
           <span className="text-xs text-gray-400 dark:text-gray-500">
-            ({totalLines} líneas OC)
+            ({totalLines} líneas LOC)
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
+++ b/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
@@ -3,6 +3,8 @@
 import { HiCheck, HiExclamation, HiClock, HiX } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
 import { type LeadTimeData, getLeadTimeStatus } from "./kpi-display.types";
+import { type I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
 
 interface KpiRowProps {
   readonly label: string;
@@ -108,6 +110,7 @@ interface LeadTimeDisplayProps {
   readonly leadTime: LeadTimeData;
   /** If true, displays as a compact horizontal row instead of full card layout */
   readonly compact?: boolean;
+  readonly dict: I18nRecord;
 }
 
 const leadTimeStatusColors = {
@@ -129,7 +132,7 @@ const leadTimeBarColors = {
  * @param leadTime - The lead time data to display
  * @param compact - If true, displays as a compact horizontal row
  */
-export function LeadTimeDisplay({ leadTime, compact }: LeadTimeDisplayProps) {
+export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProps) {
   const status = getLeadTimeStatus(leadTime);
   const StatusIcon = {
     success: HiCheck,
@@ -149,7 +152,7 @@ export function LeadTimeDisplay({ leadTime, compact }: LeadTimeDisplayProps) {
             Lead Time
           </span>
           <span className="text-xs text-gray-400 dark:text-gray-500">
-            ({totalLines} LOC)
+            ({tr("pages.planning.sidebar.form.leadTimeLocCount", dict, { count: String(totalLines) })})
           </span>
         </div>
         {/* Column 2: Progress bar + percentage + metadata */}
@@ -194,7 +197,7 @@ export function LeadTimeDisplay({ leadTime, compact }: LeadTimeDisplayProps) {
             Lead Time
           </span>
           <span className="text-xs text-gray-400 dark:text-gray-500">
-            ({totalLines} líneas LOC)
+            ({tr("pages.planning.sidebar.form.leadTimeLocLines", dict, { count: String(totalLines) })})
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
@@ -120,7 +120,7 @@ export default function KpisCard({ task, dict }: KpisCardProps) {
           Lead Time
         </span>
         <span className="text-xs text-gray-400 dark:text-gray-500">
-          ({totalLines} OC)
+          ({totalLines} LOC)
         </span>
       </div>
       {/* Column 2: Progress bar */}

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
@@ -120,7 +120,7 @@ export default function KpisCard({ task, dict }: KpisCardProps) {
           Lead Time
         </span>
         <span className="text-xs text-gray-400 dark:text-gray-500">
-          ({totalLines} LOC)
+          ({tr("pages.planning.sidebar.form.leadTimeLocCount", dict, { count: String(totalLines) })})
         </span>
       </div>
       {/* Column 2: Progress bar */}

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -292,7 +292,9 @@
           "maxUtilization": "Total",
           "weightUtilization": "Weight utilization",
           "palletUtilization": "Pallet utilization",
-          "volumeUtilization": "Volume utilization"
+          "volumeUtilization": "Volume utilization",
+          "leadTimeLocCount": "{count} LOC",
+          "leadTimeLocLines": "{count} LOC lines"
         },
         "contextMenu": {
           "reassign": "Reassign",

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -292,7 +292,9 @@
           "maxUtilization": "Total",
           "weightUtilization": "Utilización peso",
           "palletUtilization": "Utilización pallets",
-          "volumeUtilization": "Utilización volumen"
+          "volumeUtilization": "Utilización volumen",
+          "leadTimeLocCount": "{count} LOC",
+          "leadTimeLocLines": "{count} líneas LOC"
         },
         "contextMenu": {
           "reassign": "Reasignar",


### PR DESCRIPTION
replace all OC for LOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KPI and lead-time displays now use localized labels for counts and lines, supporting translated strings.
* **Style**
  * Updated unit labels in KPI displays for consistent terminology across compact and expanded views.
* **Documentation**
  * Added new localization entries for English and Spanish to enable translated lead-time labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->