### PR TITLE
Based/dashboard componets data source providers

### DIFF
--- a/apps/app/src/features/dashboard/dashlets/card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/card/dashlet.settings.tsx
@@ -14,10 +14,9 @@ import {
   buildSimplePgrestConfig,
   buildPgrestContentLabels,
   IconColorPickerRow,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type CardDataMode = "static" | "pgrest";
 
@@ -53,11 +52,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [name, setName] = useState(config.name || "Metric");
   const [value, setValue] = useState(config.value || "0");

--- a/apps/app/src/features/dashboard/dashlets/card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/card/dashlet.settings.tsx
@@ -16,6 +16,8 @@ import {
   IconColorPickerRow,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type CardDataMode = "static" | "pgrest";
 
@@ -51,6 +53,12 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [name, setName] = useState(config.name || "Metric");
   const [value, setValue] = useState(config.value || "0");
   const [descriptor, setDescriptor] = useState(config.descriptor || "");
@@ -61,9 +69,12 @@ export function DashletSettings({
   const [dataMode, setDataMode] = useState<CardDataMode>(
     config.dataMode || "static"
   );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig(config, (detected) => {
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
       if (detected.length >= 1) {
         setName(`{{row.${detected[0].key}}}`);
       }
@@ -87,6 +98,7 @@ export function DashletSettings({
       pgrestFunctionName: pg.pgrestFunctionName,
       pgrestParams: fromPgrestParamItems(pg.pgrestParams),
       pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     });
     onClose();
   };
@@ -138,6 +150,9 @@ export function DashletSettings({
           pgrest={pg}
           dictionary={dictionary}
           labels={buildPgrestContentLabels(dictionary)}
+          dataSourceId={dataSourceId}
+          onDataSourceIdChange={setDataSourceId}
+          activeProviders={activeProviders}
         />
       )}
     </>

--- a/apps/app/src/features/dashboard/dashlets/card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/card/dashlet.tsx
@@ -46,6 +46,7 @@ export interface DashletConfig {
   pgrestFunctionName: string;
   pgrestParams: PgrestParam[];
   pgrestHttpMethod: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 /** Default configuration */
@@ -133,6 +134,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
       value: config.value || "0",
       descriptor: config.descriptor || "",
     },
+    dataSourceId: config.dataSourceId,
   });
 
   const { name, value, descriptor } = resolved;

--- a/apps/app/src/features/dashboard/dashlets/common/dashlet-states.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/dashlet-states.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Spinner } from "flowbite-react";
+
+/**
+ * Standard loading state for dashlet components during PGREST data fetching.
+ */
+export function DashletLoading() {
+  return (
+    <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+      <Spinner size="sm" />
+    </div>
+  );
+}
+
+/**
+ * Standard error state for dashlet components when PGREST fetch fails.
+ */
+export function DashletError({ message }: Readonly<{ message: string }>) {
+  return (
+    <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+      <span className="text-xs text-red-600 dark:text-red-400">{message}</span>
+    </div>
+  );
+}
+
+/**
+ * Parse a resolved Handlebars field value as a number.
+ * Returns `fallback` if the value is empty, null, or not a finite number.
+ */
+export function parseResolvedNumber(raw: string | undefined | null, fallback = 0): number {
+  if (raw === "" || raw == null) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/apps/app/src/features/dashboard/dashlets/common/data-provider-entries.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/data-provider-entries.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button, TextInput } from "flowbite-react";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import type { UseDataProviderReturn } from "./use-data-provider";
+
+const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
+
+interface DataProviderEntriesProps {
+  dataProvider: UseDataProviderReturn;
+  dictionary: I18nRecord;
+}
+
+/**
+ * Reusable data provider key-value entries editor.
+ * Renders the hint text, entry rows with TextInput pairs, and an "Add Entry" button.
+ */
+export function DataProviderEntries({
+  dataProvider,
+  dictionary,
+}: Readonly<DataProviderEntriesProps>) {
+  return (
+    <>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {tr("dashboard.settings.defineVariablesHint", dictionary, {
+          code: "{{data_provider.key}}",
+        })}
+      </p>
+      <div className="space-y-2">
+        {dataProvider.dataProvider.map((entry, i) => (
+          <div
+            key={entry._id}
+            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
+          >
+            <TextInput
+              value={entry.key}
+              onChange={(e) =>
+                dataProvider.updateEntry(i, "key", e.target.value)
+              }
+              placeholder={tr("dashboard.settings.key", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <TextInput
+              value={entry.value}
+              onChange={(e) =>
+                dataProvider.updateEntry(i, "value", e.target.value)
+              }
+              placeholder={tr("common.value", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <Button
+              size="xs"
+              color="failure"
+              onClick={() => dataProvider.removeEntry(i)}
+              onMouseDown={stopPropagation}
+              className="no-drag shrink-0"
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        size="xs"
+        color="light"
+        onClick={dataProvider.addEntry}
+        onMouseDown={stopPropagation}
+        className="no-drag w-full"
+      >
+        {tr("dashboard.settings.addEntry", dictionary)}
+      </Button>
+    </>
+  );
+}

--- a/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -116,5 +116,6 @@ export {
   type SettingsFieldDef,
   type SimpleDashletSettingsProps,
   SimpleDashletSettings,
+  createSimpleDashletSettings,
   useFieldState,
 } from "./simple-dashlet-settings";

--- a/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -53,6 +53,7 @@ export {
   humanizeKey,
   toPgrestParamItems,
   fromPgrestParamItems,
+  EMPTY_PGREST_PARAMS,
 } from "./pgrest-types";
 export { parseRows, buildPgrestFetch } from "./pgrest-utils";
 export {
@@ -106,3 +107,6 @@ export {
 export { IconColorPickerRow } from "./icon-color-picker-row";
 export { usePgrestResolvedFields } from "./use-pgrest-resolved-fields";
 export { PgrestDataTab } from "./pgrest-data-tab";
+export { useActiveProviders } from "./use-active-providers";
+export { DashletLoading, DashletError, parseResolvedNumber } from "./dashlet-states";
+export { DataProviderEntries } from "./data-provider-entries";

--- a/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -111,3 +111,4 @@ export { useActiveProviders } from "./use-active-providers";
 export { DashletLoading, DashletError, parseResolvedNumber } from "./dashlet-states";
 export { DataProviderEntries } from "./data-provider-entries";
 export { type SimpleDataMode, useSimplePgrestSettings } from "./use-simple-pgrest-settings";
+export { type PgrestDashletFields, useDashletPgrest, useHybridPgrestContext } from "./use-dashlet-pgrest";

--- a/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -110,3 +110,4 @@ export { PgrestDataTab } from "./pgrest-data-tab";
 export { useActiveProviders } from "./use-active-providers";
 export { DashletLoading, DashletError, parseResolvedNumber } from "./dashlet-states";
 export { DataProviderEntries } from "./data-provider-entries";
+export { type SimpleDataMode, useSimplePgrestSettings } from "./use-simple-pgrest-settings";

--- a/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -112,3 +112,9 @@ export { DashletLoading, DashletError, parseResolvedNumber } from "./dashlet-sta
 export { DataProviderEntries } from "./data-provider-entries";
 export { type SimpleDataMode, useSimplePgrestSettings } from "./use-simple-pgrest-settings";
 export { type PgrestDashletFields, useDashletPgrest, useHybridPgrestContext } from "./use-dashlet-pgrest";
+export {
+  type SettingsFieldDef,
+  type SimpleDashletSettingsProps,
+  SimpleDashletSettings,
+  useFieldState,
+} from "./simple-dashlet-settings";

--- a/apps/app/src/features/dashboard/dashlets/common/pgrest-data-tab.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/pgrest-data-tab.tsx
@@ -9,18 +9,26 @@ import { buildPgrestContentLabels } from "./pgrest-settings-helpers";
 
 type SimpleDataMode = "static" | "pgrest";
 
+interface DataSourceOption {
+  id: string;
+  name: string;
+}
+
 interface PgrestDataTabProps {
   id: string;
   dataMode: SimpleDataMode;
   onDataModeChange: (mode: SimpleDataMode) => void;
   pgrest: ReturnType<typeof usePgrestSettingsState>;
   dictionary: I18nRecord;
+  dataSourceId?: string;
+  onDataSourceIdChange?: (id: string) => void;
+  activeProviders?: DataSourceOption[];
 }
 
 /**
  * Reusable data-provider tab content for card-style dashlet settings.
  * Renders a static/pgrest mode selector and, when pgrest is selected,
- * the full PgrestSettingsSection.
+ * the full PgrestSettingsSection (including Data Source Provider dropdown).
  */
 export function PgrestDataTab({
   id,
@@ -28,6 +36,9 @@ export function PgrestDataTab({
   onDataModeChange,
   pgrest,
   dictionary,
+  dataSourceId,
+  onDataSourceIdChange,
+  activeProviders,
 }: Readonly<PgrestDataTabProps>) {
   const labels = buildPgrestContentLabels(dictionary);
 
@@ -50,7 +61,14 @@ export function PgrestDataTab({
         ]}
       />
       {dataMode === "pgrest" && (
-        <PgrestSettingsSection pgrest={pgrest} dictionary={dictionary} labels={labels} />
+        <PgrestSettingsSection
+          pgrest={pgrest}
+          dictionary={dictionary}
+          labels={labels}
+          dataSourceId={dataSourceId}
+          onDataSourceIdChange={onDataSourceIdChange}
+          activeProviders={activeProviders}
+        />
       )}
     </>
   );

--- a/apps/app/src/features/dashboard/dashlets/common/pgrest-settings-helpers.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/pgrest-settings-helpers.ts
@@ -23,13 +23,14 @@ export function defaultOnColumnsDetected(keys: string[]): ColumnItem[] {
  * (labeled_data, card) that use raw keys and a no-op setColumns.
  */
 export function buildSimplePgrestConfig(
-  config: { pgrestFunctionName?: string; pgrestParams?: PgrestParam[]; pgrestHttpMethod?: PgrestHttpMethod },
+  config: { pgrestFunctionName?: string; pgrestParams?: PgrestParam[]; pgrestHttpMethod?: PgrestHttpMethod; dataSourceId?: string },
   onDetectionComplete?: PgrestSettingsStateConfig["onDetectionComplete"],
-): Pick<PgrestSettingsStateConfig, "pgrestFunctionName" | "pgrestParams" | "pgrestHttpMethod" | "onColumnsDetected" | "setColumns" | "onDetectionComplete"> {
+): Pick<PgrestSettingsStateConfig, "pgrestFunctionName" | "pgrestParams" | "pgrestHttpMethod" | "dataSourceId" | "onColumnsDetected" | "setColumns" | "onDetectionComplete"> {
   return {
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestParams: config.pgrestParams || [],
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    dataSourceId: config.dataSourceId,
     onColumnsDetected: defaultOnColumnsDetected,
     setColumns: () => {},
     onDetectionComplete,

--- a/apps/app/src/features/dashboard/dashlets/common/pgrest-types.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/pgrest-types.ts
@@ -25,3 +25,6 @@ export function toPgrestParamItems(params: PgrestParam[]): PgrestParamItem[] {
 export function fromPgrestParamItems(items: PgrestParamItem[]): PgrestParam[] {
   return items.map(({ key, value }) => ({ key, value }));
 }
+
+/** Stable empty array to avoid re-renders when no pgrest params are configured. */
+export const EMPTY_PGREST_PARAMS: PgrestParam[] = [];

--- a/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
-import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import type { DashletSettingsProps } from "../types";
 import { HbTextFieldList } from "./settings-fields";
 import { PgrestDataTab } from "./pgrest-data-tab";
@@ -47,7 +46,11 @@ export function useFieldState(
     for (const f of fields) {
       const v = config[f.state];
       result[f.state] =
-        v == null || typeof v === "object" ? f.staticPlaceholder : String(v);
+        typeof v === "string"
+          ? v
+          : typeof v === "number" || typeof v === "boolean"
+            ? String(v)
+            : f.staticPlaceholder;
     }
     return result;
   });

--- a/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import type { DashletSettingsProps } from "../types";
+import { HbTextFieldList } from "./settings-fields";
+import { PgrestDataTab } from "./pgrest-data-tab";
+import { SettingsModalShell } from "./settings-modal-shell";
+import { useSimplePgrestSettings } from "./use-simple-pgrest-settings";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SettingsFieldDef {
+  readonly id: string;
+  readonly labelKey: string;
+  readonly state: string;
+  readonly hbPlaceholder: string;
+  readonly staticPlaceholder: string;
+}
+
+export interface SimpleDashletSettingsProps<C extends object> {
+  /** Field definitions (id, labelKey, state, placeholders) */
+  fields: readonly SettingsFieldDef[];
+  /** Prefix used for element IDs (e.g. "si", "sp") */
+  idPrefix: string;
+  /** Standard dashlet settings props forwarded from the parent */
+  settingsProps: Readonly<DashletSettingsProps<C>>;
+  /** Extra content rendered below the HbTextFieldList on the visualization tab */
+  extraVisualization?: ReactNode;
+  /** Extra fields merged into onSave (e.g. { isSensitive, color }) */
+  extraSaveFields?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Hook: manage field state from a FIELDS config array
+// ============================================================================
+
+export function useFieldState(
+  config: Record<string, unknown>,
+  fields: readonly SettingsFieldDef[],
+) {
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    const result: Record<string, string> = {};
+    for (const f of fields) {
+      const v = config[f.state];
+      result[f.state] =
+        v == null || typeof v === "object" ? f.staticPlaceholder : String(v);
+    }
+    return result;
+  });
+
+  const setters = useMemo(() => {
+    const result: Record<string, (v: string) => void> = {};
+    for (const f of fields) {
+      const key = f.state;
+      result[key] = (v: string) =>
+        setValues((prev) => ({ ...prev, [key]: v }));
+    }
+    return result;
+    // fields is a module-level const — safe to depend on reference
+  }, [fields]);
+
+  const fieldNames = useMemo(() => fields.map((f) => f.state), [fields]);
+
+  const buildSaveValues = (): Record<string, string> => {
+    const result: Record<string, string> = {};
+    for (const f of fields) {
+      result[f.state] = values[f.state].trim() || f.staticPlaceholder;
+    }
+    return result;
+  };
+
+  return { values, setters, fieldNames, buildSaveValues };
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Shared settings shell for "Pattern A" dashlets that use
+ * `useSimplePgrestSettings` + `HbTextFieldList`.
+ *
+ * Eliminates boilerplate duplicated across stat_icon, stat_progress,
+ * stat_gradient, stat_sensitive, stat_sparkline, stat_expandable, etc.
+ */
+export function SimpleDashletSettings<C extends object>({
+  fields,
+  idPrefix,
+  settingsProps: { isOpen, onClose, config, onSave, dictionary },
+  extraVisualization,
+  extraSaveFields,
+}: Readonly<SimpleDashletSettingsProps<C>>) {
+  const configRecord = config as unknown as Record<string, unknown>;
+  const { values, setters, fieldNames, buildSaveValues } = useFieldState(
+    configRecord,
+    fields,
+  );
+
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config: config as Record<string, unknown>,
+    fieldNames,
+    fieldValues: values,
+    fieldSetters: setters,
+  });
+
+  const handleSave = () => {
+    onSave({
+      ...buildSaveValues(),
+      ...extraSaveFields,
+      ...pgrestSaveFields,
+    } as unknown as Partial<C>);
+    onClose();
+  };
+
+  const visualizationTab = extraVisualization ? (
+    <>
+      <HbTextFieldList
+        fields={fields}
+        fieldValues={values}
+        fieldSetters={setters}
+        isPgrest={isPgrest}
+        dictionary={dictionary}
+      />
+      {extraVisualization}
+    </>
+  ) : (
+    <HbTextFieldList
+      fields={fields}
+      fieldValues={values}
+      fieldSetters={setters}
+      isPgrest={isPgrest}
+      dictionary={dictionary}
+    />
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id={`${idPrefix}-data-mode`}
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
+  );
+}

--- a/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
@@ -37,6 +37,12 @@ export interface SimpleDashletSettingsProps<C extends object> {
 // Hook: manage field state from a FIELDS config array
 // ============================================================================
 
+function toStringOrDefault(v: unknown, fallback: string): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return fallback;
+}
+
 export function useFieldState(
   config: Record<string, unknown>,
   fields: readonly SettingsFieldDef[],
@@ -44,13 +50,7 @@ export function useFieldState(
   const [values, setValues] = useState<Record<string, string>>(() => {
     const result: Record<string, string> = {};
     for (const f of fields) {
-      const v = config[f.state];
-      result[f.state] =
-        typeof v === "string"
-          ? v
-          : typeof v === "number" || typeof v === "boolean"
-            ? String(v)
-            : f.staticPlaceholder;
+      result[f.state] = toStringOrDefault(config[f.state], f.staticPlaceholder);
     }
     return result;
   });

--- a/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/simple-dashlet-settings.tsx
@@ -173,3 +173,33 @@ export function SimpleDashletSettings<C extends object>({
     />
   );
 }
+
+// ============================================================================
+// Factory: create a zero-boilerplate settings component from field defs
+// ============================================================================
+
+/**
+ * Returns a `DashletSettings` component that renders `SimpleDashletSettings`
+ * with the given field definitions and ID prefix.
+ *
+ * Usage:
+ * ```ts
+ * export const DashletSettings = createSimpleDashletSettings(FIELDS, "si");
+ * ```
+ */
+export function createSimpleDashletSettings(
+  fields: readonly SettingsFieldDef[],
+  idPrefix: string,
+) {
+  return function DashletSettings(
+    props: Readonly<DashletSettingsProps<Record<string, unknown>>>,
+  ) {
+    return (
+      <SimpleDashletSettings
+        fields={fields}
+        idPrefix={idPrefix}
+        settingsProps={props}
+      />
+    );
+  };
+}

--- a/apps/app/src/features/dashboard/dashlets/common/tabbed-settings-wrapper.tsx
+++ b/apps/app/src/features/dashboard/dashlets/common/tabbed-settings-wrapper.tsx
@@ -2,13 +2,14 @@
 
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { Button, TextInput } from "flowbite-react";
+import { Button } from "flowbite-react";
 import { createPortal } from "react-dom";
 import { twMerge } from "tailwind-merge";
 import { tr } from "@/features/i18n/tr.service";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import AbsoluteModal from "@/features/common/components/absolute-modal/absolute-modal";
 import type { UseDataProviderReturn } from "./use-data-provider";
+import { DataProviderEntries } from "./data-provider-entries";
 
 // ============================================================================
 // Types
@@ -51,71 +52,6 @@ function TabButton({
     >
       {children}
     </button>
-  );
-}
-
-function DataProviderTab({
-  dataProvider,
-  dictionary,
-}: Readonly<{
-  dataProvider: UseDataProviderReturn;
-  dictionary: I18nRecord;
-}>) {
-  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
-
-  return (
-    <>
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        {tr("dashboard.settings.defineVariablesHint", dictionary, {
-          code: "{{data_provider.key}}",
-        })}
-      </p>
-      <div className="space-y-2">
-        {dataProvider.dataProvider.map((entry, i) => (
-          <div
-            key={entry._id}
-            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
-          >
-            <TextInput
-              value={entry.key}
-              onChange={(e) =>
-                dataProvider.updateEntry(i, "key", e.target.value)
-              }
-              placeholder={tr("dashboard.settings.key", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <TextInput
-              value={entry.value}
-              onChange={(e) =>
-                dataProvider.updateEntry(i, "value", e.target.value)
-              }
-              placeholder={tr("common.value", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <Button
-              size="xs"
-              color="failure"
-              onClick={() => dataProvider.removeEntry(i)}
-              onMouseDown={handleMouseDown}
-              className="no-drag shrink-0"
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-      <Button
-        size="xs"
-        color="light"
-        onClick={dataProvider.addEntry}
-        onMouseDown={handleMouseDown}
-        className="no-drag w-full"
-      >
-        {tr("dashboard.settings.addEntry", dictionary)}
-      </Button>
-    </>
   );
 }
 
@@ -174,7 +110,7 @@ export function TabbedSettingsWrapper({
               {children}
             </>
           ) : (
-            <DataProviderTab
+            <DataProviderEntries
               dataProvider={dataProvider}
               dictionary={dictionary}
             />

--- a/apps/app/src/features/dashboard/dashlets/common/use-active-providers.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-active-providers.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+interface ActiveProvider {
+  id: string;
+  name: string;
+}
+
+/**
+ * Hook that returns the list of active, successfully-tested data source providers
+ * for the current dashboard's site. Uses SWR under the hood (via useDataSources),
+ * so multiple callers with the same siteId share a single cache entry.
+ */
+export function useActiveProviders(): ActiveProvider[] {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+
+  return useMemo(
+    () =>
+      dataSources
+        .filter((ds) => ds.isActive === true && ds.lastTestResult === true)
+        .map((ds) => ({ id: ds.id, name: ds.name })),
+    [dataSources],
+  );
+}

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import type { PgrestParam, PgrestHttpMethod } from "./pgrest-types";
+import { EMPTY_PGREST_PARAMS } from "./pgrest-types";
+import type { DataProviderEntry } from "../types";
+import { usePgrestResolvedFields } from "./use-pgrest-resolved-fields";
+import { usePgrestRows } from "./use-pgrest-rows";
+import { resolveHandlebarsField, buildDataProviderContext } from "./use-handlebars-templates";
+
+// ============================================================================
+// Shared pgrest config interface
+// ============================================================================
+
+/** Pgrest fields common to all DashletConfig interfaces */
+export interface PgrestDashletFields {
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
+}
+
+// ============================================================================
+// Pattern A: Scalar fields resolved via Handlebars
+// ============================================================================
+
+/**
+ * Wraps usePgrestResolvedFields with config-level defaults.
+ * Used by card-style dashlets that resolve scalar Handlebars fields.
+ */
+export function useDashletPgrest(
+  config: PgrestDashletFields,
+  fields: Record<string, string>,
+) {
+  return usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+}
+
+// ============================================================================
+// Pattern B: Hybrid data provider + pgrest context
+// ============================================================================
+
+/**
+ * Wraps usePgrestRows and merges the first row into a data-provider context.
+ * Used by dashlets that combine a DataProvider with optional pgrest data.
+ */
+export function useHybridPgrestContext(
+  config: PgrestDashletFields,
+  dataProvider: DataProviderEntry[],
+) {
+  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
+
+  const { rows, loading, fetchError } = usePgrestRows(
+    dataMode,
+    config.pgrestFunctionName || "",
+    config.pgrestHttpMethod || "POST",
+    config.pgrestParams || EMPTY_PGREST_PARAMS,
+    config.dataSourceId,
+  );
+
+  const templateContext = useMemo(() => {
+    const dpContext = buildDataProviderContext(dataProvider);
+    if (dataMode === "pgrest" && rows.length > 0) {
+      const firstRow = rows[0];
+      return { ...dpContext, row: firstRow, ...firstRow };
+    }
+    return dpContext;
+  }, [dataProvider, dataMode, rows]);
+
+  return { templateContext, loading, fetchError };
+}

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -46,12 +46,13 @@ export function useDashletPgrest<C extends PgrestDashletFields>(
     const result: Record<string, string> = {};
     for (const key of fieldKeys) {
       const v = configRecord[key];
-      result[key] =
-        typeof v === "string"
-          ? v
-          : typeof v === "number" || typeof v === "boolean"
-            ? String(v)
-            : fieldDefaults[key];
+      if (typeof v === "string") {
+        result[key] = v;
+      } else if (typeof v === "number" || typeof v === "boolean") {
+        result[key] = String(v);
+      } else {
+        result[key] = fieldDefaults[key];
+      }
     }
     return result;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -26,11 +26,32 @@ export interface PgrestDashletFields {
 /**
  * Wraps usePgrestResolvedFields with config-level defaults.
  * Used by card-style dashlets that resolve scalar Handlebars fields.
+ *
+ * Accepts a `fieldDefaults` record (e.g. `{ title: "Metric", value: "0" }`)
+ * and builds the memoized fields internally from config values, so each
+ * dashlet component only needs a single hook call.
  */
-export function useDashletPgrest(
-  config: PgrestDashletFields,
-  fields: Record<string, string>,
+export function useDashletPgrest<C extends PgrestDashletFields>(
+  config: C,
+  fieldDefaults: Record<string, string>,
 ) {
+  const fieldKeys = Object.keys(fieldDefaults);
+
+  // Build a stable dep string from the config values matching field keys
+  const configRecord = config as unknown as Record<string, unknown>;
+  const depValues = fieldKeys.map((k) => configRecord[k]);
+  const depKey = JSON.stringify(depValues);
+
+  const fields = useMemo(() => {
+    const result: Record<string, string> = {};
+    for (const key of fieldKeys) {
+      const v = configRecord[key];
+      result[key] = v != null ? String(v) : fieldDefaults[key];
+    }
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [depKey]);
+
   return usePgrestResolvedFields({
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -67,7 +67,7 @@ export function useHybridPgrestContext(
     const dpContext = buildDataProviderContext(dataProvider);
     if (dataMode === "pgrest" && rows.length > 0) {
       const firstRow = rows[0];
-      return { ...dpContext, row: firstRow, ...firstRow };
+      return { ...dpContext, ...firstRow, row: firstRow };
     }
     return dpContext;
   }, [dataProvider, dataMode, rows]);

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -47,7 +47,11 @@ export function useDashletPgrest<C extends PgrestDashletFields>(
     for (const key of fieldKeys) {
       const v = configRecord[key];
       result[key] =
-        v == null || typeof v === "object" ? fieldDefaults[key] : String(v);
+        typeof v === "string"
+          ? v
+          : typeof v === "number" || typeof v === "boolean"
+            ? String(v)
+            : fieldDefaults[key];
     }
     return result;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -4,7 +4,7 @@ import { EMPTY_PGREST_PARAMS } from "./pgrest-types";
 import type { DataProviderEntry } from "../types";
 import { usePgrestResolvedFields } from "./use-pgrest-resolved-fields";
 import { usePgrestRows } from "./use-pgrest-rows";
-import { resolveHandlebarsField, buildDataProviderContext } from "./use-handlebars-templates";
+import { buildDataProviderContext } from "./use-handlebars-templates";
 
 // ============================================================================
 // Shared pgrest config interface

--- a/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-dashlet-pgrest.ts
@@ -46,7 +46,8 @@ export function useDashletPgrest<C extends PgrestDashletFields>(
     const result: Record<string, string> = {};
     for (const key of fieldKeys) {
       const v = configRecord[key];
-      result[key] = v != null ? String(v) : fieldDefaults[key];
+      result[key] =
+        v == null || typeof v === "object" ? fieldDefaults[key] : String(v);
     }
     return result;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/app/src/features/dashboard/dashlets/common/use-pgrest-resolved-fields.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-pgrest-resolved-fields.ts
@@ -11,6 +11,7 @@ interface PgrestResolvedFieldsConfig {
   pgrestHttpMethod: PgrestHttpMethod;
   pgrestParams: PgrestParam[];
   fields: Record<string, string>;
+  dataSourceId?: string;
 }
 
 interface PgrestResolvedFieldsResult {
@@ -29,6 +30,7 @@ export function usePgrestResolvedFields({
   pgrestHttpMethod,
   pgrestParams,
   fields,
+  dataSourceId,
 }: PgrestResolvedFieldsConfig): PgrestResolvedFieldsResult {
   const stableParams = pgrestParams.length > 0 ? pgrestParams : EMPTY_PARAMS;
 
@@ -37,6 +39,7 @@ export function usePgrestResolvedFields({
     pgrestFunctionName,
     pgrestHttpMethod,
     stableParams,
+    dataSourceId,
   );
 
   const firstRow = rows[0];

--- a/apps/app/src/features/dashboard/dashlets/common/use-pgrest-resolved-fields.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-pgrest-resolved-fields.ts
@@ -14,7 +14,7 @@ interface PgrestResolvedFieldsConfig {
   dataSourceId?: string;
 }
 
-interface PgrestResolvedFieldsResult {
+export interface PgrestResolvedFieldsResult {
   resolved: Record<string, string>;
   loading: boolean;
   fetchError: string | null;

--- a/apps/app/src/features/dashboard/dashlets/common/use-simple-pgrest-settings.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-simple-pgrest-settings.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
+import { useRef, useState } from "react";
 import type { PgrestParam, PgrestHttpMethod } from "./pgrest-types";
 import { fromPgrestParamItems } from "./pgrest-types";
 import { usePgrestSettingsState } from "./use-pgrest-settings-state";

--- a/apps/app/src/features/dashboard/dashlets/common/use-simple-pgrest-settings.ts
+++ b/apps/app/src/features/dashboard/dashlets/common/use-simple-pgrest-settings.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useRef, useState, type ReactNode } from "react";
+import type { PgrestParam, PgrestHttpMethod } from "./pgrest-types";
+import { fromPgrestParamItems } from "./pgrest-types";
+import { usePgrestSettingsState } from "./use-pgrest-settings-state";
+import { buildSimplePgrestConfig } from "./pgrest-settings-helpers";
+import { useActiveProviders } from "./use-active-providers";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type SimpleDataMode = "static" | "pgrest";
+
+interface PgrestConfigFields {
+  dataMode?: string;
+  dataSourceId?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+}
+
+interface UseSimplePgrestSettingsOptions<F extends string> {
+  /** The dashlet config (must include pgrest fields) */
+  config: PgrestConfigFields;
+  /** Ordered field names that map to state */
+  fieldNames: readonly F[];
+  /** Current values for each field (keyed by field name) */
+  fieldValues: Record<F, string>;
+  /** State setters for each field (keyed by field name) */
+  fieldSetters: Record<F, (v: string) => void>;
+}
+
+interface UseSimplePgrestSettingsReturn<F extends string> {
+  dataMode: SimpleDataMode;
+  dataSourceId: string;
+  isPgrest: boolean;
+  activeProviders: { id: string; name: string }[];
+  pg: ReturnType<typeof usePgrestSettingsState>;
+  handleDataModeChange: (mode: SimpleDataMode) => void;
+  /** Spread into onSave to include all pgrest-related config fields */
+  pgrestSaveFields: {
+    dataMode: SimpleDataMode;
+    pgrestFunctionName: string;
+    pgrestParams: PgrestParam[];
+    pgrestHttpMethod: PgrestHttpMethod;
+    dataSourceId: string | undefined;
+  };
+  /** Setter for dataSourceId state */
+  setDataSourceId: (id: string) => void;
+  /** Pre-built fieldValues record for HbTextFieldList */
+  fieldValues: Record<F, string>;
+  /** Pre-built fieldSetters record for HbTextFieldList */
+  fieldSetters: Record<F, (v: string) => void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Consolidates the boilerplate shared by all "Pattern A" dashlet settings:
+ * dataMode/dataSourceId state, static snapshot, pgrest settings state,
+ * active providers, and the common pgrest save fields.
+ */
+export function useSimplePgrestSettings<F extends string>({
+  config,
+  fieldNames,
+  fieldValues,
+  fieldSetters,
+}: UseSimplePgrestSettingsOptions<F>): UseSimplePgrestSettingsReturn<F> {
+  const activeProviders = useActiveProviders();
+
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? "",
+  );
+
+  // Snapshot of field values when entering pgrest mode
+  const staticSnapshot = useRef({ ...fieldValues });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { ...fieldValues };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      for (const key of fieldNames) {
+        fieldSetters[key](staticSnapshot.current[key]);
+      }
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig(
+      { ...config, dataSourceId: dataSourceId || undefined },
+      (detected) => {
+        for (let i = 0; i < fieldNames.length && i < detected.length; i++) {
+          fieldSetters[fieldNames[i]](`{{row.${detected[i].key}}}`);
+        }
+      },
+    ),
+  });
+
+  const isPgrest = dataMode === "pgrest";
+
+  const pgrestSaveFields = {
+    dataMode,
+    pgrestFunctionName: pg.pgrestFunctionName,
+    pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+    pgrestHttpMethod: pg.pgrestHttpMethod,
+    dataSourceId: dataSourceId || undefined,
+  };
+
+  return {
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    isPgrest,
+    activeProviders,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+    fieldValues,
+    fieldSetters,
+  };
+}

--- a/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
@@ -19,6 +19,8 @@ import { CheckboxColumnList } from "../common/settings-sections";
 import { fromPgrestParamItems } from "../common/pgrest-types";
 import { buildPgrestSettingsConfig, buildPgrestContentLabels } from "../common/pgrest-settings-helpers";
 import { tr } from "@/features/i18n/tr.service";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 export function DashletSettings({
   isOpen,
@@ -27,6 +29,12 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const s = useSettingsState({
     title: config.title,
     defaultTitle: "Data List",
@@ -51,10 +59,15 @@ export function DashletSettings({
   const [kpiColumns, setKpiColumns] = useState<string[]>(cl.kpiColumns);
   const [footerColumns, setFooterColumns] = useState<string[]>(cl.footerColumns);
 
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
   const pg = usePgrestSettingsState({
     pgrestFunctionName: config.pgrestFunctionName ?? "",
     pgrestParams: config.pgrestParams ?? [],
     pgrestHttpMethod: config.pgrestHttpMethod ?? "POST",
+    dataSourceId: dataSourceId || undefined,
     ...buildPgrestSettingsConfig(s),
     onDetectionComplete: (detected) => {
       const keys = detected.map((c) => c.key);
@@ -101,6 +114,7 @@ export function DashletSettings({
       pgrestFunctionName: pg.pgrestFunctionName,
       pgrestParams: fromPgrestParamItems(pg.pgrestParams),
       pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
       filter,
       sort,
       cardLayout,
@@ -113,6 +127,9 @@ export function DashletSettings({
       pgrest={pg}
       dictionary={dictionary}
       labels={buildPgrestContentLabels(dictionary)}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
     />
   );
 

--- a/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
@@ -18,9 +18,8 @@ import { TableListSettingsShell } from "../common/table-list-settings-shell";
 import { CheckboxColumnList } from "../common/settings-sections";
 import { fromPgrestParamItems } from "../common/pgrest-types";
 import { buildPgrestSettingsConfig, buildPgrestContentLabels } from "../common/pgrest-settings-helpers";
+import { useActiveProviders } from "../common";
 import { tr } from "@/features/i18n/tr.service";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 export function DashletSettings({
   isOpen,
@@ -29,11 +28,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const s = useSettingsState({
     title: config.title,

--- a/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
@@ -49,6 +49,7 @@ export interface DashletConfig {
   pgrestFunctionName: string;
   pgrestParams: PgrestParam[];
   pgrestHttpMethod: PgrestHttpMethod;
+  dataSourceId?: string;
   filter: FilterConfig;
   sort: SortConfig;
   cardLayout: CardLayoutConfig;
@@ -312,7 +313,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   // ── PGREST data fetching ──────────────────────────────────────────────────
   const pgrestParamsStable = useMemo(() => pgrestParams, [pgrestParams]);
   const { rows: pgrestRows, loading: pgrestLoading, fetchError: pgrestError } = usePgrestRows(
-    dataMode, pgrestFunctionName, pgrestHttpMethod, pgrestParamsStable,
+    dataMode, pgrestFunctionName, pgrestHttpMethod, pgrestParamsStable, config.dataSourceId,
   );
 
   const loading = dynamicLoading || pgrestLoading;

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { Button, TextInput } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, InfoCardIcon } from "./dashlet";
 import { ICON_OPTIONS } from "./dashlet";
@@ -15,8 +16,16 @@ import {
   HbTextField,
   HbTextareaField,
   useDataProvider,
-  TabbedSettingsWrapper,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
 
 /** Convert ICON_OPTIONS to IconPickerDropdown format */
 const ICON_PICKER_OPTIONS: IconOption<InfoCardIcon>[] = ICON_OPTIONS.map(
@@ -39,6 +48,12 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(config.title || "Metric");
   const [icon, setIcon] = useState<InfoCardIcon>(config.icon || "chart");
   const [value, setValue] = useState(config.value || "100%");
@@ -49,11 +64,42 @@ export function DashletSettings({
     config.aiPlaceholder || "AI summary will appear here"
   );
   const [viewMoreUrl, setViewMoreUrl] = useState(config.viewMoreUrl || "");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   const dp = useDataProvider(
     (config as DashletConfig & { dataProvider?: import("../types").DataProviderEntry[] })
       .dataProvider || DEFAULT_DATA_ENTRIES
   );
+
+  const staticSnapshot = useRef({ title, value, descriptor, aiPlaceholder, viewMoreUrl });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, descriptor, aiPlaceholder, viewMoreUrl };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setDescriptor(staticSnapshot.current.descriptor);
+      setAiPlaceholder(staticSnapshot.current.aiPlaceholder);
+      setViewMoreUrl(staticSnapshot.current.viewMoreUrl);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setDescriptor(`{{row.${detected[2].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
     onSave({
@@ -64,18 +110,19 @@ export function DashletSettings({
       aiPlaceholder,
       viewMoreUrl,
       dataProvider: dp.getCleanEntries(),
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     } as DashletConfig);
     onClose();
   };
 
-  return (
-    <TabbedSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dataProvider={dp}
-      dictionary={dictionary}
-    >
+  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
+
+  const visualizationTab = (
+    <>
       <HbTextField
         id="title"
         label={tr("common.title", dictionary)}
@@ -128,6 +175,79 @@ export function DashletSettings({
         onChange={setViewMoreUrl}
         placeholder="https://example.com/details"
       />
-    </TabbedSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <>
+      <PgrestDataTab
+        id="ic-data-mode"
+        dataMode={dataMode}
+        onDataModeChange={handleDataModeChange}
+        pgrest={pg}
+        dictionary={dictionary}
+        dataSourceId={dataSourceId}
+        onDataSourceIdChange={setDataSourceId}
+        activeProviders={activeProviders}
+      />
+      {/* Data provider entries */}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {tr("dashboard.settings.defineVariablesHint", dictionary, {
+          code: "{{data_provider.key}}",
+        })}
+      </p>
+      <div className="space-y-2">
+        {dp.dataProvider.map((entry, i) => (
+          <div
+            key={entry._id}
+            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
+          >
+            <TextInput
+              value={entry.key}
+              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
+              placeholder={tr("dashboard.settings.key", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <TextInput
+              value={entry.value}
+              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
+              placeholder={tr("common.value", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <Button
+              size="xs"
+              color="failure"
+              onClick={() => dp.removeEntry(i)}
+              onMouseDown={handleMouseDown}
+              className="no-drag shrink-0"
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        size="xs"
+        color="light"
+        onClick={dp.addEntry}
+        onMouseDown={handleMouseDown}
+        className="no-drag w-full"
+      >
+        {tr("dashboard.settings.addEntry", dictionary)}
+      </Button>
+    </>
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Button, TextInput } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, InfoCardIcon } from "./dashlet";
 import { ICON_OPTIONS } from "./dashlet";
@@ -20,10 +19,10 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
+  DataProviderEntries,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -48,11 +47,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title || "Metric");
   const [icon, setIcon] = useState<InfoCardIcon>(config.icon || "chart");
@@ -118,8 +113,6 @@ export function DashletSettings({
     } as DashletConfig);
     onClose();
   };
-
-  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 
   const visualizationTab = (
     <>
@@ -190,53 +183,7 @@ export function DashletSettings({
         onDataSourceIdChange={setDataSourceId}
         activeProviders={activeProviders}
       />
-      {/* Data provider entries */}
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        {tr("dashboard.settings.defineVariablesHint", dictionary, {
-          code: "{{data_provider.key}}",
-        })}
-      </p>
-      <div className="space-y-2">
-        {dp.dataProvider.map((entry, i) => (
-          <div
-            key={entry._id}
-            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
-          >
-            <TextInput
-              value={entry.key}
-              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
-              placeholder={tr("dashboard.settings.key", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <TextInput
-              value={entry.value}
-              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
-              placeholder={tr("common.value", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <Button
-              size="xs"
-              color="failure"
-              onClick={() => dp.removeEntry(i)}
-              onMouseDown={handleMouseDown}
-              className="no-drag shrink-0"
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-      <Button
-        size="xs"
-        color="light"
-        onClick={dp.addEntry}
-        onMouseDown={handleMouseDown}
-        className="no-drag w-full"
-      >
-        {tr("dashboard.settings.addEntry", dictionary)}
-      </Button>
+      <DataProviderEntries dataProvider={dp} dictionary={dictionary} />
     </>
   );
 

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
@@ -17,8 +17,8 @@ import {
 } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
-import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
+import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
+import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 
 // ============================================================================
 // Configuration Types
@@ -139,24 +139,7 @@ export function Dashlet({
     dataProvider = [],
   } = config;
 
-  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
-
-  const { rows, loading, fetchError } = usePgrestRows(
-    dataMode,
-    config.pgrestFunctionName || "",
-    config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PGREST_PARAMS,
-    config.dataSourceId,
-  );
-
-  const templateContext = useMemo(() => {
-    const dpContext = buildDataProviderContext(dataProvider);
-    if (dataMode === "pgrest" && rows.length > 0) {
-      const firstRow = rows[0];
-      return { ...dpContext, row: firstRow, ...firstRow };
-    }
-    return dpContext;
-  }, [dataProvider, dataMode, rows]);
+  const { templateContext, loading, fetchError } = useHybridPgrestContext(config, dataProvider);
 
   const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
   const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Button } from "flowbite-react";
+import { Button, Spinner } from "flowbite-react";
 import {
   HiChartBar,
   HiCurrencyDollar,
@@ -16,6 +16,8 @@ import {
   HiBolt,
 } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestRows } from "../common";
 import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 
 // ============================================================================
@@ -82,6 +84,11 @@ export interface DashletConfig {
   viewMoreUrl: string;
   /** Data provider entries for dynamic values */
   dataProvider?: DataProviderEntry[];
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 /** Default configuration */
@@ -112,15 +119,10 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 // Component
 // ============================================================================
 
+const EMPTY_PARAMS: PgrestParam[] = [];
+
 /**
  * Info Card Dashlet
- *
- * A comprehensive card displaying:
- * - Header: Title (left) + Icon (right)
- * - Body: Large value + Descriptor text
- * - Children Section: Optional nested dashlets for additional info
- * - AI Section: Placeholder for AI-generated summary
- * - Footer: Optional "View more" button (right-aligned)
  */
 export function Dashlet({
   widget,
@@ -139,13 +141,46 @@ export function Dashlet({
     dataProvider = [],
   } = config;
 
-  const templateContext = useMemo(() => buildDataProviderContext(dataProvider), [dataProvider]);
+  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
 
-  const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
-  const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);
-  const compiledDescriptor = useMemo(() => resolveHandlebarsField(descriptor, templateContext), [descriptor, templateContext]);
-  const compiledAiPlaceholder = useMemo(() => resolveHandlebarsField(aiPlaceholder, templateContext), [aiPlaceholder, templateContext]);
-  const compiledViewMoreUrl = useMemo(() => resolveHandlebarsField(viewMoreUrl, templateContext), [viewMoreUrl, templateContext]);
+  const { rows, loading, fetchError } = usePgrestRows(
+    dataMode,
+    config.pgrestFunctionName || "",
+    config.pgrestHttpMethod || "POST",
+    config.pgrestParams || EMPTY_PARAMS,
+    config.dataSourceId,
+  );
+
+  const templateContext = useMemo(() => {
+    const dpContext = buildDataProviderContext(dataProvider);
+    if (dataMode === "pgrest" && rows.length > 0) {
+      const firstRow = rows[0];
+      return { ...dpContext, row: firstRow, ...firstRow };
+    }
+    return dpContext;
+  }, [dataProvider, dataMode, rows]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const compiledTitle = resolveHandlebarsField(title, templateContext);
+  const compiledValue = resolveHandlebarsField(value, templateContext);
+  const compiledDescriptor = resolveHandlebarsField(descriptor, templateContext);
+  const compiledAiPlaceholder = resolveHandlebarsField(aiPlaceholder, templateContext);
+  const compiledViewMoreUrl = resolveHandlebarsField(viewMoreUrl, templateContext);
 
   const IconComponent = ICONS[icon] || ICONS.chart;
   const hasChildren = widget.children && widget.children.length > 0;

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
@@ -16,7 +16,7 @@ import {
   HiBolt,
 } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 
@@ -69,7 +69,7 @@ const ICONS: Record<
 ) as Record<InfoCardIcon, React.ComponentType<{ className?: string }>>;
 
 /** Configuration for this dashlet */
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   /** Title displayed in header (top-left) */
   title: string;
   /** Icon displayed in header (top-right) */
@@ -84,11 +84,6 @@ export interface DashletConfig {
   viewMoreUrl: string;
   /** Data provider entries for dynamic values */
   dataProvider?: DataProviderEntry[];
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 /** Default configuration */

--- a/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Button, Spinner } from "flowbite-react";
+import { Button } from "flowbite-react";
 import {
   HiChartBar,
   HiCurrencyDollar,
@@ -17,7 +17,7 @@ import {
 } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows } from "../common";
+import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 
 // ============================================================================
@@ -119,8 +119,6 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 // Component
 // ============================================================================
 
-const EMPTY_PARAMS: PgrestParam[] = [];
-
 /**
  * Info Card Dashlet
  */
@@ -147,7 +145,7 @@ export function Dashlet({
     dataMode,
     config.pgrestFunctionName || "",
     config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PARAMS,
+    config.pgrestParams || EMPTY_PGREST_PARAMS,
     config.dataSourceId,
   );
 
@@ -160,27 +158,14 @@ export function Dashlet({
     return dpContext;
   }, [dataProvider, dataMode, rows]);
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
+  const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
+  const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);
+  const compiledDescriptor = useMemo(() => resolveHandlebarsField(descriptor, templateContext), [descriptor, templateContext]);
+  const compiledAiPlaceholder = useMemo(() => resolveHandlebarsField(aiPlaceholder, templateContext), [aiPlaceholder, templateContext]);
+  const compiledViewMoreUrl = useMemo(() => resolveHandlebarsField(viewMoreUrl, templateContext), [viewMoreUrl, templateContext]);
 
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
-
-  const compiledTitle = resolveHandlebarsField(title, templateContext);
-  const compiledValue = resolveHandlebarsField(value, templateContext);
-  const compiledDescriptor = resolveHandlebarsField(descriptor, templateContext);
-  const compiledAiPlaceholder = resolveHandlebarsField(aiPlaceholder, templateContext);
-  const compiledViewMoreUrl = resolveHandlebarsField(viewMoreUrl, templateContext);
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const IconComponent = ICONS[icon] || ICONS.chart;
   const hasChildren = widget.children && widget.children.length > 0;

--- a/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.settings.tsx
@@ -13,6 +13,8 @@ import {
   IconColorPickerRow,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type LabeledDataMode = "static" | "pgrest";
 
@@ -44,6 +46,12 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [name, setName] = useState(config.name || "Metric");
   const [value, setValue] = useState(config.value || "0");
   const [color, setColor] = useState<ColorTheme>(config.color || "gray");
@@ -51,9 +59,12 @@ export function DashletSettings({
   const [dataMode, setDataMode] = useState<LabeledDataMode>(
     config.dataMode || "static"
   );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig(config, (detected) => {
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
       if (detected.length >= 1) {
         setName(`{{row.${detected[0].key}}}`);
       }
@@ -73,6 +84,7 @@ export function DashletSettings({
       pgrestFunctionName: pg.pgrestFunctionName,
       pgrestParams: fromPgrestParamItems(pg.pgrestParams),
       pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     });
     onClose();
   };
@@ -112,6 +124,9 @@ export function DashletSettings({
       onDataModeChange={(v) => setDataMode(v as LabeledDataMode)}
       pgrest={pg}
       dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={(v) => { setDataSourceId(v); }}
+      activeProviders={activeProviders}
     />
   );
 

--- a/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.settings.tsx
@@ -11,10 +11,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   IconColorPickerRow,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type LabeledDataMode = "static" | "pgrest";
 
@@ -46,11 +45,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [name, setName] = useState(config.name || "Metric");
   const [value, setValue] = useState(config.value || "0");

--- a/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/labeled_data/dashlet.tsx
@@ -47,6 +47,7 @@ export interface DashletConfig {
   pgrestFunctionName: string;
   pgrestParams: PgrestParam[];
   pgrestHttpMethod: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 /** Default configuration */
@@ -179,6 +180,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
       name: config.name || "Metric",
       value: config.value || "0",
     },
+    dataSourceId: config.dataSourceId,
   });
 
   const Icon = ICONS[iconType];

--- a/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
@@ -1,135 +1,23 @@
 "use client";
 
-import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
-  PgrestDataTab,
-  useActiveProviders,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
-type SimpleDataMode = "static" | "pgrest";
-
-/** Field config for the three percentage_value text fields */
-const PERCENTAGE_FIELDS = [
+const FIELDS = [
   { id: "pv-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Progress" },
   { id: "pv-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "6" },
   { id: "pv-max", labelKey: "common.max", state: "max", hbPlaceholder: "{{row.total}}", staticPlaceholder: "10" },
 ] as const;
 
-/**
- * Settings Modal for Percentage Value Dashlet
- */
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
-
-  const [title, setTitle] = useState(config.title || "Progress");
-  const [value, setValue] = useState(String(config.value ?? "6"));
-  const [max, setMax] = useState(String(config.max ?? "10"));
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
-
-  // Snapshot of static field values, saved when entering pgrest mode
-  const staticSnapshot = useRef({ title: title, value: value, max: max });
-
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      // Entering pgrest: save current static values
-      staticSnapshot.current = { title, value, max };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      // Leaving pgrest: restore static values
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setMax(staticSnapshot.current.max);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) {
-        setTitle(`{{row.${detected[0].key}}}`);
-      }
-      if (detected.length >= 2) {
-        setValue(`{{row.${detected[1].key}}}`);
-      }
-      if (detected.length >= 3) {
-        setMax(`{{row.${detected[2].key}}}`);
-      }
-    }),
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Progress",
-      value: value.trim() || "6",
-      max: max.trim() || "10",
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
-    });
-    onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, max };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    max: setMax,
-  };
-
-  const visualizationTab = (
-    <HbTextFieldList
-      fields={PERCENTAGE_FIELDS}
-      fieldValues={fieldValues}
-      fieldSetters={fieldSetters}
-      isPgrest={isPgrest}
-      dictionary={dictionary}
-    />
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="pv-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
-
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="pv"
+      settingsProps={props}
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
@@ -11,6 +11,8 @@ import {
   PgrestDataTab,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -31,6 +33,12 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(config.title || "Progress");
   const [value, setValue] = useState(String(config.value ?? "6"));
   const [max, setMax] = useState(String(config.max ?? "10"));
@@ -38,6 +46,9 @@ export function DashletSettings({
     config.dataMode === "static" || config.dataMode === "pgrest"
       ? config.dataMode
       : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
   );
 
   // Snapshot of static field values, saved when entering pgrest mode
@@ -57,7 +68,7 @@ export function DashletSettings({
   };
 
   const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig(config, (detected) => {
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
       if (detected.length >= 1) {
         setTitle(`{{row.${detected[0].key}}}`);
       }
@@ -79,6 +90,7 @@ export function DashletSettings({
       pgrestFunctionName: pg.pgrestFunctionName,
       pgrestParams: fromPgrestParamItems(pg.pgrestParams),
       pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     });
     onClose();
   };
@@ -109,6 +121,9 @@ export function DashletSettings({
       onDataModeChange={handleDataModeChange}
       pgrest={pg}
       dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
     />
   );
 

--- a/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import type { DashletSettingsProps } from "../types";
-import type { DashletConfig } from "./dashlet";
-import { SimpleDashletSettings } from "../common";
+import { createSimpleDashletSettings } from "../common";
 
-const FIELDS = [
-  { id: "pv-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Progress" },
-  { id: "pv-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "6" },
-  { id: "pv-max", labelKey: "common.max", state: "max", hbPlaceholder: "{{row.total}}", staticPlaceholder: "10" },
-] as const;
-
-export function DashletSettings(
-  props: Readonly<DashletSettingsProps<DashletConfig>>,
-) {
-  return (
-    <SimpleDashletSettings
-      fields={FIELDS}
-      idPrefix="pv"
-      settingsProps={props}
-    />
-  );
-}
+export const DashletSettings = createSimpleDashletSettings(
+  [
+    { id: "pv-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Progress" },
+    { id: "pv-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "6" },
+    { id: "pv-max", labelKey: "common.max", state: "max", hbPlaceholder: "{{row.total}}", staticPlaceholder: "10" },
+  ],
+  "pv",
+);

--- a/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.settings.tsx
@@ -9,10 +9,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -33,11 +32,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title || "Progress");
   const [value, setValue] = useState(String(config.value ?? "6"));

--- a/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/percentage_value/dashlet.tsx
@@ -21,6 +21,7 @@ export interface DashletConfig {
   pgrestFunctionName?: string;
   pgrestParams?: PgrestParam[];
   pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 /** Default configuration */
@@ -69,6 +70,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
     pgrestParams: config.pgrestParams || EMPTY_PARAMS,
     fields,
+    dataSourceId: config.dataSourceId,
   });
 
   if (loading) {

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
@@ -9,10 +9,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -32,11 +31,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title || "Monthly Revenue");
   const [value, setValue] = useState(String(config.value ?? "84500"));

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
 const FIELDS = [
   { id: "sd-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Monthly Revenue" },
@@ -19,92 +13,14 @@ const FIELDS = [
   { id: "sd-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100000" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "previousValue", "unit", "description", "target"] as const;
-
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Monthly Revenue");
-  const [value, setValue] = useState(String(config.value ?? "84500"));
-  const [previousValue, setPreviousValue] = useState(String(config.previousValue ?? "72000"));
-  const [unit, setUnit] = useState(config.unit ?? "$");
-  const [description, setDescription] = useState(config.description || "Total monthly revenue across all products");
-  const [target, setTarget] = useState(String(config.target ?? "100000"));
-
-  const fieldValues = { title, value, previousValue, unit, description, target };
-  const fieldSetters = {
-    title: setTitle,
-    value: setValue,
-    previousValue: setPreviousValue,
-    unit: setUnit,
-    description: setDescription,
-    target: setTarget,
-  };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Monthly Revenue",
-      value: value.trim() || "84500",
-      previousValue: previousValue.trim() || "72000",
-      unit: unit.trim() || "$",
-      description: description.trim(),
-      target: target.trim() || "100000",
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <HbTextFieldList
-      fields={FIELDS}
-      fieldValues={fieldValues}
-      fieldSetters={fieldSetters}
-      isPgrest={isPgrest}
-      dictionary={dictionary}
-    />
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="sd-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
-
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="sd"
+      settingsProps={props}
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
@@ -1,26 +1,15 @@
 "use client";
 
-import type { DashletSettingsProps } from "../types";
-import type { DashletConfig } from "./dashlet";
-import { SimpleDashletSettings } from "../common";
+import { createSimpleDashletSettings } from "../common";
 
-const FIELDS = [
-  { id: "sd-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Monthly Revenue" },
-  { id: "sd-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "84500" },
-  { id: "sd-prev", labelKey: "common.previousValue", state: "previousValue", hbPlaceholder: "{{row.previous}}", staticPlaceholder: "72000" },
-  { id: "sd-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "$" },
-  { id: "sd-desc", labelKey: "common.description", state: "description", hbPlaceholder: "{{row.description}}", staticPlaceholder: "Total monthly revenue across all products" },
-  { id: "sd-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100000" },
-] as const;
-
-export function DashletSettings(
-  props: Readonly<DashletSettingsProps<DashletConfig>>,
-) {
-  return (
-    <SimpleDashletSettings
-      fields={FIELDS}
-      idPrefix="sd"
-      settingsProps={props}
-    />
-  );
-}
+export const DashletSettings = createSimpleDashletSettings(
+  [
+    { id: "sd-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Monthly Revenue" },
+    { id: "sd-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "84500" },
+    { id: "sd-prev", labelKey: "common.previousValue", state: "previousValue", hbPlaceholder: "{{row.previous}}", staticPlaceholder: "72000" },
+    { id: "sd-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "$" },
+    { id: "sd-desc", labelKey: "common.description", state: "description", hbPlaceholder: "{{row.description}}", staticPlaceholder: "Total monthly revenue across all products" },
+    { id: "sd-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100000" },
+  ],
+  "sd",
+);

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
-  DashletSettingsWrapper,
-  SettingsTextField,
-  SettingsNumberField,
-  SettingsTextareaField,
-  SettingsFieldGrid,
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
+
+const FIELDS = [
+  { id: "sd-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Monthly Revenue" },
+  { id: "sd-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "84500" },
+  { id: "sd-prev", labelKey: "common.previousValue", state: "previousValue", hbPlaceholder: "{{row.previous}}", staticPlaceholder: "72000" },
+  { id: "sd-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "$" },
+  { id: "sd-desc", labelKey: "common.description", state: "description", hbPlaceholder: "{{row.description}}", staticPlaceholder: "Total monthly revenue across all products" },
+  { id: "sd-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100000" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -18,69 +32,114 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Monthly Revenue");
-  const [value, setValue] = useState(config.value || 84500);
-  const [previousValue, setPreviousValue] = useState(
-    config.previousValue || 72000
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
   );
-  const [unit, setUnit] = useState(config.unit || "$");
-  const [description, setDescription] = useState(config.description || "");
-  const [target, setTarget] = useState(config.target || 100000);
+
+  const [title, setTitle] = useState(config.title || "Monthly Revenue");
+  const [value, setValue] = useState(String(config.value ?? "84500"));
+  const [previousValue, setPreviousValue] = useState(String(config.previousValue ?? "72000"));
+  const [unit, setUnit] = useState(config.unit ?? "$");
+  const [description, setDescription] = useState(config.description || "Total monthly revenue across all products");
+  const [target, setTarget] = useState(String(config.target ?? "100000"));
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, previousValue, unit, description, target });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, previousValue, unit, description, target };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setPreviousValue(staticSnapshot.current.previousValue);
+      setUnit(staticSnapshot.current.unit);
+      setDescription(staticSnapshot.current.description);
+      setTarget(staticSnapshot.current.target);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setPreviousValue(`{{row.${detected[2].key}}}`);
+      if (detected.length >= 4) setUnit(`{{row.${detected[3].key}}}`);
+      if (detected.length >= 5) setDescription(`{{row.${detected[4].key}}}`);
+      if (detected.length >= 6) setTarget(`{{row.${detected[5].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
-    onSave({ title, value, previousValue, unit, description, target });
+    onSave({
+      title: title.trim() || "Monthly Revenue",
+      value: value.trim() || "84500",
+      previousValue: previousValue.trim() || "72000",
+      unit: unit.trim() || "$",
+      description: description.trim(),
+      target: target.trim() || "100000",
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, previousValue, unit, description, target };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    previousValue: setPreviousValue,
+    unit: setUnit,
+    description: setDescription,
+    target: setTarget,
+  };
+
+  const visualizationTab = (
+    <HbTextFieldList
+      fields={FIELDS}
+      fieldValues={fieldValues}
+      fieldSetters={fieldSetters}
+      isPgrest={isPgrest}
+      dictionary={dictionary}
+    />
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="sd-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
   return (
-    <DashletSettingsWrapper
+    <SettingsModalShell
       isOpen={isOpen}
       onClose={onClose}
       onSave={handleSave}
-      scrollable
       dictionary={dictionary}
-    >
-      <SettingsTextField
-        id="title"
-        label="Title"
-        value={title}
-        onChange={setTitle}
-      />
-      <SettingsFieldGrid cols={2}>
-        <SettingsNumberField
-          id="value"
-          label="Current Value"
-          value={value}
-          onChange={setValue}
-        />
-        <SettingsNumberField
-          id="prev"
-          label="Previous"
-          value={previousValue}
-          onChange={setPreviousValue}
-        />
-      </SettingsFieldGrid>
-      <SettingsFieldGrid cols={2}>
-        <SettingsTextField
-          id="unit"
-          label="Unit"
-          value={unit}
-          onChange={setUnit}
-        />
-        <SettingsNumberField
-          id="target"
-          label="Target"
-          value={target}
-          onChange={setTarget}
-        />
-      </SettingsFieldGrid>
-      <SettingsTextareaField
-        id="description"
-        label="Description"
-        value={description}
-        onChange={setDescription}
-        rows={2}
-      />
-    </DashletSettingsWrapper>
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.settings.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const FIELDS = [
   { id: "sd-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Monthly Revenue" },
@@ -24,6 +19,8 @@ const FIELDS = [
   { id: "sd-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100000" },
 ] as const;
 
+const FIELD_NAMES = ["title", "value", "previousValue", "unit", "description", "target"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -31,48 +28,37 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
-
   const [title, setTitle] = useState(config.title || "Monthly Revenue");
   const [value, setValue] = useState(String(config.value ?? "84500"));
   const [previousValue, setPreviousValue] = useState(String(config.previousValue ?? "72000"));
   const [unit, setUnit] = useState(config.unit ?? "$");
   const [description, setDescription] = useState(config.description || "Total monthly revenue across all products");
   const [target, setTarget] = useState(String(config.target ?? "100000"));
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, previousValue, unit, description, target });
-
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, previousValue, unit, description, target };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setPreviousValue(staticSnapshot.current.previousValue);
-      setUnit(staticSnapshot.current.unit);
-      setDescription(staticSnapshot.current.description);
-      setTarget(staticSnapshot.current.target);
-    }
-    setDataMode(mode);
+  const fieldValues = { title, value, previousValue, unit, description, target };
+  const fieldSetters = {
+    title: setTitle,
+    value: setValue,
+    previousValue: setPreviousValue,
+    unit: setUnit,
+    description: setDescription,
+    target: setTarget,
   };
 
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setPreviousValue(`{{row.${detected[2].key}}}`);
-      if (detected.length >= 4) setUnit(`{{row.${detected[3].key}}}`);
-      if (detected.length >= 5) setDescription(`{{row.${detected[4].key}}}`);
-      if (detected.length >= 6) setTarget(`{{row.${detected[5].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -83,25 +69,9 @@ export function DashletSettings({
       unit: unit.trim() || "$",
       description: description.trim(),
       target: target.trim() || "100000",
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, previousValue, unit, description, target };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    previousValue: setPreviousValue,
-    unit: setUnit,
-    description: setDescription,
-    target: setTarget,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -79,7 +79,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
 
   const change = value - previousValue;
   const changePercent = previousValue === 0 ? 0 : Number(((change / previousValue) * 100).toFixed(1));
-  const progressPercent = target > 0 ? Math.min(100, (value / target) * 100) : 0;
+  const progressPercent = target > 0 ? Math.max(0, Math.min(100, (value / target) * 100)) : 0;
   const isPositive = change >= 0;
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -3,25 +3,20 @@
 import { useMemo } from "react";
 import { HiArrowTrendingUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   previousValue: string;
   unit: string;
   description: string;
   target: string;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import { HiArrowTrendingUp } from "react-icons/hi2";
+import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -9,20 +15,25 @@ import { HiArrowTrendingUp } from "react-icons/hi2";
 
 export interface DashletConfig {
   title: string;
-  value: number;
-  previousValue: number;
+  value: string;
+  previousValue: string;
   unit: string;
   description: string;
-  target: number;
+  target: string;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Monthly Revenue",
-  value: 84500,
-  previousValue: 72000,
+  value: "84500",
+  previousValue: "72000",
   unit: "$",
   description: "Total monthly revenue across all products",
-  target: 100000,
+  target: "100000",
 };
 
 export const layoutDefaults: DashletLayoutDefaults = {
@@ -43,11 +54,59 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, previousValue, unit, description, target } = config;
+
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Monthly Revenue",
+      value: String(config.value ?? "84500"),
+      previousValue: String(config.previousValue ?? "72000"),
+      unit: config.unit ?? "$",
+      description: config.description || "Total monthly revenue across all products",
+      target: String(config.target ?? "100000"),
+    }),
+    [config.title, config.value, config.previousValue, config.unit, config.description, config.target],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Monthly Revenue";
+  const unit = resolved.unit ?? "$";
+  const description = resolved.description || "";
+
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const parsedPrev = resolved.previousValue === "" || resolved.previousValue == null ? Number.NaN : Number(resolved.previousValue);
+  const parsedTarget = resolved.target === "" || resolved.target == null ? Number.NaN : Number(resolved.target);
+
+  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
+  const previousValue = Number.isFinite(parsedPrev) ? parsedPrev : 0;
+  const target = Number.isFinite(parsedTarget) ? parsedTarget : 1;
 
   const change = value - previousValue;
-  const changePercent = ((change / previousValue) * 100).toFixed(1);
-  const progressPercent = Math.min(100, (value / target) * 100);
+  const changePercent = previousValue === 0 ? 0 : Number(((change / previousValue) * 100).toFixed(1));
+  const progressPercent = target > 0 ? Math.min(100, (value / target) * 100) : 0;
   const isPositive = change >= 0;
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -82,7 +82,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
 
   const value = parseResolvedNumber(resolved.value);
   const previousValue = parseResolvedNumber(resolved.previousValue);
-  const target = parseResolvedNumber(resolved.target, 1);
+  const target = parseResolvedNumber(resolved.target);
 
   const change = value - previousValue;
   const changePercent = previousValue === 0 ? 0 : Number(((change / previousValue) * 100).toFixed(1));

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import { HiArrowTrendingUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -71,38 +68,21 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Monthly Revenue";
   const unit = resolved.unit ?? "$";
   const description = resolved.description || "";
 
-  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
-  const parsedPrev = resolved.previousValue === "" || resolved.previousValue == null ? Number.NaN : Number(resolved.previousValue);
-  const parsedTarget = resolved.target === "" || resolved.target == null ? Number.NaN : Number(resolved.target);
-
-  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
-  const previousValue = Number.isFinite(parsedPrev) ? parsedPrev : 0;
-  const target = Number.isFinite(parsedTarget) ? parsedTarget : 1;
+  const value = parseResolvedNumber(resolved.value);
+  const previousValue = parseResolvedNumber(resolved.previousValue);
+  const target = parseResolvedNumber(resolved.target, 1);
 
   const change = value - previousValue;
   const changePercent = previousValue === 0 ? 0 : Number(((change / previousValue) * 100).toFixed(1));

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { HiArrowTrendingUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
@@ -37,6 +36,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Monthly Revenue", value: "84500", previousValue: "72000", unit: "$", description: "Total monthly revenue across all products", target: "100000" };
+
 // ============================================================================
 // Component - Style 2: Full Details Card
 // ============================================================================
@@ -47,19 +48,7 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Monthly Revenue",
-      value: String(config.value ?? "84500"),
-      previousValue: String(config.previousValue ?? "72000"),
-      unit: config.unit ?? "$",
-      description: config.description || "Total monthly revenue across all products",
-      target: String(config.target ?? "100000"),
-    }),
-    [config.title, config.value, config.previousValue, config.unit, config.description, config.target],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_detailed/dashlet.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { HiArrowTrendingUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -64,14 +64,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.previousValue, config.unit, config.description, config.target],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Button, TextInput, Label } from "flowbite-react";
 import { HiPlus, HiTrash } from "react-icons/hi2";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-
-type SimpleDataMode = "static" | "pgrest";
 
 interface DetailWithId {
   id: string;
@@ -29,6 +24,8 @@ const FIELDS = [
   { id: "se-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
 ] as const;
 
+const FIELD_NAMES = ["title", "value", "unit"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -36,19 +33,9 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
-
   const [title, setTitle] = useState(config.title || "Conversion Rate");
   const [value, setValue] = useState(String(config.value ?? "3.24"));
   const [unit, setUnit] = useState(config.unit ?? "%");
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
   // Initialize details with unique IDs
   const initializeDetails = (): DetailWithId[] => {
@@ -64,25 +51,23 @@ export function DashletSettings({
 
   const [details, setDetails] = useState(initializeDetails);
 
-  const staticSnapshot = useRef({ title, value, unit });
+  const fieldValues = { title, value, unit };
+  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -92,11 +77,7 @@ export function DashletSettings({
       value: value.trim() || "3.24",
       unit: unit.trim() || "%",
       details: detailsToSave,
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
   };
@@ -111,15 +92,6 @@ export function DashletSettings({
 
   const updateDetail = (id: string, field: "label" | "value", val: string) => {
     setDetails(details.map((d) => (d.id === id ? { ...d, [field]: val } : d)));
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
@@ -11,10 +11,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -37,11 +36,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title || "Conversion Rate");
   const [value, setValue] = useState(String(config.value ?? "3.24"));

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
@@ -1,17 +1,34 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button, TextInput, Label } from "flowbite-react";
 import { HiPlus, HiTrash } from "react-icons/hi2";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import { DashletSettingsWrapper, SettingsTitleValueUnit } from "../common";
+import {
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
+} from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
 
 interface DetailWithId {
   id: string;
   label: string;
   value: string;
 }
+
+const FIELDS = [
+  { id: "se-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Conversion Rate" },
+  { id: "se-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.rate}}", staticPlaceholder: "3.24" },
+  { id: "se-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -20,9 +37,23 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(config.title || "Conversion Rate");
-  const [value, setValue] = useState(config.value || 3.24);
-  const [unit, setUnit] = useState(config.unit || "%");
+  const [value, setValue] = useState(String(config.value ?? "3.24"));
+  const [unit, setUnit] = useState(config.unit ?? "%");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   // Initialize details with unique IDs
   const initializeDetails = (): DetailWithId[] => {
@@ -38,9 +69,40 @@ export function DashletSettings({
 
   const [details, setDetails] = useState(initializeDetails);
 
+  const staticSnapshot = useRef({ title, value, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
+    }),
+  });
+
   const handleSave = () => {
     const detailsToSave = details.map(({ label, value }) => ({ label, value }));
-    onSave({ title, value, unit, details: detailsToSave });
+    onSave({
+      title: title.trim() || "Conversion Rate",
+      value: value.trim() || "3.24",
+      unit: unit.trim() || "%",
+      details: detailsToSave,
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
@@ -56,23 +118,22 @@ export function DashletSettings({
     setDetails(details.map((d) => (d.id === id ? { ...d, [field]: val } : d)));
   };
 
-  return (
-    <DashletSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      width="w-80"
-      scrollable
-      dictionary={dictionary}
-    >
-      <SettingsTitleValueUnit
-        title={title}
-        onTitleChange={setTitle}
-        value={value}
-        onValueChange={setValue}
-        unit={unit}
-        onUnitChange={setUnit}
-        valueStep="0.01"
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <>
+      <HbTextFieldList
+        fields={FIELDS}
+        fieldValues={fieldValues}
+        fieldSetters={fieldSetters}
+        isPgrest={isPgrest}
         dictionary={dictionary}
       />
 
@@ -118,6 +179,30 @@ export function DashletSettings({
           </div>
         ))}
       </div>
-    </DashletSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="se-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.settings.tsx
@@ -5,12 +5,7 @@ import { Button, TextInput, Label } from "flowbite-react";
 import { HiPlus, HiTrash } from "react-icons/hi2";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
 interface DetailWithId {
   id: string;
@@ -24,20 +19,11 @@ const FIELDS = [
   { id: "se-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "unit"] as const;
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
+  const { config } = props;
 
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Conversion Rate");
-  const [value, setValue] = useState(String(config.value ?? "3.24"));
-  const [unit, setUnit] = useState(config.unit ?? "%");
-
-  // Initialize details with unique IDs
   const initializeDetails = (): DetailWithId[] => {
     const defaultDetails = [
       { label: "Visitors", value: "12,847" },
@@ -51,37 +37,6 @@ export function DashletSettings({
 
   const [details, setDetails] = useState(initializeDetails);
 
-  const fieldValues = { title, value, unit };
-  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    const detailsToSave = details.map(({ label, value }) => ({ label, value }));
-    onSave({
-      title: title.trim() || "Conversion Rate",
-      value: value.trim() || "3.24",
-      unit: unit.trim() || "%",
-      details: detailsToSave,
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
   const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 
   const addDetail = () =>
@@ -94,82 +49,58 @@ export function DashletSettings({
     setDetails(details.map((d) => (d.id === id ? { ...d, [field]: val } : d)));
   };
 
-  const visualizationTab = (
-    <>
-      <HbTextFieldList
-        fields={FIELDS}
-        fieldValues={fieldValues}
-        fieldSetters={fieldSetters}
-        isPgrest={isPgrest}
-        dictionary={dictionary}
-      />
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">Expandable Details</Label>
-          <Button
-            size="xs"
-            color="light"
-            onClick={addDetail}
-            onMouseDown={handleMouseDown}
-            className="no-drag"
-          >
-            <HiPlus className="mr-1 h-3 w-3" />
-            Add
-          </Button>
-        </div>
-        {details.map((d) => (
-          <div key={d.id} className="flex items-center gap-2">
-            <TextInput
-              value={d.label}
-              onChange={(e) => updateDetail(d.id, "label", e.target.value)}
-              placeholder="Label"
-              sizing="sm"
-              className="flex-1"
-            />
-            <TextInput
-              value={d.value}
-              onChange={(e) => updateDetail(d.id, "value", e.target.value)}
-              placeholder="Value"
-              sizing="sm"
-              className="flex-1"
-            />
+  return (
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="se"
+      settingsProps={props}
+      extraSaveFields={{
+        details: details.map(({ label, value }) => ({ label, value })),
+      }}
+      extraVisualization={
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">Expandable Details</Label>
             <Button
               size="xs"
-              color="failure"
-              onClick={() => removeDetail(d.id)}
+              color="light"
+              onClick={addDetail}
               onMouseDown={handleMouseDown}
               className="no-drag"
             >
-              <HiTrash className="h-3 w-3" />
+              <HiPlus className="mr-1 h-3 w-3" />
+              Add
             </Button>
           </div>
-        ))}
-      </div>
-    </>
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="se-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
-
-  return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+          {details.map((d) => (
+            <div key={d.id} className="flex items-center gap-2">
+              <TextInput
+                value={d.label}
+                onChange={(e) => updateDetail(d.id, "label", e.target.value)}
+                placeholder="Label"
+                sizing="sm"
+                className="flex-1"
+              />
+              <TextInput
+                value={d.value}
+                onChange={(e) => updateDetail(d.id, "value", e.target.value)}
+                placeholder="Value"
+                sizing="sm"
+                className="flex-1"
+              />
+              <Button
+                size="xs"
+                color="failure"
+                onClick={() => removeDetail(d.id)}
+                onMouseDown={handleMouseDown}
+                className="no-drag"
+              >
+                <HiTrash className="h-3 w-3" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      }
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -64,14 +64,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState } from "react";
-import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import { useState, useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
+import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -10,14 +15,19 @@ import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
 
 export interface DashletConfig {
   title: string;
-  value: number;
+  value: string;
   unit: string;
   details: { label: string; value: string }[];
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Conversion Rate",
-  value: 3.24,
+  value: "3.24",
   unit: "%",
   details: [
     { label: "Visitors", value: "12,847" },
@@ -45,8 +55,47 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, unit, details } = config;
+  const details = config.details || defaultConfig.details;
   const [expanded, setExpanded] = useState(false);
+
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Conversion Rate",
+      value: String(config.value ?? "3.24"),
+      unit: config.unit ?? "%",
+    }),
+    [config.title, config.value, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Conversion Rate";
+  const unit = resolved.unit ?? "%";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const displayValue = Number.isFinite(parsedValue) ? parsedValue : resolved.value;
 
   return (
     <div className="flex h-full flex-col rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
@@ -56,7 +105,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
           {title}
         </p>
         <p className="mt-1 text-3xl font-bold text-gray-900 dark:text-white">
-          {value}
+          {displayValue}
           <span className="ml-1 text-lg font-normal text-gray-500">{unit}</span>
         </p>
       </div>

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
@@ -38,6 +38,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Conversion Rate", value: "3.24", unit: "%" };
+
 // ============================================================================
 // Component - Style 6: Expandable Details
 // ============================================================================
@@ -50,16 +52,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const details = config.details || defaultConfig.details;
   const [expanded, setExpanded] = useState(false);
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Conversion Rate",
-      value: String(config.value ?? "3.24"),
-      unit: config.unit ?? "%",
-    }),
-    [config.title, config.value, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
@@ -3,23 +3,18 @@
 import { useState, useMemo } from "react";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   unit: string;
   details: { label: string; value: string }[];
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_expandable/dashlet.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -71,26 +68,13 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Conversion Rate";
   const unit = resolved.unit ?? "%";

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
@@ -10,14 +10,13 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
 import {
   ColorPickerDropdown,
   type ColorOption,
 } from "@/features/common/components/color-picker-dropdown";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -42,11 +41,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Active Users");
   const [value, setValue] = useState(String(config.value ?? "2847"));
   const [unit, setUnit] = useState(config.unit ?? "");

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
@@ -1,24 +1,19 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, GradientColor } from "./dashlet";
 import {
   HbTextFieldList,
   SettingsPickerItem,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
 import {
   ColorPickerDropdown,
   type ColorOption,
 } from "@/features/common/components/color-picker-dropdown";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const COLOR_OPTIONS: ColorOption<GradientColor>[] = [
   { value: "blue", label: "Blue", dotClass: "bg-blue-500" },
@@ -34,6 +29,8 @@ const FIELDS = [
   { id: "sg-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
 ] as const;
 
+const FIELD_NAMES = ["title", "value", "unit"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -41,39 +38,28 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Active Users");
   const [value, setValue] = useState(String(config.value ?? "2847"));
   const [unit, setUnit] = useState(config.unit ?? "");
   const [color, setColor] = useState<GradientColor>(config.color || "blue");
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, unit });
+  const fieldValues = { title, value, unit };
+  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -82,22 +68,9 @@ export function DashletSettings({
       value: value.trim() || "2847",
       unit: unit.trim(),
       color,
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, GradientColor } from "./dashlet";
-import {
-  HbTextFieldList,
-  SettingsPickerItem,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings, SettingsPickerItem } from "../common";
 import {
   ColorPickerDropdown,
   type ColorOption,
@@ -29,91 +23,29 @@ const FIELDS = [
   { id: "sg-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "unit"] as const;
-
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Active Users");
-  const [value, setValue] = useState(String(config.value ?? "2847"));
-  const [unit, setUnit] = useState(config.unit ?? "");
-  const [color, setColor] = useState<GradientColor>(config.color || "blue");
-
-  const fieldValues = { title, value, unit };
-  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Active Users",
-      value: value.trim() || "2847",
-      unit: unit.trim(),
-      color,
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <>
-      <HbTextFieldList
-        fields={FIELDS}
-        fieldValues={fieldValues}
-        fieldSetters={fieldSetters}
-        isPgrest={isPgrest}
-        dictionary={dictionary}
-      />
-      <SettingsPickerItem label="Color">
-        <ColorPickerDropdown
-          options={COLOR_OPTIONS}
-          value={color}
-          onChange={setColor}
-          title="Select color"
-        />
-      </SettingsPickerItem>
-    </>
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="sg-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
+  const [color, setColor] = useState<GradientColor>(
+    props.config.color || "blue",
   );
 
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="sg"
+      settingsProps={props}
+      extraSaveFields={{ color }}
+      extraVisualization={
+        <SettingsPickerItem label="Color">
+          <ColorPickerDropdown
+            options={COLOR_OPTIONS}
+            value={color}
+            onChange={setColor}
+            title="Select color"
+          />
+        </SettingsPickerItem>
+      }
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.settings.tsx
@@ -1,17 +1,25 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, GradientColor } from "./dashlet";
 import {
-  DashletSettingsWrapper,
-  SettingsTitleValueUnit,
+  HbTextFieldList,
   SettingsPickerItem,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
 import {
   ColorPickerDropdown,
   type ColorOption,
 } from "@/features/common/components/color-picker-dropdown";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
 
 const COLOR_OPTIONS: ColorOption<GradientColor>[] = [
   { value: "blue", label: "Blue", dotClass: "bg-blue-500" },
@@ -21,6 +29,12 @@ const COLOR_OPTIONS: ColorOption<GradientColor>[] = [
   { value: "purple", label: "Purple", dotClass: "bg-purple-500" },
 ];
 
+const FIELDS = [
+  { id: "sg-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Active Users" },
+  { id: "sg-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "2847" },
+  { id: "sg-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
+] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -28,30 +42,76 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
   const [title, setTitle] = useState(config.title || "Active Users");
-  const [value, setValue] = useState(config.value || 2847);
-  const [unit, setUnit] = useState(config.unit || "");
+  const [value, setValue] = useState(String(config.value ?? "2847"));
+  const [unit, setUnit] = useState(config.unit ?? "");
   const [color, setColor] = useState<GradientColor>(config.color || "blue");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
-    onSave({ title, value, unit, color });
+    onSave({
+      title: title.trim() || "Active Users",
+      value: value.trim() || "2847",
+      unit: unit.trim(),
+      color,
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
-  return (
-    <DashletSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-    >
-      <SettingsTitleValueUnit
-        title={title}
-        onTitleChange={setTitle}
-        value={value}
-        onValueChange={setValue}
-        unit={unit}
-        onUnitChange={setUnit}
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <>
+      <HbTextFieldList
+        fields={FIELDS}
+        fieldValues={fieldValues}
+        fieldSetters={fieldSetters}
+        isPgrest={isPgrest}
         dictionary={dictionary}
       />
       <SettingsPickerItem label="Color">
@@ -62,6 +122,30 @@ export function DashletSettings({
           title="Select color"
         />
       </SettingsPickerItem>
-    </DashletSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="sg-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -73,32 +70,18 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Active Users";
   const unit = resolved.unit ?? "";
   const color = config.color || "blue";
-  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
-  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
+  const value = parseResolvedNumber(resolved.value);
 
   return (
     <div

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
@@ -34,6 +33,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Active Users", value: "2847", unit: "" };
+
 const COLORS = {
   blue: "from-blue-500 to-blue-600",
   green: "from-green-500 to-green-600",
@@ -52,16 +53,7 @@ const COLORS = {
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Active Users",
-      value: String(config.value ?? "2847"),
-      unit: config.unit ?? "",
-    }),
-    [config.title, config.value, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -10,14 +16,19 @@ export type GradientColor = "blue" | "green" | "red" | "yellow" | "purple";
 
 export interface DashletConfig {
   title: string;
-  value: number;
+  value: string;
   unit: string;
   color: GradientColor;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Active Users",
-  value: 2847,
+  value: "2847",
   unit: "",
   color: "blue",
 };
@@ -48,7 +59,46 @@ const COLORS = {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, unit, color } = config;
+
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Active Users",
+      value: String(config.value ?? "2847"),
+      unit: config.unit ?? "",
+    }),
+    [config.title, config.value, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Active Users";
+  const unit = resolved.unit ?? "";
+  const color = config.color || "blue";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
 
   return (
     <div

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -66,14 +66,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_gradient/dashlet.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
@@ -11,16 +11,11 @@ import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } f
 
 export type GradientColor = "blue" | "green" | "red" | "yellow" | "purple";
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   unit: string;
   color: GradientColor;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const FIELDS = [
   { id: "si-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Orders" },
@@ -22,6 +17,8 @@ const FIELDS = [
   { id: "si-subtitle", labelKey: "common.subtitle", state: "subtitle", hbPlaceholder: "{{row.subtitle}}", staticPlaceholder: "Last 24 hours" },
 ] as const;
 
+const FIELD_NAMES = ["title", "value", "unit", "subtitle"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -29,41 +26,28 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Orders");
   const [value, setValue] = useState(String(config.value ?? "156"));
   const [unit, setUnit] = useState(config.unit ?? "");
   const [subtitle, setSubtitle] = useState(config.subtitle || "Last 24 hours");
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, unit, subtitle });
+  const fieldValues = { title, value, unit, subtitle };
+  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit, subtitle: setSubtitle };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, unit, subtitle };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setUnit(staticSnapshot.current.unit);
-      setSubtitle(staticSnapshot.current.subtitle);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
-      if (detected.length >= 4) setSubtitle(`{{row.${detected[3].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -72,23 +56,9 @@ export function DashletSettings({
       value: value.trim() || "156",
       unit: unit.trim(),
       subtitle: subtitle.trim(),
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, unit, subtitle };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    unit: setUnit,
-    subtitle: setSubtitle,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
@@ -1,24 +1,13 @@
 "use client";
 
-import type { DashletSettingsProps } from "../types";
-import type { DashletConfig } from "./dashlet";
-import { SimpleDashletSettings } from "../common";
+import { createSimpleDashletSettings } from "../common";
 
-const FIELDS = [
-  { id: "si-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Orders" },
-  { id: "si-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "156" },
-  { id: "si-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
-  { id: "si-subtitle", labelKey: "common.subtitle", state: "subtitle", hbPlaceholder: "{{row.subtitle}}", staticPlaceholder: "Last 24 hours" },
-] as const;
-
-export function DashletSettings(
-  props: Readonly<DashletSettingsProps<DashletConfig>>,
-) {
-  return (
-    <SimpleDashletSettings
-      fields={FIELDS}
-      idPrefix="si"
-      settingsProps={props}
-    />
-  );
-}
+export const DashletSettings = createSimpleDashletSettings(
+  [
+    { id: "si-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Orders" },
+    { id: "si-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "156" },
+    { id: "si-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
+    { id: "si-subtitle", labelKey: "common.subtitle", state: "subtitle", hbPlaceholder: "{{row.subtitle}}", staticPlaceholder: "Last 24 hours" },
+  ],
+  "si",
+);

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
@@ -9,10 +9,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -30,11 +29,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Orders");
   const [value, setValue] = useState(String(config.value ?? "156"));
   const [unit, setUnit] = useState(config.unit ?? "");

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
@@ -1,13 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
-  DashletSettingsWrapper,
-  SettingsTextField,
-  SettingsTitleValueUnit,
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
+
+const FIELDS = [
+  { id: "si-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Orders" },
+  { id: "si-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "156" },
+  { id: "si-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
+  { id: "si-subtitle", labelKey: "common.subtitle", state: "subtitle", hbPlaceholder: "{{row.subtitle}}", staticPlaceholder: "Last 24 hours" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -16,38 +30,103 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
   const [title, setTitle] = useState(config.title || "Orders");
-  const [value, setValue] = useState(config.value || 156);
-  const [unit, setUnit] = useState(config.unit || "");
+  const [value, setValue] = useState(String(config.value ?? "156"));
+  const [unit, setUnit] = useState(config.unit ?? "");
   const [subtitle, setSubtitle] = useState(config.subtitle || "Last 24 hours");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, unit, subtitle });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, unit, subtitle };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setUnit(staticSnapshot.current.unit);
+      setSubtitle(staticSnapshot.current.subtitle);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
+      if (detected.length >= 4) setSubtitle(`{{row.${detected[3].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
-    onSave({ title, value, unit, subtitle });
+    onSave({
+      title: title.trim() || "Orders",
+      value: value.trim() || "156",
+      unit: unit.trim(),
+      subtitle: subtitle.trim(),
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, unit, subtitle };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    unit: setUnit,
+    subtitle: setSubtitle,
+  };
+
+  const visualizationTab = (
+    <HbTextFieldList
+      fields={FIELDS}
+      fieldValues={fieldValues}
+      fieldSetters={fieldSetters}
+      isPgrest={isPgrest}
+      dictionary={dictionary}
+    />
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="si-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
   return (
-    <DashletSettingsWrapper
+    <SettingsModalShell
       isOpen={isOpen}
       onClose={onClose}
       onSave={handleSave}
       dictionary={dictionary}
-    >
-      <SettingsTitleValueUnit
-        title={title}
-        onTitleChange={setTitle}
-        value={value}
-        onValueChange={setValue}
-        unit={unit}
-        onUnitChange={setUnit}
-        dictionary={dictionary}
-      />
-      <SettingsTextField
-        id="subtitle"
-        label="Subtitle"
-        value={subtitle}
-        onChange={setSubtitle}
-      />
-    </DashletSettingsWrapper>
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.settings.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
 const FIELDS = [
   { id: "si-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Orders" },
@@ -17,81 +11,14 @@ const FIELDS = [
   { id: "si-subtitle", labelKey: "common.subtitle", state: "subtitle", hbPlaceholder: "{{row.subtitle}}", staticPlaceholder: "Last 24 hours" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "unit", "subtitle"] as const;
-
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Orders");
-  const [value, setValue] = useState(String(config.value ?? "156"));
-  const [unit, setUnit] = useState(config.unit ?? "");
-  const [subtitle, setSubtitle] = useState(config.subtitle || "Last 24 hours");
-
-  const fieldValues = { title, value, unit, subtitle };
-  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit, subtitle: setSubtitle };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Orders",
-      value: value.trim() || "156",
-      unit: unit.trim(),
-      subtitle: subtitle.trim(),
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <HbTextFieldList
-      fields={FIELDS}
-      fieldValues={fieldValues}
-      fieldSetters={fieldSetters}
-      isPgrest={isPgrest}
-      dictionary={dictionary}
-    />
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="si-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
-
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="si"
+      settingsProps={props}
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
@@ -3,23 +3,18 @@
 import { useMemo } from "react";
 import { HiShoppingCart } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   unit: string;
   subtitle: string;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import { HiShoppingCart } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -65,32 +62,18 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Orders";
   const unit = resolved.unit ?? "";
   const subtitle = resolved.subtitle || "";
-  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
-  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
+  const value = parseResolvedNumber(resolved.value);
 
   return (
     <div className="flex h-full items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import { HiShoppingCart } from "react-icons/hi2";
+import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -9,14 +15,19 @@ import { HiShoppingCart } from "react-icons/hi2";
 
 export interface DashletConfig {
   title: string;
-  value: number;
+  value: string;
   unit: string;
   subtitle: string;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Orders",
-  value: 156,
+  value: "156",
   unit: "",
   subtitle: "Last 24 hours",
 };
@@ -39,7 +50,47 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, unit, subtitle } = config;
+
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Orders",
+      value: String(config.value ?? "156"),
+      unit: config.unit ?? "",
+      subtitle: config.subtitle || "Last 24 hours",
+    }),
+    [config.title, config.value, config.unit, config.subtitle],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Orders";
+  const unit = resolved.unit ?? "";
+  const subtitle = resolved.subtitle || "";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
 
   return (
     <div className="flex h-full items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { HiShoppingCart } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -58,14 +58,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.unit, config.subtitle],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_icon/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { HiShoppingCart } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
@@ -33,6 +32,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Orders", value: "156", unit: "", subtitle: "Last 24 hours" };
+
 // ============================================================================
 // Component - Style 4: Icon Accent
 // ============================================================================
@@ -43,17 +44,7 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Orders",
-      value: String(config.value ?? "156"),
-      unit: config.unit ?? "",
-      subtitle: config.subtitle || "Last 24 hours",
-    }),
-    [config.title, config.value, config.unit, config.subtitle],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const FIELDS = [
   { id: "sp-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Quarterly Goal" },
@@ -22,6 +17,8 @@ const FIELDS = [
   { id: "sp-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
 ] as const;
 
+const FIELD_NAMES = ["title", "value", "target", "unit"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -29,41 +26,28 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Quarterly Goal");
   const [value, setValue] = useState(String(config.value ?? "78"));
   const [target, setTarget] = useState(String(config.target ?? "100"));
   const [unit, setUnit] = useState(config.unit ?? "%");
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, target, unit });
+  const fieldValues = { title, value, target, unit };
+  const fieldSetters = { title: setTitle, value: setValue, target: setTarget, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, target, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setTarget(staticSnapshot.current.target);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setTarget(`{{row.${detected[2].key}}}`);
-      if (detected.length >= 4) setUnit(`{{row.${detected[3].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -72,23 +56,9 @@ export function DashletSettings({
       value: value.trim() || "78",
       target: target.trim() || "100",
       unit: unit.trim() || "%",
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, target, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    target: setTarget,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
@@ -1,24 +1,13 @@
 "use client";
 
-import type { DashletSettingsProps } from "../types";
-import type { DashletConfig } from "./dashlet";
-import { SimpleDashletSettings } from "../common";
+import { createSimpleDashletSettings } from "../common";
 
-const FIELDS = [
-  { id: "sp-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Quarterly Goal" },
-  { id: "sp-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "78" },
-  { id: "sp-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100" },
-  { id: "sp-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
-] as const;
-
-export function DashletSettings(
-  props: Readonly<DashletSettingsProps<DashletConfig>>,
-) {
-  return (
-    <SimpleDashletSettings
-      fields={FIELDS}
-      idPrefix="sp"
-      settingsProps={props}
-    />
-  );
-}
+export const DashletSettings = createSimpleDashletSettings(
+  [
+    { id: "sp-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Quarterly Goal" },
+    { id: "sp-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "78" },
+    { id: "sp-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100" },
+    { id: "sp-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
+  ],
+  "sp",
+);

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
@@ -9,10 +9,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -30,11 +29,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Quarterly Goal");
   const [value, setValue] = useState(String(config.value ?? "78"));
   const [target, setTarget] = useState(String(config.target ?? "100"));

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
@@ -1,14 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
-  DashletSettingsWrapper,
-  SettingsTextField,
-  SettingsNumberField,
-  SettingsFieldGrid,
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
+
+const FIELDS = [
+  { id: "sp-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Quarterly Goal" },
+  { id: "sp-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.current}}", staticPlaceholder: "78" },
+  { id: "sp-target", labelKey: "common.target", state: "target", hbPlaceholder: "{{row.target}}", staticPlaceholder: "100" },
+  { id: "sp-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -17,49 +30,103 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
   const [title, setTitle] = useState(config.title || "Quarterly Goal");
-  const [value, setValue] = useState(config.value || 78);
-  const [target, setTarget] = useState(config.target || 100);
-  const [unit, setUnit] = useState(config.unit || "%");
+  const [value, setValue] = useState(String(config.value ?? "78"));
+  const [target, setTarget] = useState(String(config.target ?? "100"));
+  const [unit, setUnit] = useState(config.unit ?? "%");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, target, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, target, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setTarget(staticSnapshot.current.target);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setTarget(`{{row.${detected[2].key}}}`);
+      if (detected.length >= 4) setUnit(`{{row.${detected[3].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
-    onSave({ title, value, target, unit });
+    onSave({
+      title: title.trim() || "Quarterly Goal",
+      value: value.trim() || "78",
+      target: target.trim() || "100",
+      unit: unit.trim() || "%",
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, target, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    target: setTarget,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <HbTextFieldList
+      fields={FIELDS}
+      fieldValues={fieldValues}
+      fieldSetters={fieldSetters}
+      isPgrest={isPgrest}
+      dictionary={dictionary}
+    />
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="sp-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
   return (
-    <DashletSettingsWrapper
+    <SettingsModalShell
       isOpen={isOpen}
       onClose={onClose}
       onSave={handleSave}
       dictionary={dictionary}
-    >
-      <SettingsTextField
-        id="title"
-        label="Title"
-        value={title}
-        onChange={setTitle}
-      />
-      <SettingsFieldGrid cols={3}>
-        <SettingsNumberField
-          id="value"
-          label="Value"
-          value={value}
-          onChange={setValue}
-        />
-        <SettingsNumberField
-          id="target"
-          label="Target"
-          value={target}
-          onChange={setTarget}
-        />
-        <SettingsTextField
-          id="unit"
-          label="Unit"
-          value={unit}
-          onChange={setUnit}
-        />
-      </SettingsFieldGrid>
-    </DashletSettingsWrapper>
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.settings.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
 const FIELDS = [
   { id: "sp-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Quarterly Goal" },
@@ -17,81 +11,14 @@ const FIELDS = [
   { id: "sp-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "target", "unit"] as const;
-
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Quarterly Goal");
-  const [value, setValue] = useState(String(config.value ?? "78"));
-  const [target, setTarget] = useState(String(config.target ?? "100"));
-  const [unit, setUnit] = useState(config.unit ?? "%");
-
-  const fieldValues = { title, value, target, unit };
-  const fieldSetters = { title: setTitle, value: setValue, target: setTarget, unit: setUnit };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Quarterly Goal",
-      value: value.trim() || "78",
-      target: target.trim() || "100",
-      unit: unit.trim() || "%",
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <HbTextFieldList
-      fields={FIELDS}
-      fieldValues={fieldValues}
-      fieldSetters={fieldSetters}
-      isPgrest={isPgrest}
-      dictionary={dictionary}
-    />
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="sp-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
-
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="sp"
+      settingsProps={props}
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -67,14 +67,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.target, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -115,9 +115,9 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
         {/* Labels */}
         <div className="mt-1 flex justify-between text-xs text-gray-400">
           <span>0</span>
-          <span>25</span>
-          <span>50</span>
-          <span>75</span>
+          <span>{Math.round(target * 0.25)}</span>
+          <span>{Math.round(target * 0.5)}</span>
+          <span>{Math.round(target * 0.75)}</span>
           <span>{target}</span>
         </div>
       </div>

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
@@ -32,6 +31,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Quarterly Goal", value: "78", target: "100", unit: "%" };
+
 // ============================================================================
 // Component - Style 7: Progress Bar
 // ============================================================================
@@ -52,17 +53,7 @@ function getBarColor(percentage: number): string {
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Quarterly Goal",
-      value: String(config.value ?? "78"),
-      target: String(config.target ?? "100"),
-      unit: config.unit ?? "%",
-    }),
-    [config.title, config.value, config.target, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -8,15 +14,20 @@ import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 
 export interface DashletConfig {
   title: string;
-  value: number;
-  target: number;
+  value: string;
+  target: string;
   unit: string;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Quarterly Goal",
-  value: 78,
-  target: 100,
+  value: "78",
+  target: "100",
   unit: "%",
 };
 
@@ -48,9 +59,50 @@ function getBarColor(percentage: number): string {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, target, unit } = config;
 
-  const percentage = Math.min(100, (value / target) * 100);
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Quarterly Goal",
+      value: String(config.value ?? "78"),
+      target: String(config.target ?? "100"),
+      unit: config.unit ?? "%",
+    }),
+    [config.title, config.value, config.target, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Quarterly Goal";
+  const unit = resolved.unit ?? "%";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const parsedTarget = resolved.target === "" || resolved.target == null ? Number.NaN : Number(resolved.target);
+  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
+  const target = Number.isFinite(parsedTarget) ? parsedTarget : 100;
+
+  const percentage = target > 0 ? Math.min(100, (value / target) * 100) : 0;
   const barColor = getBarColor(percentage);
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -2,23 +2,18 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   target: string;
   unit: string;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -74,33 +71,18 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Quarterly Goal";
   const unit = resolved.unit ?? "%";
-  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
-  const parsedTarget = resolved.target === "" || resolved.target == null ? Number.NaN : Number(resolved.target);
-  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
-  const target = Number.isFinite(parsedTarget) ? parsedTarget : 100;
+  const value = parseResolvedNumber(resolved.value);
+  const target = parseResolvedNumber(resolved.target, 100);
 
   const percentage = target > 0 ? Math.min(100, (value / target) * 100) : 0;
   const barColor = getBarColor(percentage);

--- a/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_progress/dashlet.tsx
@@ -77,7 +77,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const value = parseResolvedNumber(resolved.value);
   const target = parseResolvedNumber(resolved.target, 100);
 
-  const percentage = target > 0 ? Math.min(100, (value / target) * 100) : 0;
+  const percentage = target > 0 ? Math.max(0, Math.min(100, (value / target) * 100)) : 0;
   const barColor = getBarColor(percentage);
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
@@ -1,10 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Label, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import { DashletSettingsWrapper, SettingsTitleValueUnit } from "../common";
+import {
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
+} from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
+
+const FIELDS = [
+  { id: "ss-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Account Balance" },
+  { id: "ss-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.balance}}", staticPlaceholder: "125847.32" },
+  { id: "ss-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.currency}}", staticPlaceholder: "$" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -13,31 +30,76 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
   const [title, setTitle] = useState(config.title || "Account Balance");
-  const [value, setValue] = useState(config.value || 125847.32);
-  const [unit, setUnit] = useState(config.unit || "$");
+  const [value, setValue] = useState(String(config.value ?? "125847.32"));
+  const [unit, setUnit] = useState(config.unit ?? "$");
   const [isSensitive, setIsSensitive] = useState(config.isSensitive ?? true);
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
-    onSave({ title, value, unit, isSensitive });
+    onSave({
+      title: title.trim() || "Account Balance",
+      value: value.trim() || "125847.32",
+      unit: unit.trim() || "$",
+      isSensitive,
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
-  return (
-    <DashletSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-    >
-      <SettingsTitleValueUnit
-        title={title}
-        onTitleChange={setTitle}
-        value={value}
-        onValueChange={setValue}
-        unit={unit}
-        onUnitChange={setUnit}
-        valueStep="0.01"
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <>
+      <HbTextFieldList
+        fields={FIELDS}
+        fieldValues={fieldValues}
+        fieldSetters={fieldSetters}
+        isPgrest={isPgrest}
         dictionary={dictionary}
       />
       <div className="flex items-center justify-between rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700">
@@ -51,6 +113,30 @@ export function DashletSettings({
           label=""
         />
       </div>
-    </DashletSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="ss-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
@@ -1,26 +1,23 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Label, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const FIELDS = [
   { id: "ss-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Account Balance" },
   { id: "ss-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.balance}}", staticPlaceholder: "125847.32" },
   { id: "ss-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.currency}}", staticPlaceholder: "$" },
 ] as const;
+
+const FIELD_NAMES = ["title", "value", "unit"] as const;
 
 export function DashletSettings({
   isOpen,
@@ -29,39 +26,28 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Account Balance");
   const [value, setValue] = useState(String(config.value ?? "125847.32"));
   const [unit, setUnit] = useState(config.unit ?? "$");
   const [isSensitive, setIsSensitive] = useState(config.isSensitive ?? true);
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, unit });
+  const fieldValues = { title, value, unit };
+  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -70,22 +56,9 @@ export function DashletSettings({
       value: value.trim() || "125847.32",
       unit: unit.trim() || "$",
       isSensitive,
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
@@ -4,12 +4,7 @@ import { useState } from "react";
 import { Label, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings } from "../common";
 
 const FIELDS = [
   { id: "ss-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Account Balance" },
@@ -17,94 +12,32 @@ const FIELDS = [
   { id: "ss-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.currency}}", staticPlaceholder: "$" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "unit"] as const;
-
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(config.title || "Account Balance");
-  const [value, setValue] = useState(String(config.value ?? "125847.32"));
-  const [unit, setUnit] = useState(config.unit ?? "$");
-  const [isSensitive, setIsSensitive] = useState(config.isSensitive ?? true);
-
-  const fieldValues = { title, value, unit };
-  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    onSave({
-      title: title.trim() || "Account Balance",
-      value: value.trim() || "125847.32",
-      unit: unit.trim() || "$",
-      isSensitive,
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <>
-      <HbTextFieldList
-        fields={FIELDS}
-        fieldValues={fieldValues}
-        fieldSetters={fieldSetters}
-        isPgrest={isPgrest}
-        dictionary={dictionary}
-      />
-      <div className="flex items-center justify-between rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700">
-        <div>
-          <Label className="text-sm font-medium">Hidden by default</Label>
-          <p className="text-xs text-gray-500">User must click to reveal</p>
-        </div>
-        <ToggleSwitch
-          checked={isSensitive}
-          onChange={setIsSensitive}
-          label=""
-        />
-      </div>
-    </>
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="ss-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
+  const [isSensitive, setIsSensitive] = useState(
+    props.config.isSensitive ?? true,
   );
 
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="ss"
+      settingsProps={props}
+      extraSaveFields={{ isSensitive }}
+      extraVisualization={
+        <div className="flex items-center justify-between rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700">
+          <div>
+            <Label className="text-sm font-medium">Hidden by default</Label>
+            <p className="text-xs text-gray-500">User must click to reveal</p>
+          </div>
+          <ToggleSwitch
+            checked={isSensitive}
+            onChange={setIsSensitive}
+            label=""
+          />
+        </div>
+      }
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.settings.tsx
@@ -10,10 +10,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -30,11 +29,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
   const [title, setTitle] = useState(config.title || "Account Balance");
   const [value, setValue] = useState(String(config.value ?? "125847.32"));
   const [unit, setUnit] = useState(config.unit ?? "$");

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { HiEye, HiEyeSlash } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
@@ -33,6 +33,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Account Balance", value: "125847.32", unit: "$" };
+
 // ============================================================================
 // Component - Style 10: Sensitive Data (Hidden by default)
 // ============================================================================
@@ -45,16 +47,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const isSensitive = config.isSensitive ?? true;
   const [isHidden, setIsHidden] = useState(isSensitive);
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Account Balance",
-      value: String(config.value ?? "125847.32"),
-      unit: config.unit ?? "$",
-    }),
-    [config.title, config.value, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import { HiEye, HiEyeSlash } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -66,26 +63,13 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Account Balance";
   const unit = resolved.unit ?? "$";

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState } from "react";
-import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import { useState, useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import { HiEye, HiEyeSlash } from "react-icons/hi2";
+import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -10,14 +15,19 @@ import { HiEye, HiEyeSlash } from "react-icons/hi2";
 
 export interface DashletConfig {
   title: string;
-  value: number;
+  value: string;
   unit: string;
   isSensitive: boolean;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Account Balance",
-  value: 125847.32,
+  value: "125847.32",
   unit: "$",
   isSensitive: true,
 };
@@ -40,15 +50,54 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, unit, isSensitive } = config;
+  const isSensitive = config.isSensitive ?? true;
   const [isHidden, setIsHidden] = useState(isSensitive);
 
-  const displayValue = isHidden
-    ? "••••••"
-    : `${unit}${value.toLocaleString(undefined, {
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Account Balance",
+      value: String(config.value ?? "125847.32"),
+      unit: config.unit ?? "$",
+    }),
+    [config.title, config.value, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Account Balance";
+  const unit = resolved.unit ?? "$";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const formattedValue = Number.isFinite(parsedValue)
+    ? `${unit}${parsedValue.toLocaleString(undefined, {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
-      })}`;
+      })}`
+    : `${unit}${resolved.value}`;
+
+  const displayValue = isHidden ? "••••••" : formattedValue;
 
   return (
     <div className="flex h-full flex-col justify-center rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
@@ -3,23 +3,18 @@
 import { useState, useMemo } from "react";
 import { HiEye, HiEyeSlash } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   unit: string;
   isSensitive: boolean;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sensitive/dashlet.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { HiEye, HiEyeSlash } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -59,14 +59,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
@@ -1,27 +1,24 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
   HbTextFieldList,
   SettingsTextField,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
 import { tr } from "@/features/i18n/tr.service";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const FIELDS = [
   { id: "sk-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Page Views" },
   { id: "sk-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "24567" },
   { id: "sk-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
 ] as const;
+
+const FIELD_NAMES = ["title", "value", "unit"] as const;
 
 export function DashletSettings({
   isOpen,
@@ -30,8 +27,6 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
-
   const [title, setTitle] = useState(
     config.title || tr("dashboard.defaults.pageViews", dictionary)
   );
@@ -42,34 +37,24 @@ export function DashletSettings({
       ", "
     )
   );
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
-  const staticSnapshot = useRef({ title, value, unit });
+  const fieldValues = { title, value, unit };
+  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, value, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setValue(staticSnapshot.current.value);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
-      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -82,22 +67,9 @@ export function DashletSettings({
       value: value.trim() || "24567",
       unit: unit.trim(),
       sparkline: sparkline.length > 0 ? sparkline : [50, 50],
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, value, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    value: setValue,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
@@ -1,14 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
 import {
-  DashletSettingsWrapper,
+  HbTextFieldList,
   SettingsTextField,
-  SettingsTitleValueUnit,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 import { tr } from "@/features/i18n/tr.service";
+
+type SimpleDataMode = "static" | "pgrest";
+
+const FIELDS = [
+  { id: "sk-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Page Views" },
+  { id: "sk-value", labelKey: "common.value", state: "value", hbPlaceholder: "{{row.count}}", staticPlaceholder: "24567" },
+  { id: "sk-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
+] as const;
 
 export function DashletSettings({
   isOpen,
@@ -17,16 +31,51 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(
     config.title || tr("dashboard.defaults.pageViews", dictionary)
   );
-  const [value, setValue] = useState(config.value || 24567);
-  const [unit, setUnit] = useState(config.unit || "");
+  const [value, setValue] = useState(String(config.value ?? "24567"));
+  const [unit, setUnit] = useState(config.unit ?? "");
   const [sparklineText, setSparklineText] = useState(
     (config.sparkline || [30, 45, 35, 50, 40, 60, 55, 70, 65, 80, 75, 90]).join(
       ", "
     )
   );
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
+
+  const staticSnapshot = useRef({ title, value, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setUnit(`{{row.${detected[2].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
     const sparkline = sparklineText
@@ -34,28 +83,35 @@ export function DashletSettings({
       .map((s) => Number(s.trim()))
       .filter((n) => !Number.isNaN(n));
     onSave({
-      title,
-      value,
-      unit,
+      title: title.trim() || "Page Views",
+      value: value.trim() || "24567",
+      unit: unit.trim(),
       sparkline: sparkline.length > 0 ? sparkline : [50, 50],
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     });
     onClose();
   };
 
-  return (
-    <DashletSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-    >
-      <SettingsTitleValueUnit
-        title={title}
-        onTitleChange={setTitle}
-        value={value}
-        onValueChange={setValue}
-        unit={unit}
-        onUnitChange={setUnit}
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, value, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    value: setValue,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <>
+      <HbTextFieldList
+        fields={FIELDS}
+        fieldValues={fieldValues}
+        fieldSetters={fieldSetters}
+        isPgrest={isPgrest}
         dictionary={dictionary}
       />
       <SettingsTextField
@@ -65,6 +121,30 @@ export function DashletSettings({
         onChange={setSparklineText}
         placeholder="30, 45, 50, 60..."
       />
-    </DashletSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="sk-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig } from "./dashlet";
-import {
-  HbTextFieldList,
-  SettingsTextField,
-  PgrestDataTab,
-  useSimplePgrestSettings,
-} from "../common";
-import { SettingsModalShell } from "../common/settings-modal-shell";
+import { SimpleDashletSettings, SettingsTextField } from "../common";
 import { tr } from "@/features/i18n/tr.service";
 
 const FIELDS = [
@@ -18,100 +12,38 @@ const FIELDS = [
   { id: "sk-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "" },
 ] as const;
 
-const FIELD_NAMES = ["title", "value", "unit"] as const;
+const DEFAULT_SPARKLINE = [30, 45, 35, 50, 40, 60, 55, 70, 65, 80, 75, 90];
 
-export function DashletSettings({
-  isOpen,
-  onClose,
-  config,
-  onSave,
-  dictionary,
-}: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const [title, setTitle] = useState(
-    config.title || tr("dashboard.defaults.pageViews", dictionary)
-  );
-  const [value, setValue] = useState(String(config.value ?? "24567"));
-  const [unit, setUnit] = useState(config.unit ?? "");
+export function DashletSettings(
+  props: Readonly<DashletSettingsProps<DashletConfig>>,
+) {
+  const { config, dictionary } = props;
   const [sparklineText, setSparklineText] = useState(
-    (config.sparkline || [30, 45, 35, 50, 40, 60, 55, 70, 65, 80, 75, 90]).join(
-      ", "
-    )
+    (config.sparkline || DEFAULT_SPARKLINE).join(", "),
   );
 
-  const fieldValues = { title, value, unit };
-  const fieldSetters = { title: setTitle, value: setValue, unit: setUnit };
-
-  const {
-    isPgrest,
-    activeProviders,
-    dataMode,
-    dataSourceId,
-    setDataSourceId,
-    pg,
-    handleDataModeChange,
-    pgrestSaveFields,
-  } = useSimplePgrestSettings({
-    config,
-    fieldNames: FIELD_NAMES,
-    fieldValues,
-    fieldSetters,
-  });
-
-  const handleSave = () => {
-    const sparkline = sparklineText
-      .split(",")
-      .map((s) => Number(s.trim()))
-      .filter((n) => !Number.isNaN(n));
-    onSave({
-      title: title.trim() || "Page Views",
-      value: value.trim() || "24567",
-      unit: unit.trim(),
-      sparkline: sparkline.length > 0 ? sparkline : [50, 50],
-      ...pgrestSaveFields,
-    });
-    onClose();
-  };
-
-  const visualizationTab = (
-    <>
-      <HbTextFieldList
-        fields={FIELDS}
-        fieldValues={fieldValues}
-        fieldSetters={fieldSetters}
-        isPgrest={isPgrest}
-        dictionary={dictionary}
-      />
-      <SettingsTextField
-        id="sparkline"
-        label={tr("dashboard.settings.sparklineData", dictionary)}
-        value={sparklineText}
-        onChange={setSparklineText}
-        placeholder="30, 45, 50, 60..."
-      />
-    </>
-  );
-
-  const dataTab = (
-    <PgrestDataTab
-      id="sk-data-mode"
-      dataMode={dataMode}
-      onDataModeChange={handleDataModeChange}
-      pgrest={pg}
-      dictionary={dictionary}
-      dataSourceId={dataSourceId}
-      onDataSourceIdChange={setDataSourceId}
-      activeProviders={activeProviders}
-    />
-  );
+  const sparkline = sparklineText
+    .split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => !Number.isNaN(n));
 
   return (
-    <SettingsModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dictionary={dictionary}
-      visualizationTab={visualizationTab}
-      dataTab={dataTab}
+    <SimpleDashletSettings
+      fields={FIELDS}
+      idPrefix="sk"
+      settingsProps={props}
+      extraSaveFields={{
+        sparkline: sparkline.length > 0 ? sparkline : [50, 50],
+      }}
+      extraVisualization={
+        <SettingsTextField
+          id="sparkline"
+          label={tr("dashboard.settings.sparklineData", dictionary)}
+          value={sparklineText}
+          onChange={setSparklineText}
+          placeholder="30, 45, 50, 60..."
+        />
+      }
     />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.settings.tsx
@@ -10,10 +10,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 import { tr } from "@/features/i18n/tr.service";
 
 type SimpleDataMode = "static" | "pgrest";
@@ -31,11 +30,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(
     config.title || tr("dashboard.defaults.pageViews", dictionary)

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
@@ -32,6 +31,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Page Views", value: "24567", unit: "" };
+
 // ============================================================================
 // Component - Style 9: Sparkline
 // ============================================================================
@@ -43,16 +44,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
   const sparkline = config.sparkline || defaultConfig.sparkline;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Page Views",
-      value: String(config.value ?? "24567"),
-      unit: config.unit ?? "",
-    }),
-    [config.title, config.value, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -8,14 +14,19 @@ import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 
 export interface DashletConfig {
   title: string;
-  value: number;
+  value: string;
   unit: string;
   sparkline: number[];
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
   title: "Page Views",
-  value: 24567,
+  value: "24567",
   unit: "",
   sparkline: [30, 45, 35, 50, 40, 60, 55, 70, 65, 80, 75, 90],
 };
@@ -38,7 +49,46 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, value, unit, sparkline } = config;
+  const sparkline = config.sparkline || defaultConfig.sparkline;
+
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Page Views",
+      value: String(config.value ?? "24567"),
+      unit: config.unit ?? "",
+    }),
+    [config.title, config.value, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Page Views";
+  const unit = resolved.unit ?? "";
+  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
+  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
 
   const min = Math.min(...sparkline);
   const max = Math.max(...sparkline);

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -64,31 +61,17 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Page Views";
   const unit = resolved.unit ?? "";
-  const parsedValue = resolved.value === "" || resolved.value == null ? Number.NaN : Number(resolved.value);
-  const value = Number.isFinite(parsedValue) ? parsedValue : 0;
+  const value = parseResolvedNumber(resolved.value);
 
   const min = Math.min(...sparkline);
   const max = Math.max(...sparkline);

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
@@ -2,23 +2,18 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
 // ============================================================================
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   unit: string;
   sparkline: number[];
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_sparkline/dashlet.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError, parseResolvedNumber } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError, parseResolvedNumber } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -57,14 +57,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.value, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
@@ -1,25 +1,20 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Button, TextInput, Label, ToggleSwitch } from "flowbite-react";
 import { HiPlus, HiTrash } from "react-icons/hi2";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, BarColor } from "./dashlet";
 import {
   HbTextFieldList,
-  usePgrestSettingsState,
-  fromPgrestParamItems,
-  buildSimplePgrestConfig,
   PgrestDataTab,
-  useActiveProviders,
+  useSimplePgrestSettings,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
 import {
   ColorPickerDropdown,
   type ColorOption,
 } from "@/features/common/components/color-picker-dropdown";
-
-type SimpleDataMode = "static" | "pgrest";
 
 const COLOR_OPTIONS: ColorOption<BarColor>[] = [
   {
@@ -62,6 +57,8 @@ const FIELDS = [
   { id: "st-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
 ] as const;
 
+const FIELD_NAMES = ["title", "unit"] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -69,19 +66,9 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const activeProviders = useActiveProviders();
-
   const [title, setTitle] = useState(config.title || "Traffic Sources");
   const [unit, setUnit] = useState(config.unit ?? "%");
   const [showHeader, setShowHeader] = useState(config.showHeader ?? true);
-  const [dataMode, setDataMode] = useState<SimpleDataMode>(
-    config.dataMode === "static" || config.dataMode === "pgrest"
-      ? config.dataMode
-      : "static",
-  );
-  const [dataSourceId, setDataSourceId] = useState<string>(
-    config.dataSourceId ?? ""
-  );
 
   // Initialize items with unique IDs
   const initializeItems = (): StackItem[] => {
@@ -97,23 +84,23 @@ export function DashletSettings({
 
   const [items, setItems] = useState(initializeItems);
 
-  const staticSnapshot = useRef({ title, unit });
+  const fieldValues = { title, unit };
+  const fieldSetters = { title: setTitle, unit: setUnit };
 
-  const handleDataModeChange = (mode: SimpleDataMode) => {
-    if (mode === "pgrest" && dataMode === "static") {
-      staticSnapshot.current = { title, unit };
-    } else if (mode === "static" && dataMode === "pgrest") {
-      setTitle(staticSnapshot.current.title);
-      setUnit(staticSnapshot.current.unit);
-    }
-    setDataMode(mode);
-  };
-
-  const pg = usePgrestSettingsState({
-    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
-      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
-      if (detected.length >= 2) setUnit(`{{row.${detected[1].key}}}`);
-    }),
+  const {
+    isPgrest,
+    activeProviders,
+    dataMode,
+    dataSourceId,
+    setDataSourceId,
+    pg,
+    handleDataModeChange,
+    pgrestSaveFields,
+  } = useSimplePgrestSettings({
+    config,
+    fieldNames: FIELD_NAMES,
+    fieldValues,
+    fieldSetters,
   });
 
   const handleSave = () => {
@@ -127,11 +114,7 @@ export function DashletSettings({
       items: itemsToSave,
       unit: unit.trim() || "%",
       showHeader,
-      dataMode,
-      pgrestFunctionName: pg.pgrestFunctionName,
-      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
-      pgrestHttpMethod: pg.pgrestHttpMethod,
-      dataSourceId: dataSourceId || undefined,
+      ...pgrestSaveFields,
     });
     onClose();
   };
@@ -160,14 +143,6 @@ export function DashletSettings({
     setItems(
       items.map((item) => (item.id === id ? { ...item, [field]: val } : item))
     );
-  };
-
-  const isPgrest = dataMode === "pgrest";
-
-  const fieldValues: Record<string, string> = { title, unit };
-  const fieldSetters: Record<string, (v: string) => void> = {
-    title: setTitle,
-    unit: setUnit,
   };
 
   const visualizationTab = (

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
@@ -11,10 +11,9 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 import {
   ColorPickerDropdown,
   type ColorOption,
@@ -70,11 +69,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title || "Traffic Sources");
   const [unit, setUnit] = useState(config.unit ?? "%");

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.settings.tsx
@@ -1,19 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button, TextInput, Label, ToggleSwitch } from "flowbite-react";
 import { HiPlus, HiTrash } from "react-icons/hi2";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, BarColor } from "./dashlet";
 import {
-  DashletSettingsWrapper,
-  SettingsTextField,
-  SettingsFieldGrid,
+  HbTextFieldList,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 import {
   ColorPickerDropdown,
   type ColorOption,
 } from "@/features/common/components/color-picker-dropdown";
+
+type SimpleDataMode = "static" | "pgrest";
 
 const COLOR_OPTIONS: ColorOption<BarColor>[] = [
   {
@@ -51,6 +58,11 @@ interface StackItem {
   color: BarColor;
 }
 
+const FIELDS = [
+  { id: "st-title", labelKey: "common.title", state: "title", hbPlaceholder: "{{row.label}}", staticPlaceholder: "Traffic Sources" },
+  { id: "st-unit", labelKey: "common.unit", state: "unit", hbPlaceholder: "{{row.unit}}", staticPlaceholder: "%" },
+] as const;
+
 export function DashletSettings({
   isOpen,
   onClose,
@@ -58,9 +70,23 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(config.title || "Traffic Sources");
-  const [unit, setUnit] = useState(config.unit || "%");
+  const [unit, setUnit] = useState(config.unit ?? "%");
   const [showHeader, setShowHeader] = useState(config.showHeader ?? true);
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   // Initialize items with unique IDs
   const initializeItems = (): StackItem[] => {
@@ -76,13 +102,42 @@ export function DashletSettings({
 
   const [items, setItems] = useState(initializeItems);
 
+  const staticSnapshot = useRef({ title, unit });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, unit };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setUnit(staticSnapshot.current.unit);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setUnit(`{{row.${detected[1].key}}}`);
+    }),
+  });
+
   const handleSave = () => {
     const itemsToSave = items.map(({ label, value, color }) => ({
       label,
       value,
       color,
     }));
-    onSave({ title, items: itemsToSave, unit, showHeader });
+    onSave({
+      title: title.trim() || "Traffic Sources",
+      items: itemsToSave,
+      unit: unit.trim() || "%",
+      showHeader,
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
+    });
     onClose();
   };
 
@@ -112,15 +167,16 @@ export function DashletSettings({
     );
   };
 
-  return (
-    <DashletSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      width="w-80"
-      scrollable
-      dictionary={dictionary}
-    >
+  const isPgrest = dataMode === "pgrest";
+
+  const fieldValues: Record<string, string> = { title, unit };
+  const fieldSetters: Record<string, (v: string) => void> = {
+    title: setTitle,
+    unit: setUnit,
+  };
+
+  const visualizationTab = (
+    <>
       <div className="flex items-center justify-between py-1">
         <Label className="text-sm font-medium">Show Header</Label>
         <div className="shrink-0">
@@ -132,22 +188,13 @@ export function DashletSettings({
         </div>
       </div>
 
-      {showHeader && (
-        <SettingsFieldGrid cols={2}>
-          <SettingsTextField
-            id="title"
-            label="Title"
-            value={title}
-            onChange={setTitle}
-          />
-          <SettingsTextField
-            id="unit"
-            label="Unit"
-            value={unit}
-            onChange={setUnit}
-          />
-        </SettingsFieldGrid>
-      )}
+      <HbTextFieldList
+        fields={FIELDS}
+        fieldValues={fieldValues}
+        fieldSetters={fieldSetters}
+        isPgrest={isPgrest}
+        dictionary={dictionary}
+      />
 
       <div className="space-y-2">
         <div className="flex items-center justify-between">
@@ -202,6 +249,30 @@ export function DashletSettings({
           </div>
         ))}
       </div>
-    </DashletSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <PgrestDataTab
+      id="st-data-mode"
+      dataMode={dataMode}
+      onDataModeChange={handleDataModeChange}
+      pgrest={pg}
+      dictionary={dictionary}
+      dataSourceId={dataSourceId}
+      onDataSourceIdChange={setDataSourceId}
+      activeProviders={activeProviders}
+    />
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
@@ -17,16 +17,11 @@ export type BarColor =
   | "bg-red-500 dark:bg-red-400"
   | "bg-cyan-500 dark:bg-cyan-400";
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   items: { label: string; value: number; color: BarColor }[];
   unit: string;
   showHeader: boolean;
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields } from "../common";
-
-const EMPTY_PARAMS: PgrestParam[] = [];
+import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -76,26 +73,13 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode: (config.dataMode as "static" | "pgrest") || "static",
     pgrestFunctionName: config.pgrestFunctionName || "",
     pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
     fields,
     dataSourceId: config.dataSourceId,
   });
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const title = resolved.title || "Traffic Sources";
   const unit = resolved.unit ?? "%";

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestDashletFields } from "../common";
 import { useDashletPgrest, DashletLoading, DashletError } from "../common";
@@ -45,6 +44,8 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
   return layoutDefaults;
 }
 
+const FIELD_DEFAULTS: Record<string, string> = { title: "Traffic Sources", unit: "%" };
+
 // ============================================================================
 // Component - Style 8: Stacked Bars
 // ============================================================================
@@ -56,15 +57,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
   const { items, showHeader = true } = config;
 
-  const fields = useMemo(
-    () => ({
-      title: config.title || "Traffic Sources",
-      unit: config.unit ?? "%",
-    }),
-    [config.title, config.unit],
-  );
-
-  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
+  const { resolved, loading, fetchError } = useDashletPgrest(config, FIELD_DEFAULTS);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestResolvedFields } from "../common";
+
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Configuration Types
@@ -19,6 +25,11 @@ export interface DashletConfig {
   items: { label: string; value: number; color: BarColor }[];
   unit: string;
   showHeader: boolean;
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
@@ -51,8 +62,43 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
  */
 export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
   const config = widget.config as unknown as DashletConfig;
-  const { title, items, unit, showHeader = true } = config;
+  const { items, showHeader = true } = config;
 
+  const fields = useMemo(
+    () => ({
+      title: config.title || "Traffic Sources",
+      unit: config.unit ?? "%",
+    }),
+    [config.title, config.unit],
+  );
+
+  const { resolved, loading, fetchError } = usePgrestResolvedFields({
+    dataMode: (config.dataMode as "static" | "pgrest") || "static",
+    pgrestFunctionName: config.pgrestFunctionName || "",
+    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
+    pgrestParams: config.pgrestParams || EMPTY_PARAMS,
+    fields,
+    dataSourceId: config.dataSourceId,
+  });
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const title = resolved.title || "Traffic Sources";
+  const unit = resolved.unit ?? "%";
   const total = items.reduce((sum, item) => sum + item.value, 0);
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_stacked/dashlet.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestResolvedFields, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
+import { useDashletPgrest, DashletLoading, DashletError } from "../common";
 
 // ============================================================================
 // Configuration Types
@@ -69,14 +69,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     [config.title, config.unit],
   );
 
-  const { resolved, loading, fetchError } = usePgrestResolvedFields({
-    dataMode: (config.dataMode as "static" | "pgrest") || "static",
-    pgrestFunctionName: config.pgrestFunctionName || "",
-    pgrestHttpMethod: config.pgrestHttpMethod || "POST",
-    pgrestParams: config.pgrestParams || EMPTY_PGREST_PARAMS,
-    fields,
-    dataSourceId: config.dataSourceId,
-  });
+  const { resolved, loading, fetchError } = useDashletPgrest(config, fields);
 
   if (loading) return <DashletLoading />;
   if (fetchError) return <DashletError message={fetchError} />;

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { Button, TextInput } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type {
   DashletConfig,
@@ -13,8 +14,16 @@ import {
   SettingsSelectField,
   HbTextField,
   useDataProvider,
-  TabbedSettingsWrapper,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
 
 export function DashletSettings({
   isOpen,
@@ -23,13 +32,48 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [title, setTitle] = useState(config.title ?? "Status");
   const [value, setValue] = useState(config.value ?? "0");
   const [subtitle, setSubtitle] = useState(config.subtitle ?? "");
   const [color, setColor] = useState<StatusColor>(config.color ?? "gray");
   const [icon, setIcon] = useState<StatusIcon>(config.icon ?? "check");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   const dp = useDataProvider(config.dataProvider ?? []);
+
+  const staticSnapshot = useRef({ title, value, subtitle });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { title, value, subtitle };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setTitle(staticSnapshot.current.title);
+      setValue(staticSnapshot.current.value);
+      setSubtitle(staticSnapshot.current.subtitle);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setTitle(`{{row.${detected[0].key}}}`);
+      if (detected.length >= 2) setValue(`{{row.${detected[1].key}}}`);
+      if (detected.length >= 3) setSubtitle(`{{row.${detected[2].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
     onSave({
@@ -39,18 +83,19 @@ export function DashletSettings({
       color,
       icon,
       dataProvider: dp.getCleanEntries(),
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     } as DashletConfig);
     onClose();
   };
 
-  return (
-    <TabbedSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dataProvider={dp}
-      dictionary={dictionary}
-    >
+  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
+
+  const visualizationTab = (
+    <>
       <HbTextField
         id="ss-title"
         label={tr("common.title", dictionary)}
@@ -86,6 +131,79 @@ export function DashletSettings({
         onChange={(v) => setIcon(v as StatusIcon)}
         options={ICON_OPTIONS.map((o) => ({ value: o.id, label: o.label }))}
       />
-    </TabbedSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <>
+      <PgrestDataTab
+        id="ss-data-mode"
+        dataMode={dataMode}
+        onDataModeChange={handleDataModeChange}
+        pgrest={pg}
+        dictionary={dictionary}
+        dataSourceId={dataSourceId}
+        onDataSourceIdChange={setDataSourceId}
+        activeProviders={activeProviders}
+      />
+      {/* Data provider entries */}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {tr("dashboard.settings.defineVariablesHint", dictionary, {
+          code: "{{data_provider.key}}",
+        })}
+      </p>
+      <div className="space-y-2">
+        {dp.dataProvider.map((entry, i) => (
+          <div
+            key={entry._id}
+            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
+          >
+            <TextInput
+              value={entry.key}
+              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
+              placeholder={tr("dashboard.settings.key", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <TextInput
+              value={entry.value}
+              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
+              placeholder={tr("common.value", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <Button
+              size="xs"
+              color="failure"
+              onClick={() => dp.removeEntry(i)}
+              onMouseDown={handleMouseDown}
+              className="no-drag shrink-0"
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        size="xs"
+        color="light"
+        onClick={dp.addEntry}
+        onMouseDown={handleMouseDown}
+        className="no-drag w-full"
+      >
+        {tr("dashboard.settings.addEntry", dictionary)}
+      </Button>
+    </>
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.settings.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Button, TextInput } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type {
   DashletConfig,
@@ -18,10 +17,10 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
+  DataProviderEntries,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -32,11 +31,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [title, setTitle] = useState(config.title ?? "Status");
   const [value, setValue] = useState(config.value ?? "0");
@@ -92,8 +87,6 @@ export function DashletSettings({
     onClose();
   };
 
-  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
-
   const visualizationTab = (
     <>
       <HbTextField
@@ -146,53 +139,7 @@ export function DashletSettings({
         onDataSourceIdChange={setDataSourceId}
         activeProviders={activeProviders}
       />
-      {/* Data provider entries */}
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        {tr("dashboard.settings.defineVariablesHint", dictionary, {
-          code: "{{data_provider.key}}",
-        })}
-      </p>
-      <div className="space-y-2">
-        {dp.dataProvider.map((entry, i) => (
-          <div
-            key={entry._id}
-            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
-          >
-            <TextInput
-              value={entry.key}
-              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
-              placeholder={tr("dashboard.settings.key", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <TextInput
-              value={entry.value}
-              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
-              placeholder={tr("common.value", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <Button
-              size="xs"
-              color="failure"
-              onClick={() => dp.removeEntry(i)}
-              onMouseDown={handleMouseDown}
-              className="no-drag shrink-0"
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-      <Button
-        size="xs"
-        color="light"
-        onClick={dp.addEntry}
-        onMouseDown={handleMouseDown}
-        className="no-drag w-full"
-      >
-        {tr("dashboard.settings.addEntry", dictionary)}
-      </Button>
+      <DataProviderEntries dataProvider={dp} dictionary={dictionary} />
     </>
   );
 

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
@@ -3,8 +3,8 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
-import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
+import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
+import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 import {
   HiWrench,
   HiCalendarDays,
@@ -175,24 +175,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataProvider = EMPTY_DATA_PROVIDER,
   } = config;
 
-  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
-
-  const { rows, loading, fetchError } = usePgrestRows(
-    dataMode,
-    config.pgrestFunctionName || "",
-    config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PGREST_PARAMS,
-    config.dataSourceId,
-  );
-
-  const templateContext = useMemo(() => {
-    const dpContext = buildDataProviderContext(dataProvider);
-    if (dataMode === "pgrest" && rows.length > 0) {
-      const firstRow = rows[0];
-      return { ...dpContext, row: firstRow, ...firstRow };
-    }
-    return dpContext;
-  }, [dataProvider, dataMode, rows]);
+  const { templateContext, loading, fetchError } = useHybridPgrestContext(config, dataProvider);
 
   const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
   const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 import {
@@ -82,18 +82,13 @@ export const COLOR_OPTIONS: ColorOption[] = [
   { id: "gray", label: "Gray" },
 ];
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   title: string;
   value: string;
   subtitle?: string;
   color: StatusColor;
   icon: StatusIcon;
   dataProvider?: DataProviderEntry[];
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestRows } from "../common";
 import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 import {
   HiWrench,
@@ -87,6 +90,11 @@ export interface DashletConfig {
   color: StatusColor;
   icon: StatusIcon;
   dataProvider?: DataProviderEntry[];
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
@@ -152,6 +160,7 @@ const COLOR_MAP: Record<
 };
 
 const EMPTY_DATA_PROVIDER: DataProviderEntry[] = [];
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Component
@@ -168,14 +177,44 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataProvider = EMPTY_DATA_PROVIDER,
   } = config;
 
-  const templateContext = useMemo(() => buildDataProviderContext(dataProvider), [dataProvider]);
+  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
 
-  const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
-  const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);
-  const compiledSubtitle = useMemo(() => {
-    if (!subtitle) return "";
-    return resolveHandlebarsField(subtitle, templateContext);
-  }, [subtitle, templateContext]);
+  const { rows, loading, fetchError } = usePgrestRows(
+    dataMode,
+    config.pgrestFunctionName || "",
+    config.pgrestHttpMethod || "POST",
+    config.pgrestParams || EMPTY_PARAMS,
+    config.dataSourceId,
+  );
+
+  const templateContext = useMemo(() => {
+    const dpContext = buildDataProviderContext(dataProvider);
+    if (dataMode === "pgrest" && rows.length > 0) {
+      const firstRow = rows[0];
+      return { ...dpContext, row: firstRow, ...firstRow };
+    }
+    return dpContext;
+  }, [dataProvider, dataMode, rows]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const compiledTitle = resolveHandlebarsField(title, templateContext);
+  const compiledValue = resolveHandlebarsField(value, templateContext);
+  const compiledSubtitle = subtitle ? resolveHandlebarsField(subtitle, templateContext) : "";
 
   const colors = COLOR_MAP[color] ?? COLOR_MAP.gray;
   const IconComponent = ICONS[icon] ?? ICONS.check;

--- a/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/stat_status/dashlet.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows } from "../common";
+import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 import {
   HiWrench,
@@ -160,7 +159,6 @@ const COLOR_MAP: Record<
 };
 
 const EMPTY_DATA_PROVIDER: DataProviderEntry[] = [];
-const EMPTY_PARAMS: PgrestParam[] = [];
 
 // ============================================================================
 // Component
@@ -183,7 +181,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode,
     config.pgrestFunctionName || "",
     config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PARAMS,
+    config.pgrestParams || EMPTY_PGREST_PARAMS,
     config.dataSourceId,
   );
 
@@ -196,25 +194,15 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     return dpContext;
   }, [dataProvider, dataMode, rows]);
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
+  const compiledTitle = useMemo(() => resolveHandlebarsField(title, templateContext), [title, templateContext]);
+  const compiledValue = useMemo(() => resolveHandlebarsField(value, templateContext), [value, templateContext]);
+  const compiledSubtitle = useMemo(() => {
+    if (!subtitle) return "";
+    return resolveHandlebarsField(subtitle, templateContext);
+  }, [subtitle, templateContext]);
 
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
-
-  const compiledTitle = resolveHandlebarsField(title, templateContext);
-  const compiledValue = resolveHandlebarsField(value, templateContext);
-  const compiledSubtitle = subtitle ? resolveHandlebarsField(subtitle, templateContext) : "";
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
 
   const colors = COLOR_MAP[color] ?? COLOR_MAP.gray;
   const IconComponent = ICONS[icon] ?? ICONS.check;

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Button, Label, Textarea, TextInput, ToggleSwitch } from "flowbite-react";
+import { Label, Textarea, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, TextAlign } from "./dashlet";
 import { tr } from "@/features/i18n/tr.service";
@@ -14,10 +14,10 @@ import {
   fromPgrestParamItems,
   buildSimplePgrestConfig,
   PgrestDataTab,
+  useActiveProviders,
+  DataProviderEntries,
 } from "../common";
 import { SettingsModalShell } from "../common/settings-modal-shell";
-import { useDashboard } from "@/features/dashboard/context/dashboard-context";
-import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
 
 type SimpleDataMode = "static" | "pgrest";
 
@@ -28,11 +28,7 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
-  const { siteId } = useDashboard();
-  const { dataSources } = useDataSources(siteId ?? undefined);
-  const activeProviders = dataSources.filter(
-    (ds) => ds.isActive === true && ds.lastTestResult === true
-  );
+  const activeProviders = useActiveProviders();
 
   const [text, setText] = useState(config.text ?? "Add your text or quote here...");
   const [italic, setItalic] = useState(config.italic ?? true);
@@ -80,7 +76,6 @@ export function DashletSettings({
     onClose();
   };
 
-  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
   const textStatus = getHandlebarsStatus(text);
 
   const visualizationTab = (
@@ -133,53 +128,7 @@ export function DashletSettings({
         onDataSourceIdChange={setDataSourceId}
         activeProviders={activeProviders}
       />
-      {/* Data provider entries */}
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        {tr("dashboard.settings.defineVariablesHint", dictionary, {
-          code: "{{data_provider.key}}",
-        })}
-      </p>
-      <div className="space-y-2">
-        {dp.dataProvider.map((entry, i) => (
-          <div
-            key={entry._id}
-            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
-          >
-            <TextInput
-              value={entry.key}
-              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
-              placeholder={tr("dashboard.settings.key", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <TextInput
-              value={entry.value}
-              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
-              placeholder={tr("common.value", dictionary)}
-              sizing="sm"
-              className="flex-1"
-            />
-            <Button
-              size="xs"
-              color="failure"
-              onClick={() => dp.removeEntry(i)}
-              onMouseDown={handleMouseDown}
-              className="no-drag shrink-0"
-            >
-              ✕
-            </Button>
-          </div>
-        ))}
-      </div>
-      <Button
-        size="xs"
-        color="light"
-        onClick={dp.addEntry}
-        onMouseDown={handleMouseDown}
-        className="no-drag w-full"
-      >
-        {tr("dashboard.settings.addEntry", dictionary)}
-      </Button>
+      <DataProviderEntries dataProvider={dp} dictionary={dictionary} />
     </>
   );
 

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
@@ -4,7 +4,6 @@ import { useRef, useState } from "react";
 import { Label, Textarea, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, TextAlign } from "./dashlet";
-import { tr } from "@/features/i18n/tr.service";
 import {
   SettingsSelectField,
   getHandlebarsStatus,

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.settings.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { Label, Textarea, ToggleSwitch } from "flowbite-react";
+import { useRef, useState } from "react";
+import { Button, Label, Textarea, TextInput, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, TextAlign } from "./dashlet";
+import { tr } from "@/features/i18n/tr.service";
 import {
   SettingsSelectField,
   getHandlebarsStatus,
   getFlowbiteColor,
   useDataProvider,
-  TabbedSettingsWrapper,
+  usePgrestSettingsState,
+  fromPgrestParamItems,
+  buildSimplePgrestConfig,
+  PgrestDataTab,
 } from "../common";
+import { SettingsModalShell } from "../common/settings-modal-shell";
+import { useDashboard } from "@/features/dashboard/context/dashboard-context";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+
+type SimpleDataMode = "static" | "pgrest";
 
 export function DashletSettings({
   isOpen,
@@ -19,11 +28,42 @@ export function DashletSettings({
   onSave,
   dictionary,
 }: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true
+  );
+
   const [text, setText] = useState(config.text ?? "Add your text or quote here...");
   const [italic, setItalic] = useState(config.italic ?? true);
   const [align, setAlign] = useState<TextAlign>(config.align ?? "left");
+  const [dataMode, setDataMode] = useState<SimpleDataMode>(
+    config.dataMode === "static" || config.dataMode === "pgrest"
+      ? config.dataMode
+      : "static",
+  );
+  const [dataSourceId, setDataSourceId] = useState<string>(
+    config.dataSourceId ?? ""
+  );
 
   const dp = useDataProvider(config.dataProvider ?? []);
+
+  const staticSnapshot = useRef({ text });
+
+  const handleDataModeChange = (mode: SimpleDataMode) => {
+    if (mode === "pgrest" && dataMode === "static") {
+      staticSnapshot.current = { text };
+    } else if (mode === "static" && dataMode === "pgrest") {
+      setText(staticSnapshot.current.text);
+    }
+    setDataMode(mode);
+  };
+
+  const pg = usePgrestSettingsState({
+    ...buildSimplePgrestConfig({ ...config, dataSourceId: dataSourceId || undefined }, (detected) => {
+      if (detected.length >= 1) setText(`{{row.${detected[0].key}}}`);
+    }),
+  });
 
   const handleSave = () => {
     onSave({
@@ -31,20 +71,20 @@ export function DashletSettings({
       italic,
       align,
       dataProvider: dp.getCleanEntries(),
+      dataMode,
+      pgrestFunctionName: pg.pgrestFunctionName,
+      pgrestParams: fromPgrestParamItems(pg.pgrestParams),
+      pgrestHttpMethod: pg.pgrestHttpMethod,
+      dataSourceId: dataSourceId || undefined,
     } as DashletConfig);
     onClose();
   };
 
+  const handleMouseDown = (e: React.MouseEvent) => e.stopPropagation();
   const textStatus = getHandlebarsStatus(text);
 
-  return (
-    <TabbedSettingsWrapper
-      isOpen={isOpen}
-      onClose={onClose}
-      onSave={handleSave}
-      dataProvider={dp}
-      dictionary={dictionary}
-    >
+  const visualizationTab = (
+    <>
       <div>
         <Label htmlFor="tc-text" className="mb-1 block text-sm font-medium">
           Text
@@ -78,6 +118,79 @@ export function DashletSettings({
           label=""
         />
       </div>
-    </TabbedSettingsWrapper>
+    </>
+  );
+
+  const dataTab = (
+    <>
+      <PgrestDataTab
+        id="tc-data-mode"
+        dataMode={dataMode}
+        onDataModeChange={handleDataModeChange}
+        pgrest={pg}
+        dictionary={dictionary}
+        dataSourceId={dataSourceId}
+        onDataSourceIdChange={setDataSourceId}
+        activeProviders={activeProviders}
+      />
+      {/* Data provider entries */}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {tr("dashboard.settings.defineVariablesHint", dictionary, {
+          code: "{{data_provider.key}}",
+        })}
+      </p>
+      <div className="space-y-2">
+        {dp.dataProvider.map((entry, i) => (
+          <div
+            key={entry._id}
+            className="flex items-center gap-2 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-700"
+          >
+            <TextInput
+              value={entry.key}
+              onChange={(e) => dp.updateEntry(i, "key", e.target.value)}
+              placeholder={tr("dashboard.settings.key", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <TextInput
+              value={entry.value}
+              onChange={(e) => dp.updateEntry(i, "value", e.target.value)}
+              placeholder={tr("common.value", dictionary)}
+              sizing="sm"
+              className="flex-1"
+            />
+            <Button
+              size="xs"
+              color="failure"
+              onClick={() => dp.removeEntry(i)}
+              onMouseDown={handleMouseDown}
+              className="no-drag shrink-0"
+            >
+              ✕
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        size="xs"
+        color="light"
+        onClick={dp.addEntry}
+        onMouseDown={handleMouseDown}
+        className="no-drag w-full"
+      >
+        {tr("dashboard.settings.addEntry", dictionary)}
+      </Button>
+    </>
+  );
+
+  return (
+    <SettingsModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      dictionary={dictionary}
+      visualizationTab={visualizationTab}
+      dataTab={dataTab}
+    />
   );
 }

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
-import type { PgrestParam, PgrestHttpMethod } from "../common";
+import type { PgrestDashletFields } from "../common";
 import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 
@@ -12,16 +12,11 @@ import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 
 export type TextAlign = "left" | "center" | "right";
 
-export interface DashletConfig {
+export interface DashletConfig extends PgrestDashletFields {
   text: string;
   italic: boolean;
   align: TextAlign;
   dataProvider?: DataProviderEntry[];
-  dataMode?: string;
-  pgrestFunctionName?: string;
-  pgrestParams?: PgrestParam[];
-  pgrestHttpMethod?: PgrestHttpMethod;
-  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows } from "../common";
+import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
 import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 
 // ============================================================================
@@ -50,7 +49,6 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 // ============================================================================
 
 const EMPTY_DATA_PROVIDER: DataProviderEntry[] = [];
-const EMPTY_PARAMS: PgrestParam[] = [];
 
 const ALIGN_CLASS: Record<TextAlign, string> = {
   left: "text-left",
@@ -73,7 +71,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataMode,
     config.pgrestFunctionName || "",
     config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PARAMS,
+    config.pgrestParams || EMPTY_PGREST_PARAMS,
     config.dataSourceId,
   );
 
@@ -86,23 +84,10 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     return dpContext;
   }, [dataProvider, dataMode, rows]);
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
+  const compiledText = useMemo(() => resolveHandlebarsField(text, templateContext), [text, templateContext]);
 
-  if (fetchError) {
-    return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
-      </div>
-    );
-  }
-
-  const compiledText = resolveHandlebarsField(text, templateContext);
+  if (loading) return <DashletLoading />;
+  if (fetchError) return <DashletError message={fetchError} />;
   const alignClass = ALIGN_CLASS[align] ?? ALIGN_CLASS.left;
 
   return (

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
@@ -3,8 +3,8 @@
 import { useMemo } from "react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
 import type { PgrestParam, PgrestHttpMethod } from "../common";
-import { usePgrestRows, EMPTY_PGREST_PARAMS, DashletLoading, DashletError } from "../common";
-import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
+import { useHybridPgrestContext, DashletLoading, DashletError } from "../common";
+import { resolveHandlebarsField } from "../common/use-handlebars-templates";
 
 // ============================================================================
 // Configuration Types
@@ -65,24 +65,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataProvider = EMPTY_DATA_PROVIDER,
   } = config;
 
-  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
-
-  const { rows, loading, fetchError } = usePgrestRows(
-    dataMode,
-    config.pgrestFunctionName || "",
-    config.pgrestHttpMethod || "POST",
-    config.pgrestParams || EMPTY_PGREST_PARAMS,
-    config.dataSourceId,
-  );
-
-  const templateContext = useMemo(() => {
-    const dpContext = buildDataProviderContext(dataProvider);
-    if (dataMode === "pgrest" && rows.length > 0) {
-      const firstRow = rows[0];
-      return { ...dpContext, row: firstRow, ...firstRow };
-    }
-    return dpContext;
-  }, [dataProvider, dataMode, rows]);
+  const { templateContext, loading, fetchError } = useHybridPgrestContext(config, dataProvider);
 
   const compiledText = useMemo(() => resolveHandlebarsField(text, templateContext), [text, templateContext]);
 

--- a/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
+++ b/apps/app/src/features/dashboard/dashlets/text_card/dashlet.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useMemo } from "react";
-import Handlebars from "handlebars";
+import { Spinner } from "flowbite-react";
 import type { DashletComponentProps, DashletLayoutDefaults, DataProviderEntry } from "../types";
+import type { PgrestParam, PgrestHttpMethod } from "../common";
+import { usePgrestRows } from "../common";
+import { resolveHandlebarsField, buildDataProviderContext } from "../common/use-handlebars-templates";
 
 // ============================================================================
 // Configuration Types
@@ -15,6 +18,11 @@ export interface DashletConfig {
   italic: boolean;
   align: TextAlign;
   dataProvider?: DataProviderEntry[];
+  dataMode?: string;
+  pgrestFunctionName?: string;
+  pgrestParams?: PgrestParam[];
+  pgrestHttpMethod?: PgrestHttpMethod;
+  dataSourceId?: string;
 }
 
 export const defaultConfig: DashletConfig = {
@@ -42,6 +50,7 @@ export function getLayoutDefaults(): DashletLayoutDefaults {
 // ============================================================================
 
 const EMPTY_DATA_PROVIDER: DataProviderEntry[] = [];
+const EMPTY_PARAMS: PgrestParam[] = [];
 
 const ALIGN_CLASS: Record<TextAlign, string> = {
   left: "text-left",
@@ -58,22 +67,42 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     dataProvider = EMPTY_DATA_PROVIDER,
   } = config;
 
+  const dataMode = (config.dataMode as "static" | "pgrest") || "static";
+
+  const { rows, loading, fetchError } = usePgrestRows(
+    dataMode,
+    config.pgrestFunctionName || "",
+    config.pgrestHttpMethod || "POST",
+    config.pgrestParams || EMPTY_PARAMS,
+    config.dataSourceId,
+  );
+
   const templateContext = useMemo(() => {
-    const data_provider: Record<string, string> = {};
-    for (const entry of dataProvider) {
-      if (entry.key) data_provider[entry.key] = entry.value;
+    const dpContext = buildDataProviderContext(dataProvider);
+    if (dataMode === "pgrest" && rows.length > 0) {
+      const firstRow = rows[0];
+      return { ...dpContext, row: firstRow, ...firstRow };
     }
-    return { data_provider };
-  }, [dataProvider]);
+    return dpContext;
+  }, [dataProvider, dataMode, rows]);
 
-  const compiledText = useMemo(() => {
-    try {
-      return Handlebars.compile(text)(templateContext);
-    } catch {
-      return text;
-    }
-  }, [text, templateContext]);
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
 
+  if (fetchError) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+        <span className="text-xs text-red-600 dark:text-red-400">{fetchError}</span>
+      </div>
+    );
+  }
+
+  const compiledText = resolveHandlebarsField(text, templateContext);
   const alignClass = ALIGN_CLASS[align] ?? ALIGN_CLASS.left;
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashlets can switch between static and PGREST-backed data modes, select/persist a data source, and auto-detect/map remote fields into templates.
  * New loading and error states surface while remote data resolves; provider lists show only active, tested sources.

* **Refactor**
  * Settings UI standardized to a two-tab modal (Visualization + Data) across dashlets; data-provider entries and PGREST settings unified for consistent editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->