### PR TITLE
feat(ext-tasks): external user task execution via email link

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "App: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npx turbo run dev --filter=@modulariot/app",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "App: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3050/app",
+      "webRoot": "${workspaceFolder}/apps/app"
+    },
+    {
+      "name": "App: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npx turbo run dev --filter=@modulariot/app",
+      "cwd": "${workspaceFolder}",
+      "serverReadyAction": {
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -43,6 +43,9 @@ STREAMHUB_AUDIENCE=your_audience
 STREAMHUB_URL=https://pgrest.streamhub.cl
 STREAMHUB_IOT_URL=https://iot.streamhub.cl
 
+# ─── External Tasks (n8n webhooks) ─────────────────────────────────
+EXT_TASKS_WEBHOOK_URL=https://router.streamhub.cl/webhook/{workflow-id}
+
 # ─── Mapbox ──────────────────────────────────────────────────────
 NEXT_PUBLIC_DISPLAY_GEOGRAPHIC_VIEW=TRUE
 NEXT_PUBLIC_MAPBOX_API_KEY=your_mapbox_api_key

--- a/apps/app/src/app/[lang]/ext/tasks/[taskType]/[token]/page.tsx
+++ b/apps/app/src/app/[lang]/ext/tasks/[taskType]/[token]/page.tsx
@@ -1,0 +1,20 @@
+import NavbarSignIn from "@/features/auth/components/navbar-sign-in";
+import { getDictionary } from "@/features/i18n/i18n.service";
+import { ParamsWithLang } from "@/features/i18n/i18n.service.types";
+import ExtTaskExecutor from "@/features/ext-tasks/components/ext-task-executor";
+
+export default async function ExtTaskPage({
+  params,
+}: ParamsWithLang<{ taskType: string; token: string }>) {
+  const { lang, taskType, token } = await params;
+  const [, dict] = await getDictionary(lang);
+
+  return (
+    <div className="flex flex-col w-full justify-center items-center">
+      <NavbarSignIn />
+      <div className="flex w-full max-w-md flex-col items-center gap-4 px-5 pt-20">
+        <ExtTaskExecutor token={token} taskType={taskType} dict={dict} />
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/[lang]/ext/tasks/layout.tsx
+++ b/apps/app/src/app/[lang]/ext/tasks/layout.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import type { PropsWithChildren } from "react";
+import { Inter } from "next/font/google";
+import { twMerge } from "tailwind-merge";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export default function ExtTasksLayout({ children }: PropsWithChildren) {
+  return (
+    <main className={twMerge(inter.className, "dark:bg-gray-900 h-full")}>
+      {children}
+    </main>
+  );
+}

--- a/apps/app/src/app/[lang]/ext/tasks/layout.tsx
+++ b/apps/app/src/app/[lang]/ext/tasks/layout.tsx
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export default function ExtTasksLayout({ children }: PropsWithChildren) {
+export default function ExtTasksLayout({ children }: Readonly<PropsWithChildren>) {
   return (
     <main className={twMerge(inter.className, "dark:bg-gray-900 h-full")}>
       {children}

--- a/apps/app/src/app/api/ext/tasks/execute/route.ts
+++ b/apps/app/src/app/api/ext/tasks/execute/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  validateAndGetTask,
+  ExtTaskError,
+} from "@/features/ext-tasks/providers/ext-task.provider";
+import { getTaskHandler } from "@/features/ext-tasks/handlers";
+import { handleApiError } from "@/app/api/utils/api-error-handler";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { token, taskType } = body as {
+      token?: string;
+      taskType?: string;
+    };
+
+    if (!token || !taskType) {
+      return NextResponse.json(
+        { error: "Missing required fields: token, taskType", status: 400 },
+        { status: 400 },
+      );
+    }
+
+    // Validate token — ExtTaskError uses specific status codes (400, 404, 410)
+    const task = await validateAndGetTask(token, taskType);
+
+    // Execute handler — upstream failures should return 502, not leak status codes
+    const handler = getTaskHandler(taskType);
+    try {
+      const result = await handler(task.payload);
+      return NextResponse.json(result);
+    } catch (handlerError) {
+      return handleApiError(
+        handlerError,
+        `executing ${taskType} handler`,
+        "Task execution failed. Please try again later.",
+      );
+    }
+  } catch (error) {
+    if (error instanceof ExtTaskError) {
+      return NextResponse.json(
+        { error: error.message, status: error.statusCode },
+        { status: error.statusCode },
+      );
+    }
+
+    return handleApiError(error, "processing external task");
+  }
+}

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="es">
+    <html lang="es" suppressHydrationWarning>
       <head>
         <ThemeModeScript />
       </head>

--- a/apps/app/src/auth.config.ts
+++ b/apps/app/src/auth.config.ts
@@ -111,7 +111,8 @@ export const authConfig: NextAuthConfig = {
           nextUrl.pathname.endsWith("/totem") ||
           nextUrl.pathname.endsWith("/favicon.ico") ||
           nextUrl.pathname.endsWith("/app/release") ||
-          nextUrl.pathname.includes("/release/")
+          nextUrl.pathname.includes("/release/") ||
+          nextUrl.pathname.includes("/ext/")
         ) {
           authAuthzLogger.debug( { path: nextUrl.pathname }, "Public route access granted");
           return;

--- a/apps/app/src/features/ext-tasks/components/ext-task-executor.tsx
+++ b/apps/app/src/features/ext-tasks/components/ext-task-executor.tsx
@@ -29,7 +29,7 @@ export default function ExtTaskExecutor({
   token,
   taskType,
   dict,
-}: ExtTaskExecutorProps) {
+}: Readonly<ExtTaskExecutorProps>) {
   const [state, setState] = useState<ViewState>("loading");
   const t = dict.ext_tasks;
 

--- a/apps/app/src/features/ext-tasks/components/ext-task-executor.tsx
+++ b/apps/app/src/features/ext-tasks/components/ext-task-executor.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, Spinner } from "flowbite-react";
+import {
+  HiCheckCircle,
+  HiExclamationCircle,
+  HiClock,
+  HiXCircle,
+} from "react-icons/hi";
+import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
+import type { TaskExecutionStatus } from "../ext-task.types";
+
+interface ExtTaskExecutorProps {
+  token: string;
+  taskType: string;
+  dict: I18nDictionary;
+}
+
+type ViewState = "loading" | TaskExecutionStatus;
+
+const STATUS_MAP: Record<number, TaskExecutionStatus> = {
+  410: "expired",
+  404: "invalid",
+  400: "invalid",
+};
+
+export default function ExtTaskExecutor({
+  token,
+  taskType,
+  dict,
+}: ExtTaskExecutorProps) {
+  const [state, setState] = useState<ViewState>("loading");
+  const t = dict.ext_tasks;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function execute() {
+      try {
+        const res = await fetch("/app/api/ext/tasks/execute", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token, taskType }),
+        });
+
+        if (cancelled) return;
+
+        if (res.ok) {
+          const data = await res.json();
+          setState(data.status as TaskExecutionStatus);
+        } else {
+          const mapped = STATUS_MAP[res.status];
+          setState(mapped ?? "error");
+        }
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    }
+
+    execute();
+    return () => {
+      cancelled = true;
+    };
+  }, [token, taskType]);
+
+  return (
+    <Card className="w-full">
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {state === "loading" && (
+          <>
+            <Spinner size="xl" />
+            <p className="text-gray-600 dark:text-gray-400">{t.processing}</p>
+          </>
+        )}
+
+        {state === "completed" && (
+          <>
+            <HiCheckCircle className="h-16 w-16 text-green-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white">
+              {t.completed}
+            </p>
+          </>
+        )}
+
+        {state === "already_completed" && (
+          <>
+            <HiCheckCircle className="h-16 w-16 text-blue-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white">
+              {t.already_completed}
+            </p>
+          </>
+        )}
+
+        {state === "expired" && (
+          <>
+            <HiClock className="h-16 w-16 text-yellow-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white">
+              {t.expired}
+            </p>
+          </>
+        )}
+
+        {state === "invalid" && (
+          <>
+            <HiXCircle className="h-16 w-16 text-red-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white">
+              {t.invalid}
+            </p>
+          </>
+        )}
+
+        {state === "error" && (
+          <>
+            <HiExclamationCircle className="h-16 w-16 text-red-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white">
+              {t.error}
+            </p>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/app/src/features/ext-tasks/ext-task.types.ts
+++ b/apps/app/src/features/ext-tasks/ext-task.types.ts
@@ -1,0 +1,17 @@
+export interface ExternalTask {
+  taskType: string;
+  payload: Record<string, unknown>;
+  expiresAt: string; // ISO date
+}
+
+export type TaskExecutionStatus =
+  | "completed"
+  | "already_completed"
+  | "expired"
+  | "invalid"
+  | "error";
+
+export interface TaskExecutionResult {
+  status: TaskExecutionStatus;
+  message?: string;
+}

--- a/apps/app/src/features/ext-tasks/handlers/acknowledge.handler.ts
+++ b/apps/app/src/features/ext-tasks/handlers/acknowledge.handler.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { getSharedAuthToken } from "@/app/api/utils/streamhub-api-client";
+import fetcher from "@/features/common/providers/fetcher";
+import type { TaskExecutionResult } from "../ext-task.types";
+
+export async function acknowledgeHandler(
+  payload: Record<string, unknown>,
+): Promise<TaskExecutionResult> {
+  const webhookUrl = process.env.EXT_TASKS_WEBHOOK_URL;
+  if (!webhookUrl) {
+    throw new Error("EXT_TASKS_WEBHOOK_URL is not configured");
+  }
+
+  const authToken = getSharedAuthToken();
+  const token = await authToken.getToken();
+
+  await fetcher(webhookUrl, {
+    method: "POST", 
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  return { status: "completed" };
+}

--- a/apps/app/src/features/ext-tasks/handlers/index.ts
+++ b/apps/app/src/features/ext-tasks/handlers/index.ts
@@ -1,0 +1,18 @@
+import type { TaskExecutionResult } from "../ext-task.types";
+import { acknowledgeHandler } from "./acknowledge.handler";
+
+type TaskHandler = (
+  payload: Record<string, unknown>,
+) => Promise<TaskExecutionResult>;
+
+const handlers: Record<string, TaskHandler> = {
+  acknowledge: acknowledgeHandler,
+};
+
+export function getTaskHandler(taskType: string): TaskHandler {
+  const handler = handlers[taskType];
+  if (!handler) {
+    throw new Error(`Unknown task type: ${taskType}`);
+  }
+  return handler;
+}

--- a/apps/app/src/features/ext-tasks/providers/ext-task.provider.ts
+++ b/apps/app/src/features/ext-tasks/providers/ext-task.provider.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import type { ExternalTask } from "../ext-task.types";
+
+/**
+ * Validates a token and extracts the external task data.
+ *
+ * **Interim implementation**: base64url-decodes the token JSON payload.
+ * **Future**: Replace internals with Alfresco node lookup by token UUID.
+ * The function signature stays the same — this is the only integration point.
+ */
+export async function validateAndGetTask(
+  token: string,
+  taskType: string,
+): Promise<ExternalTask> {
+  let decoded: ExternalTask;
+
+  try {
+    const json = Buffer.from(token, "base64url").toString("utf-8");
+    decoded = JSON.parse(json) as ExternalTask;
+  } catch {
+    throw new ExtTaskError("Invalid token", 404);
+  }
+
+  if (decoded.taskType !== taskType) {
+    throw new ExtTaskError("Token task type mismatch", 400);
+  }
+
+  if (!decoded.expiresAt || new Date(decoded.expiresAt) < new Date()) {
+    throw new ExtTaskError("Token has expired", 410);
+  }
+
+  return decoded;
+}
+
+export class ExtTaskError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "ExtTaskError";
+    this.statusCode = statusCode;
+  }
+}

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -2047,5 +2047,13 @@
       "successNotification": "Calendar created successfully",
       "errorNotification": "Failed to create calendar"
     }
+  },
+  "ext_tasks": {
+    "processing": "Processing your request...",
+    "completed": "Action completed successfully",
+    "already_completed": "This action has already been completed",
+    "expired": "This link has expired",
+    "error": "Something went wrong. Please try again later.",
+    "invalid": "This link is not valid"
   }
 }

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -2079,5 +2079,13 @@
       "successNotification": "Calendario creado correctamente",
       "errorNotification": "Error al crear el calendario"
     }
+  },
+  "ext_tasks": {
+    "processing": "Procesando tu solicitud...",
+    "completed": "Acción completada exitosamente",
+    "already_completed": "Esta acción ya fue completada",
+    "expired": "Este enlace ha expirado",
+    "error": "Algo salió mal. Por favor, intenta más tarde.",
+    "invalid": "Este enlace no es válido"
   }
 }


### PR DESCRIPTION
## Summary

- Add public page at `/app/[lang]/ext/tasks/[taskType]/[token]` for unauthenticated users to execute actions via email links
- First use case: **symptom acknowledgment** — page auto-POSTs to an n8n webhook with StreamHub OAuth2 auth and shows the result
- Interim token strategy uses base64url-encoded JSON; `validateAndGetTask()` is the single integration point for future Alfresco lookup
- Whitelist `/ext/` routes in auth config for public access
- Add root `.vscode/launch.json` for debugging the app via turborepo
- Fix `ThemeModeScript` hydration mismatch with `suppressHydrationWarning`

## Test plan

- [x] Generate a test token: `Buffer.from(JSON.stringify({ taskType: "acknowledge", payload: { symptom_is: "SYM-12345", status_validation: "validated" }, expiresAt: "2026-04-01T00:00:00Z" })).toString("base64url")`
- [x] Visit `/app/es/ext/tasks/acknowledge/{token}` in incognito — should auto-execute and show result
- [x] Generate an expired token (past `expiresAt`) — should show "expired" state
- [x] Visit with garbage token — should show "invalid" state
- [x] Verify i18n works for both `/en/` and `/es/` paths
- [x] Verify VS Code debug configurations launch correctly

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External task execution with token-based flow, real-time status UI (loading, completed, already completed, expired, invalid, error)
  * Extensible handlers with webhook-based acknowledgment support
  * Localized status messages added (English and Spanish)
* **Chores**
  * Example environment variable added for external task webhooks
* **Other**
  * Public routes updated to allow external task pages and layout/hydration improved for those pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->