### PR TITLE
Based/dashboard json components saved alfresco

### DIFF
--- a/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
@@ -11,7 +11,13 @@ interface SlugPageParams extends ParamsWithLang {
 
 export default async function SlugDashboardPage({ params }: Readonly<SlugPageParams>) {
   const { lang, slug } = await params;
-  const [, dictionary] = await getDictionary(lang);
+
+  // Run independent async work in parallel
+  const [dictionaryResult, session] = await Promise.all([
+    getDictionary(lang),
+    auth(),
+  ]);
+  const [, dictionary] = dictionaryResult;
 
   // e.g. "dashboard" → "dashboard-config", "maintenanceStatus" → "maintenanceStatus-config"
   const storageKey = `${slug}-config`;
@@ -22,16 +28,15 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
 
   // Resolve user's primary site for Alfresco persistence
   let siteId: string | null = null;
-  try {
-    const session = await auth();
-    if (session) {
+  if (session) {
+    try {
       const sites = await getUserSites(session);
       if (sites.length > 0) {
         siteId = sites[0].shortName;
       }
+    } catch {
+      // If site resolution fails, fall back to localStorage-only mode
     }
-  } catch {
-    // If site resolution fails, fall back to localStorage-only mode
   }
 
   return (

--- a/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { DashboardProvider, DashboardView } from "@/features/dashboard";
 import { getDictionary } from "@/features/i18n/i18n.service";
 import { ParamsWithLang } from "@/features/i18n/i18n.service.types";
 import { loadDefaultConfig } from "./load-default-config";
+import { auth } from "@/auth";
+import { getUserSites } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 
 interface SlugPageParams extends ParamsWithLang {
   params: Promise<{ lang: string; slug: string }>;
@@ -18,12 +20,27 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
   // Returns null if the file doesn't exist — dashboard starts empty as usual
   const defaultConfig = loadDefaultConfig(slug);
 
+  // Resolve user's primary site for Alfresco persistence
+  let siteId: string | null = null;
+  try {
+    const session = await auth();
+    if (session) {
+      const sites = await getUserSites(session);
+      if (sites.length > 0) {
+        siteId = sites[0].shortName;
+      }
+    }
+  } catch {
+    // If site resolution fails, fall back to localStorage-only mode
+  }
+
   return (
     <div className="h-full overflow-auto p-4">
       <DashboardProvider
         dictionary={dictionary}
         storageKey={storageKey}
         defaultConfig={defaultConfig}
+        siteId={siteId}
       >
         <DashboardView />
       </DashboardProvider>

--- a/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
@@ -29,7 +29,10 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
     try {
       const sites = await getUserSites(session);
       if (sites.length > 0) {
-        siteId = sites[0].shortName;
+        const sorted = [...sites].sort((a, b) =>
+          a.shortName.localeCompare(b.shortName)
+        );
+        siteId = sorted[0].shortName;
       }
     } catch {
       // If site resolution fails, fall back to default config only

--- a/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
@@ -19,9 +19,6 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
   ]);
   const [, dictionary] = dictionaryResult;
 
-  // e.g. "dashboard" → "dashboard-config", "maintenanceStatus" → "maintenanceStatus-config"
-  const storageKey = `${slug}-config`;
-
   // Try to load a default config from src/features/dashboard/defaults/{slug}-config.json
   // Returns null if the file doesn't exist — dashboard starts empty as usual
   const defaultConfig = loadDefaultConfig(slug);
@@ -35,7 +32,7 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
         siteId = sites[0].shortName;
       }
     } catch {
-      // If site resolution fails, fall back to localStorage-only mode
+      // If site resolution fails, fall back to default config only
     }
   }
 
@@ -43,7 +40,7 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
     <div className="h-full overflow-auto p-4">
       <DashboardProvider
         dictionary={dictionary}
-        storageKey={storageKey}
+        slug={slug}
         defaultConfig={defaultConfig}
         siteId={siteId}
       >

--- a/apps/app/src/app/api/dashboard/config/route.ts
+++ b/apps/app/src/app/api/dashboard/config/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  getPlainTextNode,
+  uploadNodeContent,
+  resolveNodeByPath,
+  ensureFolder,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import {
+  handleApiError,
+  unauthorizedResponse,
+  badRequestResponse,
+} from "@/app/api/utils/api-error-handler";
+
+/**
+ * GET /api/dashboard/config?site={siteShortName}&slug={slug}
+ *
+ * Reads a dashboard config JSON from Alfresco:
+ *   Sites/{site}/documentLibrary/dashboard/{slug}-config.json
+ *
+ * Returns { data: <parsed JSON> } or { data: null } if the file doesn't exist yet.
+ */
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = request.nextUrl;
+  const site = searchParams.get("site");
+  const slug = searchParams.get("slug");
+
+  if (!site || !slug) {
+    return badRequestResponse("Missing required query parameters: site, slug");
+  }
+
+  try {
+    const relativePath = `Sites/${site}/documentLibrary/dashboard/${slug}-config.json`;
+    const nodeId = await resolveNodeByPath(session, relativePath);
+
+    if (!nodeId) {
+      return NextResponse.json({ data: null });
+    }
+
+    const content = await getPlainTextNode(session, nodeId);
+    const parsed = JSON.parse(content);
+
+    return NextResponse.json({ data: parsed });
+  } catch (error) {
+    return handleApiError(error, "reading dashboard config from Alfresco");
+  }
+}
+
+/**
+ * PUT /api/dashboard/config
+ *
+ * Saves a dashboard config JSON to Alfresco:
+ *   Sites/{site}/documentLibrary/dashboard/{slug}-config.json
+ *
+ * Body: { site: string, slug: string, config: DashboardStorageSchema }
+ */
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    const body = (await request.json()) as {
+      site?: string;
+      slug?: string;
+      config?: unknown;
+    };
+    const { site, slug, config } = body;
+
+    if (!site || !slug || !config) {
+      return badRequestResponse(
+        "Missing required fields: site, slug, config"
+      );
+    }
+
+    // Ensure the "dashboard" folder exists under documentLibrary
+    const docLibPath = `Sites/${site}/documentLibrary`;
+    const docLibNodeId = await resolveNodeByPath(session, docLibPath);
+    if (!docLibNodeId) {
+      return NextResponse.json(
+        { error: `documentLibrary not found for site '${site}'` },
+        { status: 404 }
+      );
+    }
+    await ensureFolder(session, docLibNodeId, "dashboard");
+
+    // Upload the config file into the existing folder
+    const filename = `${slug}-config.json`;
+    const blob = new Blob([JSON.stringify(config)], {
+      type: "application/json",
+    });
+    const file = new File([blob], filename, { type: "application/json" });
+
+    const result = await uploadNodeContent(session, {
+      filedata: file,
+      siteId: site,
+      containerId: "documentLibrary",
+      uploadDirectory: "/dashboard",
+      filename,
+      overwrite: true,
+    });
+
+    if (!result || (result.status && result.status.code >= 400)) {
+      return NextResponse.json(
+        { error: result?.status?.message ?? "Upload failed" },
+        { status: result?.status?.code ?? 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return handleApiError(error, "saving dashboard config to Alfresco");
+  }
+}

--- a/apps/app/src/app/api/dashboard/config/route.ts
+++ b/apps/app/src/app/api/dashboard/config/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import {
-  getPlainTextNode,
-  uploadNodeContent,
-  resolveNodeByPath,
-  ensureFolder,
+  getDashboardConfig,
+  saveDashboardConfig,
 } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import {
   handleApiError,
@@ -15,10 +13,8 @@ import {
 /**
  * GET /api/dashboard/config?site={siteShortName}&slug={slug}
  *
- * Reads a dashboard config JSON from Alfresco:
- *   Sites/{site}/documentLibrary/dashboard/{slug}-config.json
- *
- * Returns { data: <parsed JSON> } or { data: null } if the file doesn't exist yet.
+ * Proxies to the Alfresco dashboard config webscript.
+ * Returns { data: <parsed JSON> } or { data: null } if no config exists yet.
  */
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -35,17 +31,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const relativePath = `Sites/${site}/documentLibrary/dashboard/${slug}-config.json`;
-    const nodeId = await resolveNodeByPath(session, relativePath);
-
-    if (!nodeId) {
-      return NextResponse.json({ data: null });
-    }
-
-    const content = await getPlainTextNode(session, nodeId);
-    const parsed = JSON.parse(content);
-
-    return NextResponse.json({ data: parsed });
+    const result = await getDashboardConfig(session, site, slug);
+    return NextResponse.json(result);
   } catch (error) {
     return handleApiError(error, "reading dashboard config from Alfresco");
   }
@@ -54,9 +41,7 @@ export async function GET(request: NextRequest) {
 /**
  * PUT /api/dashboard/config
  *
- * Saves a dashboard config JSON to Alfresco:
- *   Sites/{site}/documentLibrary/dashboard/{slug}-config.json
- *
+ * Proxies to the Alfresco dashboard config webscript.
  * Body: { site: string, slug: string, config: DashboardStorageSchema }
  */
 export async function PUT(request: NextRequest) {
@@ -79,41 +64,8 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    // Ensure the "dashboard" folder exists under documentLibrary
-    const docLibPath = `Sites/${site}/documentLibrary`;
-    const docLibNodeId = await resolveNodeByPath(session, docLibPath);
-    if (!docLibNodeId) {
-      return NextResponse.json(
-        { error: `documentLibrary not found for site '${site}'` },
-        { status: 404 }
-      );
-    }
-    await ensureFolder(session, docLibNodeId, "dashboard");
-
-    // Upload the config file into the existing folder
-    const filename = `${slug}-config.json`;
-    const blob = new Blob([JSON.stringify(config)], {
-      type: "application/json",
-    });
-    const file = new File([blob], filename, { type: "application/json" });
-
-    const result = await uploadNodeContent(session, {
-      filedata: file,
-      siteId: site,
-      containerId: "documentLibrary",
-      uploadDirectory: "/dashboard",
-      filename,
-      overwrite: true,
-    });
-
-    if (!result || (result.status && result.status.code >= 400)) {
-      return NextResponse.json(
-        { error: result?.status?.message ?? "Upload failed" },
-        { status: result?.status?.code ?? 500 }
-      );
-    }
-
-    return NextResponse.json({ success: true });
+    const result = await saveDashboardConfig(session, site, slug, config);
+    return NextResponse.json(result);
   } catch (error) {
     return handleApiError(error, "saving dashboard config to Alfresco");
   }

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -703,19 +703,17 @@ export async function ensureFolder(
     return createdId;
   } catch (error: unknown) {
     const fetcherErr = error as FetcherError;
-    // 409 = folder already exists — resolve its nodeId
+    // 409 = folder already exists — resolve its nodeId by relativePath from parent
     if (fetcherErr?.status === 409) {
-      const childrenUrl = `${createUrl}?where=(isFolder=true AND name='${folderName}')`;
-      const { url: listUrl, headers: listHeaders } = prepareAlfrescoAuth(
-        childrenUrl,
-        session
-      );
-      const childrenResponse = (await fetcher(listUrl, {
+      const nodeUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}?relativePath=${encodeURIComponent(folderName)}`;
+      const { url: resolveUrl, headers: resolveHeaders } =
+        prepareAlfrescoAuth(nodeUrl, session);
+      const resolved = (await fetcher(resolveUrl, {
         method: "GET",
-        headers: listHeaders,
-      })) as { list?: { entries?: { entry: { id: string } }[] } };
+        headers: resolveHeaders,
+      })) as { entry?: { id?: string } };
 
-      const existingId = childrenResponse?.list?.entries?.[0]?.entry?.id;
+      const existingId = resolved?.entry?.id;
       if (existingId) {
         return existingId;
       }

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -36,6 +36,7 @@ import type {
   StatisticsTasksResponse,
 } from "./alfresco-api.types";
 import fetcher from "../fetcher";
+import type { FetcherError } from "../fetcher.types";
 import { GetEntityInfoResponse } from "../microboxlabs-api/microboxlabs-api.types";
 import type { Session } from "next-auth";
 import { createManagedLogger, logError } from "@/lib/logger";
@@ -664,11 +665,8 @@ export async function resolveNodeByPath(
     })) as { entry?: { id?: string } };
     return response?.entry?.id ?? null;
   } catch (error: unknown) {
-    if (
-      error instanceof Error &&
-      "status" in error &&
-      (error as { status: number }).status === 404
-    ) {
+    const fetcherErr = error as FetcherError;
+    if (fetcherErr?.status === 404) {
       return null;
     }
     throw error;
@@ -677,6 +675,7 @@ export async function resolveNodeByPath(
 
 /**
  * Ensure a folder exists under a parent node. Creates it if missing.
+ * Uses create-first strategy to avoid TOCTOU races — handles 409 (already exists).
  * Returns the folder's nodeId.
  */
 export async function ensureFolder(
@@ -684,39 +683,45 @@ export async function ensureFolder(
   parentNodeId: string,
   folderName: string
 ): Promise<string> {
-  const childrenUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}/children?where=(isFolder=true AND name='${folderName}')`;
-  const { url, headers } = prepareAlfrescoAuth(childrenUrl, session);
-
-  const childrenResponse = (await fetcher(url, {
-    method: "GET",
-    headers,
-  })) as { list?: { entries?: { entry: { id: string } }[] } };
-
-  const existing = childrenResponse?.list?.entries?.[0]?.entry?.id;
-  if (existing) {
-    return existing;
-  }
-
   const createUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}/children`;
-  const { url: createEndpoint, headers: createHeaders } = prepareAlfrescoAuth(
-    createUrl,
-    session
-  );
+  const { url, headers } = prepareAlfrescoAuth(createUrl, session);
 
-  const created = (await fetcher(createEndpoint, {
-    method: "POST",
-    headers: { ...createHeaders, "Content-Type": "application/json" },
-    body: JSON.stringify({
-      name: folderName,
-      nodeType: "cm:folder",
-    }),
-  })) as { entry?: { id?: string } };
+  try {
+    const created = (await fetcher(url, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: folderName,
+        nodeType: "cm:folder",
+      }),
+    })) as { entry?: { id?: string } };
 
-  const createdId = created?.entry?.id;
-  if (!createdId) {
-    throw new Error(`Failed to create folder '${folderName}'`);
+    const createdId = created?.entry?.id;
+    if (!createdId) {
+      throw new Error(`Failed to create folder '${folderName}'`);
+    }
+    return createdId;
+  } catch (error: unknown) {
+    const fetcherErr = error as FetcherError;
+    // 409 = folder already exists — resolve its nodeId
+    if (fetcherErr?.status === 409) {
+      const childrenUrl = `${createUrl}?where=(isFolder=true AND name='${folderName}')`;
+      const { url: listUrl, headers: listHeaders } = prepareAlfrescoAuth(
+        childrenUrl,
+        session
+      );
+      const childrenResponse = (await fetcher(listUrl, {
+        method: "GET",
+        headers: listHeaders,
+      })) as { list?: { entries?: { entry: { id: string } }[] } };
+
+      const existingId = childrenResponse?.list?.entries?.[0]?.entry?.id;
+      if (existingId) {
+        return existingId;
+      }
+    }
+    throw error;
   }
-  return createdId;
 }
 
 export async function getUserFilters(

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -1477,3 +1477,43 @@ export async function updateTaskServiceCategory(
     mintral_serviceCategory: serviceTypeCode,
   });
 }
+
+/**
+ * Reads a dashboard config from Alfresco via the dashboard config webscript.
+ * Returns the parsed config or null if no config exists yet.
+ */
+export async function getDashboardConfig(
+  session: Session,
+  site: string,
+  slug: string
+): Promise<{ data: unknown | null }> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/modular/dashboard/config?site=${encodeURIComponent(site)}&slug=${encodeURIComponent(slug)}`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  const result = await fetcher(url, {
+    method: "GET",
+    headers,
+  });
+  return result as { data: unknown | null };
+}
+
+/**
+ * Saves a dashboard config to Alfresco via the dashboard config webscript.
+ */
+export async function saveDashboardConfig(
+  session: Session,
+  site: string,
+  slug: string,
+  config: unknown
+): Promise<{ success: boolean }> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/modular/dashboard/config`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  const result = await fetcher(url, {
+    method: "PUT",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ site, slug, config }),
+  });
+  return result as { success: boolean };
+}

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -1486,14 +1486,14 @@ export async function getDashboardConfig(
   session: Session,
   site: string,
   slug: string
-): Promise<{ data: unknown | null }> {
+): Promise<{ data: unknown }> {
   const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/modular/dashboard/config?site=${encodeURIComponent(site)}&slug=${encodeURIComponent(slug)}`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
   const result = await fetcher(url, {
     method: "GET",
     headers,
   });
-  return result as { data: unknown | null };
+  return result as { data: unknown };
 }
 
 /**

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -647,6 +647,78 @@ export async function getGroupsForPerson(session: Session): Promise<string[]> {
   return groups.list?.entries?.map(({ entry }) => entry.id!) ?? [];
 }
 
+/**
+ * Resolve a node by relativePath. Returns the nodeId or null if not found (404).
+ */
+export async function resolveNodeByPath(
+  session: Session,
+  relativePath: string
+): Promise<string | null> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-?relativePath=${encodeURIComponent(relativePath)}`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+
+  try {
+    const response = (await fetcher(url, {
+      method: "GET",
+      headers,
+    })) as { entry?: { id?: string } };
+    return response?.entry?.id ?? null;
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      "status" in error &&
+      (error as { status: number }).status === 404
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Ensure a folder exists under a parent node. Creates it if missing.
+ * Returns the folder's nodeId.
+ */
+export async function ensureFolder(
+  session: Session,
+  parentNodeId: string,
+  folderName: string
+): Promise<string> {
+  const childrenUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}/children?where=(isFolder=true AND name='${folderName}')`;
+  const { url, headers } = prepareAlfrescoAuth(childrenUrl, session);
+
+  const childrenResponse = (await fetcher(url, {
+    method: "GET",
+    headers,
+  })) as { list?: { entries?: { entry: { id: string } }[] } };
+
+  const existing = childrenResponse?.list?.entries?.[0]?.entry?.id;
+  if (existing) {
+    return existing;
+  }
+
+  const createUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}/children`;
+  const { url: createEndpoint, headers: createHeaders } = prepareAlfrescoAuth(
+    createUrl,
+    session
+  );
+
+  const created = (await fetcher(createEndpoint, {
+    method: "POST",
+    headers: { ...createHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: folderName,
+      nodeType: "cm:folder",
+    }),
+  })) as { entry?: { id?: string } };
+
+  const createdId = created?.entry?.id;
+  if (!createdId) {
+    throw new Error(`Failed to create folder '${folderName}'`);
+  }
+  return createdId;
+}
+
 export async function getUserFilters(
   session: Session,
   group: string

--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -659,10 +659,10 @@ export async function resolveNodeByPath(
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
 
   try {
-    const response = (await fetcher(url, {
+    const response = await fetcher<{ entry?: { id?: string } }>(url, {
       method: "GET",
       headers,
-    })) as { entry?: { id?: string } };
+    });
     return response?.entry?.id ?? null;
   } catch (error: unknown) {
     const fetcherErr = error as FetcherError;
@@ -687,14 +687,14 @@ export async function ensureFolder(
   const { url, headers } = prepareAlfrescoAuth(createUrl, session);
 
   try {
-    const created = (await fetcher(url, {
+    const created = await fetcher<{ entry?: { id?: string } }>(url, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
       body: JSON.stringify({
         name: folderName,
         nodeType: "cm:folder",
       }),
-    })) as { entry?: { id?: string } };
+    });
 
     const createdId = created?.entry?.id;
     if (!createdId) {
@@ -708,10 +708,10 @@ export async function ensureFolder(
       const nodeUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${parentNodeId}?relativePath=${encodeURIComponent(folderName)}`;
       const { url: resolveUrl, headers: resolveHeaders } =
         prepareAlfrescoAuth(nodeUrl, session);
-      const resolved = (await fetcher(resolveUrl, {
+      const resolved = await fetcher<{ entry?: { id?: string } }>(resolveUrl, {
         method: "GET",
         headers: resolveHeaders,
-      })) as { entry?: { id?: string } };
+      });
 
       const existingId = resolved?.entry?.id;
       if (existingId) {

--- a/apps/app/src/features/dashboard/context/dashboard-context.tsx
+++ b/apps/app/src/features/dashboard/context/dashboard-context.tsx
@@ -119,18 +119,18 @@ function getNextPosition(
 
 interface DashboardProviderProps extends PropsWithChildren {
   dictionary: I18nRecord;
-  /** localStorage key used to persist this dashboard's config (e.g. "dashboard-config") */
-  storageKey: string;
-  /** Optional server-loaded default config. Used only when localStorage has no data yet. */
+  /** Dashboard slug (e.g. "dashboard", "maintenanceStatus") */
+  slug: string;
+  /** Optional server-loaded default config. */
   defaultConfig?: DashboardStorageSchema | null;
-  /** Optional Alfresco site short name. When provided, configs are also persisted to Alfresco. */
+  /** Optional Alfresco site short name. When provided, configs are fetched from and persisted to Alfresco. */
   siteId?: string | null;
 }
 
 export function DashboardProvider({
   children,
   dictionary,
-  storageKey,
+  slug,
   defaultConfig,
   siteId,
 }: Readonly<DashboardProviderProps>) {
@@ -150,7 +150,7 @@ export function DashboardProvider({
     exportDashboard,
     importDashboard,
     downloadDashboard,
-  } = useDashboardStorage(storageKey, defaultConfig, siteId);
+  } = useDashboardStorage(slug, defaultConfig, siteId);
 
   const createWidget = useCallback(
     (

--- a/apps/app/src/features/dashboard/context/dashboard-context.tsx
+++ b/apps/app/src/features/dashboard/context/dashboard-context.tsx
@@ -123,6 +123,8 @@ interface DashboardProviderProps extends PropsWithChildren {
   storageKey: string;
   /** Optional server-loaded default config. Used only when localStorage has no data yet. */
   defaultConfig?: DashboardStorageSchema | null;
+  /** Optional Alfresco site short name. When provided, configs are also persisted to Alfresco. */
+  siteId?: string | null;
 }
 
 export function DashboardProvider({
@@ -130,6 +132,7 @@ export function DashboardProvider({
   dictionary,
   storageKey,
   defaultConfig,
+  siteId,
 }: Readonly<DashboardProviderProps>) {
   const {
     widgets,
@@ -147,7 +150,7 @@ export function DashboardProvider({
     exportDashboard,
     importDashboard,
     downloadDashboard,
-  } = useDashboardStorage(storageKey, defaultConfig);
+  } = useDashboardStorage(storageKey, defaultConfig, siteId);
 
   const createWidget = useCallback(
     (

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -129,7 +129,7 @@ export function useDashboardStorage(
   }, [response, fallback]);
 
   // Edit mode — ephemeral React state only
-  const [editMode, setEditModeState] = useState(false);
+  const [editMode, setEditMode] = useState(false);
 
   // Refs for debounced Alfresco save
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -396,14 +396,6 @@ export function useDashboardStorage(
       saveData(newData);
     },
     [resolvedConfig, saveData]
-  );
-
-  // Set edit mode (ephemeral — React state only)
-  const setEditMode = useCallback(
-    (mode: boolean) => {
-      setEditModeState(mode);
-    },
-    []
   );
 
   // Set dashboard name

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   type Widget,
   type DashboardStorageSchema,
@@ -73,53 +73,199 @@ function updateChildrenLayouts(
   return widget;
 }
 
+/** Strip editMode from config before persisting to Alfresco */
+function stripEphemeralState(
+  data: DashboardStorageSchema
+): DashboardStorageSchema {
+  return {
+    ...data,
+    preferences: { ...data.preferences, editMode: false },
+  };
+}
+
+const ALFRESCO_DEBOUNCE_MS = 2000;
+const ALFRESCO_MAX_RETRIES = 3;
+const ALFRESCO_RETRY_BASE_MS = 1000;
+
 /**
- * Hook for persisting dashboard data to localStorage.
+ * Hook for persisting dashboard data to localStorage and optionally to Alfresco.
  * @param storageKey    - The localStorage key to use (e.g. "dashboard-config")
  * @param defaultConfig - Optional server-loaded default config. Used only when
  *                        localStorage has no saved data for this key yet.
+ * @param siteId        - Optional Alfresco site short name. When provided, configs
+ *                        are also persisted to Alfresco as source of truth.
  */
 export function useDashboardStorage(
   storageKey: string,
-  defaultConfig?: DashboardStorageSchema | null
+  defaultConfig?: DashboardStorageSchema | null,
+  siteId?: string | null
 ) {
   const [data, setData] = useState<DashboardStorageSchema>(DEFAULT_STORAGE);
   const [isLoaded, setIsLoaded] = useState(false);
 
-  // Load data from localStorage on mount (or when key changes)
+  // Refs for debounced Alfresco save
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSaveRef = useRef<DashboardStorageSchema | null>(null);
+  const siteIdRef = useRef(siteId);
+  siteIdRef.current = siteId;
+
+  // Derive slug from storageKey: "dashboard-config" → "dashboard"
+  const slug = storageKey.replace(/-config$/, "");
+
+  /** Save config to Alfresco with retry */
+  const saveToAlfresco = useCallback(
+    async (configData: DashboardStorageSchema, retryCount = 0) => {
+      const currentSiteId = siteIdRef.current;
+      if (!currentSiteId) return;
+
+      try {
+        const response = await fetch("/api/dashboard/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            site: currentSiteId,
+            slug,
+            config: stripEphemeralState(configData),
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Alfresco save failed: ${response.status}`);
+        }
+      } catch (error) {
+        if (retryCount < ALFRESCO_MAX_RETRIES - 1) {
+          const delay =
+            ALFRESCO_RETRY_BASE_MS * Math.pow(2, retryCount);
+          console.warn(
+            `Alfresco save failed, retrying in ${delay}ms (attempt ${retryCount + 2}/${ALFRESCO_MAX_RETRIES})`,
+            error
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          return saveToAlfresco(configData, retryCount + 1);
+        }
+        console.error(
+          "Failed to save dashboard config to Alfresco after retries:",
+          error
+        );
+      }
+    },
+    [slug]
+  );
+
+  /** Schedule a debounced Alfresco save */
+  const scheduleSaveToAlfresco = useCallback(
+    (configData: DashboardStorageSchema) => {
+      if (!siteIdRef.current) return;
+
+      pendingSaveRef.current = configData;
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        const pending = pendingSaveRef.current;
+        pendingSaveRef.current = null;
+        debounceTimerRef.current = null;
+        if (pending) {
+          void saveToAlfresco(pending);
+        }
+      }, ALFRESCO_DEBOUNCE_MS);
+    },
+    [saveToAlfresco]
+  );
+
+  // Flush pending Alfresco save on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      const pending = pendingSaveRef.current;
+      pendingSaveRef.current = null;
+      if (pending && siteIdRef.current) {
+        void saveToAlfresco(pending);
+      }
+    };
+  }, [saveToAlfresco]);
+
+  // Load data from localStorage on mount, then background-fetch from Alfresco
   useEffect(() => {
     setIsLoaded(false);
     setData(DEFAULT_STORAGE);
+
+    let localData: DashboardStorageSchema = DEFAULT_STORAGE;
+
+    // Phase 1: Instant load from localStorage
     try {
       const stored = localStorage.getItem(storageKey);
 
       if (stored) {
-        // User already has a saved config — always prefer it over the default
         const parsed = JSON.parse(stored);
         if (parsed.version === 2) {
           const migratedWidgets = parsed.widgets.map((w: Widget, i: number) =>
             ensureWidgetDefaults(w, i)
           );
           const name = parsed.name || DEFAULT_STORAGE.name;
-          setData({ ...parsed, name, widgets: migratedWidgets });
+          localData = { ...parsed, name, widgets: migratedWidgets };
         } else {
-          setData(defaultConfig ?? DEFAULT_STORAGE);
+          localData = defaultConfig ?? DEFAULT_STORAGE;
         }
       } else if (defaultConfig) {
-        // No saved config yet — seed with the server-provided default
         const migratedWidgets = defaultConfig.widgets.map(
           (w: Widget, i: number) => ensureWidgetDefaults(w, i)
         );
-        setData({ ...defaultConfig, widgets: migratedWidgets });
+        localData = { ...defaultConfig, widgets: migratedWidgets };
       }
     } catch (error) {
       console.error("Failed to load dashboard data:", error);
-      setData(defaultConfig ?? DEFAULT_STORAGE);
+      localData = defaultConfig ?? DEFAULT_STORAGE;
     }
+    setData(localData);
     setIsLoaded(true);
-  }, [storageKey]); // defaultConfig is intentionally omitted — it's stable per page load
 
-  // Save data to localStorage
+    // Phase 2: Background fetch from Alfresco (source of truth)
+    if (siteId) {
+      const fetchSlug = storageKey.replace(/-config$/, "");
+      fetch(
+        `/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(fetchSlug)}`
+      )
+        .then((res) => res.json())
+        .then((result: { data: DashboardStorageSchema | null }) => {
+          if (result.data) {
+            const alfrescoData = result.data;
+            const migratedWidgets = alfrescoData.widgets.map(
+              (w: Widget, i: number) => ensureWidgetDefaults(w, i)
+            );
+            const resolved: DashboardStorageSchema = {
+              ...alfrescoData,
+              widgets: migratedWidgets,
+              // Preserve local editMode (ephemeral)
+              preferences: {
+                ...alfrescoData.preferences,
+                editMode: localData?.preferences?.editMode ?? false,
+              },
+            };
+
+            setData(resolved);
+            try {
+              localStorage.setItem(storageKey, JSON.stringify(resolved));
+            } catch {
+              // localStorage write failure is non-critical
+            }
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            "Failed to fetch dashboard config from Alfresco, using local data:",
+            error
+          );
+        });
+    }
+  }, [storageKey, siteId]); // defaultConfig is intentionally omitted — it's stable per page load
+
+  // Save data to localStorage + schedule Alfresco save
   const saveData = useCallback(
     (newData: DashboardStorageSchema) => {
       setData(newData);
@@ -128,8 +274,9 @@ export function useDashboardStorage(
       } catch (error) {
         console.error("Failed to save dashboard data:", error);
       }
+      scheduleSaveToAlfresco(newData);
     },
-    [storageKey]
+    [storageKey, scheduleSaveToAlfresco]
   );
 
   // Find widget by ID (recursive search)

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -107,6 +107,7 @@ export function useDashboardStorage(
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSaveRef = useRef<DashboardStorageSchema | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const hasLocalEditsRef = useRef(false);
   const siteIdRef = useRef(siteId);
   siteIdRef.current = siteId;
 
@@ -208,6 +209,7 @@ export function useDashboardStorage(
   useEffect(() => {
     setIsLoaded(false);
     setData(DEFAULT_STORAGE);
+    hasLocalEditsRef.current = false;
 
     let localData: DashboardStorageSchema = DEFAULT_STORAGE;
 
@@ -251,6 +253,8 @@ export function useDashboardStorage(
         .then((res) => res.json())
         .then((result: { data: DashboardStorageSchema | null }) => {
           if (abortController.signal.aborted) return;
+          // Skip applying Alfresco data if user has made local edits since mount
+          if (hasLocalEditsRef.current) return;
           if (result.data) {
             const alfrescoData = result.data;
             const migratedWidgets = alfrescoData.widgets.map(
@@ -290,6 +294,7 @@ export function useDashboardStorage(
   // Save data to localStorage + schedule Alfresco save
   const saveData = useCallback(
     (newData: DashboardStorageSchema) => {
+      hasLocalEditsRef.current = true;
       setData(newData);
       try {
         localStorage.setItem(storageKey, JSON.stringify(newData));

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -250,7 +250,12 @@ export function useDashboardStorage(
         `/app/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`,
         { signal: abortController.signal }
       )
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`Alfresco fetch failed: ${res.status} ${res.statusText}`);
+          }
+          return res.json();
+        })
         .then((result: { data: DashboardStorageSchema | null }) => {
           if (abortController.signal.aborted) return;
           // Skip applying Alfresco data if user has made local edits since mount

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -103,9 +103,10 @@ export function useDashboardStorage(
   const [data, setData] = useState<DashboardStorageSchema>(DEFAULT_STORAGE);
   const [isLoaded, setIsLoaded] = useState(false);
 
-  // Refs for debounced Alfresco save
+  // Refs for debounced Alfresco save and background fetch
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSaveRef = useRef<DashboardStorageSchema | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const siteIdRef = useRef(siteId);
   siteIdRef.current = siteId;
 
@@ -175,7 +176,7 @@ export function useDashboardStorage(
     [saveToAlfresco]
   );
 
-  // Flush pending Alfresco save on unmount
+  // Flush pending Alfresco save on unmount using keepalive fetch
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
@@ -183,12 +184,25 @@ export function useDashboardStorage(
         debounceTimerRef.current = null;
       }
       const pending = pendingSaveRef.current;
+      const currentSiteId = siteIdRef.current;
       pendingSaveRef.current = null;
-      if (pending && siteIdRef.current) {
-        void saveToAlfresco(pending);
+      if (pending && currentSiteId) {
+        // Use keepalive to ensure the request completes even during page teardown
+        fetch("/api/dashboard/config", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            site: currentSiteId,
+            slug,
+            config: stripEphemeralState(pending),
+          }),
+          keepalive: true,
+        }).catch(() => {
+          // Best-effort — data is already in localStorage
+        });
       }
     };
-  }, [saveToAlfresco]);
+  }, [slug]);
 
   // Load data from localStorage on mount, then background-fetch from Alfresco
   useEffect(() => {
@@ -227,12 +241,16 @@ export function useDashboardStorage(
 
     // Phase 2: Background fetch from Alfresco (source of truth)
     if (siteId) {
-      const fetchSlug = storageKey.replace(/-config$/, "");
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
       fetch(
-        `/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(fetchSlug)}`
+        `/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`,
+        { signal: abortController.signal }
       )
         .then((res) => res.json())
         .then((result: { data: DashboardStorageSchema | null }) => {
+          if (abortController.signal.aborted) return;
           if (result.data) {
             const alfrescoData = result.data;
             const migratedWidgets = alfrescoData.widgets.map(
@@ -241,10 +259,9 @@ export function useDashboardStorage(
             const resolved: DashboardStorageSchema = {
               ...alfrescoData,
               widgets: migratedWidgets,
-              // Preserve local editMode (ephemeral)
               preferences: {
                 ...alfrescoData.preferences,
-                editMode: localData?.preferences?.editMode ?? false,
+                editMode: false,
               },
             };
 
@@ -257,13 +274,18 @@ export function useDashboardStorage(
           }
         })
         .catch((error: unknown) => {
+          if (abortController.signal.aborted) return;
           console.warn(
             "Failed to fetch dashboard config from Alfresco, using local data:",
             error
           );
         });
+
+      return () => {
+        abortController.abort();
+      };
     }
-  }, [storageKey, siteId]); // defaultConfig is intentionally omitted — it's stable per page load
+  }, [storageKey, siteId, slug]); // defaultConfig is intentionally omitted — it's stable per page load
 
   // Save data to localStorage + schedule Alfresco save
   const saveData = useCallback(
@@ -441,16 +463,21 @@ export function useDashboardStorage(
     [data, saveData]
   );
 
-  // Set edit mode
+  // Set edit mode (ephemeral — only localStorage, no Alfresco save)
   const setEditMode = useCallback(
     (editMode: boolean) => {
       const newData: DashboardStorageSchema = {
         ...data,
         preferences: { ...data.preferences, editMode },
       };
-      saveData(newData);
+      setData(newData);
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(newData));
+      } catch {
+        // non-critical
+      }
     },
-    [data, saveData]
+    [data, storageKey]
   );
 
   // Set dashboard name

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -120,7 +120,7 @@ export function useDashboardStorage(
       if (!currentSiteId) return;
 
       try {
-        const response = await fetch("/api/dashboard/config", {
+        const response = await fetch("/app/api/dashboard/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -188,7 +188,7 @@ export function useDashboardStorage(
       pendingSaveRef.current = null;
       if (pending && currentSiteId) {
         // Use keepalive to ensure the request completes even during page teardown
-        fetch("/api/dashboard/config", {
+        fetch("/app/api/dashboard/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -245,7 +245,7 @@ export function useDashboardStorage(
       abortControllerRef.current = abortController;
 
       fetch(
-        `/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`,
+        `/app/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`,
         { signal: abortController.signal }
       )
         .then((res) => res.json())

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -101,7 +101,9 @@ export function useDashboardStorage(
   defaultConfig?: DashboardStorageSchema | null,
   siteId?: string | null
 ) {
-  const fallback = defaultConfig ?? DEFAULT_STORAGE;
+  // Stabilize fallback via ref — defaultConfig comes from server props and is
+  // referentially stable per page load, but we guard against inline objects.
+  const fallbackRef = useRef(defaultConfig ?? DEFAULT_STORAGE);
 
   // SWR key — null when no siteId (disables fetch)
   const swrKey = siteId
@@ -115,18 +117,22 @@ export function useDashboardStorage(
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       dedupingInterval: 60000,
-      fallbackData: { data: fallback },
+      fallbackData: { data: fallbackRef.current },
     }
   );
 
+  const rawConfig = response?.data ?? fallbackRef.current;
+
   // Resolved config with widget defaults applied
-  const resolvedConfig = useMemo(() => {
-    const raw = response?.data ?? fallback;
-    return {
-      ...raw,
-      widgets: raw.widgets.map((w, i) => ensureWidgetDefaults(w, i)),
-    };
-  }, [response, fallback]);
+  const resolvedConfig = useMemo(() => ({
+    ...rawConfig,
+    widgets: rawConfig.widgets.map((w, i) => ensureWidgetDefaults(w, i)),
+  }), [rawConfig]);
+
+  // Keep a ref so mutation callbacks don't depend on resolvedConfig directly,
+  // preventing cascading callback recreation on every widget change.
+  const configRef = useRef(resolvedConfig);
+  configRef.current = resolvedConfig;
 
   // Edit mode — ephemeral React state only
   const [editMode, setEditMode] = useState(false);
@@ -144,7 +150,7 @@ export function useDashboardStorage(
       if (!currentSiteId) return;
 
       try {
-        const response = await fetch("/app/api/dashboard/config", {
+        const res = await fetch("/app/api/dashboard/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -154,8 +160,8 @@ export function useDashboardStorage(
           }),
         });
 
-        if (!response.ok) {
-          throw new Error(`Alfresco save failed: ${response.status}`);
+        if (!res.ok) {
+          throw new Error(`Alfresco save failed: ${res.status}`);
         }
       } catch (error) {
         if (retryCount < ALFRESCO_MAX_RETRIES - 1) {
@@ -211,6 +217,7 @@ export function useDashboardStorage(
       const currentSiteId = siteIdRef.current;
       pendingSaveRef.current = null;
       if (pending && currentSiteId) {
+        // Raw fetch with keepalive for page teardown — shared fetcher doesn't support keepalive
         fetch("/app/api/dashboard/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -236,6 +243,18 @@ export function useDashboardStorage(
     [mutate, scheduleSaveToAlfresco]
   );
 
+  // Helper: update config via a transform on the current widgets.
+  // Reads from configRef so mutation callbacks remain stable.
+  const updateConfig = useCallback(
+    (patch: Partial<DashboardStorageSchema> | ((current: DashboardStorageSchema) => DashboardStorageSchema)) => {
+      const current = configRef.current;
+      const newData = typeof patch === "function" ? patch(current) : { ...current, ...patch };
+      saveData(newData);
+      return newData;
+    },
+    [saveData]
+  );
+
   // isLoaded: null key means no fetch needed → immediately loaded
   const isLoaded = swrKey ? !isLoading : true;
 
@@ -243,7 +262,7 @@ export function useDashboardStorage(
   const findWidget = useCallback(
     (
       widgetId: string,
-      widgets: Widget[] = resolvedConfig.widgets
+      widgets: Widget[] = configRef.current.widgets
     ): Widget | undefined => {
       for (const widget of widgets) {
         if (widget.id === widgetId) return widget;
@@ -254,14 +273,14 @@ export function useDashboardStorage(
       }
       return undefined;
     },
-    [resolvedConfig.widgets]
+    []
   );
 
   // Find parent widget (recursive)
   const findParent = useCallback(
     (
       widgetId: string,
-      widgets: Widget[] = resolvedConfig.widgets,
+      widgets: Widget[] = configRef.current.widgets,
       parent: Widget | null = null
     ): Widget | null | undefined => {
       for (const widget of widgets) {
@@ -273,26 +292,22 @@ export function useDashboardStorage(
       }
       return undefined;
     },
-    [resolvedConfig.widgets]
+    []
   );
 
   // Add a widget at root level
   const addWidget = useCallback(
     (widget: Widget) => {
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        widgets: [...resolvedConfig.widgets, widget],
-      };
-      saveData(newData);
+      updateConfig((c) => ({ ...c, widgets: [...c.widgets, widget] }));
       return widget;
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Add a widget as child of another widget
   const addChildWidget = useCallback(
     (parentId: string, widget: Widget) => {
-      const updateChildren = (widgets: Widget[]): Widget[] =>
+      const addToParent = (widgets: Widget[]): Widget[] =>
         widgets.map((w) => {
           if (w.id === parentId) {
             return {
@@ -302,19 +317,15 @@ export function useDashboardStorage(
             };
           }
           if (w.children) {
-            return { ...w, children: updateChildren(w.children) };
+            return { ...w, children: addToParent(w.children) };
           }
           return w;
         });
 
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        widgets: updateChildren(resolvedConfig.widgets),
-      };
-      saveData(newData);
+      updateConfig((c) => ({ ...c, widgets: addToParent(c.widgets) }));
       return widget;
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Update a widget's config
@@ -323,11 +334,7 @@ export function useDashboardStorage(
       const updateInTree = (widgets: Widget[]): Widget[] =>
         widgets.map((w) => {
           if (w.id === widgetId) {
-            return {
-              ...w,
-              config,
-              updatedAt: new Date().toISOString(),
-            };
+            return { ...w, config, updatedAt: new Date().toISOString() };
           }
           if (w.children) {
             return { ...w, children: updateInTree(w.children) };
@@ -335,13 +342,9 @@ export function useDashboardStorage(
           return w;
         });
 
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        widgets: updateInTree(resolvedConfig.widgets),
-      };
-      saveData(newData);
+      updateConfig((c) => ({ ...c, widgets: updateInTree(c.widgets) }));
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Update widget layouts (for drag/drop/resize)
@@ -350,30 +353,14 @@ export function useDashboardStorage(
       parentId: string | null,
       layouts: { i: string; x: number; y: number; w: number; h: number }[]
     ) => {
-      if (parentId === null) {
-        const updatedWidgets = resolvedConfig.widgets.map((widget) =>
-          applyLayoutToWidget(widget, layouts)
-        );
-
-        const newData: DashboardStorageSchema = {
-          ...resolvedConfig,
-          widgets: updatedWidgets,
-        };
-        saveData(newData);
-        return;
-      }
-
-      const updatedWidgets = resolvedConfig.widgets.map((w) =>
-        updateChildrenLayouts(w, parentId, layouts)
-      );
-
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        widgets: updatedWidgets,
-      };
-      saveData(newData);
+      updateConfig((c) => {
+        if (parentId === null) {
+          return { ...c, widgets: c.widgets.map((w) => applyLayoutToWidget(w, layouts)) };
+        }
+        return { ...c, widgets: c.widgets.map((w) => updateChildrenLayouts(w, parentId, layouts)) };
+      });
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Delete a widget (and its children)
@@ -389,45 +376,38 @@ export function useDashboardStorage(
             return w;
           });
 
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        widgets: removeFromTree(resolvedConfig.widgets),
-      };
-      saveData(newData);
+      updateConfig((c) => ({ ...c, widgets: removeFromTree(c.widgets) }));
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Set dashboard name
   const setDashboardName = useCallback(
     (name: string) => {
-      const newData: DashboardStorageSchema = {
-        ...resolvedConfig,
-        name,
-      };
-      saveData(newData);
+      updateConfig({ name });
     },
-    [resolvedConfig, saveData]
+    [updateConfig]
   );
 
   // Download dashboard as JSON file
   const downloadDashboard = useCallback(() => {
-    const json = JSON.stringify(resolvedConfig, null, 2);
+    const current = configRef.current;
+    const json = JSON.stringify(current, null, 2);
     const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${resolvedConfig.name.replaceAll(/\s+/g, "_").toLowerCase()}_dashboard.json`;
+    link.download = `${current.name.replaceAll(/\s+/g, "_").toLowerCase()}_dashboard.json`;
     document.body.appendChild(link);
     link.click();
     link.remove();
     URL.revokeObjectURL(url);
-  }, [resolvedConfig]);
+  }, []);
 
   // Export dashboard as JSON string
   const exportDashboard = useCallback((): string => {
-    return JSON.stringify(resolvedConfig, null, 2);
-  }, [resolvedConfig]);
+    return JSON.stringify(configRef.current, null, 2);
+  }, []);
 
   // Import dashboard from JSON string
   const importDashboard = useCallback(

--- a/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import useSWR from "swr";
+import fetcher from "@/features/common/providers/fetcher";
 import {
   type Widget,
   type DashboardStorageSchema,
@@ -88,31 +90,52 @@ const ALFRESCO_MAX_RETRIES = 3;
 const ALFRESCO_RETRY_BASE_MS = 1000;
 
 /**
- * Hook for persisting dashboard data to localStorage and optionally to Alfresco.
- * @param storageKey    - The localStorage key to use (e.g. "dashboard-config")
- * @param defaultConfig - Optional server-loaded default config. Used only when
- *                        localStorage has no saved data for this key yet.
+ * Hook for persisting dashboard data via SWR + Alfresco.
+ * @param slug          - Dashboard slug (e.g. "dashboard", "maintenanceStatus")
+ * @param defaultConfig - Optional server-loaded default config.
  * @param siteId        - Optional Alfresco site short name. When provided, configs
- *                        are also persisted to Alfresco as source of truth.
+ *                        are fetched from and persisted to Alfresco.
  */
 export function useDashboardStorage(
-  storageKey: string,
+  slug: string,
   defaultConfig?: DashboardStorageSchema | null,
   siteId?: string | null
 ) {
-  const [data, setData] = useState<DashboardStorageSchema>(DEFAULT_STORAGE);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const fallback = defaultConfig ?? DEFAULT_STORAGE;
 
-  // Refs for debounced Alfresco save and background fetch
+  // SWR key — null when no siteId (disables fetch)
+  const swrKey = siteId
+    ? `/app/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`
+    : null;
+
+  const { data: response, mutate, isLoading } = useSWR<{ data: DashboardStorageSchema | null }>(
+    swrKey,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 60000,
+      fallbackData: { data: fallback },
+    }
+  );
+
+  // Resolved config with widget defaults applied
+  const resolvedConfig = useMemo(() => {
+    const raw = response?.data ?? fallback;
+    return {
+      ...raw,
+      widgets: raw.widgets.map((w, i) => ensureWidgetDefaults(w, i)),
+    };
+  }, [response, fallback]);
+
+  // Edit mode — ephemeral React state only
+  const [editMode, setEditModeState] = useState(false);
+
+  // Refs for debounced Alfresco save
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSaveRef = useRef<DashboardStorageSchema | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const hasLocalEditsRef = useRef(false);
   const siteIdRef = useRef(siteId);
   siteIdRef.current = siteId;
-
-  // Derive slug from storageKey: "dashboard-config" → "dashboard"
-  const slug = storageKey.replace(/-config$/, "");
 
   /** Save config to Alfresco with retry */
   const saveToAlfresco = useCallback(
@@ -188,7 +211,6 @@ export function useDashboardStorage(
       const currentSiteId = siteIdRef.current;
       pendingSaveRef.current = null;
       if (pending && currentSiteId) {
-        // Use keepalive to ensure the request completes even during page teardown
         fetch("/app/api/dashboard/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -199,123 +221,29 @@ export function useDashboardStorage(
           }),
           keepalive: true,
         }).catch(() => {
-          // Best-effort — data is already in localStorage
+          // Best-effort flush
         });
       }
     };
   }, [slug]);
 
-  // Load data from localStorage on mount, then background-fetch from Alfresco
-  useEffect(() => {
-    setIsLoaded(false);
-    setData(DEFAULT_STORAGE);
-    hasLocalEditsRef.current = false;
-
-    let localData: DashboardStorageSchema = DEFAULT_STORAGE;
-
-    // Phase 1: Instant load from localStorage
-    try {
-      const stored = localStorage.getItem(storageKey);
-
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (parsed.version === 2) {
-          const migratedWidgets = parsed.widgets.map((w: Widget, i: number) =>
-            ensureWidgetDefaults(w, i)
-          );
-          const name = parsed.name || DEFAULT_STORAGE.name;
-          localData = { ...parsed, name, widgets: migratedWidgets };
-        } else {
-          localData = defaultConfig ?? DEFAULT_STORAGE;
-        }
-      } else if (defaultConfig) {
-        const migratedWidgets = defaultConfig.widgets.map(
-          (w: Widget, i: number) => ensureWidgetDefaults(w, i)
-        );
-        localData = { ...defaultConfig, widgets: migratedWidgets };
-      }
-    } catch (error) {
-      console.error("Failed to load dashboard data:", error);
-      localData = defaultConfig ?? DEFAULT_STORAGE;
-    }
-    setData(localData);
-    setIsLoaded(true);
-
-    // Phase 2: Background fetch from Alfresco (source of truth)
-    if (siteId) {
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
-      fetch(
-        `/app/api/dashboard/config?site=${encodeURIComponent(siteId)}&slug=${encodeURIComponent(slug)}`,
-        { signal: abortController.signal }
-      )
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error(`Alfresco fetch failed: ${res.status} ${res.statusText}`);
-          }
-          return res.json();
-        })
-        .then((result: { data: DashboardStorageSchema | null }) => {
-          if (abortController.signal.aborted) return;
-          // Skip applying Alfresco data if user has made local edits since mount
-          if (hasLocalEditsRef.current) return;
-          if (result.data) {
-            const alfrescoData = result.data;
-            const migratedWidgets = alfrescoData.widgets.map(
-              (w: Widget, i: number) => ensureWidgetDefaults(w, i)
-            );
-            const resolved: DashboardStorageSchema = {
-              ...alfrescoData,
-              widgets: migratedWidgets,
-              preferences: {
-                ...alfrescoData.preferences,
-                editMode: false,
-              },
-            };
-
-            setData(resolved);
-            try {
-              localStorage.setItem(storageKey, JSON.stringify(resolved));
-            } catch {
-              // localStorage write failure is non-critical
-            }
-          }
-        })
-        .catch((error: unknown) => {
-          if (abortController.signal.aborted) return;
-          console.warn(
-            "Failed to fetch dashboard config from Alfresco, using local data:",
-            error
-          );
-        });
-
-      return () => {
-        abortController.abort();
-      };
-    }
-  }, [storageKey, siteId, slug]); // defaultConfig is intentionally omitted — it's stable per page load
-
-  // Save data to localStorage + schedule Alfresco save
+  // Save data: optimistic SWR mutate + debounced Alfresco PUT
   const saveData = useCallback(
     (newData: DashboardStorageSchema) => {
-      hasLocalEditsRef.current = true;
-      setData(newData);
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(newData));
-      } catch (error) {
-        console.error("Failed to save dashboard data:", error);
-      }
+      void mutate({ data: newData }, { revalidate: false });
       scheduleSaveToAlfresco(newData);
     },
-    [storageKey, scheduleSaveToAlfresco]
+    [mutate, scheduleSaveToAlfresco]
   );
+
+  // isLoaded: null key means no fetch needed → immediately loaded
+  const isLoaded = swrKey ? !isLoading : true;
 
   // Find widget by ID (recursive search)
   const findWidget = useCallback(
     (
       widgetId: string,
-      widgets: Widget[] = data.widgets
+      widgets: Widget[] = resolvedConfig.widgets
     ): Widget | undefined => {
       for (const widget of widgets) {
         if (widget.id === widgetId) return widget;
@@ -326,15 +254,14 @@ export function useDashboardStorage(
       }
       return undefined;
     },
-    [data.widgets]
+    [resolvedConfig.widgets]
   );
 
   // Find parent widget (recursive)
-  // Returns undefined if widget not found, null if widget is at root level
   const findParent = useCallback(
     (
       widgetId: string,
-      widgets: Widget[] = data.widgets,
+      widgets: Widget[] = resolvedConfig.widgets,
       parent: Widget | null = null
     ): Widget | null | undefined => {
       for (const widget of widgets) {
@@ -346,20 +273,20 @@ export function useDashboardStorage(
       }
       return undefined;
     },
-    [data.widgets]
+    [resolvedConfig.widgets]
   );
 
   // Add a widget at root level
   const addWidget = useCallback(
     (widget: Widget) => {
       const newData: DashboardStorageSchema = {
-        ...data,
-        widgets: [...data.widgets, widget],
+        ...resolvedConfig,
+        widgets: [...resolvedConfig.widgets, widget],
       };
       saveData(newData);
       return widget;
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
   // Add a widget as child of another widget
@@ -381,13 +308,13 @@ export function useDashboardStorage(
         });
 
       const newData: DashboardStorageSchema = {
-        ...data,
-        widgets: updateChildren(data.widgets),
+        ...resolvedConfig,
+        widgets: updateChildren(resolvedConfig.widgets),
       };
       saveData(newData);
       return widget;
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
   // Update a widget's config
@@ -409,12 +336,12 @@ export function useDashboardStorage(
         });
 
       const newData: DashboardStorageSchema = {
-        ...data,
-        widgets: updateInTree(data.widgets),
+        ...resolvedConfig,
+        widgets: updateInTree(resolvedConfig.widgets),
       };
       saveData(newData);
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
   // Update widget layouts (for drag/drop/resize)
@@ -423,32 +350,30 @@ export function useDashboardStorage(
       parentId: string | null,
       layouts: { i: string; x: number; y: number; w: number; h: number }[]
     ) => {
-      // If parentId is null, update root-level widgets
       if (parentId === null) {
-        const updatedWidgets = data.widgets.map((widget) =>
+        const updatedWidgets = resolvedConfig.widgets.map((widget) =>
           applyLayoutToWidget(widget, layouts)
         );
 
         const newData: DashboardStorageSchema = {
-          ...data,
+          ...resolvedConfig,
           widgets: updatedWidgets,
         };
         saveData(newData);
         return;
       }
 
-      // Otherwise update children of a specific parent
-      const updatedWidgets = data.widgets.map((w) =>
+      const updatedWidgets = resolvedConfig.widgets.map((w) =>
         updateChildrenLayouts(w, parentId, layouts)
       );
 
       const newData: DashboardStorageSchema = {
-        ...data,
+        ...resolvedConfig,
         widgets: updatedWidgets,
       };
       saveData(newData);
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
   // Delete a widget (and its children)
@@ -465,61 +390,52 @@ export function useDashboardStorage(
           });
 
       const newData: DashboardStorageSchema = {
-        ...data,
-        widgets: removeFromTree(data.widgets),
+        ...resolvedConfig,
+        widgets: removeFromTree(resolvedConfig.widgets),
       };
       saveData(newData);
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
-  // Set edit mode (ephemeral — only localStorage, no Alfresco save)
+  // Set edit mode (ephemeral — React state only)
   const setEditMode = useCallback(
-    (editMode: boolean) => {
-      const newData: DashboardStorageSchema = {
-        ...data,
-        preferences: { ...data.preferences, editMode },
-      };
-      setData(newData);
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(newData));
-      } catch {
-        // non-critical
-      }
+    (mode: boolean) => {
+      setEditModeState(mode);
     },
-    [data, storageKey]
+    []
   );
 
   // Set dashboard name
   const setDashboardName = useCallback(
     (name: string) => {
       const newData: DashboardStorageSchema = {
-        ...data,
+        ...resolvedConfig,
         name,
       };
       saveData(newData);
     },
-    [data, saveData]
+    [resolvedConfig, saveData]
   );
 
   // Download dashboard as JSON file
   const downloadDashboard = useCallback(() => {
-    const json = JSON.stringify(data, null, 2);
+    const json = JSON.stringify(resolvedConfig, null, 2);
     const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${data.name.replaceAll(/\s+/g, "_").toLowerCase()}_dashboard.json`;
+    link.download = `${resolvedConfig.name.replaceAll(/\s+/g, "_").toLowerCase()}_dashboard.json`;
     document.body.appendChild(link);
     link.click();
     link.remove();
     URL.revokeObjectURL(url);
-  }, [data]);
+  }, [resolvedConfig]);
 
   // Export dashboard as JSON string
   const exportDashboard = useCallback((): string => {
-    return JSON.stringify(data, null, 2);
-  }, [data]);
+    return JSON.stringify(resolvedConfig, null, 2);
+  }, [resolvedConfig]);
 
   // Import dashboard from JSON string
   const importDashboard = useCallback(
@@ -527,7 +443,6 @@ export function useDashboardStorage(
       try {
         const parsed = JSON.parse(jsonString) as unknown;
 
-        // Validate basic structure
         if (
           typeof parsed !== "object" ||
           parsed === null ||
@@ -539,7 +454,6 @@ export function useDashboardStorage(
 
         const imported = parsed as DashboardStorageSchema;
 
-        // Check version
         if (imported.version !== 2) {
           return {
             success: false,
@@ -547,7 +461,6 @@ export function useDashboardStorage(
           };
         }
 
-        // Ensure all widgets have proper defaults
         const normalizedWidgets = imported.widgets.map((widget, index) =>
           ensureWidgetDefaults(widget, index)
         );
@@ -572,9 +485,9 @@ export function useDashboardStorage(
   );
 
   return {
-    widgets: data.widgets,
-    preferences: data.preferences,
-    dashboardName: data.name,
+    widgets: resolvedConfig.widgets,
+    preferences: { editMode },
+    dashboardName: resolvedConfig.name,
     isLoaded,
     addWidget,
     addChildWidget,

--- a/apps/app/src/features/dashboard/types/dashboard.types.ts
+++ b/apps/app/src/features/dashboard/types/dashboard.types.ts
@@ -36,7 +36,7 @@ export interface Widget {
   componentId: string;
   /** Grid layout position and size */
   layout: GridLayoutItem;
-  /** Dashlet-specific configuration (persisted to localStorage) */
+  /** Dashlet-specific configuration */
   config: Record<string, unknown>;
   /** Nested widgets (for container types) */
   children?: Widget[];
@@ -55,7 +55,7 @@ export interface DashboardPreferences {
   editMode: boolean;
 }
 
-/** Versioned storage schema for localStorage (supports migrations) */
+/** Versioned storage schema for dashboard config (supports migrations) */
 export interface DashboardStorageSchema {
   /** Schema version for migrations */
   version: 2;
@@ -77,5 +77,3 @@ export const DEFAULT_STORAGE: DashboardStorageSchema = {
   },
 };
 
-/** localStorage key for dashboard data */
-export const STORAGE_KEY = "dashboard-config";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard settings now persist locally and can optionally sync to your primary site (auto-detected) for cross-device continuity.
  * Dashboards are identified by slug plus optional site resolution for consistent lookup.
* **Reliability**
  * Saves are debounced, retried with backoff, and flushed on exit for safer persistence.
* **API**
  * New endpoints to read and save dashboard configs remotely.
* **Behavior**
  * Edit mode remains ephemeral and is not persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->