### PR TITLE
feat: Runtime config module for server-side env vars

### DIFF
--- a/apps/app/src/app/api/runtime-config/route.ts
+++ b/apps/app/src/app/api/runtime-config/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { RUNTIME_CONFIG_WHITELIST } from "@/features/runtime-config/runtime-config.constants";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  const config: Record<string, string> = {};
+
+  for (const [key, envVar] of Object.entries(RUNTIME_CONFIG_WHITELIST)) {
+    config[key] = process.env[envVar] ?? "";
+  }
+
+  return NextResponse.json(config, {
+    headers: {
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/apps/app/src/features/layout/components/secured-layout.tsx
+++ b/apps/app/src/features/layout/components/secured-layout.tsx
@@ -12,6 +12,7 @@ import { SecuredSidebar } from "./secured-sidebar/secured-sidebar";
 import FooterSecuredLayout from "./footer-secured/footer-secured";
 import SseListener from "@/features/sse/components/sse-listener/sse-listener";
 import { getPublicOrgLogo } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { RuntimeConfigProvider } from "@/features/runtime-config/runtime-config-context";
 
 export default async function SecuredLayout({
   children,
@@ -23,6 +24,7 @@ export default async function SecuredLayout({
   const session = await auth();
   const initialOrgLogo = await getPublicOrgLogo();
   return (
+    <RuntimeConfigProvider>
     <SidebarProvider initialCollapsed={(await sidebarCookie.get()).isCollapsed}>
       <SseListener dictionary={dictionary} tenantId={session!.user!.email} />
       <SecuredNavbar
@@ -44,5 +46,6 @@ export default async function SecuredLayout({
       </div>
       <FooterSecuredLayout messages={dict} />
     </SidebarProvider>
+    </RuntimeConfigProvider>
   );
 }

--- a/apps/app/src/features/runtime-config/runtime-config-context.tsx
+++ b/apps/app/src/features/runtime-config/runtime-config-context.tsx
@@ -34,7 +34,7 @@ export function RuntimeConfigProvider({ children }: Readonly<{ children: React.R
 
   useEffect(() => {
     if (config) return;
-    fetchConfig().then(setConfig);
+    fetchConfig().then(setConfig).catch(console.error);
   }, [config]);
 
   return (

--- a/apps/app/src/features/runtime-config/runtime-config-context.tsx
+++ b/apps/app/src/features/runtime-config/runtime-config-context.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import type { RuntimeConfig } from "./runtime-config.types";
+
+const RuntimeConfigContext = createContext<RuntimeConfig | null>(null);
+
+let cachedConfig: RuntimeConfig | null = null;
+let fetchPromise: Promise<RuntimeConfig> | null = null;
+
+function fetchConfig(): Promise<RuntimeConfig> {
+  if (cachedConfig) return Promise.resolve(cachedConfig);
+  if (fetchPromise) return fetchPromise;
+
+  fetchPromise = fetch("/app/api/runtime-config")
+    .then((res) => {
+      if (!res.ok) throw new Error(`Runtime config fetch failed: ${res.status}`);
+      return res.json();
+    })
+    .then((data: RuntimeConfig) => {
+      cachedConfig = data;
+      return data;
+    })
+    .catch((err) => {
+      fetchPromise = null;
+      throw err;
+    });
+
+  return fetchPromise;
+}
+
+export function RuntimeConfigProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState<RuntimeConfig | null>(cachedConfig);
+
+  useEffect(() => {
+    if (config) return;
+    fetchConfig().then(setConfig);
+  }, [config]);
+
+  return (
+    <RuntimeConfigContext.Provider value={config}>
+      {children}
+    </RuntimeConfigContext.Provider>
+  );
+}
+
+export function useRuntimeConfig(): RuntimeConfig | null {
+  return useContext(RuntimeConfigContext);
+}

--- a/apps/app/src/features/runtime-config/runtime-config-context.tsx
+++ b/apps/app/src/features/runtime-config/runtime-config-context.tsx
@@ -29,7 +29,7 @@ function fetchConfig(): Promise<RuntimeConfig> {
   return fetchPromise;
 }
 
-export function RuntimeConfigProvider({ children }: { children: React.ReactNode }) {
+export function RuntimeConfigProvider({ children }: Readonly<{ children: React.ReactNode }>) {
   const [config, setConfig] = useState<RuntimeConfig | null>(cachedConfig);
 
   useEffect(() => {

--- a/apps/app/src/features/runtime-config/runtime-config.constants.ts
+++ b/apps/app/src/features/runtime-config/runtime-config.constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Whitelist of server env vars exposed to the client at runtime.
+ * Map: client key -> server env var name.
+ * Only add non-secret, public-safe values here.
+ */
+export const RUNTIME_CONFIG_WHITELIST: Record<string, string> = {
+  ECM_API_URL: "ECM_API_URL",
+} as const;

--- a/apps/app/src/features/runtime-config/runtime-config.types.ts
+++ b/apps/app/src/features/runtime-config/runtime-config.types.ts
@@ -1,0 +1,7 @@
+/**
+ * Runtime configuration values exposed to the client.
+ * Only add keys here that are safe to expose publicly (no secrets).
+ */
+export interface RuntimeConfig {
+  ECM_API_URL: string;
+}

--- a/apps/app/src/features/sse/components/sse-listener/sse-listener.tsx
+++ b/apps/app/src/features/sse/components/sse-listener/sse-listener.tsx
@@ -26,8 +26,8 @@ export default function SseListener({
   const notificationTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
-    // Wait for runtime config to load before connecting
-    if (!runtimeConfig?.ECM_API_URL) return;
+    // Wait for runtime config and tenantId before connecting
+    if (!runtimeConfig?.ECM_API_URL || !tenantId) return;
 
     // Initialize the global EventSource if not already done
     if (!isInitialized) {
@@ -112,7 +112,7 @@ export default function SseListener({
         clearTimeout(notificationTimeoutRef.current);
       }
     };
-  }, [dictionary, runtimeConfig]);
+  }, [dictionary, runtimeConfig, tenantId]);
 
   return null;
 }

--- a/apps/app/src/features/sse/components/sse-listener/sse-listener.tsx
+++ b/apps/app/src/features/sse/components/sse-listener/sse-listener.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef } from "react";
 import { configureLocale } from "@/features/common/services/days.service";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import InnerData from "@/features/common/components/notification/notification-types/inner-data";
+import { useRuntimeConfig } from "@/features/runtime-config/runtime-config-context";
 
 // Global singleton to track SSE connection
 let globalEventSource: EventSource | null = null;
@@ -20,14 +21,18 @@ export default function SseListener({
 }) {
   configureLocale();
 
+  const runtimeConfig = useRuntimeConfig();
   const lastNotificationRef = useRef<string>("");
   const notificationTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
+    // Wait for runtime config to load before connecting
+    if (!runtimeConfig?.ECM_API_URL) return;
+
     // Initialize the global EventSource if not already done
     if (!isInitialized) {
       globalEventSource = new EventSource(
-        `${process.env.NEXT_PUBLIC_ECM_API_URL}/api/v1/events/tenant/${tenantId}/stream`
+        `${runtimeConfig.ECM_API_URL}/api/v1/events/tenant/${tenantId}/stream`
       );
 
       isInitialized = true;
@@ -107,7 +112,7 @@ export default function SseListener({
         clearTimeout(notificationTimeoutRef.current);
       }
     };
-  }, [dictionary]);
+  }, [dictionary, runtimeConfig]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

- Add `/api/runtime-config` endpoint that serves whitelisted server env vars at runtime
- Add `RuntimeConfigProvider` + `useRuntimeConfig()` hook for typed client-side access
- Replace build-time `NEXT_PUBLIC_ECM_API_URL` with runtime `ECM_API_URL` in SSE listener

Enables deploying the same build artifact to dev/staging/prod without recompiling.

Closes #160

## Test plan

- [ ] Verify SSE listener connects using runtime config value
- [ ] Confirm `GET /app/api/runtime-config` returns `ECM_API_URL`
- [ ] Test that changing `ECM_API_URL` env var at runtime reflects without rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime configuration API and client-side provider/hook to expose non-secret runtime settings to the app.
  * Introduced a whitelist-driven config surface (currently includes ECM_API_URL) with client typing.

* **Refactor**
  * Event streaming updated to read the API base URL from the runtime configuration and react to config changes.
  * Config responses are cached (5-minute cache) and client fetches are deduplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->