### PR TITLE
fix: persist geographic view filters in URL to survive SWR revalidation

### DIFF
--- a/apps/app/src/features/geographic-view/components/filter-component.tsx
+++ b/apps/app/src/features/geographic-view/components/filter-component.tsx
@@ -28,35 +28,21 @@ export default function FilterComponent({
   onChange?: (updatedOptions: Option[]) => void;
 }) {
   const [expanded, set_expanded] = useState(false);
-  const [filter_options, set_filter_options] = useState<Option[]>(options);
 
-  // Calculate the number of activated options
-  const activatedCount = filter_options.filter(
-    (option) => option.activated
-  ).length;
+  const activatedCount = options.filter((option) => option.activated).length;
 
-  // Handle option toggle with direct onChange call
   const handleOptionToggle = (index: number) => {
-    const new_options = [...filter_options];
-    new_options[index].activated = !new_options[index].activated;
-    set_filter_options(new_options);
-
-    // Call onChange directly after state update
+    const new_options = options.map((opt, i) =>
+      i === index ? { ...opt, activated: !opt.activated } : opt
+    );
     if (onChange) {
       onChange(new_options);
     }
   };
 
-  // Handle clear all options
   const handleClearOptions = () => {
-    const new_options = [...filter_options];
-    new_options.forEach((option) => {
-      option.activated = false;
-    });
-    set_filter_options(new_options);
+    const new_options = options.map((opt) => ({ ...opt, activated: false }));
     set_expanded(false);
-
-    // Call onChange directly after state update
     if (onChange) {
       onChange(new_options);
     }
@@ -93,7 +79,7 @@ export default function FilterComponent({
       <div
         className={`h-10 transition-all duration-300 ease-in-out !flex justify-center items-center flex-row gap-2 w-fit ${expanded ? "animate-show" : "animate-hide-width"}  `}
       >
-        {filter_options.map((option, index) => (
+        {options.map((option, index) => (
           <div
             onClick={() => handleOptionToggle(index)}
             key={index}

--- a/apps/app/src/features/geographic-view/components/filters.tsx
+++ b/apps/app/src/features/geographic-view/components/filters.tsx
@@ -14,6 +14,7 @@ import PinIcon from "@/features/icons/pin-icon";
 import { useState, useEffect } from "react";
 import CustomTooltip from "@/features/common/components/custom-tooltip/custom-tooltip";
 import { tr } from "@/features/i18n/tr.service";
+import { useMapFilters } from "../hooks/use-map-filters";
 
 function set_filtered_positions(
   originalPositions: MapPosition[],
@@ -72,6 +73,8 @@ export default function Filters({
   originalPositions: MapPosition[];
   setPositions: (positions: MapPosition[]) => void;
 }) {
+  const { getInitialActivated, syncFiltersToUrl } = useMapFilters();
+
   const [activeFilters, setActiveFilters] = useState<{
     conditions: Option[];
     speed: Option[];
@@ -90,7 +93,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.code_black, false),
       },
       {
         text: "Alerta Critica",
@@ -104,7 +107,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.critical_condition, false),
       },
       {
         text: "En Observacion",
@@ -118,7 +121,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.under_observation, false),
       },
       {
         text: "Comprometida",
@@ -132,7 +135,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.compromised_condition, false),
       },
       {
         text: "En Tratamiento",
@@ -146,7 +149,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.under_treatment, false),
       },
       {
         text: "Estable",
@@ -160,7 +163,7 @@ export default function Filters({
             placement="bottom"
           />
         ),
-        activated: false,
+        activated: getInitialActivated("conditions", icu_codes.stable, false),
       },
     ],
     speed: [
@@ -169,21 +172,21 @@ export default function Filters({
         filter_value: "1",
         code: "1",
         icon: blue_pin.src,
-        activated: false,
+        activated: getInitialActivated("speed", "1", false),
       },
       {
         text: (dict.symptoms as I18nRecord).high_speed as string,
         filter_value: "2",
         code: "2",
         icon: yellow_pin.src,
-        activated: false,
+        activated: getInitialActivated("speed", "2", false),
       },
       {
         text: (dict.symptoms as I18nRecord).very_high_speed as string,
         filter_value: "3",
         code: "3",
         icon: red_pin.src,
-        activated: false,
+        activated: getInitialActivated("speed", "3", false),
       },
     ],
     tripStates: [
@@ -205,7 +208,7 @@ export default function Filters({
             </div>
           </CustomTooltip>
         ),
-        activated: true,
+        activated: getInitialActivated("trip", "1", true),
       },
       {
         text: "Sin viaje",
@@ -225,31 +228,15 @@ export default function Filters({
             </div>
           </CustomTooltip>
         ),
-        activated: false,
+        activated: getInitialActivated("trip", "2", false),
       },
     ],
   });
 
-  // Initialize filtered positions on mount and when filters change
+  // Re-apply filters when data changes
   useEffect(() => {
     set_filtered_positions(originalPositions, activeFilters, setPositions);
   }, [activeFilters, originalPositions, setPositions]);
-
-  useEffect(() => {
-    const defaultPositions = originalPositions.filter(
-      (position) => position.in_trip === true
-    );
-    setPositions(defaultPositions);
-
-    // Ensure the trip state filter is properly activated
-    setActiveFilters((prev) => ({
-      ...prev,
-      tripStates: prev.tripStates.map((state, index) => ({
-        ...state,
-        activated: index === 0, // Only activate the first trip state (with trip)
-      })),
-    }));
-  }, [originalPositions, setPositions]);
 
   const handle_filter_change = (
     updated_options: Option[],
@@ -261,6 +248,7 @@ export default function Filters({
     };
 
     setActiveFilters(newFilters);
+    syncFiltersToUrl(newFilters);
   };
 
   return (

--- a/apps/app/src/features/geographic-view/hooks/use-map-filters.ts
+++ b/apps/app/src/features/geographic-view/hooks/use-map-filters.ts
@@ -1,0 +1,64 @@
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useCallback } from "react";
+import { Option } from "../components/filter-component";
+
+type FilterType = "trip" | "conditions" | "speed";
+
+export function useMapFilters() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const getInitialActivated = (
+    filterType: FilterType,
+    code: string,
+    defaultActivated: boolean
+  ): boolean => {
+    const param = searchParams.get(filterType);
+    if (param === null) return defaultActivated;
+    const codes = param.split(",");
+    return codes.includes(code);
+  };
+
+  const syncFiltersToUrl = useCallback(
+    (filters: {
+      conditions: Option[];
+      speed: Option[];
+      tripStates: Option[];
+    }) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      const setFilterParam = (
+        key: FilterType,
+        options: Option[],
+        defaultCodes: string[]
+      ) => {
+        const activeCodes = options
+          .filter((o) => o.activated)
+          .map((o) => o.code);
+
+        const isDefault =
+          activeCodes.length === defaultCodes.length &&
+          defaultCodes.every((c) => activeCodes.includes(c));
+
+        if (activeCodes.length === 0 || isDefault) {
+          params.delete(key);
+        } else {
+          params.set(key, activeCodes.join(","));
+        }
+      };
+
+      setFilterParam("trip", filters.tripStates, ["1"]);
+      setFilterParam("conditions", filters.conditions, []);
+      setFilterParam("speed", filters.speed, []);
+
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    },
+    [searchParams, router, pathname]
+  );
+
+  return { getInitialActivated, syncFiltersToUrl };
+}


### PR DESCRIPTION
## Summary
- **Create `useMapFilters` hook** that reads/writes filter state to URL search params (`?trip=1,2&conditions=4&speed=1,3`)
- **Remove buggy `useEffect`** in `filters.tsx` that unconditionally reset filters to "Con viaje" defaults whenever `originalPositions` changed (on SWR revalidation)
- **Make `FilterComponent` fully controlled** by removing internal `useState` that duplicated parent state and never re-synced

Closes #96

## Test plan
- [x] Load `/geographic-view` with no params → "Con viaje" active by default, URL stays clean
- [x] Toggle filters → URL updates (e.g. `?trip=1,2&speed=1`)
- [x] Tab away and return (triggers SWR revalidation) → filters preserved
- [x] Copy URL with params, open in new tab → same filters applied
- [x] Clear all filters in a group → param removed from URL
- [x] Verify `search` param still works alongside filter params

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Map filters are now synchronized with the URL, enabling users to easily share, save, and return to specific filter configurations.
  * Filter states are initialized from URL parameters, ensuring consistent behavior across page navigation and browser sessions.
  * Enhanced filter management and reliability throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->