### PR TITLE
fix: update base URL for Alfresco API datasource

### DIFF
--- a/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -1465,7 +1465,7 @@ async function callDataSourceAction<TResponse = unknown>(
 
   const queryString = queryParams.toString();
   const suffix = queryString ? `?${queryString}` : "";
-  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/datasource/${action}${suffix}`;
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/microboxlabs/dashboards/datasource/${action}${suffix}`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
 
   const result = await fetcher(url, {


### PR DESCRIPTION
Changed the base URL in the Alfresco API provider to point to the correct microboxlabs dashboard datasource endpoint, ensuring proper data fetching for actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the data source API endpoint configuration to ensure proper connectivity with the backend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->