### PR TITLE
feat(miot-cli): add parallelism to calendar commands

### DIFF
--- a/packages/miot-cli/package.json
+++ b/packages/miot-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
+++ b/packages/miot-cli/src/__tests__/commands/calendar-list.test.ts
@@ -35,7 +35,7 @@ describe("calendar list", () => {
 
   it("should call calendars.list and print JSON", async () => {
     const mockCalendars = [
-      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true },
+      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true, parallelism: 1 },
     ];
     const mockClient = {
       calendars: { list: vi.fn().mockResolvedValue(mockCalendars) },
@@ -109,7 +109,7 @@ describe("calendar list", () => {
 
   it("should print table output", async () => {
     const mockCalendars = [
-      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true, hasSlotManager: true },
+      { id: "1", code: "test", name: "Test", timezone: "UTC", active: true, hasSlotManager: true, parallelism: 1 },
     ];
     const mockClient = {
       calendars: { list: vi.fn().mockResolvedValue(mockCalendars) },
@@ -143,6 +143,7 @@ describe("calendar get", () => {
       name: "Test",
       timezone: "UTC",
       active: true,
+      parallelism: 1,
     };
     const mockClient = {
       calendars: { get: vi.fn().mockResolvedValue(mockCalendar) },
@@ -178,6 +179,7 @@ describe("calendar create", () => {
       name: "New Calendar",
       timezone: "UTC",
       active: true,
+      parallelism: 1,
     };
     const mockClient = {
       calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
@@ -216,6 +218,7 @@ describe("calendar create", () => {
       name: "New Calendar",
       timezone: "UTC",
       active: true,
+      parallelism: 1,
     };
     const mockClient = {
       calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
@@ -248,7 +251,7 @@ describe("calendar create", () => {
   });
 
   it("should pass groups when --group is provided", async () => {
-    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true };
+    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true, parallelism: 1 };
     const mockClient = {
       calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
     };
@@ -270,7 +273,7 @@ describe("calendar create", () => {
   });
 
   it("should pass multiple groups when --group is repeated", async () => {
-    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true };
+    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true, parallelism: 1 };
     const mockClient = {
       calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
     };
@@ -290,10 +293,32 @@ describe("calendar create", () => {
       groups: ["scl", "north"],
     });
   });
+
+  it("should pass parallelism when --parallelism is provided", async () => {
+    const mockCalendar = { id: "1", code: "c", name: "n", timezone: "UTC", active: true, parallelism: 3 };
+    const mockClient = {
+      calendars: { create: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "create",
+      "--code", "c", "--name", "n", "--parallelism", "3",
+    ]);
+
+    expect(mockClient.calendars.create).toHaveBeenCalledWith({
+      code: "c",
+      name: "n",
+      timezone: undefined,
+      description: undefined,
+      parallelism: 3,
+    });
+  });
 });
 
 describe("calendar update", () => {
-  const mockCalendar = { id: "cal-1", code: "cal-1", name: "New Name", timezone: "UTC", active: true };
+  const mockCalendar = { id: "cal-1", code: "cal-1", name: "New Name", timezone: "UTC", active: true, parallelism: 1 };
 
   beforeEach(() => {
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -345,7 +370,7 @@ describe("calendar update", () => {
     expect(mockClient.calendars.update).toHaveBeenCalledWith("cal-1", { groups: ["scl", "north"] });
   });
 
-  it("should not include groups in body when --group is not provided", async () => {
+  it("should not include groups or parallelism in body when not provided", async () => {
     const mockClient = {
       calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
     };
@@ -358,8 +383,22 @@ describe("calendar update", () => {
 
     expect(mockClient.calendars.update).toHaveBeenCalledWith(
       "cal-1",
-      expect.not.objectContaining({ groups: expect.anything() }),
+      expect.not.objectContaining({ groups: expect.anything(), parallelism: expect.anything() }),
     );
+  });
+
+  it("should pass parallelism when --parallelism is provided", async () => {
+    const mockClient = {
+      calendars: { update: vi.fn().mockResolvedValue(mockCalendar) },
+    };
+    mockGetActionContext.mockReturnValue({ client: mockClient as any, outputMode: "json" });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node", "miot", "calendar", "update", "cal-1", "--parallelism", "5",
+    ]);
+
+    expect(mockClient.calendars.update).toHaveBeenCalledWith("cal-1", { parallelism: 5 });
   });
 });
 

--- a/packages/miot-cli/src/cli.ts
+++ b/packages/miot-cli/src/cli.ts
@@ -1,12 +1,16 @@
+import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerCalendarCommand } from "./commands/calendar/index.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 const program = new Command();
 
 program
   .name("miot")
   .description("ModularIoT CLI — manage calendars, bookings, slots, and more")
-  .version("0.1.0")
+  .version(version)
   .option("--base-url <url>", "API base URL (or MIOT_BASE_URL env)")
   .option("--token <token>", "Auth token (or MIOT_TOKEN env)")
   .option("--profile <name>", "Named profile from ~/.miotrc.json")

--- a/packages/miot-cli/src/commands/calendar/create.ts
+++ b/packages/miot-cli/src/commands/calendar/create.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { getActionContext } from "../../action-context.js";
 import { printJson, printDetail, printSuccess } from "../../output.js";
 import { handleError } from "../../utils/error.js";
+import { parseOptionalInt } from "../../utils/parse.js";
 
 export function registerCreateCommand(parent: Command): void {
   parent
@@ -13,6 +14,7 @@ export function registerCreateCommand(parent: Command): void {
     .option("--description <desc>", "Description")
     .option("--no-auto-slot-manager", "Skip auto-provisioning a default SlotManager on creation")
     .option("--group <code>", "Assign to group by code (repeatable)", (val, acc: string[]) => [...acc, val], [] as string[])
+    .option("--parallelism <n>", "Parallel resources per slot (default: 1)")
     .action(async (_opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -23,6 +25,7 @@ export function registerCreateCommand(parent: Command): void {
           description?: string;
           autoSlotManager: boolean;
           group: string[];
+          parallelism?: string;
         };
 
         const calendar = await client.calendars.create({
@@ -32,6 +35,7 @@ export function registerCreateCommand(parent: Command): void {
           description: opts.description,
           ...(opts.autoSlotManager === false && { autoSlotManager: false }),
           ...(opts.group.length > 0 && { groups: opts.group }),
+          parallelism: parseOptionalInt(opts.parallelism, "--parallelism"),
         });
 
         if (outputMode === "json") {
@@ -54,6 +58,7 @@ export function registerUpdateCommand(parent: Command): void {
     .option("--timezone <tz>", "Timezone")
     .option("--description <desc>", "Description")
     .option("--group <code>", "Assign to group by code (repeatable)", (val, acc: string[]) => [...acc, val], [] as string[])
+    .option("--parallelism <n>", "Parallel resources per slot (default: 1)")
     .action(async (id: string, _opts, cmd) => {
       const { client, outputMode } = getActionContext(cmd);
       try {
@@ -63,6 +68,7 @@ export function registerUpdateCommand(parent: Command): void {
           timezone?: string;
           description?: string;
           group: string[];
+          parallelism?: string;
         };
 
         const body = {
@@ -73,6 +79,7 @@ export function registerUpdateCommand(parent: Command): void {
             description: opts.description,
           }),
           ...(opts.group.length > 0 && { groups: opts.group }),
+          ...(opts.parallelism !== undefined && { parallelism: parseOptionalInt(opts.parallelism, "--parallelism") }),
         };
 
         const calendar = await client.calendars.update(id, body as Parameters<typeof client.calendars.update>[1]);

--- a/packages/miot-cli/src/commands/calendar/list.ts
+++ b/packages/miot-cli/src/commands/calendar/list.ts
@@ -36,6 +36,7 @@ export function registerListCommand(parent: Command): void {
             { header: "TIMEZONE", key: "timezone" },
             { header: "ACTIVE", key: "active" },
             { header: "HAS SM", key: "hasSlotManager" },
+            { header: "PARALLELISM", key: "parallelism" },
           ]);
         }
       } catch (err) {

--- a/skills/miot-calendar/SKILL.md
+++ b/skills/miot-calendar/SKILL.md
@@ -40,6 +40,7 @@ Key relationships:
 - Time windows define the **rules**; slots are the **instances** generated from those rules.
 - A slot has `capacity` and `currentOccupancy`; `availableCapacity = capacity - currentOccupancy`.
 - A booking ties a resource to a specific slot. It requires the slot to be OPEN with remaining capacity.
+- A calendar has `parallelism` (default: 1) — the number of parallel resources that can use a slot simultaneously (e.g. multiple loading docks).
 
 ## Common Workflows
 
@@ -137,6 +138,7 @@ Explain the error in plain language to the user.
 - Hour: 0–23, Minutes: 0–59.
 - `calendar purge` is **irreversible** — deletes the calendar and all its slots, bookings, time windows, and slot manager. Always confirm with the user before running.
 - `hasSlotManager` on a calendar response indicates whether a SlotManager is provisioned. Use `--no-auto-slot-manager` on `calendar create` to suppress auto-provisioning.
+- `parallelism` (default: 1) controls how many parallel resources can use a slot. Set via `--parallelism <n>` on `calendar create` or `calendar update`.
 
 ## Full CLI Reference
 

--- a/skills/miot-calendar/references/reference.md
+++ b/skills/miot-calendar/references/reference.md
@@ -69,7 +69,8 @@ List all calendars.
     "name": "Vehicle Inspection",
     "timezone": "America/New_York",
     "active": true,
-    "hasSlotManager": true
+    "hasSlotManager": true,
+    "parallelism": 1
   }
 ]
 ```
@@ -91,7 +92,8 @@ Get a single calendar by ID.
   "name": "Vehicle Inspection",
   "timezone": "America/New_York",
   "active": true,
-  "hasSlotManager": true
+  "hasSlotManager": true,
+  "parallelism": 1
 }
 ```
 
@@ -108,6 +110,7 @@ Create a new calendar.
 | `--timezone <tz>` | string | no | Timezone |
 | `--description <desc>` | string | no | Description |
 | `--no-auto-slot-manager` | boolean | no | Skip auto-provisioning a default SlotManager on creation |
+| `--parallelism <n>` | integer | no | Parallel resources per slot (default: 1) |
 
 **JSON output:** Same shape as `calendar get`. When `--no-auto-slot-manager` is passed, `hasSlotManager` will be `false`.
 
@@ -125,6 +128,8 @@ Update an existing calendar.
 | `--name <name>` | string | Update calendar name |
 | `--timezone <tz>` | string | Update timezone |
 | `--description <desc>` | string | Update description |
+| `--group <code>` | string | Assign to group by code (repeatable) |
+| `--parallelism <n>` | integer | Parallel resources per slot (default: 1) |
 
 **JSON output:** Same shape as `calendar get`.
 
@@ -441,8 +446,7 @@ Create a new time window.
 | `--end-hour <hour>` | integer | yes | End hour (0–23, must be > start-hour) |
 | `--valid-from <date>` | string | yes | Valid from date (YYYY-MM-DD) |
 | `--valid-to <date>` | string | no | Valid to date (YYYY-MM-DD) |
-| `--slot-duration <minutes>` | integer | no | Slot duration in minutes |
-| `--capacity <n>` | integer | no | Capacity per slot |
+| `--capacity <n>` | integer | no | Total capacity for the window |
 | `--days-of-week <days>` | string | no | Days of week (e.g. `"1,2,3,4,5"`) |
 
 **JSON output:** Created time window object.
@@ -462,9 +466,8 @@ Update an existing time window.
 | `--end-hour <hour>` | integer | yes | End hour (0–23) |
 | `--valid-from <date>` | string | yes | Valid from date (YYYY-MM-DD) |
 | `--valid-to <date>` | string | no | Valid to date (YYYY-MM-DD) |
-| `--slot-duration <minutes>` | integer | no | Slot duration in minutes |
-| `--capacity <n>` | integer | no | Capacity per slot |
-| `--days-of-week <days>` | string | no | Days of week |
+| `--capacity <n>` | integer | no | Total capacity for the window |
+| `--days-of-week <days>` | string | no | Days of week (e.g. `"1,2,3,4,5"`) |
 
 **JSON output:** Updated time window object.
 


### PR DESCRIPTION
## Summary

- Add `--parallelism <n>` flag to `miot calendar create` and `miot calendar update`
- Add `PARALLELISM` column to `miot calendar list` table output
- Read CLI version dynamically from `package.json` instead of hardcoded string
- Bump miot-cli to v0.3.0
- Update tests, reference docs, and skill docs

## Test plan

- [x] All 47 unit tests pass (`npx vitest run`)
- [x] Type-check passes (`turbo run check-types --filter=@microboxlabs/miot-cli`)
- [x] Manual E2E: create calendar with `--parallelism 1`, update to `--parallelism 2`, verify slot regeneration and booking capacity
- [x] `miot --version` returns `0.3.0`

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)