### PR TITLE
feat: CI/CD pipeline to build and publish quarkus-srv Docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,15 +33,20 @@ run-name: ${{ github.actor }} is building ${{ github.repository }} 🚀
 
 on:
   push:
+    paths:
+      - 'turbo-repo/**'
     branches:
       - trunk
       - main
     tags:
       - "v*"
   pull_request:
+    paths:
+      - 'turbo-repo/**'
     branches:
       - trunk
       - main
+  workflow_dispatch:
 
 env:
   # Registry configuration

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -84,7 +84,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Build & Test
-        run: ./mvnw clean verify
+        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true
         working-directory: quarkus-srv
 
       - name: SonarCloud Scan

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -1,9 +1,22 @@
 # =============================================================================
 # Quarkus CI — ModularIoT Backend
 # =============================================================================
-# Builds and tests the Quarkus multi-module backend.
+# Builds, tests, and publishes the Quarkus multi-module backend modulith.
 # Triggers only on changes within quarkus-srv/.
-# Uses sonar-maven-plugin for SonarCloud (recommended for Maven projects).
+#
+# Docker Image:
+#   - GitHub Container Registry (GHCR) — Primary registry
+#   - Docker Hub — Secondary mirror (non-PR only)
+#
+# Tagging Strategy:
+#   - PRs:        ghcr.io/<org>/miot-srv:pr-<number>
+#   - main/trunk: ghcr.io/<org>/miot-srv:latest
+#   - Tags:       ghcr.io/<org>/miot-srv:<version>
+#
+# Required Secrets:
+#   - DOCKERHUB_USERNAME: Docker Hub username
+#   - DOCKERHUB_TOKEN:    Docker Hub access token
+#   - SONAR_TOKEN:        SonarCloud analysis token
 # =============================================================================
 
 name: Quarkus CI
@@ -13,6 +26,8 @@ on:
     paths:
       - 'quarkus-srv/**'
     branches: [trunk, main]
+    tags:
+      - 'v*'
   pull_request:
     paths:
       - 'quarkus-srv/**'
@@ -20,16 +35,27 @@ on:
   workflow_dispatch:
 
 env:
-  JAVA_VERSION: "21"
+  GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  IMAGE_NAME: microboxlabs/miot-srv
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'temurin'
 
 jobs:
-  build:
+  # ===========================================================================
+  # Build JVM — Compile, Test, Package, and SonarCloud
+  # ===========================================================================
+  build-jvm:
     name: Build & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     permissions:
       contents: read
+      packages: write
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -40,10 +66,22 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
           cache-dependency-path: quarkus-srv/pom.xml
+
+      - name: Determine version
+        id: version
+        working-directory: quarkus-srv
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
 
       - name: Build & Test
         run: ./mvnw clean verify
@@ -60,3 +98,127 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Upload JVM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jvm-build
+          path: |
+            quarkus-srv/miot-cli/target/quarkus-app/
+            quarkus-srv/Dockerfile
+          retention-days: 1
+
+  # ===========================================================================
+  # Docker JVM — Build and Publish Image
+  # ===========================================================================
+  docker-jvm:
+    name: Docker Image
+    runs-on: ubuntu-latest
+    needs: build-jvm
+
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    outputs:
+      image-digest: ${{ steps.build-push.outputs.digest }}
+
+    steps:
+      - name: Download JVM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: jvm-build
+          path: .
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ github.event_name != 'pull_request' && format('{0}/{1}', env.DOCKERHUB_REGISTRY, env.IMAGE_NAME) || '' }}
+          tags: |
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=ModularIoT Server
+            org.opencontainers.image.description=Quarkus modulith backend for ModularIoT — fleet, driver and resource management
+            org.opencontainers.image.vendor=MicroboxLabs
+
+      - name: Build and push Docker image
+        id: build-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image summary
+        run: |
+          echo "## Docker Image Published 🐳" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  # ===========================================================================
+  # Security Scan — Trivy (non-PR only)
+  # ===========================================================================
+  security-scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: docker-jvm
+    if: github.event_name != 'pull_request'
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+        continue-on-error: true
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+        continue-on-error: true

--- a/quarkus-srv/Dockerfile
+++ b/quarkus-srv/Dockerfile
@@ -1,7 +1,26 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.23
 
-WORKDIR /app
-COPY miot-cli/target/quarkus-app/ /app/
+ENV LANGUAGE='en_US:en'
 
-ENTRYPOINT ["java", "-jar", "quarkus-run.jar"]
+WORKDIR /deployments
+
+# Four distinct layers for optimal cache reuse:
+# lib/ and quarkus/ change rarely; app/ changes on each build
+COPY --chown=185 miot-cli/target/quarkus-app/lib/     /deployments/lib/
+COPY --chown=185 miot-cli/target/quarkus-app/*.jar    /deployments/
+COPY --chown=185 miot-cli/target/quarkus-app/app/     /deployments/app/
+COPY --chown=185 miot-cli/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8180
+USER 185
+
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/opt/jboss/container/java/run/run-java.sh"]
+
+# Default: start all components. Override to select specific ones:
+#   docker run <image> miot fleet
+#   docker run <image> miot driver
+#   docker run <image> miot fleet driver
 CMD ["miot", "all"]

--- a/turbo-repo/packages/miot-resource-client/eslint.config.mjs
+++ b/turbo-repo/packages/miot-resource-client/eslint.config.mjs
@@ -1,0 +1,9 @@
+import { config as baseConfig } from "@repo/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...baseConfig,
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+];

--- a/turbo-repo/packages/miot-resource-client/package.json
+++ b/turbo-repo/packages/miot-resource-client/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@microboxlabs/miot-resource-client",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microboxlabs/modulariot",
+    "directory": "packages/miot-resource-client"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "*",
+    "@repo/typescript-config": "*",
+    "tsup": "^8.0.0",
+    "typescript": "5.8.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/client.test.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/client.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { createMiotResourceClient, MiotResourceApiError } from "../index.js";
+import type { ErrorResponse } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+describe("createMiotResourceClient", () => {
+  const baseUrl = "https://api.example.com";
+
+  describe("URL building", () => {
+    it("builds a full URL from baseUrl and path", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.fleet.listTrucks();
+
+      expect(call.url).toBe("https://api.example.com/api/v1/fleet/trucks");
+    });
+
+    it("appends query parameters", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.fleet.listTrucks({ page: 1, size: 10 });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("page")).toBe("1");
+      expect(url.searchParams.get("size")).toBe("10");
+    });
+
+    it("omits undefined query values", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.fleet.listTrucks({ page: 0, size: undefined });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("page")).toBe("0");
+      expect(url.searchParams.has("size")).toBe(false);
+    });
+  });
+
+  describe("request headers", () => {
+    it("sends config-level headers on every request", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({
+        baseUrl,
+        fetch: fn,
+        headers: { Authorization: "Bearer token-123" },
+      });
+
+      await client.fleet.listTrucks();
+
+      expect(call.init.headers).toEqual(
+        expect.objectContaining({ Authorization: "Bearer token-123" }),
+      );
+    });
+
+    it("sets Content-Type when body is present", async () => {
+      const { fn, call } = createMockFetch({});
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.drivers.create({ firstName: "John", lastName: "Doe" });
+
+      expect(call.init.headers).toEqual(
+        expect.objectContaining({ "Content-Type": "application/json" }),
+      );
+    });
+
+    it("does not set Content-Type for GET requests", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.fleet.listTrucks();
+
+      const headers = call.init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBeUndefined();
+    });
+  });
+
+  describe("response handling", () => {
+    it("returns parsed JSON for 2xx responses", async () => {
+      const mockData = [{ id: 1 }];
+      const { fn } = createMockFetch(mockData);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      const result = await client.fleet.listTrucks();
+
+      expect(result).toEqual(mockData);
+    });
+
+    it("throws MiotResourceApiError on non-2xx responses", async () => {
+      const errorBody: ErrorResponse = {
+        error: "Not Found",
+        message: "Truck not found",
+        status: 404,
+        timestamp: "2025-01-01T00:00:00Z",
+      };
+      const { fn } = createMockFetch(errorBody, 404);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await expect(client.fleet.getTruck(999)).rejects.toThrow(
+        MiotResourceApiError,
+      );
+    });
+
+    it("includes status and body on MiotResourceApiError", async () => {
+      const errorBody: ErrorResponse = {
+        error: "Bad Request",
+        message: "Invalid input",
+        status: 400,
+        timestamp: "2025-01-01T00:00:00Z",
+      };
+      const { fn } = createMockFetch(errorBody, 400);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      try {
+        await client.drivers.get(0);
+        expect.fail("should have thrown");
+      } catch (err) {
+        const error = err as MiotResourceApiError;
+        expect(error.name).toBe("MiotResourceApiError");
+        expect(error.status).toBe(400);
+        expect(error.body).toEqual(errorBody);
+        expect(error.message).toBe("Invalid input");
+      }
+    });
+  });
+
+  describe("request body serialization", () => {
+    it("serializes body as JSON string", async () => {
+      const { fn, call } = createMockFetch({});
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      const body = { firstName: "John", lastName: "Doe" };
+      await client.drivers.create(body);
+
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+
+    it("does not send body for GET requests", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl, fetch: fn });
+
+      await client.fleet.listTrucks();
+
+      expect(call.init.body).toBeUndefined();
+    });
+  });
+});

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/drivers.test.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/drivers.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { createMiotResourceClient } from "../index.js";
+import type { BulkSyncResponse, Driver, EntityEvent } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+const BASE_URL = "https://api.example.com";
+const DRIVERS = "/api/v1/drivers";
+
+const tenant = { id: 1, code: "t-1", name: "Tenant 1", active: true };
+
+const sampleDriver: Driver = {
+  id: 1, tenant, clientId: "c-1", entityId: "uuid-driver-1",
+  externalId: "ext-driver-1", status: "ACTIVE", alfrescoNodeId: "node-1",
+  active: true, createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+  firstName: "John", lastName: "Doe", rut: "12345678-9",
+};
+
+const sampleEvent: EntityEvent = {
+  id: 10, clientId: "c-1", entityType: "DRIVER", entityId: "uuid-driver-1",
+  eventType: "CREATED", eventSource: "api", actor: "user-1",
+  payload: "{}", metadata: "{}", createdAt: "2025-01-01T00:00:00Z",
+};
+
+describe("drivers", () => {
+  describe("list", () => {
+    it("sends GET to /drivers", async () => {
+      const { fn, call } = createMockFetch([sampleDriver]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.drivers.list();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}`);
+      expect(result).toEqual([sampleDriver]);
+    });
+
+    it("passes pagination params", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.drivers.list({ page: 1, size: 50 });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("page")).toBe("1");
+      expect(url.searchParams.get("size")).toBe("50");
+    });
+  });
+
+  describe("get", () => {
+    it("sends GET to /drivers/:id", async () => {
+      const { fn, call } = createMockFetch(sampleDriver);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.drivers.get(1);
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}/1`);
+      expect(result).toEqual(sampleDriver);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST with body", async () => {
+      const { fn, call } = createMockFetch(sampleDriver);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { firstName: "John", lastName: "Doe", rut: "12345678-9" };
+
+      await client.drivers.create(body);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}`);
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+  });
+
+  describe("update", () => {
+    it("sends PUT with body to /drivers/:id", async () => {
+      const { fn, call } = createMockFetch(sampleDriver);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { firstName: "Jane", phone: "+56912345678" };
+
+      await client.drivers.update(1, body);
+
+      expect(call.init.method).toBe("PUT");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}/1`);
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+  });
+
+  describe("changeStatus", () => {
+    it("sends PATCH to /drivers/:id/status", async () => {
+      const { fn, call } = createMockFetch(sampleDriver);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.drivers.changeStatus(1, { status: "BLOCKED", reason: "Compliance" });
+
+      expect(call.init.method).toBe("PATCH");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}/1/status`);
+      expect(call.init.body).toBe(JSON.stringify({ status: "BLOCKED", reason: "Compliance" }));
+    });
+  });
+
+  describe("listEvents", () => {
+    it("sends GET to /drivers/:id/events", async () => {
+      const { fn, call } = createMockFetch([sampleEvent]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.drivers.listEvents(1, { limit: 10 });
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toContain(`${DRIVERS}/1/events`);
+      expect(new URL(call.url).searchParams.get("limit")).toBe("10");
+      expect(result).toEqual([sampleEvent]);
+    });
+
+    it("works without limit param", async () => {
+      const { fn, call } = createMockFetch([sampleEvent]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.drivers.listEvents(1);
+
+      expect(new URL(call.url).searchParams.has("limit")).toBe(false);
+    });
+  });
+
+  describe("bulkSync", () => {
+    const bulkResponse: BulkSyncResponse = {
+      created: 2, updated: 1, skipped: 0, errors: [],
+    };
+
+    it("sends POST to /drivers/bulk-sync", async () => {
+      const { fn, call } = createMockFetch(bulkResponse);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = {
+        sourceSystem: "erp",
+        entities: [
+          { externalId: "ext-1", fields: { firstName: "John" } },
+          { externalId: "ext-2", fields: { firstName: "Jane" } },
+        ],
+      };
+
+      const result = await client.drivers.bulkSync(body);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.url).toBe(`${BASE_URL}${DRIVERS}/bulk-sync`);
+      expect(call.init.body).toBe(JSON.stringify(body));
+      expect(result).toEqual(bulkResponse);
+    });
+
+    it("returns counts and errors from response", async () => {
+      const responseWithErrors: BulkSyncResponse = {
+        created: 1, updated: 0, skipped: 0,
+        errors: [{ externalId: "ext-bad", message: "Invalid RUT" }],
+      };
+      const { fn } = createMockFetch(responseWithErrors);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.drivers.bulkSync({ sourceSystem: "erp", entities: [] });
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.externalId).toBe("ext-bad");
+    });
+  });
+});

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/fleet.test.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/fleet.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { createMiotResourceClient } from "../index.js";
+import type { Carrier, EntityEvent, Trailer, Truck, Vehicle } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+const BASE_URL = "https://api.example.com";
+const FLEET = "/api/v1/fleet";
+
+const tenant = { id: 1, code: "t-1", name: "Tenant 1", active: true };
+
+const sampleTruck: Truck = {
+  id: 1, tenant, clientId: "c-1", entityId: "uuid-truck-1",
+  externalId: "ext-1", status: "ACTIVE", alfrescoNodeId: "node-1",
+  active: true, createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+  licensePlate: "ABC123", vin: "VIN123", brand: "Volvo", model: "FH16",
+  year: 2022, maxWeight: 25000, volume: 100, truckType: "RIGID",
+};
+
+const sampleTrailer: Trailer = {
+  id: 2, tenant, clientId: "c-1", entityId: "uuid-trailer-1",
+  externalId: "ext-2", status: "ACTIVE", alfrescoNodeId: "node-2",
+  active: true, createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+  licensePlate: "XYZ456", trailerType: "FLATBED", maxWeight: 20000, axleCount: 3,
+};
+
+const sampleCarrier: Carrier = {
+  id: 3, tenant, clientId: "c-1", entityId: "uuid-carrier-1",
+  externalId: "ext-3", status: "ACTIVE", alfrescoNodeId: "node-3",
+  active: true, createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
+  name: "Acme Transport", rut: "76543210-1", transportLicense: "LIC-001",
+  transportLicenseExpires: "2026-12-31T00:00:00Z",
+};
+
+const sampleVehicle: Vehicle = {
+  id: 4, tenant, plate: "DEF789", vin: "VIN456",
+  brand: "Mercedes", model: "Actros", year: 2021, active: true,
+};
+
+const sampleEvent: EntityEvent = {
+  id: 10, clientId: "c-1", entityType: "TRUCK", entityId: "uuid-truck-1",
+  eventType: "STATUS_CHANGED", eventSource: "api", actor: "user-1",
+  payload: "{}", metadata: "{}", createdAt: "2025-01-01T00:00:00Z",
+};
+
+describe("fleet", () => {
+  describe("trucks", () => {
+    it("listTrucks sends GET to /fleet/trucks", async () => {
+      const { fn, call } = createMockFetch([sampleTruck]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.listTrucks();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trucks`);
+    });
+
+    it("listTrucks passes pagination params", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.listTrucks({ page: 2, size: 10 });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("page")).toBe("2");
+      expect(url.searchParams.get("size")).toBe("10");
+    });
+
+    it("getTruck sends GET to /fleet/trucks/:id", async () => {
+      const { fn, call } = createMockFetch(sampleTruck);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.getTruck(1);
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trucks/1`);
+      expect(result).toEqual(sampleTruck);
+    });
+
+    it("createTruck sends POST with body", async () => {
+      const { fn, call } = createMockFetch(sampleTruck);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { licensePlate: "ABC123", brand: "Volvo" };
+
+      await client.fleet.createTruck(body);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trucks`);
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+
+    it("changeTruckStatus sends PATCH to /fleet/trucks/:id/status", async () => {
+      const { fn, call } = createMockFetch(sampleTruck);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.changeTruckStatus(1, { status: "INACTIVE", reason: "Maintenance" });
+
+      expect(call.init.method).toBe("PATCH");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trucks/1/status`);
+    });
+
+    it("listTruckEvents sends GET to /fleet/trucks/:id/events", async () => {
+      const { fn, call } = createMockFetch([sampleEvent]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.listTruckEvents(1, { limit: 20 });
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toContain(`${FLEET}/trucks/1/events`);
+      expect(new URL(call.url).searchParams.get("limit")).toBe("20");
+      expect(result).toEqual([sampleEvent]);
+    });
+  });
+
+  describe("trailers", () => {
+    it("listTrailers sends GET to /fleet/trailers", async () => {
+      const { fn, call } = createMockFetch([sampleTrailer]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.listTrailers();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trailers`);
+      expect(result).toEqual([sampleTrailer]);
+    });
+
+    it("getTrailer sends GET to /fleet/trailers/:id", async () => {
+      const { fn, call } = createMockFetch(sampleTrailer);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.getTrailer(2);
+
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trailers/2`);
+      expect(result).toEqual(sampleTrailer);
+    });
+
+    it("createTrailer sends POST with body", async () => {
+      const { fn, call } = createMockFetch(sampleTrailer);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { licensePlate: "XYZ456", trailerType: "FLATBED" };
+
+      await client.fleet.createTrailer(body);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+
+    it("changeTrailerStatus sends PATCH to /fleet/trailers/:id/status", async () => {
+      const { fn, call } = createMockFetch(sampleTrailer);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.changeTrailerStatus(2, { status: "INACTIVE" });
+
+      expect(call.init.method).toBe("PATCH");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/trailers/2/status`);
+    });
+
+    it("listTrailerEvents sends GET to /fleet/trailers/:id/events", async () => {
+      const { fn, call } = createMockFetch([sampleEvent]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.listTrailerEvents(2);
+
+      expect(call.url).toContain(`${FLEET}/trailers/2/events`);
+    });
+  });
+
+  describe("carriers", () => {
+    it("listCarriers sends GET to /fleet/carriers", async () => {
+      const { fn, call } = createMockFetch([sampleCarrier]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.listCarriers();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/carriers`);
+      expect(result).toEqual([sampleCarrier]);
+    });
+
+    it("getCarrier sends GET to /fleet/carriers/:id", async () => {
+      const { fn, call } = createMockFetch(sampleCarrier);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.getCarrier(3);
+
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/carriers/3`);
+      expect(result).toEqual(sampleCarrier);
+    });
+
+    it("createCarrier sends POST with body", async () => {
+      const { fn, call } = createMockFetch(sampleCarrier);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { name: "Acme Transport", rut: "76543210-1" };
+
+      await client.fleet.createCarrier(body);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+
+    it("changeCarrierStatus sends PATCH to /fleet/carriers/:id/status", async () => {
+      const { fn, call } = createMockFetch(sampleCarrier);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.changeCarrierStatus(3, { status: "SUSPENDED" });
+
+      expect(call.init.method).toBe("PATCH");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/carriers/3/status`);
+    });
+
+    it("listCarrierEvents sends GET to /fleet/carriers/:id/events", async () => {
+      const { fn, call } = createMockFetch([sampleEvent]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.fleet.listCarrierEvents(3, { limit: 5 });
+
+      expect(call.url).toContain(`${FLEET}/carriers/3/events`);
+      expect(new URL(call.url).searchParams.get("limit")).toBe("5");
+    });
+  });
+
+  describe("vehicles", () => {
+    it("listVehicles sends GET to /fleet/vehicles", async () => {
+      const { fn, call } = createMockFetch([sampleVehicle]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.fleet.listVehicles();
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${FLEET}/vehicles`);
+      expect(result).toEqual([sampleVehicle]);
+    });
+  });
+});

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/sync.test.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/sync.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { createMiotResourceClient } from "../index.js";
+import type { SyncCursor } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+const BASE_URL = "https://api.example.com";
+const CURSOR = "/api/v1/sync/cursor";
+
+const sampleCursor: SyncCursor = {
+  sourceSystem: "erp",
+  entityType: "DRIVER",
+  cursorType: "timestamp",
+  cursorValue: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-15T12:00:00Z",
+};
+
+describe("sync", () => {
+  describe("getCursor", () => {
+    it("sends GET to /sync/cursor/:sourceSystem/:entityType", async () => {
+      const { fn, call } = createMockFetch(sampleCursor);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.sync.getCursor("erp", "DRIVER");
+
+      expect(call.init.method).toBe("GET");
+      expect(call.url).toBe(`${BASE_URL}${CURSOR}/erp/DRIVER`);
+      expect(result).toEqual(sampleCursor);
+    });
+
+    it("encodes path segments correctly", async () => {
+      const { fn, call } = createMockFetch(sampleCursor);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.sync.getCursor("my-system", "TRUCK");
+
+      expect(call.url).toBe(`${BASE_URL}${CURSOR}/my-system/TRUCK`);
+    });
+  });
+
+  describe("advanceCursor", () => {
+    it("sends PUT with body to /sync/cursor/:sourceSystem/:entityType", async () => {
+      const { fn, call } = createMockFetch(sampleCursor);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = {
+        cursorType: "timestamp",
+        cursorValue: "2025-06-01T00:00:00Z",
+        entitiesSynced: 150,
+        errors: 0,
+      };
+
+      const result = await client.sync.advanceCursor("erp", "DRIVER", body);
+
+      expect(call.init.method).toBe("PUT");
+      expect(call.url).toBe(`${BASE_URL}${CURSOR}/erp/DRIVER`);
+      expect(call.init.body).toBe(JSON.stringify(body));
+      expect(result).toEqual(sampleCursor);
+    });
+
+    it("sends partial body when only some fields are provided", async () => {
+      const { fn, call } = createMockFetch(sampleCursor);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, fetch: fn });
+      const body = { cursorValue: "2025-06-01T00:00:00Z" };
+
+      await client.sync.advanceCursor("erp", "TRUCK", body);
+
+      expect(call.init.body).toBe(JSON.stringify(body));
+    });
+  });
+});

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/test-utils.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/test-utils.ts
@@ -1,0 +1,19 @@
+export function createMockFetch<T>(response: T, status = 200) {
+  const call = { url: "", init: {} as RequestInit };
+  const fn = async (url: string | URL | Request, init: RequestInit = {}) => {
+    if (typeof url === "string") {
+      call.url = url;
+    } else if (url instanceof URL) {
+      call.url = url.href;
+    } else {
+      call.url = url.url;
+    }
+    call.init = init;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => response,
+    } as Response;
+  };
+  return { fn, call };
+}

--- a/turbo-repo/packages/miot-resource-client/src/client.ts
+++ b/turbo-repo/packages/miot-resource-client/src/client.ts
@@ -1,0 +1,82 @@
+import type { ClientConfig } from "./types.js";
+import { MiotResourceApiError } from "./errors.js";
+import { createFleetApi } from "./resources/fleet.js";
+import { createDriversApi } from "./resources/drivers.js";
+import { createSyncApi } from "./resources/sync.js";
+
+export interface FetchOptions<TBody = unknown> {
+  body?: TBody;
+  query?: Record<string, string | number | boolean | undefined>;
+  headers?: Record<string, string>;
+}
+
+export type Fetcher = <T, TBody = unknown>(
+  method: string,
+  path: string,
+  options?: FetchOptions<TBody>,
+) => Promise<T>;
+
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string | number | boolean | undefined>,
+): string {
+  const url = new URL(path, baseUrl);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+  return url.toString();
+}
+
+export function createMiotResourceClient(config: ClientConfig) {
+  const fetchFn = config.fetch ?? globalThis.fetch;
+
+  const fetcher: Fetcher = async <T>(
+    method: string,
+    path: string,
+    options?: FetchOptions,
+  ): Promise<T> => {
+    const url = buildUrl(config.baseUrl, path, options?.query);
+
+    const headers: Record<string, string> = {
+      ...config.headers,
+      ...options?.headers,
+    };
+
+    if (options?.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const response = await fetchFn(url, {
+      method,
+      headers,
+      body: options?.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    if (!response.ok) {
+      let body: import("./types.js").ErrorResponse | string;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text();
+      }
+      throw new MiotResourceApiError(response.status, body);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  };
+
+  return {
+    fleet: createFleetApi(fetcher),
+    drivers: createDriversApi(fetcher),
+    sync: createSyncApi(fetcher),
+  };
+}

--- a/turbo-repo/packages/miot-resource-client/src/errors.ts
+++ b/turbo-repo/packages/miot-resource-client/src/errors.ts
@@ -1,0 +1,12 @@
+import type { ErrorResponse } from "./types.js";
+
+export class MiotResourceApiError extends Error {
+  override name = "MiotResourceApiError" as const;
+
+  constructor(
+    public readonly status: number,
+    public readonly body: ErrorResponse | string,
+  ) {
+    super(typeof body === "string" ? body : body.message);
+  }
+}

--- a/turbo-repo/packages/miot-resource-client/src/index.ts
+++ b/turbo-repo/packages/miot-resource-client/src/index.ts
@@ -1,0 +1,26 @@
+export { createMiotResourceClient } from "./client.js";
+export { MiotResourceApiError } from "./errors.js";
+export type {
+  EntityType,
+  Tenant,
+  EntityEvent,
+  StatusChangeRequest,
+  PageParams,
+  Truck,
+  CreateTruckRequest,
+  Trailer,
+  CreateTrailerRequest,
+  Carrier,
+  CreateCarrierRequest,
+  Vehicle,
+  Driver,
+  CreateDriverRequest,
+  UpdateDriverRequest,
+  BulkSyncEntity,
+  BulkSyncRequest,
+  BulkSyncResponse,
+  SyncCursor,
+  AdvanceCursorRequest,
+  ErrorResponse,
+  ClientConfig,
+} from "./types.js";

--- a/turbo-repo/packages/miot-resource-client/src/resources/drivers.ts
+++ b/turbo-repo/packages/miot-resource-client/src/resources/drivers.ts
@@ -1,0 +1,45 @@
+import type { Fetcher } from "../client.js";
+import type {
+  BulkSyncRequest,
+  BulkSyncResponse,
+  CreateDriverRequest,
+  Driver,
+  EntityEvent,
+  PageParams,
+  StatusChangeRequest,
+  UpdateDriverRequest,
+} from "../types.js";
+
+const BASE = "/api/v1/drivers";
+
+export function createDriversApi(fetcher: Fetcher) {
+  return {
+    list(params?: PageParams): Promise<Driver[]> {
+      return fetcher("GET", BASE, { query: params });
+    },
+
+    get(id: number): Promise<Driver> {
+      return fetcher("GET", `${BASE}/${id}`);
+    },
+
+    create(body: CreateDriverRequest): Promise<Driver> {
+      return fetcher("POST", BASE, { body });
+    },
+
+    update(id: number, body: UpdateDriverRequest): Promise<Driver> {
+      return fetcher("PUT", `${BASE}/${id}`, { body });
+    },
+
+    changeStatus(id: number, body: StatusChangeRequest): Promise<Driver> {
+      return fetcher("PATCH", `${BASE}/${id}/status`, { body });
+    },
+
+    listEvents(id: number, params?: { limit?: number }): Promise<EntityEvent[]> {
+      return fetcher("GET", `${BASE}/${id}/events`, { query: params });
+    },
+
+    bulkSync(body: BulkSyncRequest): Promise<BulkSyncResponse> {
+      return fetcher("POST", `${BASE}/bulk-sync`, { body });
+    },
+  };
+}

--- a/turbo-repo/packages/miot-resource-client/src/resources/fleet.ts
+++ b/turbo-repo/packages/miot-resource-client/src/resources/fleet.ts
@@ -1,0 +1,91 @@
+import type { Fetcher } from "../client.js";
+import type {
+  Carrier,
+  CreateCarrierRequest,
+  CreateTrailerRequest,
+  CreateTruckRequest,
+  EntityEvent,
+  PageParams,
+  StatusChangeRequest,
+  Trailer,
+  Truck,
+  Vehicle,
+} from "../types.js";
+
+const BASE = "/api/v1/fleet";
+
+export function createFleetApi(fetcher: Fetcher) {
+  return {
+    // --- Trucks ---
+
+    listTrucks(params?: PageParams): Promise<Truck[]> {
+      return fetcher("GET", `${BASE}/trucks`, { query: params });
+    },
+
+    getTruck(id: number): Promise<Truck> {
+      return fetcher("GET", `${BASE}/trucks/${id}`);
+    },
+
+    createTruck(body: CreateTruckRequest): Promise<Truck> {
+      return fetcher("POST", `${BASE}/trucks`, { body });
+    },
+
+    changeTruckStatus(id: number, body: StatusChangeRequest): Promise<Truck> {
+      return fetcher("PATCH", `${BASE}/trucks/${id}/status`, { body });
+    },
+
+    listTruckEvents(id: number, params?: { limit?: number }): Promise<EntityEvent[]> {
+      return fetcher("GET", `${BASE}/trucks/${id}/events`, { query: params });
+    },
+
+    // --- Trailers ---
+
+    listTrailers(params?: PageParams): Promise<Trailer[]> {
+      return fetcher("GET", `${BASE}/trailers`, { query: params });
+    },
+
+    getTrailer(id: number): Promise<Trailer> {
+      return fetcher("GET", `${BASE}/trailers/${id}`);
+    },
+
+    createTrailer(body: CreateTrailerRequest): Promise<Trailer> {
+      return fetcher("POST", `${BASE}/trailers`, { body });
+    },
+
+    changeTrailerStatus(id: number, body: StatusChangeRequest): Promise<Trailer> {
+      return fetcher("PATCH", `${BASE}/trailers/${id}/status`, { body });
+    },
+
+    listTrailerEvents(id: number, params?: { limit?: number }): Promise<EntityEvent[]> {
+      return fetcher("GET", `${BASE}/trailers/${id}/events`, { query: params });
+    },
+
+    // --- Carriers ---
+
+    listCarriers(params?: PageParams): Promise<Carrier[]> {
+      return fetcher("GET", `${BASE}/carriers`, { query: params });
+    },
+
+    getCarrier(id: number): Promise<Carrier> {
+      return fetcher("GET", `${BASE}/carriers/${id}`);
+    },
+
+    createCarrier(body: CreateCarrierRequest): Promise<Carrier> {
+      return fetcher("POST", `${BASE}/carriers`, { body });
+    },
+
+    changeCarrierStatus(id: number, body: StatusChangeRequest): Promise<Carrier> {
+      return fetcher("PATCH", `${BASE}/carriers/${id}/status`, { body });
+    },
+
+    listCarrierEvents(id: number, params?: { limit?: number }): Promise<EntityEvent[]> {
+      return fetcher("GET", `${BASE}/carriers/${id}/events`, { query: params });
+    },
+
+    // --- Vehicles (read-only legacy) ---
+
+    listVehicles(): Promise<Vehicle[]> {
+      return fetcher("GET", `${BASE}/vehicles`);
+    },
+  };
+}

--- a/turbo-repo/packages/miot-resource-client/src/resources/sync.ts
+++ b/turbo-repo/packages/miot-resource-client/src/resources/sync.ts
@@ -1,0 +1,20 @@
+import type { Fetcher } from "../client.js";
+import type { AdvanceCursorRequest, SyncCursor } from "../types.js";
+
+const BASE = "/api/v1/sync/cursor";
+
+export function createSyncApi(fetcher: Fetcher) {
+  return {
+    getCursor(sourceSystem: string, entityType: string): Promise<SyncCursor> {
+      return fetcher("GET", `${BASE}/${sourceSystem}/${entityType}`);
+    },
+
+    advanceCursor(
+      sourceSystem: string,
+      entityType: string,
+      body: AdvanceCursorRequest,
+    ): Promise<SyncCursor> {
+      return fetcher("PUT", `${BASE}/${sourceSystem}/${entityType}`, { body });
+    },
+  };
+}

--- a/turbo-repo/packages/miot-resource-client/src/types.ts
+++ b/turbo-repo/packages/miot-resource-client/src/types.ts
@@ -1,0 +1,257 @@
+// --- Enums ---
+
+export type EntityType = "DRIVER" | "TRUCK" | "TRAILER" | "CARRIER";
+
+// --- Shared ---
+
+export interface Tenant {
+  id: number;
+  code: string;
+  name: string;
+  active: boolean;
+}
+
+export interface EntityEvent {
+  id: number;
+  clientId: string;
+  entityType: EntityType;
+  entityId: string;
+  eventType: string;
+  eventSource: string;
+  actor: string;
+  payload: string;
+  metadata: string;
+  createdAt: string;
+}
+
+export interface StatusChangeRequest {
+  status: string;
+  reason?: string;
+}
+
+export interface PageParams {
+  page?: number;
+  size?: number;
+  [key: string]: string | number | boolean | undefined;
+}
+
+// --- Fleet: Trucks ---
+
+export interface Truck {
+  id: number;
+  tenant: Tenant;
+  clientId: string;
+  entityId: string;
+  externalId: string;
+  status: string;
+  alfrescoNodeId: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  licensePlate: string;
+  vin: string;
+  brand: string;
+  model: string;
+  year: number;
+  maxWeight: number;
+  volume: number;
+  truckType: string;
+}
+
+export interface CreateTruckRequest {
+  externalId?: string;
+  licensePlate?: string;
+  vin?: string;
+  brand?: string;
+  model?: string;
+  year?: number;
+  maxWeight?: number;
+  volume?: number;
+  truckType?: string;
+}
+
+// --- Fleet: Trailers ---
+
+export interface Trailer {
+  id: number;
+  tenant: Tenant;
+  clientId: string;
+  entityId: string;
+  externalId: string;
+  status: string;
+  alfrescoNodeId: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  licensePlate: string;
+  trailerType: string;
+  maxWeight: number;
+  axleCount: number;
+}
+
+export interface CreateTrailerRequest {
+  externalId?: string;
+  licensePlate?: string;
+  trailerType?: string;
+  maxWeight?: number;
+  axleCount?: number;
+}
+
+// --- Fleet: Carriers ---
+
+export interface Carrier {
+  id: number;
+  tenant: Tenant;
+  clientId: string;
+  entityId: string;
+  externalId: string;
+  status: string;
+  alfrescoNodeId: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  name: string;
+  rut: string;
+  transportLicense: string;
+  transportLicenseExpires: string;
+}
+
+export interface CreateCarrierRequest {
+  externalId?: string;
+  name?: string;
+  rut?: string;
+  transportLicense?: string;
+  transportLicenseExpires?: string;
+}
+
+// --- Fleet: Vehicles (read-only legacy) ---
+
+export interface Vehicle {
+  id: number;
+  tenant: Tenant;
+  plate: string;
+  vin: string;
+  brand: string;
+  model: string;
+  year: number;
+  active: boolean;
+}
+
+// --- Drivers ---
+
+export interface Driver {
+  id: number;
+  tenant: Tenant;
+  clientId: string;
+  entityId: string;
+  externalId: string;
+  status: string;
+  alfrescoNodeId: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  firstName: string;
+  lastName: string;
+  rut: string;
+  phone?: string;
+  mobilePhone?: string;
+  email?: string;
+  licenseNumber?: string;
+  licenseCategory?: string;
+  licenseExpires?: string;
+  carrierId?: number;
+  isOccasional?: boolean;
+  operationBlocked?: boolean;
+  addressStreet?: string;
+  addressCity?: string;
+  addressPostalCode?: string;
+  addressCountry?: string;
+  deactivatedAt?: string;
+  sourceSystem?: string;
+}
+
+export interface CreateDriverRequest {
+  externalId?: string;
+  firstName?: string;
+  lastName?: string;
+  rut?: string;
+  phone?: string;
+  mobilePhone?: string;
+  email?: string;
+  licenseNumber?: string;
+  licenseCategory?: string;
+  licenseExpires?: string;
+  carrierExternalId?: string;
+  isOccasional?: boolean;
+  operationBlocked?: boolean;
+}
+
+export interface UpdateDriverRequest {
+  firstName?: string;
+  lastName?: string;
+  rut?: string;
+  phone?: string;
+  mobilePhone?: string;
+  email?: string;
+  licenseNumber?: string;
+  licenseCategory?: string;
+  licenseExpires?: string;
+  carrierExternalId?: string;
+  isOccasional?: boolean;
+  operationBlocked?: boolean;
+}
+
+// --- Bulk sync ---
+
+export interface BulkSyncEntity {
+  externalId: string;
+  fields?: Record<string, unknown>;
+  sourceMetadata?: Record<string, unknown>;
+  aspectProperties?: Record<string, unknown>;
+}
+
+export interface BulkSyncRequest {
+  sourceSystem: string;
+  entities: BulkSyncEntity[];
+}
+
+export interface BulkSyncResponse {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: Array<{ externalId: string; message: string }>;
+}
+
+// --- Sync cursors ---
+
+export interface SyncCursor {
+  sourceSystem: string;
+  entityType: string;
+  cursorType: string;
+  cursorValue: string;
+  updatedAt: string;
+}
+
+export interface AdvanceCursorRequest {
+  cursorType?: string;
+  cursorValue?: string;
+  entitiesSynced?: number;
+  errors?: number;
+}
+
+// --- Error ---
+
+export interface ErrorResponse {
+  error: string;
+  message: string;
+  status: number;
+  timestamp: string;
+}
+
+// --- Client config ---
+
+export interface ClientConfig {
+  baseUrl: string;
+  headers?: Record<string, string>;
+  fetch?: typeof fetch;
+}

--- a/turbo-repo/packages/miot-resource-client/tsconfig.json
+++ b/turbo-repo/packages/miot-resource-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo-repo/packages/miot-resource-client/tsup.config.ts
+++ b/turbo-repo/packages/miot-resource-client/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  // Explicit .mjs/.cjs extensions so "type":"module" is not needed in package.json
+  outExtension: ({ format }) => ({ js: format === "esm" ? ".mjs" : ".cjs" }),
+});


### PR DESCRIPTION
Closes #192

## Summary
- Extends `.github/workflows/quarkus.yml` with `docker-jvm` and `security-scan` jobs, mirroring the `miot-calendar` pipeline structure
- Updates `quarkus-srv/Dockerfile` from `eclipse-temurin:21-jre-alpine` to `ubi9/openjdk-21` with four-layer caching, non-root user, and JBoss `run-java.sh`
- Publishes `ghcr.io/microboxlabs/miot-srv` to GHCR (always) and Docker Hub (non-PR), multi-platform `amd64`+`arm64`

## Test plan
- [x] PR build triggers `build-jvm` → `docker-jvm` successfully
- [x] Image tagged `pr-192` appears on GHCR
- [x] `docker run ghcr.io/microboxlabs/miot-srv:pr-192 miot fleet` starts only the fleet component
- [x] Merge to trunk produces `latest` and `sha-<short>` tags on both GHCR and Docker Hub
- [x] `security-scan` runs and uploads SARIF to GitHub code scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-stage CI pipeline with build, multi-arch image build/publish, gated security scanning, and automatic versioning from v* tags.
  * New MIoT Resource Client package exposing typed client APIs for fleet, drivers, and sync, plus a dedicated API error type.

* **Tests**
  * Comprehensive unit test suites and test utilities added for the new client surface.

* **Chores**
  * CI trigger and workflow improvements, runtime/container layout and startup adjustments, and test-time component flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->