### PR TITLE
feat: update requiredGroups for sidebar items to restrict access to G…

### DIFF
--- a/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
+++ b/apps/app/src/app/[lang]/(secured)/home/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { ParamsWithLang } from "@/features/i18n/i18n.service.types";
 import { loadDefaultConfig } from "./load-default-config";
 import { auth } from "@/auth";
 import { getUserSites } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { RouteGuard } from "@/features/auth/components/route-guard";
 
 interface SlugPageParams extends ParamsWithLang {
   params: Promise<{ lang: string; slug: string }>;
@@ -40,15 +41,17 @@ export default async function SlugDashboardPage({ params }: Readonly<SlugPagePar
   }
 
   return (
-    <div className="h-full overflow-auto p-4">
-      <DashboardProvider
-        dictionary={dictionary}
-        slug={slug}
-        defaultConfig={defaultConfig}
-        siteId={siteId}
-      >
-        <DashboardView />
-      </DashboardProvider>
-    </div>
+    <RouteGuard path="/home" fallbackPath={`/${lang}/home`}>
+      <div className="h-full overflow-auto p-4">
+        <DashboardProvider
+          dictionary={dictionary}
+          slug={slug}
+          defaultConfig={defaultConfig}
+          siteId={siteId}
+        >
+          <DashboardView />
+        </DashboardProvider>
+      </div>
+    </RouteGuard>
   );
 }

--- a/apps/app/src/features/auth/config/route-permissions.ts
+++ b/apps/app/src/features/auth/config/route-permissions.ts
@@ -24,9 +24,13 @@ const BLOCKED_GROUPS = {
   GROUP_MINTRAL_REVISOR: ["/symptoms", "/geographic-view"], // Revisors cannot access symptoms and geographic view
 };
 
+// Dashboard access roles
+const DASHBOARD_ROLES = ["GROUP_DASHBOARD"];
+
 export const ROUTE_PERMISSIONS = {
   // Main routes
   "/": [], // Public route
+  "/home": DASHBOARD_ROLES,
   "/shipping": KANBAN_ACCESS_ROLES,
   "/finished": FULL_ACCESS_ROLES,
   "/reports": FULL_ACCESS_ROLES,

--- a/apps/app/src/features/layout/models/pages.ts
+++ b/apps/app/src/features/layout/models/pages.ts
@@ -23,49 +23,49 @@ export const pages: SidebarItem[] = [
               totals: {
                 totals: 10,
               },
-              requiredGroups: [],
-              blockedGroups: [], // Allow access for MINTRAL_REVISOR
+              requiredGroups: ["GROUP_DASHBOARD"],
+              blockedGroups: [], 
             },
             {
               href: "/home/maintenanceStatus",
               label: "maintenanceStatus", // Estado de Mantención
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
             {
               href: "/home/vehicleTechnicalHealth",
               label: "vehicleTechnicalHealth", // Salud Técnica del Vehículo
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
             {
               href: "/home/devicesAndTelemetry",
               label: "devicesAndTelemetry", // Dispositivos y Telemetría
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
             {
               href: "/home/operativeEvents",
               label: "operativeEvents", // Eventos Operativos
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
             {
               href: "/home/fleetUsage",
               label: "fleetUsage", // Uso de Flota
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
             {
               href: "/home/generalInfo",
               label: "generalInfo", // Información General
               totals: {},
-              requiredGroups: [],
+              requiredGroups: ["GROUP_DASHBOARD"],
               blockedGroups: [],
             },
           ]


### PR DESCRIPTION
…ROUP_DASHBOARD

- Modified the `requiredGroups` for multiple sidebar items to ensure only users in the GROUP_DASHBOARD can access them. This change enhances access control across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Dashboard pages now require the appropriate dashboard role; access restrictions applied to maintenance status, vehicle technical health, telemetry, operative events, fleet usage, and general information sections.

* **New Features**
  * Home/dashboard route is now protected by a route guard that enforces permissions and provides a fallback navigation when access is not allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->