### PR TITLE
feat(miot-cli): add --group flag to calendar create and update

### DIFF
--- a/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
+++ b/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
@@ -246,6 +246,121 @@ describe("calendar create", () => {
       autoSlotManager: false,
     });
   });
+
+  it("should pass groups when --group is provided", async () => {
+    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true };
+    const mockClient = {
+      calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "create",
+      "--code", "c", "--name", "n", "--group", "scl",
+    ]);
+
+    expect(mockClient.calendars.create).toHaveBeenCalledWith({
+      code: "c",
+      name: "n",
+      timezone: undefined,
+      description: undefined,
+      groups: ["scl"],
+    });
+  });
+
+  it("should pass multiple groups when --group is repeated", async () => {
+    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true };
+    const mockClient = {
+      calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "create",
+      "--code", "c", "--name", "n", "--group", "scl", "--group", "north",
+    ]);
+
+    expect(mockClient.calendars.create).toHaveBeenCalledWith({
+      code: "c",
+      name: "n",
+      timezone: undefined,
+      description: undefined,
+      groups: ["scl", "north"],
+    });
+  });
+});
+
+describe("calendar update", () => {
+  const mockCalendar = { id: "cal-1", code: "cal-1", name: "New Name", timezone: "UTC", active: true };
+
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call calendars.update with provided fields", async () => {
+    const mockClient = {
+      calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "update", "cal-1", "--name", "New Name",
+    ]);
+
+    expect(mockClient.calendars.update).toHaveBeenCalledWith("cal-1", { name: "New Name" });
+  });
+
+  it("should pass groups when --group is provided", async () => {
+    const mockClient = {
+      calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "update", "cal-1", "--group", "scl",
+    ]);
+
+    expect(mockClient.calendars.update).toHaveBeenCalledWith("cal-1", { groups: ["scl"] });
+  });
+
+  it("should pass multiple groups when --group is repeated", async () => {
+    const mockClient = {
+      calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "update", "cal-1", "--group", "scl", "--group", "north",
+    ]);
+
+    expect(mockClient.calendars.update).toHaveBeenCalledWith("cal-1", { groups: ["scl", "north"] });
+  });
+
+  it("should not include groups in body when --group is not provided", async () => {
+    const mockClient = {
+      calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "update", "cal-1", "--name", "New Name",
+    ]);
+
+    expect(mockClient.calendars.update).toHaveBeenCalledWith(
+      "cal-1",
+      expect.not.objectContaining({ groups: expect.anything() }),
+    );
+  });
 });
 
 describe("calendar purge", () => {

--- a/packages/miot-cli/src/commands/calendar/create.ts
+++ b/packages/miot-cli/src/commands/calendar/create.ts
@@ -12,6 +12,7 @@ export function registerCreateCommand(parent: Command): void {
     .option("--timezone <tz>", "Timezone")
     .option("--description <desc>", "Description")
     .option("--no-auto-slot-manager", "Skip auto-provisioning a default SlotManager on creation")
+    .option("--group <code>", "Assign to group by code (repeatable)", (val, acc: string[]) => [...acc, val], [] as string[])
     .action(async (_opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -21,6 +22,7 @@ export function registerCreateCommand(parent: Command): void {
           timezone?: string;
           description?: string;
           autoSlotManager: boolean;
+          group: string[];
         };
 
         const calendar = await client.calendars.create({
@@ -29,6 +31,7 @@ export function registerCreateCommand(parent: Command): void {
           timezone: opts.timezone,
           description: opts.description,
           ...(opts.autoSlotManager === false && { autoSlotManager: false }),
+          ...(opts.group.length > 0 && { groups: opts.group }),
         });
 
         if (outputMode === "json") {
@@ -50,6 +53,7 @@ export function registerUpdateCommand(parent: Command): void {
     .option("--name <name>", "Calendar name")
     .option("--timezone <tz>", "Timezone")
     .option("--description <desc>", "Description")
+    .option("--group <code>", "Assign to group by code (repeatable)", (val, acc: string[]) => [...acc, val], [] as string[])
     .action(async (id: string, _opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -58,6 +62,7 @@ export function registerUpdateCommand(parent: Command): void {
           name?: string;
           timezone?: string;
           description?: string;
+          group: string[];
         };
 
         const body = {
@@ -67,6 +72,7 @@ export function registerUpdateCommand(parent: Command): void {
           ...(opts.description !== undefined && {
             description: opts.description,
           }),
+          ...(opts.group.length > 0 && { groups: opts.group }),
         };
 
         const calendar = await client.calendars.update(id, body as Parameters<typeof client.calendars.update>[1]);


### PR DESCRIPTION
## Summary

- Add repeatable `--group <code>` option to `miot calendar create` and `miot calendar update`
- Group codes are passed directly to the API's `groups` field (no ID resolution needed)
- No-op when omitted — existing workflows unaffected

## Usage

```bash
miot calendar create --code my-cal --name "My Cal" --group scl
miot calendar create --code my-cal --name "My Cal" --group scl --group north
miot calendar update <id> --group scl
```

## Test plan

- [x] `calendar create --group <code>` → response includes the group in `groups[]`
- [x] `calendar create --group <code1> --group <code2>` → both groups present
- [x] `calendar update <id> --group <code>` → calendar updated with group
- [x] Omitting `--group` → no change to existing behavior

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar create and update commands now support associating calendars with groups via a new repeatable --group option. Multiple groups can be specified per calendar.

* **Tests**
  * Added coverage verifying create/update behavior with single, multiple, and absent --group values to ensure groups are included only when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->