### PR TITLE
feat: add drag-and-drop support for web images in multimedia manager and spacing in bento box

### DIFF
--- a/apps/app/src/features/task-forms/components/task-bento-form/bento.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/bento.tsx
@@ -87,33 +87,39 @@ export default function Bento({
           />
         </div>
 
-        {/* Geographic - spans 4 columns on landscape */}
-        <div className="col-span-1 lg:col-span-4 bg-white dark:bg-gray-800 rounded-lg overflow-hidden sm:border border-gray-300 dark:border-gray-700 sm:min-h-[343px] min-h-fit hidden lg:flex">
-          <div className="h-full w-full">
-            <Geographic
-              task={task}
-              dictionary={dict as unknown as Record<string, string>}
-            />
+        {/* Geographic + File Images container - full width with custom grid */}
+        <div className="col-span-1 lg:col-span-5 grid grid-cols-1 lg:grid-cols-6 gap-2">
+          {/* Geographic - spans 4/6 columns */}
+          <div className="col-span-1 lg:col-span-4 bg-white dark:bg-gray-800 rounded-lg overflow-hidden sm:border border-gray-300 dark:border-gray-700 sm:min-h-[343px] min-h-fit hidden lg:flex">
+            <div className="h-full w-full">
+              <Geographic
+                task={task}
+                dictionary={dict as unknown as Record<string, string>}
+              />
+            </div>
+          </div>
+
+          {/* File Images - spans 2/6 columns */}
+          <div className="col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 rounded-lg p-2 border border-gray-300 dark:border-gray-700">
+            <FileImages task={task} dictionary={dict as I18nRecord} />
           </div>
         </div>
 
-        {/* File Images */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-2 border border-gray-300 dark:border-gray-700 col-span-1">
-          <FileImages task={task} dictionary={dict as I18nRecord} />
-        </div>
+        {/* Historic Loads + Symptoms container - full width with custom grid */}
+        <div className="col-span-1 lg:col-span-5 grid grid-cols-1 lg:grid-cols-6 gap-2">
+          {/* Historic Loads - spans 4/6 columns */}
+          <div className="col-span-1 lg:col-span-4 bg-white dark:bg-gray-800 rounded-lg min-h-[300px] max-h-[520px] overflow-auto">
+            <HistoricLoads
+              task={task}
+              dictionary={dict as unknown as Record<string, string>}
+              active={active}
+            />
+          </div>
 
-        {/* Historic Loads - spans 4 columns */}
-        <div className="col-span-1 lg:col-span-4 bg-white dark:bg-gray-800 rounded-lg min-h-[300px] max-h-[360px] lg:max-h-full">
-          <HistoricLoads
-            task={task}
-            dictionary={dict as unknown as Record<string, string>}
-            active={active}
-          />
-        </div>
-
-        {/* Conditions */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden col-span-1">
-          <SymptomsCard task={task} dict={dict as I18nRecord} />
+          {/* Conditions - spans 2/6 columns */}
+          <div className="col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden">
+            <SymptomsCard task={task} dict={dict as I18nRecord} />
+          </div>
         </div>
 
         {/* Forum - full width */}

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.test.ts
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  extractImageUrlFromDrop,
+  isValidImageUrl,
+  fetchImageAsFile,
+  ALLOWED_FILE_TYPES,
+  ALLOWED_IMAGE_EXTENSIONS,
+} from "./file-images";
+
+// Helper to create a mock DataTransfer object
+function createMockDataTransfer(data: Record<string, string>): DataTransfer {
+  return {
+    getData: (type: string) => data[type] || "",
+    setData: vi.fn(),
+    clearData: vi.fn(),
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: Object.keys(data),
+    dropEffect: "none",
+    effectAllowed: "none",
+  } as unknown as DataTransfer;
+}
+
+describe("extractImageUrlFromDrop", () => {
+  describe("text/uri-list extraction", () => {
+    it("should extract first URL from text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list": "https://example.com/image.jpg",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image.jpg");
+    });
+
+    it("should extract first URL from multiple URLs in text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list":
+          "https://example.com/image1.jpg\nhttps://example.com/image2.png\nhttps://example.com/image3.jpeg",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image1.jpg");
+    });
+
+    it("should skip commented lines (starting with #) in text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list":
+          "# This is a comment\nhttps://example.com/actual-image.jpg\n# Another comment",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/actual-image.jpg");
+    });
+
+    it("should handle only commented lines and return null", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list": "# Comment 1\n# Comment 2\n# Comment 3",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+
+    it("should skip empty lines in text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list":
+          "\n\nhttps://example.com/image.jpg\n\nhttps://example.com/image2.png",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image.jpg");
+    });
+  });
+
+  describe("text/plain extraction", () => {
+    it("should extract http URL from text/plain when no text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/plain": "http://example.com/image.jpg",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("http://example.com/image.jpg");
+    });
+
+    it("should extract https URL from text/plain when no text/uri-list", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/plain": "https://example.com/image.png",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image.png");
+    });
+
+    it("should return null for text/plain that does not start with http/https", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/plain": "just some random text",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for ftp:// URLs in text/plain", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/plain": "ftp://example.com/image.jpg",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+
+    it("should prioritize text/uri-list over text/plain", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list": "https://priority.com/uri-list.jpg",
+        "text/plain": "https://fallback.com/plain.jpg",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://priority.com/uri-list.jpg");
+    });
+  });
+
+  describe("text/html extraction (img src)", () => {
+    it("should extract img src from text/html with double quotes", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/html":
+          '<img src="https://example.com/image.jpg" alt="test image">',
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image.jpg");
+    });
+
+    it("should extract img src from text/html with single quotes", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/html":
+          "<img src='https://example.com/image.png' alt='test image'>",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://example.com/image.png");
+    });
+
+    it("should extract img src from complex HTML", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/html":
+          '<div class="wrapper"><img class="image" src="https://cdn.example.com/photos/image.jpeg" width="100"></div>',
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://cdn.example.com/photos/image.jpeg");
+    });
+
+    it("should return null when HTML has no img tag", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/html": '<div><a href="https://example.com">Link</a></div>',
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+
+    it("should prioritize text/uri-list over text/html", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list": "https://priority.com/uri-list.jpg",
+        "text/html": '<img src="https://fallback.com/html.jpg">',
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBe("https://priority.com/uri-list.jpg");
+    });
+  });
+
+  describe("no valid data", () => {
+    it("should return null when all data types are empty", () => {
+      const dataTransfer = createMockDataTransfer({});
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when all data types have empty strings", () => {
+      const dataTransfer = createMockDataTransfer({
+        "text/uri-list": "",
+        "text/plain": "",
+        "text/html": "",
+      });
+      const result = extractImageUrlFromDrop(dataTransfer);
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("isValidImageUrl", () => {
+  describe("valid URLs (syntactic validation only)", () => {
+    it("should return true for https URL with .jpg extension", () => {
+      expect(isValidImageUrl("https://example.com/photo.jpg")).toBe(true);
+    });
+
+    it("should return true for https URL with .png extension", () => {
+      expect(isValidImageUrl("https://example.com/photo.png")).toBe(true);
+    });
+
+    it("should return true for https URL without extension", () => {
+      expect(isValidImageUrl("https://example.com/image")).toBe(true);
+    });
+
+    it("should return true for http URL", () => {
+      expect(isValidImageUrl("http://example.com/photo.jpg")).toBe(true);
+    });
+
+    it("should return true for URL with query parameters", () => {
+      expect(isValidImageUrl("https://example.com/serve?id=123")).toBe(true);
+    });
+
+    it("should return true for URL with hash", () => {
+      expect(isValidImageUrl("https://example.com/photo#section")).toBe(true);
+    });
+
+    it("should return true for CDN URLs without file extensions", () => {
+      expect(isValidImageUrl("https://cdn.example.com/serve/12345")).toBe(true);
+    });
+
+    it("should return true for URLs with any file extension (MIME validated by fetch)", () => {
+      // These are syntactically valid URLs - actual content type is validated by fetchImageAsFile
+      expect(isValidImageUrl("https://example.com/animation.gif")).toBe(true);
+      expect(isValidImageUrl("https://example.com/image.webp")).toBe(true);
+      expect(isValidImageUrl("https://example.com/document.pdf")).toBe(true);
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("should return false for empty string", () => {
+      expect(isValidImageUrl("")).toBe(false);
+    });
+
+    it("should return false for null/undefined coerced to string", () => {
+      expect(isValidImageUrl(null as unknown as string)).toBe(false);
+      expect(isValidImageUrl(undefined as unknown as string)).toBe(false);
+    });
+
+    it("should return false for plain text that is not a URL", () => {
+      expect(isValidImageUrl("just some text")).toBe(false);
+    });
+
+    it("should return false for relative path", () => {
+      expect(isValidImageUrl("/images/photo.jpg")).toBe(false);
+    });
+
+    it("should return false for malformed URL", () => {
+      expect(isValidImageUrl("ht tp://example.com/photo.jpg")).toBe(false);
+    });
+  });
+
+  describe("ALLOWED_IMAGE_EXTENSIONS constant", () => {
+    it("should contain exactly jpg, jpeg, png", () => {
+      expect(ALLOWED_IMAGE_EXTENSIONS).toEqual(new Set(["jpg", "jpeg", "png"]));
+    });
+  });
+});
+
+describe("fetchImageAsFile", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("successful fetch returning image blob", () => {
+    it("should return a File with correct name when URL has filename", async () => {
+      const mockBlob = new Blob(["fake image data"], { type: "image/jpeg" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/photos/my-photo.jpg"
+      );
+
+      expect(result).toBeInstanceOf(File);
+      expect(result?.name).toBe("my-photo.jpg");
+      expect(result?.type).toBe("image/jpeg");
+    });
+
+    it("should synthesize filename for extensionless URL using blob type", async () => {
+      const mockBlob = new Blob(["fake image data"], { type: "image/png" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/image-server/12345"
+      );
+
+      expect(result).toBeInstanceOf(File);
+      expect(result?.name).toMatch(/^downloaded-image-\d+\.png$/);
+      expect(result?.type).toBe("image/png");
+    });
+
+    it("should handle URL with path but no extension", async () => {
+      const mockBlob = new Blob(["fake image data"], { type: "image/jpeg" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://cdn.example.com/serve/image"
+      );
+
+      expect(result).toBeInstanceOf(File);
+      expect(result?.name).toMatch(/^downloaded-image-\d+\.jpeg$/);
+    });
+  });
+
+  describe("non-image blob responses", () => {
+    it("should return null for text/plain blob", async () => {
+      const mockBlob = new Blob(["text content"], { type: "text/plain" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/fake-image.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for application/json blob", async () => {
+      const mockBlob = new Blob(['{"data": "json"}'], {
+        type: "application/json",
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/api/image.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for application/pdf blob", async () => {
+      const mockBlob = new Blob(["pdf content"], { type: "application/pdf" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/document.pdf");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("disallowed MIME types (from ALLOWED_FILE_TYPES)", () => {
+    it("should return null for image/gif (not in ALLOWED_FILE_TYPES)", async () => {
+      const mockBlob = new Blob(["gif data"], { type: "image/gif" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/animation.gif"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for image/webp (not in ALLOWED_FILE_TYPES)", async () => {
+      const mockBlob = new Blob(["webp data"], { type: "image/webp" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/photo.webp");
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for image/svg+xml (not in ALLOWED_FILE_TYPES)", async () => {
+      const mockBlob = new Blob(["<svg></svg>"], { type: "image/svg+xml" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/icon.svg");
+
+      expect(result).toBeNull();
+    });
+
+    it("should accept image/jpeg (in ALLOWED_FILE_TYPES)", async () => {
+      const mockBlob = new Blob(["jpeg data"], { type: "image/jpeg" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/photo.jpeg");
+
+      expect(result).toBeInstanceOf(File);
+    });
+
+    it("should accept image/png (in ALLOWED_FILE_TYPES)", async () => {
+      const mockBlob = new Blob(["png data"], { type: "image/png" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/photo.png");
+
+      expect(result).toBeInstanceOf(File);
+    });
+  });
+
+  describe("fetch failures and CORS errors", () => {
+    it("should return null when fetch throws an error (CORS)", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("CORS error"));
+
+      const result = await fetchImageAsFile(
+        "https://blocked-domain.com/image.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when fetch throws network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await fetchImageAsFile(
+        "https://unreachable.com/image.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok (404)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/not-found.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok (500)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/server-error.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok (403 Forbidden)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/forbidden.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when fetch is aborted (AbortError)", async () => {
+      const abortError = new DOMException("Aborted", "AbortError");
+      global.fetch = vi.fn().mockRejectedValue(abortError);
+
+      const result = await fetchImageAsFile(
+        "https://slow-server.com/image.jpg"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should pass AbortController signal to fetch", async () => {
+      const mockBlob = new Blob(["data"], { type: "image/jpeg" });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      await fetchImageAsFile("https://example.com/photo.jpg");
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://example.com/photo.jpg",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+  });
+
+  describe("proper File creation", () => {
+    it("should create File with blob data", async () => {
+      const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+      const mockBlob = new Blob([imageData], { type: "image/png" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile("https://example.com/image.png");
+
+      expect(result).toBeInstanceOf(File);
+      expect(result?.size).toBe(4);
+    });
+
+    it("should preserve original filename from URL path", async () => {
+      const mockBlob = new Blob(["data"], { type: "image/jpeg" });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+
+      const result = await fetchImageAsFile(
+        "https://example.com/uploads/my-vacation-photo.jpg"
+      );
+
+      expect(result?.name).toBe("my-vacation-photo.jpg");
+    });
+  });
+
+  describe("ALLOWED_FILE_TYPES constant", () => {
+    it("should contain exactly the expected MIME types", () => {
+      expect(ALLOWED_FILE_TYPES).toEqual(
+        new Set(["image/jpeg", "image/jpg", "image/png", "application/pdf"])
+      );
+    });
+  });
+});

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
@@ -19,14 +19,14 @@ import { AlfrescoFileEntry } from "./image.types";
 import ImageElement from "./image-element";
 import ImageViewerConnector from "./image-viewer-connector";
 
-const ALLOWED_FILE_TYPES = new Set([
+export const ALLOWED_FILE_TYPES = new Set([
   "image/jpeg",
   "image/jpg",
   "image/png",
   "application/pdf",
 ]);
 
-const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png"]);
+export const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png"]);
 
 function filterValidFiles(
   files: File[],
@@ -40,7 +40,9 @@ function filterValidFiles(
   return validFiles;
 }
 
-function extractImageUrlFromDrop(dataTransfer: DataTransfer): string | null {
+export function extractImageUrlFromDrop(
+  dataTransfer: DataTransfer
+): string | null {
   // Try to get URL from text/uri-list (most common for dragged images)
   const uriList = dataTransfer.getData("text/uri-list");
   if (uriList) {
@@ -62,8 +64,8 @@ function extractImageUrlFromDrop(dataTransfer: DataTransfer): string | null {
   // Try to extract image URL from HTML (for some browsers)
   const html = dataTransfer.getData("text/html");
   if (html) {
-    const srcMatch = html.match(/src=["']([^"']+)["']/);
-    if (srcMatch && srcMatch[1]) {
+    const srcMatch = /src=["']([^"']+)["']/.exec(html);
+    if (srcMatch?.[1]) {
       return srcMatch[1];
     }
   }
@@ -71,16 +73,26 @@ function extractImageUrlFromDrop(dataTransfer: DataTransfer): string | null {
   return null;
 }
 
-function isValidImageUrl(url: string): boolean {
-  const urlLower = url.toLowerCase();
-  return Array.from(ALLOWED_IMAGE_EXTENSIONS).some(
-    (ext) => urlLower.includes(`.${ext}`) || urlLower.includes(`image/${ext}`)
-  );
+export function isValidImageUrl(url: string): boolean {
+  if (!url || typeof url !== "string") return false;
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
+const FETCH_TIMEOUT_MS = 10000;
+
+export async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
   try {
-    const response = await fetch(imageUrl);
+    const response = await fetch(imageUrl, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
     if (!response.ok) return null;
 
     const blob = await response.blob();
@@ -99,6 +111,7 @@ async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
 
     return new File([blob], filename, { type: blob.type });
   } catch {
+    clearTimeout(timeoutId);
     return null;
   }
 }

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
@@ -26,15 +26,76 @@ const ALLOWED_FILE_TYPES = new Set([
   "application/pdf",
 ]);
 
-function filterValidFiles(files: File[], dictionary: I18nRecord): File[] | null {
-  const validFiles = files.filter((file) =>
-    ALLOWED_FILE_TYPES.has(file.type)
-  );
+const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png"]);
+
+function filterValidFiles(
+  files: File[],
+  dictionary: I18nRecord
+): File[] | null {
+  const validFiles = files.filter((file) => ALLOWED_FILE_TYPES.has(file.type));
   if (validFiles.length !== files.length) {
     alert(tr("bento.multimedia.only_jpg_jpeg_png_pdf_allowed", dictionary));
     return null;
   }
   return validFiles;
+}
+
+function extractImageUrlFromDrop(dataTransfer: DataTransfer): string | null {
+  // Try to get URL from text/uri-list (most common for dragged images)
+  const uriList = dataTransfer.getData("text/uri-list");
+  if (uriList) {
+    const urls = uriList.split("\n").filter((url) => url.trim() && !url.startsWith("#"));
+    if (urls.length > 0) return urls[0];
+  }
+
+  // Try to get URL from text/plain
+  const plainText = dataTransfer.getData("text/plain");
+  if (plainText && (plainText.startsWith("http://") || plainText.startsWith("https://"))) {
+    return plainText;
+  }
+
+  // Try to extract image URL from HTML (for some browsers)
+  const html = dataTransfer.getData("text/html");
+  if (html) {
+    const srcMatch = html.match(/src=["']([^"']+)["']/);
+    if (srcMatch && srcMatch[1]) {
+      return srcMatch[1];
+    }
+  }
+
+  return null;
+}
+
+function isValidImageUrl(url: string): boolean {
+  const urlLower = url.toLowerCase();
+  return Array.from(ALLOWED_IMAGE_EXTENSIONS).some(
+    (ext) => urlLower.includes(`.${ext}`) || urlLower.includes(`image/${ext}`)
+  );
+}
+
+async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) return null;
+
+    const blob = await response.blob();
+    
+    // Validate mime type
+    if (!blob.type.startsWith("image/")) return null;
+    if (!ALLOWED_FILE_TYPES.has(blob.type)) return null;
+
+    // Extract filename from URL or generate one
+    const urlPath = new URL(imageUrl).pathname;
+    const urlFilename = urlPath.split("/").pop() || "";
+    const extension = blob.type.split("/")[1] || "jpg";
+    const filename = urlFilename.includes(".") 
+      ? urlFilename 
+      : `downloaded-image-${Date.now()}.${extension}`;
+
+    return new File([blob], filename, { type: blob.type });
+  } catch {
+    return null;
+  }
 }
 
 export default function FileImages({
@@ -47,6 +108,7 @@ export default function FileImages({
   const [selectedImage, setSelectedImage] = useState<number | null>(null);
   const [selectedDocument, setSelectedDocument] = useState<any | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [isFetchingFromUrl, setIsFetchingFromUrl] = useState(false);
   const [isClasificationFormOpen, setIsClasificationFormOpen] = useState(false);
   const [isDocumentListOpen, setIsDocumentListOpen] = useState(false);
   const [uploadableFiles, setUploadableFiles] = useState<any[]>([]);
@@ -136,21 +198,48 @@ export default function FileImages({
         }
         setIsDragOver(false);
       }}
-      onDrop={(e) => {
+      onDrop={async (e) => {
         e.preventDefault();
-        if (isDocumentListOpen || isClasificationFormOpen) {
+        if (isDocumentListOpen || isClasificationFormOpen || isFetchingFromUrl) {
           return;
         }
 
         setIsDragOver(false);
-        const validFiles = filterValidFiles(
-          Array.from(e.dataTransfer.files),
-          dictionary
-        );
-        if (!validFiles) return;
 
-        setUploadableFiles(validFiles);
-        setIsClasificationFormOpen(true);
+        // First try to handle as regular files (from filesystem)
+        if (e.dataTransfer.files.length > 0) {
+          const validFiles = filterValidFiles(
+            Array.from(e.dataTransfer.files),
+            dictionary
+          );
+          if (!validFiles) return;
+
+          setUploadableFiles(validFiles);
+          setIsClasificationFormOpen(true);
+          return;
+        }
+
+        // If no files, try to extract image URL (dragged from web)
+        const imageUrl = extractImageUrlFromDrop(e.dataTransfer);
+        if (!imageUrl) return;
+
+        if (!isValidImageUrl(imageUrl)) {
+          alert(tr("bento.multimedia.only_jpg_jpeg_png_pdf_allowed", dictionary));
+          return;
+        }
+
+        setIsFetchingFromUrl(true);
+        try {
+          const file = await fetchImageAsFile(imageUrl);
+          if (file) {
+            setUploadableFiles([file]);
+            setIsClasificationFormOpen(true);
+          } else {
+            alert(tr("bento.multimedia.fetch_image_error", dictionary));
+          }
+        } finally {
+          setIsFetchingFromUrl(false);
+        }
       }}
     >
       {/* Drag and drop overlay */}
@@ -159,6 +248,17 @@ export default function FileImages({
           isDragOver ? "animate-fade-in-fast" : "animate-fade-out-fast"
         }`}
       />
+      {/* Loading overlay for URL fetch */}
+      {isFetchingFromUrl && (
+        <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center rounded-lg bg-gray-900/60 z-30">
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+            <p className="text-white text-sm">
+              {tr("bento.multimedia.fetching_image", dictionary)}
+            </p>
+          </div>
+        </div>
+      )}
       <div
         className={`flex w-full p-2 flex-col items-center justify-center rounded-lg border-2 border-dashed ${
           isDragOver

--- a/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
+++ b/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-images.tsx
@@ -44,13 +44,18 @@ function extractImageUrlFromDrop(dataTransfer: DataTransfer): string | null {
   // Try to get URL from text/uri-list (most common for dragged images)
   const uriList = dataTransfer.getData("text/uri-list");
   if (uriList) {
-    const urls = uriList.split("\n").filter((url) => url.trim() && !url.startsWith("#"));
+    const urls = uriList
+      .split("\n")
+      .filter((url) => url.trim() && !url.startsWith("#"));
     if (urls.length > 0) return urls[0];
   }
 
   // Try to get URL from text/plain
   const plainText = dataTransfer.getData("text/plain");
-  if (plainText && (plainText.startsWith("http://") || plainText.startsWith("https://"))) {
+  if (
+    plainText &&
+    (plainText.startsWith("http://") || plainText.startsWith("https://"))
+  ) {
     return plainText;
   }
 
@@ -79,7 +84,7 @@ async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
     if (!response.ok) return null;
 
     const blob = await response.blob();
-    
+
     // Validate mime type
     if (!blob.type.startsWith("image/")) return null;
     if (!ALLOWED_FILE_TYPES.has(blob.type)) return null;
@@ -88,8 +93,8 @@ async function fetchImageAsFile(imageUrl: string): Promise<File | null> {
     const urlPath = new URL(imageUrl).pathname;
     const urlFilename = urlPath.split("/").pop() || "";
     const extension = blob.type.split("/")[1] || "jpg";
-    const filename = urlFilename.includes(".") 
-      ? urlFilename 
+    const filename = urlFilename.includes(".")
+      ? urlFilename
       : `downloaded-image-${Date.now()}.${extension}`;
 
     return new File([blob], filename, { type: blob.type });
@@ -121,10 +126,7 @@ export default function FileImages({
     : undefined;
 
   // Use the optimistic upload hook instead of the basic one
-  const {
-    data,
-    uploadFile,
-  } = useOptimisticFileUpload(packageId);
+  const { data, uploadFile } = useOptimisticFileUpload(packageId);
 
   const files = useMemo(() => data?.data?.list?.entries || [], [data]);
 
@@ -200,7 +202,11 @@ export default function FileImages({
       }}
       onDrop={async (e) => {
         e.preventDefault();
-        if (isDocumentListOpen || isClasificationFormOpen || isFetchingFromUrl) {
+        if (
+          isDocumentListOpen ||
+          isClasificationFormOpen ||
+          isFetchingFromUrl
+        ) {
           return;
         }
 
@@ -224,7 +230,9 @@ export default function FileImages({
         if (!imageUrl) return;
 
         if (!isValidImageUrl(imageUrl)) {
-          alert(tr("bento.multimedia.only_jpg_jpeg_png_pdf_allowed", dictionary));
+          alert(
+            tr("bento.multimedia.only_jpg_jpeg_png_pdf_allowed", dictionary)
+          );
           return;
         }
 
@@ -248,15 +256,10 @@ export default function FileImages({
           isDragOver ? "animate-fade-in-fast" : "animate-fade-out-fast"
         }`}
       />
-      {/* Loading overlay for URL fetch */}
+      {/* Small loading indicator for URL fetch */}
       {isFetchingFromUrl && (
-        <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center rounded-lg bg-gray-900/60 z-30">
-          <div className="flex flex-col items-center gap-3">
-            <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
-            <p className="text-white text-sm">
-              {tr("bento.multimedia.fetching_image", dictionary)}
-            </p>
-          </div>
+        <div className="absolute top-2 right-2 z-30">
+          <div className="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
         </div>
       )}
       <div

--- a/apps/app/src/lang/en.json
+++ b/apps/app/src/lang/en.json
@@ -1790,6 +1790,8 @@
     },
     "multimedia": {
       "only_jpg_jpeg_png_pdf_allowed": "Only JPG, JPEG, PNG and PDF files are allowed.",
+      "fetch_image_error": "Could not fetch the image from the URL. Please try downloading it first.",
+      "fetching_image": "Fetching image...",
       "select_document_type": "Select a document type",
       "select_document_type_error": "You must select a document type",
       "categories": {

--- a/apps/app/src/lang/es.json
+++ b/apps/app/src/lang/es.json
@@ -1820,6 +1820,8 @@
     },
     "multimedia": {
       "only_jpg_jpeg_png_pdf_allowed": "Solo se permiten archivos JPG, JPEG, PNG y PDF.",
+      "fetch_image_error": "No se pudo obtener la imagen desde la URL. Por favor, intente descargarla primero.",
+      "fetching_image": "Obteniendo imagen...",
       "select_document_type": "Selecciona un Tipo de Documento",
       "select_document_type_error": "Debe seleccionar un tipo de documento",
       "categories": {


### PR DESCRIPTION
## Summary
Adds support for drag-and-drop images directly from web pages (like Google Images) in the multimedia manager component.

## Changes
- Added URL extraction from drag events (`text/uri-list`, `text/plain`, `text/html`)
- Added `fetchImageAsFile` function to download and convert web images to uploadable files
- Updated `onDrop` handler to handle both local files and web-dragged images
- Added small spinner indicator while fetching image from URL
- Added translation keys for error messages

## Notes
Due to CORS restrictions, fetching images from some external sites may fail. In those cases, users will see an error message suggesting they download the image first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image drag-and-drop now supports URLs as well as direct file drops; shows a small loader while fetching and surfaces an error message if fetch fails.

* **Localization**
  * Added English and Spanish translations for image fetch/loading messages.

* **Refactor**
  * Task form layout reorganized into a responsive multi-column grid for improved side-by-side sections.

* **Tests**
  * Added comprehensive tests covering URL extraction, validation, fetching, and file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #101