### PR TITLE
fix(client): remove hardcoded /app basePath from document download URLs

### DIFF
--- a/apps/app/src/features/shipping/components/download-signed-document/download-signed-document.tsx
+++ b/apps/app/src/features/shipping/components/download-signed-document/download-signed-document.tsx
@@ -16,13 +16,13 @@ export default function DownloadSignedDocument({
   documentId,
   asLink = false,
   name,
-}: DownloadSignedDocumentProps) {
+}: Readonly<DownloadSignedDocumentProps>) {
   const documentPath =
     documentId && typeof documentId?.replace === "function"
       ? documentId?.replace(":/", "")
       : documentId;
 
-  const href = `/app/api/document/download?documentId=${documentPath}`;
+  const href = `/api/document/download?documentId=${documentPath}`;
 
   if (asLink) {
     return (

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image-element.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image-element.tsx
@@ -49,7 +49,7 @@ export default function ImageElement({
           ] as keyof typeof categories
         ]?.label
       }
-      downloadUrl={`/app/api/document/download?documentId=${file.entry.id}`}
+      downloadUrl={`/api/document/download?documentId=${file.entry.id}`}
       dictionary={dictionary}
     />
   );


### PR DESCRIPTION
## Summary

- Removes `/app` hardcoded prefix from `href` in `download-signed-document.tsx`
- Removes `/app` hardcoded prefix from `downloadUrl` in `image-element.tsx`

Next.js prepends `basePath` automatically — hardcoding it caused double-prefixing and broken download links (regression from 8fc347a6).

## Test plan

- [ ] Open a shipping order with a signed document and verify the download link resolves correctly
- [ ] Open a task form with an image attachment and verify the image download works

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated document download endpoints across shipping and task management features to use a unified API path structure, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->