### PR TITLE
feat(release): integrate organization logo into NavbarSignIn component

### DIFF
--- a/apps/app/src/app/[lang]/release/[version]/page.tsx
+++ b/apps/app/src/app/[lang]/release/[version]/page.tsx
@@ -3,16 +3,18 @@ import { getDictionary } from "@/features/i18n/i18n.service";
 import ReleaseNotes from "@/features/layout/components/release-view/release-notes";
 import OtherVersions from "@/features/layout/components/release-view/other-versions";
 import { I18nRecord, ParamsWithLang } from "@/features/i18n/i18n.service.types";
+import { getPublicOrgLogo } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 export default async function Page({
   params,
 }: ParamsWithLang<{ version: string }>) {
   const paramsResult = await params;
   const { lang, version } = paramsResult;
   const [, dict] = await getDictionary(lang);
+  const orgLogo = await getPublicOrgLogo();
 
   return (
     <div className="flex flex-col w-full justify-center items-center">
-      <NavbarSignIn />
+      <NavbarSignIn orgLogoUrl={orgLogo} />
       <div className="flex w-1/3 min-w-[400px] flex-col gap-4 pb-5 px-5 text-gray-900 dark:text-gray-100">
         <ReleaseNotes version={version} />
         <div className="border-t border-gray-200 dark:border-gray-800 mt-5 pt-2 flex flex-col gap-2 w-full justify-center items-center">

--- a/apps/app/src/app/[lang]/totem/page.tsx
+++ b/apps/app/src/app/[lang]/totem/page.tsx
@@ -10,7 +10,7 @@ import { getPublicOrgLogo } from "@/features/common/providers/alfresco-api/alfre
 export default async function TotemPage({ params }: ParamsWithLang) {
   const { lang } = await params;
   const [_dict, dictionary] = await getDictionary(lang ?? defaultLocale);
-  const orgLogo = await getPublicOrgLogo().catch(() => null);
+  const orgLogo = await getPublicOrgLogo();
 
   return (
     <div className="flex flex-col items-center justify-center w-screen h-screen">

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -827,25 +827,29 @@ export async function getPublicOrgLogo(): Promise<string | null> {
     return null;
   }
 
-  const logoUrl = `${ecmApiUrl}/alfresco/s/public/org/logo`;
+  try {
+    const logoUrl = `${ecmApiUrl}/alfresco/s/public/org/logo`;
 
-  const response = await fetch(logoUrl, {
-    method: "GET",
-    cache: "no-store",
-  });
+    const response = await fetch(logoUrl, {
+      method: "GET",
+      cache: "no-store",
+    });
 
-  if (!response.ok) {
+    if (!response.ok) {
+      return null;
+    }
+
+    // Get the content type from the response
+    const contentType = response.headers.get("content-type") ?? "image/png";
+
+    // Convert to base64 data URL
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const base64Logo = `data:${contentType};base64,${buffer.toString("base64")}`;
+
+    return base64Logo;
+  } catch {
     return null;
   }
-
-  // Get the content type from the response
-  const contentType = response.headers.get("content-type") ?? "image/png";
-
-  // Convert to base64 data URL
-  const buffer = Buffer.from(await response.arrayBuffer());
-  const base64Logo = `data:${contentType};base64,${buffer.toString("base64")}`;
-
-  return base64Logo;
 }
 
 export async function getInfoEntity(


### PR DESCRIPTION
release page get the organization logo first, is there are not images or logos to show gets the main logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization logo now appears on the sign-in and totem navigation interfaces for improved branding.

* **Bug Fixes**
  * Logo fetching was made more resilient: failures now safely yield no logo instead of causing errors.

* **Chores**
  * Logo-loading behavior standardized across relevant pages to ensure consistent display and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->