### PR TITLE
feat: Filmstrip sidebar with timelapse video support

### DIFF
--- a/apps/app/src/app/api/timelapse/route.ts
+++ b/apps/app/src/app/api/timelapse/route.ts
@@ -1,0 +1,35 @@
+import { requireAuth } from "../utils/alfresco-crud-client";
+import { getTimelapseMetadata } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+export async function GET(req: NextRequest) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const url = new URL(req.url);
+  const licensePlate = url.searchParams.get("license_plate");
+  const timestamp = url.searchParams.get("timestamp");
+
+  if (!licensePlate || !timestamp) {
+    return NextResponse.json(
+      { error: "Missing license_plate or timestamp" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const metadata = await getTimelapseMetadata(
+      authResult.session,
+      licensePlate,
+      timestamp
+    );
+    return NextResponse.json(metadata);
+  } catch (error) {
+    logger.error({ err: error }, "Failed to fetch timelapse metadata");
+    return NextResponse.json(
+      { error: "Failed to fetch timelapse metadata" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/app/src/app/api/timelapse/stream/route.ts
+++ b/apps/app/src/app/api/timelapse/stream/route.ts
@@ -1,0 +1,59 @@
+import { auth } from "@/auth";
+import { prepareAlfrescoAuth } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const sessionId = url.searchParams.get("session_id");
+
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "Missing session_id" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { url: alfrescoUrl, headers } = prepareAlfrescoAuth(
+      `${process.env.ECM_API_URL}/alfresco/s/mintral/timelapse/stream?session_id=${encodeURIComponent(sessionId)}`,
+      session
+    );
+
+    const response = await fetch(alfrescoUrl, {
+      headers: {
+        ...headers,
+        Accept: "*/*",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Alfresco responded with status: ${response.status}`);
+    }
+
+    const contentType = response.headers.get("Content-Type");
+    const contentLength = response.headers.get("Content-Length");
+
+    const responseHeaders: Record<string, string> = {
+      "Content-Type": contentType || "video/mp4",
+      "Cache-Control": "public, max-age=3600",
+    };
+
+    if (contentLength) {
+      responseHeaders["Content-Length"] = contentLength;
+    }
+
+    return new NextResponse(response.body, { headers: responseHeaders });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to stream timelapse" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -1436,6 +1436,42 @@ export async function getServiceTypes(
   return serviceTypesSchema.parse(await response.json());
 }
 
+const timelapseMetadataSchema = z.object({
+  streamUrl: z.string(),
+  estimatedDurationSeconds: z.number(),
+  framerate: z.number(),
+  downloadUrl: z.string(),
+  videoSizeBytes: z.number(),
+  sessionId: z.string(),
+  deviceId: z.string(),
+  licensePlate: z.string(),
+  nodeRef: z.string(),
+  location: z.object({
+    latitude: z.number(),
+    longitude: z.number(),
+  }).nullable().optional(),
+  state: z.string(),
+  startTimestamp: z.string(),
+  endTimestamp: z.string(),
+  frameCount: z.number(),
+  clientId: z.string(),
+  projectId: z.string(),
+});
+
+export type TimelapseMetadata = z.infer<typeof timelapseMetadataSchema>;
+
+export async function getTimelapseMetadata(
+  session: Session,
+  licensePlate: string,
+  timestamp: string
+): Promise<TimelapseMetadata> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/timelapse?license_plate=${encodeURIComponent(licensePlate)}&timestamp=${encodeURIComponent(timestamp)}`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw new Error(`timelapse: ${response.status}`);
+  return timelapseMetadataSchema.parse(await response.json());
+}
+
 export async function updateTaskServiceCategory(
   session: Session,
   taskId: string,

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -1436,7 +1436,7 @@ export async function getServiceTypes(
   return serviceTypesSchema.parse(await response.json());
 }
 
-const timelapseMetadataSchema = z.object({
+export const timelapseMetadataSchema = z.object({
   streamUrl: z.string(),
   estimatedDurationSeconds: z.number(),
   framerate: z.number(),

--- a/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
@@ -114,12 +114,10 @@ function VideoFilmstripFrame({
     <div className="flex items-stretch px-1 py-2">
       <SprocketStrip />
       <div className="flex-1 mx-1 relative overflow-hidden border border-gray-300 dark:border-gray-600 rounded-sm bg-gray-200 dark:bg-gray-800">
-        <div
-          className="relative w-full aspect-[4/3] cursor-pointer"
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
+          className="relative w-full aspect-[4/3] cursor-pointer border-none bg-transparent p-0 block"
           onClick={togglePlay}
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); togglePlay(); } }}
         >
           <video
             ref={videoRef}
@@ -169,7 +167,7 @@ function VideoFilmstripFrame({
               <MdOutlineRemoveRedEye className="w-5 h-5 text-white" />
             </Button>
           </div>
-        </div>
+        </button>
       </div>
       <SprocketStrip />
     </div>

--- a/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
@@ -29,12 +29,12 @@ function FilmstripFrame({
   index,
   setSelected,
   dictionary,
-}: {
+}: Readonly<{
   image: string;
   index: number;
   setSelected: (index: number) => void;
   dictionary?: I18nRecord;
-}) {
+}>) {
   return (
     <div className="flex items-stretch px-1 py-2">
       <SprocketStrip />
@@ -91,12 +91,10 @@ function formatDuration(seconds: number): string {
 function VideoFilmstripFrame({
   timelapse,
   onOpenViewer,
-  dictionary,
-}: {
+}: Readonly<{
   timelapse: TimelapseData;
   onOpenViewer: () => void;
-  dictionary?: I18nRecord;
-}) {
+}>) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [playing, setPlaying] = useState(false);
 
@@ -116,7 +114,13 @@ function VideoFilmstripFrame({
     <div className="flex items-stretch px-1 py-2">
       <SprocketStrip />
       <div className="flex-1 mx-1 relative overflow-hidden border border-gray-300 dark:border-gray-600 rounded-sm bg-gray-200 dark:bg-gray-800">
-        <div className="relative w-full aspect-[4/3] cursor-pointer" onClick={togglePlay}>
+        <div
+          className="relative w-full aspect-[4/3] cursor-pointer"
+          role="button"
+          tabIndex={0}
+          onClick={togglePlay}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); togglePlay(); } }}
+        >
           <video
             ref={videoRef}
             src={timelapse.proxyStreamUrl}
@@ -170,6 +174,11 @@ function VideoFilmstripFrame({
       <SprocketStrip />
     </div>
   );
+}
+
+function scrollIndicatorOpacity(open: boolean, canScrollDown: boolean): string {
+  if (!open) return "duration-100 opacity-0";
+  return canScrollDown ? "opacity-100 duration-500" : "duration-300 opacity-0";
 }
 
 export default function ImageSelector({
@@ -231,7 +240,6 @@ export default function ImageSelector({
             <VideoFilmstripFrame
               timelapse={timelapse}
               onOpenViewer={() => setShowVideoViewer(true)}
-              dictionary={dictionary}
             />
           )}
           {images.map((image, index) => (
@@ -260,7 +268,7 @@ export default function ImageSelector({
 
       {/* Scroll indicator */}
       <div
-        className={`absolute bottom-5 z-[2] pointer-events-none transition-all ${open ? "left-[140px]" : "left-0"} ${open ? (canScrollDown ? "opacity-100 duration-500" : "duration-300 opacity-0") : "duration-100 opacity-0"}`}
+        className={`absolute bottom-5 z-[2] pointer-events-none transition-all ${open ? "left-[140px]" : "left-0"} ${scrollIndicatorOpacity(open, canScrollDown)}`}
       >
         <div className="animate-bounce text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 rounded-full px-2 py-1 shadow border border-gray-300 dark:border-gray-600">
           ↓

--- a/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/image-selector.tsx
@@ -1,28 +1,196 @@
 import { useState, useRef, useEffect } from "react";
-import { FaChevronRight, FaImage } from "react-icons/fa";
+import { FaImage, FaPlay, FaPause } from "react-icons/fa";
 import { MdOutlineFileDownload, MdOutlineRemoveRedEye } from "react-icons/md";
 import Image from "next/image";
 import ImageViewer from "./image-viewer";
+import VideoViewer from "./video-viewer";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { downloadImage } from "../../utils/download-image";
 import { Button } from "flowbite-react";
+import type { TimelapseData } from "../../hooks/use-timelapse";
+
+function SprocketStrip() {
+  return (
+    <div
+      className="shrink-0 w-5"
+      style={{
+        backgroundImage:
+          "repeating-linear-gradient(to bottom, transparent 0px, transparent 4px, var(--sprocket-color) 4px, var(--sprocket-color) 12px, transparent 12px, transparent 20px)",
+        backgroundSize: "12px 20px",
+        backgroundRepeat: "repeat-y",
+        backgroundPosition: "center",
+      }}
+    />
+  );
+}
+
+function FilmstripFrame({
+  image,
+  index,
+  setSelected,
+  dictionary,
+}: {
+  image: string;
+  index: number;
+  setSelected: (index: number) => void;
+  dictionary?: I18nRecord;
+}) {
+  return (
+    <div className="flex items-stretch px-1 py-2">
+      <SprocketStrip />
+      <div className="flex-1 mx-1 relative overflow-hidden border border-gray-300 dark:border-gray-600 rounded-sm bg-gray-200 dark:bg-gray-800">
+        <div className="relative w-full aspect-[4/3]">
+          {image ? (
+            <Image
+              src={image}
+              alt={`Evidence ${index + 1}`}
+              width={200}
+              height={150}
+              className="object-cover w-full h-full"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-gray-300 dark:bg-gray-700">
+              <FaImage className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+            </div>
+          )}
+          <div className="absolute inset-0 opacity-0 flex justify-center items-center text-white transition-all duration-300 hover:opacity-100 backdrop-blur-[10px] bg-black/30 gap-2">
+            <Button
+              className="flex flex-col items-center justify-center bg-blue-500 rounded-full p-2 hover:bg-blue-600 cursor-pointer transition-all duration-300"
+              onClick={() => setSelected(index)}
+            >
+              <MdOutlineRemoveRedEye className="w-6 h-6" />
+            </Button>
+            <Button
+              className="flex flex-col items-center justify-center bg-blue-500 rounded-full p-2 hover:bg-blue-600 cursor-pointer transition-all duration-300"
+              onClick={async (e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                try {
+                  await downloadImage(image, dictionary);
+                } catch (error) {
+                  console.error("Download error:", error);
+                }
+              }}
+            >
+              <MdOutlineFileDownload className="w-6 h-6" />
+            </Button>
+          </div>
+        </div>
+      </div>
+      <SprocketStrip />
+    </div>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function VideoFilmstripFrame({
+  timelapse,
+  onOpenViewer,
+  dictionary,
+}: {
+  timelapse: TimelapseData;
+  onOpenViewer: () => void;
+  dictionary?: I18nRecord;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const togglePlay = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      video.play();
+      setPlaying(true);
+    } else {
+      video.pause();
+      setPlaying(false);
+    }
+  };
+
+  return (
+    <div className="flex items-stretch px-1 py-2">
+      <SprocketStrip />
+      <div className="flex-1 mx-1 relative overflow-hidden border border-gray-300 dark:border-gray-600 rounded-sm bg-gray-200 dark:bg-gray-800">
+        <div className="relative w-full aspect-[4/3] cursor-pointer" onClick={togglePlay}>
+          <video
+            ref={videoRef}
+            src={timelapse.proxyStreamUrl}
+            preload="metadata"
+            playsInline
+            muted
+            loop
+            className="object-cover w-full h-full"
+            onPlay={() => setPlaying(true)}
+            onPause={() => setPlaying(false)}
+          />
+
+          {/* Paused overlay: play icon + duration */}
+          {!playing && (
+            <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+              <FaPlay className="w-8 h-8 text-white drop-shadow-lg" />
+              <div className="absolute bottom-1 right-1 bg-black/70 text-white text-xs px-1.5 py-0.5 rounded">
+                {formatDuration(timelapse.estimatedDurationSeconds)}
+              </div>
+            </div>
+          )}
+
+          {/* Playing hover overlay: pause icon */}
+          {playing && (
+            <div className="absolute inset-0 opacity-0 hover:opacity-100 bg-black/30 flex items-center justify-center transition-opacity duration-200">
+              <FaPause className="w-8 h-8 text-white drop-shadow-lg" />
+            </div>
+          )}
+
+          {/* Processing badge */}
+          {timelapse.state === "PROCESSING" && (
+            <div className="absolute top-1 left-1 bg-yellow-500 text-white text-xs px-1.5 py-0.5 rounded font-medium">
+              Processing...
+            </div>
+          )}
+
+          {/* Eye icon overlay on hover */}
+          <div className="absolute top-1 right-1 opacity-0 hover:opacity-100 transition-opacity duration-200">
+            <Button
+              className="bg-blue-500 rounded-full p-1.5 hover:bg-blue-600 cursor-pointer transition-all duration-300"
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                onOpenViewer();
+              }}
+            >
+              <MdOutlineRemoveRedEye className="w-5 h-5 text-white" />
+            </Button>
+          </div>
+        </div>
+      </div>
+      <SprocketStrip />
+    </div>
+  );
+}
 
 export default function ImageSelector({
   images,
   dictionary,
+  timelapse,
 }: {
   images: string[];
   dictionary: I18nRecord;
+  timelapse?: TimelapseData | null;
 }) {
   const [open, setOpen] = useState(true);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const [selected, setSelected] = useState<number | null>(null);
+  const [showVideoViewer, setShowVideoViewer] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const checkScroll = () => {
-      const el = scrollRef.current?.querySelector(".overflow-y-auto");
+      const el = scrollRef.current;
       if (!el) return;
 
       const scrollable = el.scrollHeight > el.clientHeight;
@@ -32,11 +200,10 @@ export default function ImageSelector({
       setCanScrollDown(scrollable && !scrolledToBottom);
     };
 
-    const el = scrollRef.current?.querySelector(".overflow-y-auto");
+    const el = scrollRef.current;
     if (el) {
       el.addEventListener("scroll", checkScroll);
       window.addEventListener("resize", checkScroll);
-      // Initial check
       checkScroll();
     }
 
@@ -50,44 +217,71 @@ export default function ImageSelector({
 
   return (
     <div
-      ref={scrollRef}
-      className="h-full bg-white dark:bg-gray-800 pointer-events-auto transition-all duration-300 relative"
+      className="h-full pointer-events-auto relative flex [--sprocket-color:theme(colors.gray.400)] dark:[--sprocket-color:theme(colors.gray.700)]"
     >
+      {/* Filmstrip panel */}
       <div
-        className={`overflow-y-auto overflow-x-hidden h-full transition-all duration-300 ${open ? "max-w-80 border-r-2 border-gray-300 dark:border-gray-700" : "max-w-0 overflow-hidden"}`}
+        className={`h-full bg-gray-100 dark:bg-gray-900 overflow-hidden transition-all duration-500 ease-in-out ${open ? "w-[280px]" : "w-0"}`}
       >
-        {images.map((image, index) => (
-          <ImageComponent
-            key={index}
-            image={image}
-            index={index}
-            setSelected={setSelected}
-            dictionary={dictionary}
-          />
-        ))}
-        {/* Scroll down indicator */}
+        <div
+          ref={scrollRef}
+          className="h-full overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100 dark:scrollbar-thumb-gray-700 dark:scrollbar-track-gray-900"
+        >
+          {timelapse && (
+            <VideoFilmstripFrame
+              timelapse={timelapse}
+              onOpenViewer={() => setShowVideoViewer(true)}
+              dictionary={dictionary}
+            />
+          )}
+          {images.map((image, index) => (
+            <FilmstripFrame
+              key={index}
+              image={image}
+              index={index}
+              setSelected={setSelected}
+              dictionary={dictionary}
+            />
+          ))}
+        </div>
       </div>
+
+      {/* Grabber tab */}
       <div
-        className="absolute right-[-2em] z-10 top-1/2 -translate-y-1/2 h-10 w-[2em] bg-white rounded-r-lg px-1 hover:px-2 border-r border-y border-gray-200 flex items-center justify-center cursor-pointer"
+        className="absolute right-[-32px] top-4 z-10 w-8 h-10 bg-gray-100/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-r-lg flex items-center justify-center cursor-pointer hover:bg-gray-200/90 dark:hover:bg-gray-800/90 transition-colors duration-200"
         onClick={() => setOpen(!open)}
       >
-        <FaChevronRight
-          className={`w-5 h-5 transition-all duration-300 ${open ? "rotate-180" : ""}`}
-        />
+        <div className="flex flex-col gap-[3px]">
+          <span className="block w-4 h-[2px] bg-gray-500 dark:bg-gray-400 rounded-full" />
+          <span className="block w-4 h-[2px] bg-gray-500 dark:bg-gray-400 rounded-full" />
+          <span className="block w-4 h-[2px] bg-gray-500 dark:bg-gray-400 rounded-full" />
+        </div>
       </div>
+
+      {/* Scroll indicator */}
       <div
-        className={`absolute bottom-5 left-1/2 -translate-x-1/2 z-[2] pointer-events-none transition-all ${open ? (canScrollDown ? "opacity-100 duration-500" : "duration-300 opacity-0") : "duration-100 opacity-0"} `}
+        className={`absolute bottom-5 z-[2] pointer-events-none transition-all ${open ? "left-[140px]" : "left-0"} ${open ? (canScrollDown ? "opacity-100 duration-500" : "duration-300 opacity-0") : "duration-100 opacity-0"}`}
       >
-        <div className="animate-bounce text-gray-400 bg-white rounded-full px-2 py-1 shadow border border-gray-500">
+        <div className="animate-bounce text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 rounded-full px-2 py-1 shadow border border-gray-300 dark:border-gray-600">
           ↓
         </div>
       </div>
+
       <ImageViewer
         images={images}
         selected={selected}
         setSelected={setSelected}
         dictionary={dictionary}
       />
+
+      {timelapse && (
+        <VideoViewer
+          videoUrl={timelapse.proxyStreamUrl}
+          show={showVideoViewer}
+          onClose={() => setShowVideoViewer(false)}
+          dictionary={dictionary}
+        />
+      )}
     </div>
   );
 }

--- a/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
@@ -1,6 +1,7 @@
 import { Button, Modal, ModalBody } from "flowbite-react";
 import { MdOutlineFileDownload } from "react-icons/md";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
 import { logger } from "@/lib/logger";
 import { toast } from "sonner";
 
@@ -71,7 +72,7 @@ export default function VideoViewer({
                 URL.revokeObjectURL(blobUrl);
               } catch (error) {
                 logger.error({ err: error, videoUrl }, "Video download failed");
-                toast.error("Download failed — opening in a new tab");
+                toast.error(tr("geographic_view.download_failed", dictionary));
                 window.open(videoUrl, "_blank");
               }
             }}

--- a/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
@@ -1,0 +1,72 @@
+import { Button, Modal, ModalBody } from "flowbite-react";
+import { MdOutlineFileDownload } from "react-icons/md";
+import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { downloadImage } from "../../utils/download-image";
+
+const modalTheme = {
+  root: {
+    base: "fixed inset-0 z-50 h-full w-full overflow-hidden",
+    sizes: {
+      "7xl": "max-w-none",
+    },
+  },
+  content: {
+    base: "relative w-[80%] h-[80%] md:h-[80%] p-0",
+    inner:
+      "relative flex flex-col h-full max-h-none bg-white dark:bg-gray-700 rounded-lg border border-gray-800 overflow-hidden",
+  },
+  body: {
+    base: "flex flex-col flex-1 overflow-hidden p-0",
+  },
+};
+
+export default function VideoViewer({
+  videoUrl,
+  show,
+  onClose,
+  dictionary,
+}: Readonly<{
+  videoUrl: string;
+  show: boolean;
+  onClose: () => void;
+  dictionary: I18nRecord;
+}>) {
+  return (
+    <Modal
+      dismissible
+      show={show}
+      onClose={onClose}
+      size="7xl"
+      theme={modalTheme}
+      className="z-[800] backdrop-blur-[10px]"
+    >
+      <ModalBody>
+        <div className="relative flex items-center justify-center bg-gray-300 dark:bg-gray-600 rounded-t-lg shadow-lg w-full flex-1 min-h-0 overflow-hidden">
+          <video
+            src={videoUrl}
+            controls
+            autoPlay
+            playsInline
+            className="w-full h-full object-contain"
+          />
+        </div>
+        <div className="w-full flex-shrink-0 flex justify-end items-center p-2">
+          <Button
+            color="blue"
+            onClick={async () => {
+              try {
+                await downloadImage(videoUrl, dictionary);
+              } catch (error) {
+                console.error("Download error:", error);
+              }
+            }}
+            pill
+            size="sm"
+          >
+            <MdOutlineFileDownload className="w-4 h-4" />
+          </Button>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
@@ -1,7 +1,8 @@
 import { Button, Modal, ModalBody } from "flowbite-react";
 import { MdOutlineFileDownload } from "react-icons/md";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
-import { downloadImage } from "../../utils/download-image";
+import { logger } from "@/lib/logger";
+import { toast } from "sonner";
 
 const modalTheme = {
   root: {
@@ -54,10 +55,23 @@ export default function VideoViewer({
           <Button
             color="blue"
             onClick={async () => {
+              const filename = `timelapse-${new Date().toISOString().slice(0, 10)}.mp4`;
               try {
-                await downloadImage(videoUrl, dictionary);
+                const response = await fetch(videoUrl, { mode: "cors" });
+                if (!response.ok) throw new Error("Fetch failed");
+                const blob = await response.blob();
+                const blobUrl = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.download = filename;
+                link.href = blobUrl;
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(blobUrl);
               } catch (error) {
-                console.error("Download error:", error);
+                logger.error({ err: error, videoUrl }, "Video download failed");
+                toast.error("Download failed — opening in a new tab");
+                window.open(videoUrl, "_blank");
               }
             }}
             pill

--- a/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
+++ b/apps/app/src/features/geographic-view/components/image-viewer/video-viewer.tsx
@@ -48,6 +48,7 @@ export default function VideoViewer({
             controls
             autoPlay
             playsInline
+            muted
             className="w-full h-full object-contain"
           />
         </div>

--- a/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
+++ b/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
@@ -26,6 +26,7 @@ import { TreatmentsGeneralResponseItem } from "@/app/api/treatments/general/rout
 // import { BsSignStop } from "react-icons/bs";
 import { ConditionsAgg } from "@/features/symptoms/types/timeline";
 import ImageSelector from "./image-viewer/image-selector";
+import { useTimelapse } from "../hooks/use-timelapse";
 import { logger } from "@/lib/logger";
 import { tr } from "@/features/i18n/tr.service";
 import PulseRange from "./tool-bar/pulse-range";
@@ -113,6 +114,7 @@ type MapVisualizationProps = {
   ) => void;
   setSelectedTreatmentIndex?: (treatmentIndex: ConditionsAgg | null) => void;
   minimized?: boolean;
+  licensePlate?: string | null;
 };
 
 type GeometryFeature = {
@@ -136,6 +138,7 @@ export default function MapVisualizationTrip({
   setSelectedTreatment,
   setSelectedTreatmentIndex,
   minimized = false,
+  licensePlate,
 }: MapVisualizationProps) {
   const [rotation, _] = useState(0);
   const [mapStyle, setMapStyle] = useState("satellite");
@@ -148,6 +151,11 @@ export default function MapVisualizationTrip({
   const [pictures_list, setPicturesList] = useState<string[]>([]);
 
   const mapRef = useRef<MapRef>(null);
+
+  const { timelapse } = useTimelapse(
+    licensePlate ?? null,
+    selectedTreatmentIndex?.start ?? null
+  );
 
   useEffect(() => {
     if (selectedTreatmentIndex && selectedTreatmentIndex.evidences) {
@@ -434,10 +442,12 @@ export default function MapVisualizationTrip({
 
   return (
     <div className="h-full w-full relative overflow-hidden">
+      {(pictures_list.length > 0 || timelapse) && !minimized ? (
+        <div className="z-[700] absolute top-0 left-0 h-full pointer-events-none">
+          <ImageSelector images={pictures_list} dictionary={dict} timelapse={timelapse} />
+        </div>
+      ) : null}
       <div className="z-[700] absolute bottom-0 left-0 right-0 w-full pointer-events-none">
-        {pictures_list.length > 0 && !minimized ? (
-          <ImageSelector images={pictures_list} dictionary={dict} />
-        ) : null}
         <ToolBar
           dictionary={dict}
           positions={positions ?? []}

--- a/apps/app/src/features/geographic-view/hooks/use-timelapse.ts
+++ b/apps/app/src/features/geographic-view/hooks/use-timelapse.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import type { TimelapseMetadata } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+
+export type TimelapseData = TimelapseMetadata & {
+  proxyStreamUrl: string;
+};
+
+export function useTimelapse(
+  licensePlate: string | null,
+  timestamp: string | null
+) {
+  const [timelapse, setTimelapse] = useState<TimelapseData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!licensePlate || !timestamp) {
+      setTimelapse(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    fetch(
+      `/app/api/timelapse?license_plate=${encodeURIComponent(licensePlate)}&timestamp=${encodeURIComponent(timestamp)}`
+    )
+      .then(async (res) => {
+        if (cancelled) return;
+        if (!res.ok) {
+          setTimelapse(null);
+          return;
+        }
+        const metadata: TimelapseMetadata = await res.json();
+        setTimelapse({
+          ...metadata,
+          proxyStreamUrl: `/app/api/timelapse/stream?session_id=${encodeURIComponent(metadata.sessionId)}`,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err);
+        setTimelapse(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [licensePlate, timestamp]);
+
+  return { timelapse, loading, error };
+}

--- a/apps/app/src/features/geographic-view/hooks/use-timelapse.ts
+++ b/apps/app/src/features/geographic-view/hooks/use-timelapse.ts
@@ -1,57 +1,41 @@
-import { useState, useEffect } from "react";
-import type { TimelapseMetadata } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import useSWR from "swr";
+import {
+  timelapseMetadataSchema,
+  type TimelapseMetadata,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 
 export type TimelapseData = TimelapseMetadata & {
   proxyStreamUrl: string;
 };
 
+async function timelapseFetcher(url: string): Promise<TimelapseData | null> {
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  const json = await res.json();
+  const metadata = timelapseMetadataSchema.parse(json);
+  return {
+    ...metadata,
+    proxyStreamUrl: `/app/api/timelapse/stream?session_id=${encodeURIComponent(metadata.sessionId)}`,
+  };
+}
+
 export function useTimelapse(
   licensePlate: string | null,
   timestamp: string | null
 ) {
-  const [timelapse, setTimelapse] = useState<TimelapseData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const key =
+    licensePlate && timestamp
+      ? `/app/api/timelapse?license_plate=${encodeURIComponent(licensePlate)}&timestamp=${encodeURIComponent(timestamp)}`
+      : null;
 
-  useEffect(() => {
-    if (!licensePlate || !timestamp) {
-      setTimelapse(null);
-      setLoading(false);
-      setError(null);
-      return;
+  const { data, error, isLoading } = useSWR<TimelapseData | null>(
+    key,
+    timelapseFetcher,
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
     }
+  );
 
-    let cancelled = false;
-    setLoading(true);
-
-    fetch(
-      `/app/api/timelapse?license_plate=${encodeURIComponent(licensePlate)}&timestamp=${encodeURIComponent(timestamp)}`
-    )
-      .then(async (res) => {
-        if (cancelled) return;
-        if (!res.ok) {
-          setTimelapse(null);
-          return;
-        }
-        const metadata: TimelapseMetadata = await res.json();
-        setTimelapse({
-          ...metadata,
-          proxyStreamUrl: `/app/api/timelapse/stream?session_id=${encodeURIComponent(metadata.sessionId)}`,
-        });
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(err);
-        setTimelapse(null);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [licensePlate, timestamp]);
-
-  return { timelapse, loading, error };
+  return { timelapse: data ?? null, loading: isLoading, error: error ?? null };
 }

--- a/apps/app/src/features/shipping/components/geographic.tsx
+++ b/apps/app/src/features/shipping/components/geographic.tsx
@@ -34,6 +34,7 @@ export default function Geographic({
         dict={dictionary}
         selectedTreatmentIndex={null}
         minimized={true}
+        licensePlate={(task.mintral_truckLicensePlate as string) ?? null}
       />
     </div>
   );

--- a/apps/app/src/features/symptoms/components/map-view/general-map.tsx
+++ b/apps/app/src/features/symptoms/components/map-view/general-map.tsx
@@ -251,6 +251,7 @@ export default function GeneralMap({
             selectedTreatmentIndex={selectedTreatmentIndex ?? null}
             setSelectedTreatment={setSelectedTreatment}
             setSelectedTreatmentIndex={setSelectedTreatmentIndex}
+            licensePlate={treatmentData?.trip_info?.asset_id ?? null}
           />
         </div>
       </div>

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -1606,7 +1606,9 @@
     "accumulated_time": "Driving time",
     "show_stops": "Show stops",
     "hide_stops": "Hide stops",
-    "image_prefix": "image"
+    "image_prefix": "image",
+    "processing": "Processing...",
+    "download_failed": "Download failed — opening in a new tab"
   },
   "release": {
     "other_versions": "Other Versions",

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -1632,7 +1632,9 @@
     "accumulated_time": "Tiempo de conducción",
     "show_stops": "Mostrar paradas",
     "hide_stops": "Ocultar paradas",
-    "image_prefix": "imagen"
+    "image_prefix": "imagen",
+    "processing": "Procesando...",
+    "download_failed": "Descarga fallida — abriendo en nueva pestaña"
   },
   "release": {
     "other_versions": "Otras versiones",


### PR DESCRIPTION
## Summary

- Redesign image viewer as a left-side sliding filmstrip sidebar with sprocket-hole aesthetic, grabber tab, and scroll indicator
- Integrate timelapse video support via Alfresco API proxy (`/alfresco/s/mintral/timelapse`), rendered as a playable video frame above evidence images
- Add full-size `VideoViewer` modal with native controls and download button (downloads as `.mp4`)

Closes #79

## Test plan

- [x] Open a symptom treatment page with evidence images — filmstrip sidebar appears on the left
- [x] Click grabber tab to expand/collapse with smooth animation
- [x] Hover image frames to see view (eye) and download buttons
- [x] Verify Network tab: `/api/timelapse?license_plate=...&timestamp=...` fires on treatment select
- [x] If timelapse available: video frame at top of filmstrip with play icon + duration badge
- [x] Click video to play inline; hover while playing shows pause icon
- [x] Click eye icon on video: opens full-size modal with native `<video controls>`
- [x] Download video from modal — file is `.mp4` with correct name
- [x] If `state=PROCESSING`: yellow "Processing..." badge visible on video frame
- [x] If no timelapse: filmstrip shows only images, no console errors
- [x] Shipping geographic view (`minimized=true`) unaffected
- [x] Light/dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Timelapse video viewing now available for trips with integrated map and image viewer support
- Play/pause controls and visual duration indicators for timelapse playback
- Download timelapse videos with automatic date-based naming
- Full-featured video viewer with playback controls and fallback viewing options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->