### PR TITLE
feat: align schemas with migration plan — lean Alfresco, driver address fields

### DIFF
--- a/ecm-srv/miot-resource-directory-repo/src/main/resources/alfresco/module/miot-resource-directory-repo/messages/content-model.properties
+++ b/ecm-srv/miot-resource-directory-repo/src/main/resources/alfresco/module/miot-resource-directory-repo/messages/content-model.properties
@@ -1,4 +1,6 @@
 # ModularIoT Resource Directory Content Model Labels
+# Entity types hold identity only — MER fields live in PostgreSQL.
+# Client-specific extension attributes are added at runtime via CMM API.
 
 # Entity types
 miot_resourceDirectory.type.miot_resourceEntity.title=Resource Entity
@@ -20,35 +22,36 @@ miot_resourceDirectory.aspect.miot_scorable.title=Scorable
 miot_resourceDirectory.aspect.miot_insurable.title=Insurable
 miot_resourceDirectory.aspect.miot_inspectable.title=Inspectable
 
-# Base entity properties
+# Base entity identity properties
 miot_resourceDirectory.property.miot_entityId.title=Entity UUID
 miot_resourceDirectory.property.miot_externalId.title=External ID
 miot_resourceDirectory.property.miot_clientId.title=Client ID
 miot_resourceDirectory.property.miot_entityStatus.title=Status
 miot_resourceDirectory.property.miot_sourceSystem.title=Source System
 
-# Vehicle properties
-miot_resourceDirectory.property.miot_licensePlate.title=License Plate
-miot_resourceDirectory.property.miot_vin.title=VIN
-miot_resourceDirectory.property.miot_vehicleType.title=Vehicle Type
-miot_resourceDirectory.property.miot_maxWeight.title=Max Weight
-miot_resourceDirectory.property.miot_volume.title=Volume
-
-# Trailer properties
-miot_resourceDirectory.property.miot_trailerType.title=Trailer Type
-
-# Driver properties
-miot_resourceDirectory.property.miot_firstName.title=First Name
-miot_resourceDirectory.property.miot_lastName.title=Last Name
-miot_resourceDirectory.property.miot_rut.title=RUT
-miot_resourceDirectory.property.miot_licenseNumber.title=License Number
-miot_resourceDirectory.property.miot_licenseCategory.title=License Category
-miot_resourceDirectory.property.miot_licenseExpires.title=License Expiry
-
-# Carrier properties
-miot_resourceDirectory.property.miot_carrierName.title=Carrier Name
-miot_resourceDirectory.property.miot_transportLicense.title=Transport License
-miot_resourceDirectory.property.miot_transportLicenseExpires.title=Transport License Expiry
+# Document type properties
+miot_resourceDirectory.property.miot_docLicenseCategory.title=License Category
+miot_resourceDirectory.property.miot_issuingAuthority.title=Issuing Authority
+miot_resourceDirectory.property.miot_expiryDate.title=Expiry Date
+miot_resourceDirectory.property.miot_licenseStatus.title=License Status
+miot_resourceDirectory.property.miot_examType.title=Exam Type
+miot_resourceDirectory.property.miot_examDate.title=Exam Date
+miot_resourceDirectory.property.miot_validUntil.title=Valid Until
+miot_resourceDirectory.property.miot_examResult.title=Result
+miot_resourceDirectory.property.miot_certType.title=Certification Type
+miot_resourceDirectory.property.miot_certExpiry.title=Certification Expiry
+miot_resourceDirectory.property.miot_issuedBy.title=Issued By
+miot_resourceDirectory.property.miot_policyNumber.title=Policy Number
+miot_resourceDirectory.property.miot_insurer.title=Insurer
+miot_resourceDirectory.property.miot_coverage.title=Coverage
+miot_resourceDirectory.property.miot_policyExpiry.title=Policy Expiry
+miot_resourceDirectory.property.miot_inspectionType.title=Inspection Type
+miot_resourceDirectory.property.miot_inspectionDate.title=Inspection Date
+miot_resourceDirectory.property.miot_inspectionResult.title=Result
+miot_resourceDirectory.property.miot_nextDue.title=Next Due
+miot_resourceDirectory.property.miot_evalPeriod.title=Evaluation Period
+miot_resourceDirectory.property.miot_overallRating.title=Overall Rating
+miot_resourceDirectory.property.miot_evaluator.title=Evaluator
 
 # Scorable aspect
 miot_resourceDirectory.property.miot_compositeScore.title=Composite Score

--- a/ecm-srv/miot-resource-directory-repo/src/main/resources/alfresco/module/miot-resource-directory-repo/model/content-model.xml
+++ b/ecm-srv/miot-resource-directory-repo/src/main/resources/alfresco/module/miot-resource-directory-repo/model/content-model.xml
@@ -88,116 +88,45 @@
                     <description>Origin system (e.g. alerce, api, manual)</description>
                     <type>d:text</type>
                 </property>
-                <property name="miot:licensePlate">
-                    <title>License Plate</title>
-                    <type>d:text</type>
-                    <index enabled="true">
-                        <tokenised>false</tokenised>
-                    </index>
-                </property>
-                <property name="miot:maxWeight">
-                    <title>Max Weight (kg)</title>
-                    <type>d:double</type>
-                </property>
             </properties>
         </type>
+
+        <!--
+            Entity subtypes are lean: identity only (inherited from miot:resourceEntity).
+            MER fields (name, phone, address, license, etc.) live in PostgreSQL only.
+            Client-specific extension attributes are added at runtime via CMM API aspects.
+            These subtypes exist to:
+              1. Enable type-specific Alfresco searches and rules
+              2. Allow type-specific child associations (document types)
+              3. Support type-specific workflow triggers
+        -->
 
         <!-- Vehicle (truck) entity -->
         <type name="miot:vehicle">
             <title>Vehicle</title>
-            <description>Fleet vehicle (truck)</description>
+            <description>Fleet vehicle (truck) — document container</description>
             <parent>miot:resourceEntity</parent>
-            <properties>
-                <property name="miot:vin">
-                    <title>VIN</title>
-                    <type>d:text</type>
-                    <index enabled="true">
-                        <tokenised>false</tokenised>
-                    </index>
-                </property>
-                <property name="miot:vehicleType">
-                    <title>Vehicle Type</title>
-                    <type>d:text</type>
-                </property>
-                <property name="miot:volume">
-                    <title>Volume (m³)</title>
-                    <type>d:double</type>
-                </property>
-            </properties>
         </type>
 
         <!-- Trailer entity -->
         <type name="miot:trailer">
             <title>Trailer</title>
-            <description>Fleet trailer</description>
+            <description>Fleet trailer — document container</description>
             <parent>miot:resourceEntity</parent>
-            <properties>
-                <property name="miot:trailerType">
-                    <title>Trailer Type</title>
-                    <type>d:text</type>
-                </property>
-            </properties>
         </type>
 
         <!-- Driver entity -->
         <type name="miot:driver">
             <title>Driver</title>
-            <description>Driver/operator</description>
+            <description>Driver/operator — document container</description>
             <parent>miot:resourceEntity</parent>
-            <properties>
-                <property name="miot:firstName">
-                    <title>First Name</title>
-                    <type>d:text</type>
-                    <mandatory>true</mandatory>
-                </property>
-                <property name="miot:lastName">
-                    <title>Last Name</title>
-                    <type>d:text</type>
-                    <mandatory>true</mandatory>
-                </property>
-                <property name="miot:rut">
-                    <title>RUT</title>
-                    <description>Chilean national ID</description>
-                    <type>d:text</type>
-                    <index enabled="true">
-                        <tokenised>false</tokenised>
-                    </index>
-                </property>
-                <property name="miot:licenseNumber">
-                    <title>License Number</title>
-                    <type>d:text</type>
-                </property>
-                <property name="miot:licenseCategory">
-                    <title>License Category</title>
-                    <type>d:text</type>
-                </property>
-                <property name="miot:licenseExpires">
-                    <title>License Expiry Date</title>
-                    <type>d:datetime</type>
-                </property>
-            </properties>
         </type>
 
         <!-- Carrier entity -->
         <type name="miot:carrier">
             <title>Carrier</title>
-            <description>Transport carrier company</description>
+            <description>Transport carrier company — document container</description>
             <parent>miot:resourceEntity</parent>
-            <properties>
-                <property name="miot:carrierName">
-                    <title>Carrier Name</title>
-                    <type>d:text</type>
-                    <mandatory>true</mandatory>
-                </property>
-                <property name="miot:transportLicense">
-                    <title>Transport License</title>
-                    <type>d:text</type>
-                </property>
-                <property name="miot:transportLicenseExpires">
-                    <title>Transport License Expiry</title>
-                    <type>d:datetime</type>
-                </property>
-            </properties>
         </type>
 
         <!-- ================================================================

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/model/Driver.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/model/Driver.java
@@ -42,4 +42,22 @@ public class Driver extends BaseResourceEntity {
 
     @Column(name = "operation_blocked")
     public boolean operationBlocked = false;
+
+    @Column(name = "address_street")
+    public String addressStreet;
+
+    @Column(name = "address_city")
+    public String addressCity;
+
+    @Column(name = "address_postal_code")
+    public String addressPostalCode;
+
+    @Column(name = "address_country")
+    public String addressCountry;
+
+    @Column(name = "deactivated_at")
+    public Instant deactivatedAt;
+
+    @Column(name = "source_system")
+    public String sourceSystem;
 }

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverBulkSyncService.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverBulkSyncService.java
@@ -113,6 +113,22 @@ public class DriverBulkSyncService {
         d.licenseCategory = strField(fields, "licenseCategory", null);
         d.isOccasional = boolField(fields, "isOccasional", false);
         d.operationBlocked = boolField(fields, "operationBlocked", false);
+        d.addressStreet = strField(fields, "addressStreet", null);
+        d.addressCity = strField(fields, "addressCity", null);
+        d.addressPostalCode = strField(fields, "addressPostalCode", null);
+        d.addressCountry = strField(fields, "addressCountry", null);
+        d.sourceSystem = sourceSystem;
+
+        // Derive status
+        String deactivatedAt = strField(fields, "deactivatedAt", null);
+        boolean blocked = boolField(fields, "operationBlocked", false);
+        if (deactivatedAt != null && !deactivatedAt.isBlank()) {
+            d.status = "INACTIVE";
+            d.active = false;
+            d.deactivatedAt = Instant.parse(deactivatedAt);
+        } else if (blocked) {
+            d.status = "SUSPENDED";
+        }
 
         // Resolve carrier FK
         String carrierExternalId = strField(fields, "carrierExternalId", null);
@@ -146,6 +162,19 @@ public class DriverBulkSyncService {
         diffField(changes, "email", driver.email, strField(fields, "email", null), v -> driver.email = v);
         diffField(changes, "licenseNumber", driver.licenseNumber, strField(fields, "licenseNumber", null), v -> driver.licenseNumber = v);
         diffField(changes, "licenseCategory", driver.licenseCategory, strField(fields, "licenseCategory", null), v -> driver.licenseCategory = v);
+        diffField(changes, "addressStreet", driver.addressStreet, strField(fields, "addressStreet", null), v -> driver.addressStreet = v);
+        diffField(changes, "addressCity", driver.addressCity, strField(fields, "addressCity", null), v -> driver.addressCity = v);
+        diffField(changes, "addressPostalCode", driver.addressPostalCode, strField(fields, "addressPostalCode", null), v -> driver.addressPostalCode = v);
+        diffField(changes, "addressCountry", driver.addressCountry, strField(fields, "addressCountry", null), v -> driver.addressCountry = v);
+
+        // Derive status from deactivatedAt and operationBlocked
+        String deactivatedAt = strField(fields, "deactivatedAt", null);
+        if (deactivatedAt != null && !deactivatedAt.isBlank() && !"INACTIVE".equals(driver.status)) {
+            changes.put("status", Map.of("old", driver.status, "new", "INACTIVE"));
+            driver.status = "INACTIVE";
+            driver.active = false;
+            driver.deactivatedAt = Instant.parse(deactivatedAt);
+        }
 
         Boolean isOccasional = boolFieldNullable(fields, "isOccasional");
         if (isOccasional != null && !Objects.equals(isOccasional, driver.isOccasional)) {

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
@@ -126,7 +126,10 @@ public class DriverService {
                     String oldStatus = driver.status;
                     driver.status = req.status();
                     driver.updatedAt = Instant.now();
-                    if ("DEACTIVATED".equals(req.status())) driver.active = false;
+                    if ("INACTIVE".equals(req.status())) {
+                        driver.active = false;
+                        driver.deactivatedAt = Instant.now();
+                    }
 
                     return eventService.record(clientId, EntityType.DRIVER, driver.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,

--- a/quarkus-srv/miot-driver/src/main/resources/db/migration/driver/V3.1.0__add_driver_address_and_status_constraint.sql
+++ b/quarkus-srv/miot-driver/src/main/resources/db/migration/driver/V3.1.0__add_driver_address_and_status_constraint.sql
@@ -1,0 +1,14 @@
+-- Add missing columns for address, deactivation tracking, and source system
+-- Add status CHECK constraint matching the directory lifecycle model
+
+ALTER TABLE miot_driver.rd_drivers
+    ADD COLUMN address_street      VARCHAR(255),
+    ADD COLUMN address_city        VARCHAR(100),
+    ADD COLUMN address_postal_code VARCHAR(20),
+    ADD COLUMN address_country     VARCHAR(10),
+    ADD COLUMN deactivated_at      TIMESTAMPTZ,
+    ADD COLUMN source_system       VARCHAR(50);
+
+ALTER TABLE miot_driver.rd_drivers
+    ADD CONSTRAINT ck_rd_drivers_status
+    CHECK (status IN ('ACTIVE', 'INACTIVE', 'SUSPENDED', 'PENDING'));

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/CarrierService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/CarrierService.java
@@ -72,7 +72,7 @@ public class CarrierService {
                     String oldStatus = carrier.status;
                     carrier.status = req.status();
                     carrier.updatedAt = Instant.now();
-                    if ("DEACTIVATED".equals(req.status())) carrier.active = false;
+                    if ("INACTIVE".equals(req.status())) carrier.active = false;
                     return eventService.record(clientId, EntityType.CARRIER, carrier.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TrailerService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TrailerService.java
@@ -72,7 +72,7 @@ public class TrailerService {
                     String oldStatus = trailer.status;
                     trailer.status = req.status();
                     trailer.updatedAt = Instant.now();
-                    if ("DEACTIVATED".equals(req.status())) trailer.active = false;
+                    if ("INACTIVE".equals(req.status())) trailer.active = false;
                     return eventService.record(clientId, EntityType.TRAILER, trailer.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckService.java
@@ -76,7 +76,7 @@ public class TruckService {
                     String oldStatus = truck.status;
                     truck.status = req.status();
                     truck.updatedAt = Instant.now();
-                    if ("DEACTIVATED".equals(req.status())) truck.active = false;
+                    if ("INACTIVE".equals(req.status())) truck.active = false;
                     return eventService.record(clientId, EntityType.TRUCK, truck.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))


### PR DESCRIPTION
## Summary

- Align driver database schema with the Alerce migration plan
- Slim down Alfresco content model to identity-only entity types (MER fields stay in PostgreSQL)
- Standardize status lifecycle across all entity services

## Changes

### Database (V3.1.0 migration)
- Add columns to `miot_driver.rd_drivers`: `address_street`, `address_city`, `address_postal_code`, `address_country`, `deactivated_at`, `source_system`
- Add `CHECK (status IN ('ACTIVE', 'INACTIVE', 'SUSPENDED', 'PENDING'))` constraint

### Alfresco content model (lean)
- Entity subtypes (vehicle, trailer, driver, carrier) are now identity-only — no MER field duplication
- Base type `miot:resourceEntity` keeps only: entityId, externalId, clientId, entityStatus, sourceSystem
- Document types and shared aspects (scorable, insurable, inspectable) unchanged
- Client-specific attributes created at runtime via CMM API

### Quarkus services
- Driver entity model gains 6 new fields
- Bulk-sync maps address, deactivatedAt, sourceSystem, derives status
- All services use `INACTIVE` instead of `DEACTIVATED`, set `deactivatedAt` timestamp

## Test plan

- [ ] `./mvnw clean install -DskipTests` passes
- [ ] `./start.sh all` applies V3.1.0 migration
- [ ] `rd_drivers` has 28 columns including new address/deactivation fields
- [ ] Status CHECK constraint enforces ACTIVE/INACTIVE/SUSPENDED/PENDING
- [ ] Alfresco content model deploys with lean entity types (verify via `/api/classes/miot_driver`)

Relates to #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driver profiles now include address fields (street, city, postal code, country) and deactivation date tracking

* **Updates**
  * Standardized entity deactivation status: "INACTIVE" replaces "DEACTIVATED" across vehicles, trailers, carriers, and drivers
  * Restructured entity models to function as document containers with core identity properties only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->