### PR TITLE
feat(planning): integrate real service types from Alfresco

### DIFF
--- a/apps/app/src/app/api/planning/service-type/route.ts
+++ b/apps/app/src/app/api/planning/service-type/route.ts
@@ -1,0 +1,33 @@
+import { requireAuth } from "../../utils/alfresco-crud-client";
+import { updateTaskServiceCategory } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { NextResponse } from "next/server";
+
+export async function PATCH(request: Request) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  let body: { taskId?: string; serviceTypeCode?: string };
+  try {
+    body = (await request.json()) as { taskId?: string; serviceTypeCode?: string };
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { taskId, serviceTypeCode } = body;
+  if (!taskId || !serviceTypeCode) {
+    return NextResponse.json(
+      { error: "taskId and serviceTypeCode are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await updateTaskServiceCategory(authResult.session, taskId, serviceTypeCode);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to update service category" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/app/src/app/api/planning/service-type/route.ts
+++ b/apps/app/src/app/api/planning/service-type/route.ts
@@ -1,6 +1,7 @@
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { updateTaskServiceCategory } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 
 export async function PATCH(request: Request) {
   const authResult = await requireAuth();
@@ -25,6 +26,7 @@ export async function PATCH(request: Request) {
     await updateTaskServiceCategory(authResult.session, taskId, serviceTypeCode);
     return new NextResponse(null, { status: 204 });
   } catch (error) {
+    logger.error({ err: error }, "Failed to update service category");
     return NextResponse.json(
       { error: "Failed to update service category" },
       { status: 500 }

--- a/apps/app/src/app/api/planning/service-type/route.ts
+++ b/apps/app/src/app/api/planning/service-type/route.ts
@@ -2,25 +2,33 @@ import { requireAuth } from "../../utils/alfresco-crud-client";
 import { updateTaskServiceCategory } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
+
+const PatchBodySchema = z.object({
+  taskId: z.string(),
+  serviceTypeCode: z.string(),
+});
 
 export async function PATCH(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
 
-  let body: { taskId?: string; serviceTypeCode?: string };
+  let rawBody: unknown;
   try {
-    body = (await request.json()) as { taskId?: string; serviceTypeCode?: string };
+    rawBody = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { taskId, serviceTypeCode } = body;
-  if (!taskId || !serviceTypeCode) {
+  const parsed = PatchBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
     return NextResponse.json(
       { error: "taskId and serviceTypeCode are required" },
       { status: 400 }
     );
   }
+
+  const { taskId, serviceTypeCode } = parsed.data;
 
   try {
     await updateTaskServiceCategory(authResult.session, taskId, serviceTypeCode);

--- a/apps/app/src/app/api/service-types/route.ts
+++ b/apps/app/src/app/api/service-types/route.ts
@@ -1,0 +1,18 @@
+import { requireAuth } from "../utils/alfresco-crud-client";
+import { getServiceTypes } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  try {
+    const types = await getServiceTypes(authResult.session);
+    return NextResponse.json(types);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch service types" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/app/src/app/api/service-types/route.ts
+++ b/apps/app/src/app/api/service-types/route.ts
@@ -1,6 +1,7 @@
 import { requireAuth } from "../utils/alfresco-crud-client";
 import { getServiceTypes } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 
 export async function GET() {
   const authResult = await requireAuth();
@@ -10,6 +11,7 @@ export async function GET() {
     const types = await getServiceTypes(authResult.session);
     return NextResponse.json(types);
   } catch (error) {
+    logger.error({ err: error }, "Failed to fetch service types");
     return NextResponse.json(
       { error: "Failed to fetch service types" },
       { status: 500 }

--- a/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -20,6 +20,7 @@ import {
   createBooking,
   cancelBooking,
   listBookings,
+  updateServiceCategory,
 } from "@/features/common/providers/client-api.provider";
 import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
@@ -562,6 +563,7 @@ export interface SelectedService {
   loadWeightUtilization?: number; // Weight capacity utilization %
   loadPalletUtilization?: number; // Pallet position utilization %
   loadVolumeUtilization?: number; // Volumetric utilization %
+  serviceCategory?: string; // Alfresco mintral_serviceCategory code
 }
 
 /**
@@ -595,8 +597,9 @@ interface PlanningSelectionContextType {
   reassigningService: ReassigningService | null;
   selectSlot: (slot: SelectedSlot) => void;
   selectService: (service: SelectedService) => void;
-  /** Confirm service assignment. Pass finalSlot to override the selected slot with specific time/andén */
-  confirmService: (finalSlot?: SelectedSlot) => Promise<boolean>;
+  /** Confirm service assignment. Pass finalSlot to override the selected slot with specific time/andén.
+   * Pass serviceOverrides to merge additional fields into the selected service before confirming. */
+  confirmService: (finalSlot?: SelectedSlot, serviceOverrides?: Partial<SelectedService>) => Promise<boolean>;
   clearService: () => void;
   closeSidebar: () => void;
   clearSelection: () => void;
@@ -665,6 +668,7 @@ const StoredServiceSchema = z
     loadWeightUtilization: z.number().optional(),
     loadPalletUtilization: z.number().optional(),
     loadVolumeUtilization: z.number().optional(),
+    serviceCategory: z.string().optional(),
     _anden: z.number().optional(),
   })
   .optional();
@@ -1141,16 +1145,21 @@ export function PlanningSelectionProvider({
   );
 
   const confirmService = useCallback(
-    async (finalSlot?: SelectedSlot): Promise<boolean> => {
+    async (finalSlot?: SelectedSlot, serviceOverrides?: Partial<SelectedService>): Promise<boolean> => {
       // Use finalSlot if provided, otherwise fall back to selectedSlot
       const slotToUse = finalSlot ?? selectedSlot;
 
       if (!slotToUse || !selectedService) return false;
 
+      // Merge any overrides (e.g. serviceCategory) into the service for this confirmation
+      const effectiveService = serviceOverrides
+        ? { ...selectedService, ...serviceOverrides }
+        : selectedService;
+
       // Check if slot has room (unless re-planning same service)
       const existingInSlot = getServicesForSlot(slotToUse);
       const isReplanning = existingInSlot.some(
-        (ps) => ps.service.id === selectedService.id
+        (ps) => ps.service.id === effectiveService.id
       );
 
       if (!isReplanning && existingInSlot.length >= MAX_SERVICES_PER_SLOT) {
@@ -1167,14 +1176,14 @@ export function PlanningSelectionProvider({
 
       // Create the new planned service with the final slot (including time and andén)
       const newPlannedService: PlannedService = {
-        service: selectedService,
+        service: effectiveService,
         slot: slotToUse,
       };
 
       // Optimistic update: replace the existing entry with the new slot
       setPlannedServices((prev) => {
         const filtered = prev.filter(
-          (p) => p.service.id !== selectedService.id
+          (p) => p.service.id !== effectiveService.id
         );
         return [...filtered, newPlannedService];
       });
@@ -1182,17 +1191,17 @@ export function PlanningSelectionProvider({
       // Create / reassign booking in the calendar backend
       if (calendarId) {
         // Capture the old booking ID before any state updates.
-        const oldBookingId = bookingIds.get(selectedService.id);
+        const oldBookingId = bookingIds.get(effectiveService.id);
 
         try {
           const bookingBody: BookingRequest = {
             calendarId,
             resource: {
-              id: selectedService.id,
+              id: effectiveService.id,
               type: "service",
-              label: selectedService.cliente,
+              label: effectiveService.cliente,
               data: {
-                ...selectedService,
+                ...effectiveService,
                 ...(slotToUse.anden === undefined ? {} : { _anden: slotToUse.anden }),
               },
             },
@@ -1208,7 +1217,7 @@ export function PlanningSelectionProvider({
           const booking = await createBooking(bookingBody);
           setBookingIds((prev) => {
             const next = new Map(prev);
-            next.set(selectedService.id, booking.id);
+            next.set(effectiveService.id, booking.id);
             return next;
           });
 
@@ -1218,13 +1227,23 @@ export function PlanningSelectionProvider({
               console.warn("Failed to cancel old booking:", err)
             );
           }
+
+          // Fire-and-forget: update Alfresco task service category
+          if (effectiveService.serviceCategory) {
+            updateServiceCategory(
+              effectiveService.id,
+              effectiveService.serviceCategory
+            ).catch((err) =>
+              console.error("Failed to update service category:", err)
+            );
+          }
         } catch (err) {
           console.warn("Failed to create booking:", err);
           // Rollback local state: restore the original PlannedService on
           // reassignment, or simply remove the new entry on a fresh assignment.
           setPlannedServices((prev) => {
             const withoutNew = prev.filter(
-              (p) => p.service.id !== selectedService.id
+              (p) => p.service.id !== effectiveService.id
             );
             return originalPlannedService
               ? [...withoutNew, originalPlannedService]

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -141,6 +141,7 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     loadWeightUtilization: task.mintral_loadWeightUtilization,
     loadPalletUtilization: task.mintral_loadPalletUtilization,
     loadVolumeUtilization: task.mintral_loadVolumeUtilization,
+    serviceCategory: task.mintral_serviceCategory ?? undefined,
   };
 }
 

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -339,16 +339,14 @@ export function PlanningSidebarForm({
 
   // Extract incident codes and create code-to-label map for tooltips
   const codeToLabelMap = new Map<string, string>();
-  const incidentCodes = selectedService.mintral_incidents
-    ? selectedService.mintral_incidents.map((incident) => {
-        const rawCode = incident[0];
-        const label = incident[1];
-        // Remove "mintral_incident_" prefix to get just the code (e.g., "C307")
-        const code = rawCode.replace(/^mintral_incident_/i, "");
-        codeToLabelMap.set(code, label);
-        return code;
-      })
-    : [];
+  const incidentCodes = (selectedService.mintral_incidents ?? []).map((incident) => {
+    const rawCode = incident[0];
+    const label = incident[1];
+    // Remove "mintral_incident_" prefix to get just the code (e.g., "C307")
+    const code = rawCode.replace(/^mintral_incident_/i, "");
+    codeToLabelMap.set(code, label);
+    return code;
+  });
 
   // Categorize incidencias into primary (always visible) and secondary (expandable)
   const { primary, secondary } = categorizeIncidencias(incidentCodes);

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -599,7 +599,7 @@ export function PlanningSidebarForm({
               </button>
 
               {/* Dropdown menu */}
-              {isTripTypeDropdownOpen && !isLoadingServiceTypes && (
+              {isTripTypeDropdownOpen && (
                 <div className="absolute z-10 w-full bottom-full mb-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
                   {serviceCategoryOptions.map((option) => (
                     <button

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -16,6 +16,7 @@ import {
   type SelectedService,
   type SelectedSlot,
 } from "./planning-selection-context";
+import { useServiceTypes } from "@/features/common/providers/client-api.provider";
 import { HiCheck, HiChevronDown, HiExclamation } from "react-icons/hi";
 import { categorizeIncidencias } from "./incidencias.types";
 import { ShowNotification } from "@/features/notifications/notification";
@@ -120,18 +121,19 @@ export function PlanningSidebarForm({
   const [selectedTime, setSelectedTime] = useState<string>("");
   const [selectedAnden, setSelectedAnden] = useState<number>(1);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [selectedTripType, setSelectedTripType] = useState<string>("tipo_1");
+  const [selectedServiceCategory, setSelectedServiceCategory] = useState<string>(
+    selectedService?.serviceCategory ?? ""
+  );
   const [isTripTypeDropdownOpen, setIsTripTypeDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const tripTypeDropdownRef = useRef<HTMLDivElement>(null);
 
-  const tripTypeOptions = [
-    { value: "tipo_1", label: "Tipo 1" },
-    { value: "tipo_2", label: "Tipo 2" },
-    { value: "tipo_3", label: "Tipo 3" },
-    { value: "tipo_4", label: "Tipo 4" },
-    { value: "otro", label: "Otro" },
-  ];
+  const { serviceTypes, isLoading: isLoadingServiceTypes } = useServiceTypes();
+  const serviceCategoryOptions = serviceTypes.map((t) => ({
+    value: t.code,
+    label: t.name,
+  }));
+
   const {
     confirmService,
     selectedSlot,
@@ -291,9 +293,12 @@ export function PlanningSidebarForm({
     }
 
     const wasReassigning = reassigningService !== null;
-    // Pass the final slot directly to confirmService
+    // Pass the final slot directly to confirmService, along with service category override
+    const serviceOverrides = selectedServiceCategory
+      ? { serviceCategory: selectedServiceCategory }
+      : undefined;
     try {
-      const result = await confirmService(finalSlot);
+      const result = await confirmService(finalSlot, serviceOverrides);
       if (wasReassigning || result) {
         ShowNotification({
           type: "success",
@@ -563,26 +568,30 @@ export function PlanningSidebarForm({
       {timeOptions.length > 0 && (
         <FormSection title="Asignación de horario">
           <div className="space-y-3">
-            {/* Trip Type Dropdown */}
+            {/* Service Category Dropdown */}
             <div ref={tripTypeDropdownRef} className="relative">
               <Label
-                htmlFor="trip-type-select"
+                htmlFor="service-category-select"
                 className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block"
               >
-                Tipo de viaje
+                Categoría de servicio
               </Label>
 
               {/* Dropdown trigger button */}
               <button
                 type="button"
+                disabled={isLoadingServiceTypes}
                 onClick={() =>
                   setIsTripTypeDropdownOpen(!isTripTypeDropdownOpen)
                 }
-                className="w-full flex items-center justify-between px-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-blue-500 dark:hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+                className="w-full flex items-center justify-between px-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-blue-500 dark:hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 <span className="font-medium text-gray-900 dark:text-white">
-                  {tripTypeOptions.find((opt) => opt.value === selectedTripType)
-                    ?.label || "Seleccionar tipo"}
+                  {isLoadingServiceTypes
+                    ? "Cargando…"
+                    : (serviceCategoryOptions.find(
+                        (opt) => opt.value === selectedServiceCategory
+                      )?.label ?? "Seleccionar categoría")}
                 </span>
                 <HiChevronDown
                   className={`w-4 h-4 text-gray-500 transition-transform ${isTripTypeDropdownOpen ? "rotate-180" : ""}`}
@@ -590,29 +599,29 @@ export function PlanningSidebarForm({
               </button>
 
               {/* Dropdown menu */}
-              {isTripTypeDropdownOpen && (
+              {isTripTypeDropdownOpen && !isLoadingServiceTypes && (
                 <div className="absolute z-10 w-full bottom-full mb-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                  {tripTypeOptions.map((option) => (
+                  {serviceCategoryOptions.map((option) => (
                     <button
                       key={option.value}
                       type="button"
                       onClick={() => {
-                        setSelectedTripType(option.value);
+                        setSelectedServiceCategory(option.value);
                         setIsTripTypeDropdownOpen(false);
                       }}
                       className={`w-full flex items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
-                        option.value === selectedTripType
+                        option.value === selectedServiceCategory
                           ? "bg-blue-50 dark:bg-blue-900/20"
                           : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
                       } cursor-pointer`}
                     >
                       <div className="flex items-center gap-2">
-                        {option.value === selectedTripType && (
+                        {option.value === selectedServiceCategory && (
                           <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />
                         )}
                         <span
                           className={`text-sm ${
-                            option.value === selectedTripType
+                            option.value === selectedServiceCategory
                               ? "text-blue-700 dark:text-blue-300"
                               : "text-gray-900 dark:text-white"
                           }`}

--- a/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -574,7 +574,7 @@ export function PlanningSidebarForm({
                 htmlFor="service-category-select"
                 className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block"
               >
-                Categoría de servicio
+                {tr("pages.planning.sidebar.form.serviceCategory", dict)}
               </Label>
 
               {/* Dropdown trigger button */}
@@ -588,10 +588,10 @@ export function PlanningSidebarForm({
               >
                 <span className="font-medium text-gray-900 dark:text-white">
                   {isLoadingServiceTypes
-                    ? "Cargando…"
+                    ? tr("pages.planning.sidebar.form.serviceCategoryLoading", dict)
                     : (serviceCategoryOptions.find(
                         (opt) => opt.value === selectedServiceCategory
-                      )?.label ?? "Seleccionar categoría")}
+                      )?.label ?? tr("pages.planning.sidebar.form.serviceCategoryPlaceholder", dict))}
                 </span>
                 <HiChevronDown
                   className={`w-4 h-4 text-gray-500 transition-transform ${isTripTypeDropdownOpen ? "rotate-180" : ""}`}

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -39,6 +39,7 @@ import fetcher from "../fetcher";
 import { GetEntityInfoResponse } from "../microboxlabs-api/microboxlabs-api.types";
 import type { Session } from "next-auth";
 import { createManagedLogger, logError } from "@/lib/logger";
+import { z } from "zod";
 
 const alfrescoApiLogger = createManagedLogger(
   "alfresco-api",
@@ -1416,6 +1417,15 @@ export async function calculateETA(
   return result as ETAResponse;
 }
 
+const serviceTypeSchema = z.object({
+  nodeRef: z.string(),
+  code: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  isActive: z.boolean(),
+});
+const serviceTypesSchema = z.array(serviceTypeSchema);
+
 export async function getServiceTypes(
   session: Session
 ): Promise<ServiceType[]> {
@@ -1423,7 +1433,7 @@ export async function getServiceTypes(
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
   const response = await fetch(url, { headers });
   if (!response.ok) throw new Error(`service-types: ${response.status}`);
-  return response.json() as Promise<ServiceType[]>;
+  return serviceTypesSchema.parse(await response.json());
 }
 
 export async function updateTaskServiceCategory(

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -6,6 +6,7 @@ import {
   NodeEntry,
   AlfrescoApi,
 } from "@alfresco/js-api";
+import type { ServiceType } from "./service-types.types";
 import type {
   EndTaskResponse,
   FastTasksResponse,
@@ -1413,4 +1414,24 @@ export async function calculateETA(
   });
 
   return result as ETAResponse;
+}
+
+export async function getServiceTypes(
+  session: Session
+): Promise<ServiceType[]> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/service-types`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw new Error(`service-types: ${response.status}`);
+  return response.json() as Promise<ServiceType[]>;
+}
+
+export async function updateTaskServiceCategory(
+  session: Session,
+  taskId: string,
+  serviceTypeCode: string
+): Promise<void> {
+  await formProcessor(session, "task", taskId, {
+    mintral_serviceCategory: serviceTypeCode,
+  });
 }

--- a/apps/app/src/features/common/providers/alfresco-api/service-types.types.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/service-types.types.ts
@@ -1,0 +1,7 @@
+export interface ServiceType {
+  nodeRef: string;
+  code: string;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+}

--- a/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/apps/app/src/features/common/providers/client-api.provider.ts
@@ -57,6 +57,7 @@ import type {
   BookingResponse,
   BookingListResponse,
 } from "@microboxlabs/miot-calendar-client";
+import type { ServiceType } from "./alfresco-api/service-types.types";
 
 
 
@@ -1631,4 +1632,30 @@ export async function listBookings(
     return json as BookingListResponse;
   }
   return parsed.data as BookingListResponse;
+}
+
+export function useServiceTypes() {
+  const { data, error, isLoading } = useSWR<ServiceType[], FetcherError>(
+    "/app/api/service-types",
+    fetcher,
+    { errorRetryCount: 3, errorRetryInterval: 5000 }
+  );
+  return {
+    serviceTypes: (data ?? []).filter((t) => t.isActive),
+    error,
+    isLoading,
+  };
+}
+
+export async function updateServiceCategory(
+  taskId: string,
+  serviceTypeCode: string
+): Promise<void> {
+  const response = await fetch("/app/api/planning/service-type", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ taskId, serviceTypeCode }),
+  });
+  if (!response.ok)
+    throw new Error(`updateServiceCategory: ${response.status}`);
 }

--- a/apps/app/src/features/shipping/types/common.types.ts
+++ b/apps/app/src/features/shipping/types/common.types.ts
@@ -56,6 +56,7 @@ export type KanbanBoardTask = {
   mintral_deliveryComplianceRate?: number;
   mintral_compliantOrderLines?: number;
   mintral_nonCompliantOrderLines?: number;
+  mintral_serviceCategory?: string;
 };
 
 export type KanbanBoardTaskMember = {

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -294,7 +294,10 @@
           "palletUtilization": "Pallet utilization",
           "volumeUtilization": "Volume utilization",
           "leadTimeLocCount": "{count} LOC",
-          "leadTimeLocLines": "{count} LOC lines"
+          "leadTimeLocLines": "{count} LOC lines",
+          "serviceCategory": "Service Category",
+          "serviceCategoryLoading": "Loading\u2026",
+          "serviceCategoryPlaceholder": "Select category"
         },
         "contextMenu": {
           "reassign": "Reassign",

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -294,7 +294,10 @@
           "palletUtilization": "Utilización pallets",
           "volumeUtilization": "Utilización volumen",
           "leadTimeLocCount": "{count} LOC",
-          "leadTimeLocLines": "{count} líneas LOC"
+          "leadTimeLocLines": "{count} líneas LOC",
+          "serviceCategory": "Categoría de servicio",
+          "serviceCategoryLoading": "Cargando\u2026",
+          "serviceCategoryPlaceholder": "Seleccionar categoría"
         },
         "contextMenu": {
           "reassign": "Reasignar",


### PR DESCRIPTION
Closes #67

## Summary

- Replaces the hardcoded `tipo_1`…`tipo_4` / `otro` dropdown in the "Asignación de Horario" section with a live list of service categories fetched from Alfresco `/mintral/service-types`
- Writes the selected `serviceCategory` back to the Alfresco task as `mintral_serviceCategory` after a booking is confirmed
- Pre-selects the previously saved category when the sidebar is reopened

## Changes

| File | Change |
|------|--------|
| `service-types.types.ts` | New — `ServiceType` interface |
| `alfresco-api.provider.ts` | Add `getServiceTypes()` and `updateTaskServiceCategory()` |
| `app/api/service-types/route.ts` | New — `GET` proxy to Alfresco `/mintral/service-types` |
| `app/api/planning/service-type/route.ts` | New — `PATCH` updates `mintral_serviceCategory` on task |
| `client-api.provider.ts` | Add `useServiceTypes()` SWR hook + `updateServiceCategory()` |
| `planning-selection-context.tsx` | Add `serviceCategory` to `SelectedService`; `confirmService` accepts `serviceOverrides`; fire-and-forget PATCH after booking |
| `planning-sidebar-client.tsx` | Map `mintral_serviceCategory` from `KanbanBoardTask` into `SelectedService` |
| `planning-sidebar-form.tsx` | Replace hardcoded options with live hook; loading state; pre-select saved value |
| `common.types.ts` | Add `mintral_serviceCategory` to `KanbanBoardTask` |

## Test plan

- [x] "Asignación de Horario" dropdown shows real names from Alfresco (only `isActive: true`)
- [x] Confirming a slot writes `mintral_serviceCategory` to the Alfresco task
- [x] Reloading the planning view pre-selects the previously saved category
- [x] `tipoViaje` (Sider / Doble Sider / Rampla) displays correctly and is unaffected
- [x] Dropdown shows "Cargando…" and is disabled while service types are fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic "Service Category" selector in planning, populated from backend service types.
  * Option to override service details at confirmation time; overrides applied to bookings and local UI.
  * Ability to assign/update a service category for a task and synchronize it with the backend (non-blocking background update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->