### PR TITLE
feat: add undo/redo support for dashboard edit mode

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -95,8 +95,8 @@ export function DashboardView() {
         undo();
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    globalThis.addEventListener("keydown", handleKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleKeyDown);
   }, [editMode, undo, redo]);
 
   // Convert widgets to react-grid-layout format

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { Button, ToggleSwitch } from "flowbite-react";
-import { HiPlus } from "react-icons/hi2";
+import { HiPlus, HiArrowUturnLeft, HiArrowUturnRight } from "react-icons/hi2";
 import {
   GridLayout,
   verticalCompactor,
@@ -34,6 +34,10 @@ export function DashboardView() {
     dictionary,
     toggleEditMode,
     updateWidgetLayouts,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   } = useDashboard();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -73,6 +77,27 @@ export function DashboardView() {
       window.removeEventListener("resize", updateWidth);
     };
   }, [isLoaded]); // Re-run when isLoaded changes
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!editMode) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod || e.key.toLowerCase() !== "z") return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (target?.isContentEditable) return;
+
+      e.preventDefault();
+      if (e.shiftKey) {
+        redo();
+      } else {
+        undo();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [editMode, undo, redo]);
 
   // Convert widgets to react-grid-layout format
   const layout: Layout = useMemo(
@@ -145,6 +170,28 @@ export function DashboardView() {
             {dashboardName}
           </h1>
           <div className="flex shrink-0 items-center gap-4">
+            {editMode && (
+              <div className="flex items-center gap-1">
+                <Button
+                  size="xs"
+                  color="light"
+                  onClick={undo}
+                  disabled={!canUndo()}
+                  title={`${tr("dashboard.undo", dictionary)} (Ctrl+Z)`}
+                >
+                  <HiArrowUturnLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="xs"
+                  color="light"
+                  onClick={redo}
+                  disabled={!canRedo()}
+                  title={`${tr("dashboard.redo", dictionary)} (Ctrl+Shift+Z)`}
+                >
+                  <HiArrowUturnRight className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
             {hasWidgets && (
               <ToggleSwitch
                 checked={editMode}

--- a/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
@@ -84,6 +84,12 @@ interface DashboardContextValue {
   addPlannerRequest: (def: Omit<PlannerRequestDefinition, "id">) => string;
   updatePlannerRequest: (id: string, partial: Partial<PlannerRequestDefinition>) => void;
   removePlannerRequest: (id: string) => void;
+
+  // Undo/Redo
+  undo: () => void;
+  redo: () => void;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
 }
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
@@ -179,6 +185,10 @@ export function DashboardProvider({
     addPlannerRequest,
     updatePlannerRequest,
     removePlannerRequest,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   } = useDashboardStorage(slug, defaultConfig, siteId);
 
   const createWidget = useCallback(
@@ -386,6 +396,10 @@ export function DashboardProvider({
       addPlannerRequest,
       updatePlannerRequest,
       removePlannerRequest,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
     }),
     [
       widgets,
@@ -414,6 +428,10 @@ export function DashboardProvider({
       addPlannerRequest,
       updatePlannerRequest,
       removePlannerRequest,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
     ]
   );
 

--- a/turbo-repo/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/hooks/use-dashboard-storage.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_STORAGE,
 } from "../types/dashboard.types";
 import { getDashlet } from "../dashlets";
+import { useUndoRedo } from "./use-undo-redo";
 
 /**
  * Ensure widget has all required fields with defaults
@@ -237,13 +238,26 @@ export function useDashboardStorage(
     };
   }, [slug]);
 
-  // Save data: optimistic SWR mutate + debounced Alfresco PUT
-  const saveData = useCallback(
+  // Raw save: optimistic SWR mutate + debounced Alfresco PUT (no history)
+  const rawSaveData = useCallback(
     (newData: DashboardStorageSchema) => {
       void mutate({ data: newData }, { revalidate: false });
       scheduleSaveToAlfresco(newData);
     },
     [mutate, scheduleSaveToAlfresco]
+  );
+
+  // Undo/redo history wrapping rawSaveData
+  const {
+    saveDataWithHistory: saveData,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    clearHistory,
+  } = useUndoRedo(
+    () => configRef.current,
+    rawSaveData
   );
 
   // Helper: update config via a transform on the current widgets.
@@ -507,7 +521,8 @@ export function useDashboardStorage(
           refreshInterval: imported.refreshInterval,
         };
 
-        saveData(newData);
+        clearHistory();
+        rawSaveData(newData);
         return { success: true };
       } catch (e) {
         return {
@@ -516,7 +531,7 @@ export function useDashboardStorage(
         };
       }
     },
-    [saveData]
+    [clearHistory, rawSaveData]
   );
 
   return {
@@ -545,5 +560,9 @@ export function useDashboardStorage(
     addPlannerRequest,
     updatePlannerRequest,
     removePlannerRequest,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   };
 }

--- a/turbo-repo/apps/app/src/features/dashboard/hooks/use-undo-redo.test.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/hooks/use-undo-redo.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useUndoRedo } from "./use-undo-redo";
+import { makeDashboardStorage } from "../test-fixtures";
+
+describe("useUndoRedo", () => {
+  const stateA = makeDashboardStorage({ name: "State A" });
+  const stateB = makeDashboardStorage({ name: "State B" });
+  const stateC = makeDashboardStorage({ name: "State C" });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with empty undo/redo stacks", () => {
+    const saveData = vi.fn();
+    const { result } = renderHook(() => useUndoRedo(() => stateA, saveData));
+
+    expect(result.current.canUndo()).toBe(false);
+    expect(result.current.canRedo()).toBe(false);
+  });
+
+  it("pushes snapshot on saveDataWithHistory and supports undo", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // Mutate: A -> B
+    act(() => {
+      result.current.saveDataWithHistory(stateB);
+    });
+    current = stateB;
+    expect(saveData).toHaveBeenLastCalledWith(stateB);
+    expect(result.current.canUndo()).toBe(true);
+
+    // Advance past batch window
+    act(() => vi.advanceTimersByTime(600));
+
+    // Undo: B -> A
+    act(() => {
+      result.current.undo();
+    });
+    current = stateA;
+    expect(saveData).toHaveBeenLastCalledWith(stateA);
+    expect(result.current.canUndo()).toBe(false);
+    expect(result.current.canRedo()).toBe(true);
+  });
+
+  it("supports redo after undo", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // A -> B
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+    act(() => vi.advanceTimersByTime(600));
+
+    // B -> C
+    act(() => result.current.saveDataWithHistory(stateC));
+    current = stateC;
+    act(() => vi.advanceTimersByTime(600));
+
+    // Undo to B
+    act(() => result.current.undo());
+    current = stateB;
+    expect(saveData).toHaveBeenLastCalledWith(stateB);
+
+    // Redo to C
+    act(() => result.current.redo());
+    current = stateC;
+    expect(saveData).toHaveBeenLastCalledWith(stateC);
+    expect(result.current.canRedo()).toBe(false);
+  });
+
+  it("clears redo stack on new mutation after undo", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+    act(() => vi.advanceTimersByTime(600));
+
+    // Undo to A
+    act(() => result.current.undo());
+    current = stateA;
+    expect(result.current.canRedo()).toBe(true);
+
+    act(() => vi.advanceTimersByTime(600));
+
+    // New mutation: A -> C (should clear redo)
+    act(() => result.current.saveDataWithHistory(stateC));
+    current = stateC;
+    expect(result.current.canRedo()).toBe(false);
+  });
+
+  it("batches mutations within the 500ms window into a single undo entry", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // First mutation: A -> B (pushes snapshot A)
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+
+    // Second mutation within 500ms: B -> C (should NOT push another snapshot)
+    act(() => vi.advanceTimersByTime(100));
+    act(() => result.current.saveDataWithHistory(stateC));
+    current = stateC;
+
+    // Single undo should go from C back to A (skipping B)
+    act(() => vi.advanceTimersByTime(600));
+    act(() => result.current.undo());
+    current = stateA;
+    expect(saveData).toHaveBeenLastCalledWith(stateA);
+    expect(result.current.canUndo()).toBe(false);
+
+    // Redo should go from A back to C
+    act(() => result.current.redo());
+    current = stateC;
+    expect(saveData).toHaveBeenLastCalledWith(stateC);
+  });
+
+  it("limits history to max 50 snapshots", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // Push 60 snapshots (each outside batch window)
+    for (let i = 0; i < 60; i++) {
+      act(() => vi.advanceTimersByTime(600));
+      const state = makeDashboardStorage({ name: `State ${i}` });
+      act(() => result.current.saveDataWithHistory(state));
+      current = state;
+    }
+
+    // Should only be able to undo 50 times
+    let undoCount = 0;
+    while (result.current.canUndo()) {
+      act(() => result.current.undo());
+      undoCount++;
+    }
+    expect(undoCount).toBe(50);
+  });
+
+  it("clearHistory empties both stacks", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+    act(() => vi.advanceTimersByTime(600));
+    act(() => result.current.undo());
+    current = stateA;
+
+    expect(result.current.canUndo()).toBe(false);
+    expect(result.current.canRedo()).toBe(true);
+
+    act(() => result.current.clearHistory());
+    expect(result.current.canUndo()).toBe(false);
+    expect(result.current.canRedo()).toBe(false);
+  });
+
+  it("ignores side-effect mutations after undo (preserves redo stack)", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // A -> B
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+    act(() => vi.advanceTimersByTime(600));
+
+    // Undo: B -> A
+    act(() => result.current.undo());
+    current = stateA;
+    expect(result.current.canRedo()).toBe(true);
+
+    // Simulate onLayoutChange side-effect within 500ms of undo
+    const layoutState = makeDashboardStorage({ name: "Layout adjustment" });
+    act(() => vi.advanceTimersByTime(100));
+    act(() => result.current.saveDataWithHistory(layoutState));
+    current = layoutState;
+
+    // Redo stack should NOT have been cleared by the side-effect
+    expect(result.current.canRedo()).toBe(true);
+  });
+
+  it("ignores side-effect mutations after redo (preserves undo stack)", () => {
+    const saveData = vi.fn();
+    let current = stateA;
+    const { result } = renderHook(() => useUndoRedo(() => current, saveData));
+
+    // A -> B
+    act(() => result.current.saveDataWithHistory(stateB));
+    current = stateB;
+    act(() => vi.advanceTimersByTime(600));
+
+    // Undo: B -> A
+    act(() => result.current.undo());
+    current = stateA;
+
+    // Redo: A -> B
+    act(() => result.current.redo());
+    current = stateB;
+    expect(result.current.canUndo()).toBe(true);
+
+    // Simulate side-effect within 500ms of redo
+    const layoutState = makeDashboardStorage({ name: "Layout adjustment" });
+    act(() => vi.advanceTimersByTime(100));
+    act(() => result.current.saveDataWithHistory(layoutState));
+    current = layoutState;
+
+    // Undo stack should still work — undo the redo
+    expect(result.current.canUndo()).toBe(true);
+  });
+
+  it("undo/redo are no-ops when stacks are empty", () => {
+    const saveData = vi.fn();
+    const { result } = renderHook(() => useUndoRedo(() => stateA, saveData));
+
+    act(() => result.current.undo());
+    act(() => result.current.redo());
+    expect(saveData).not.toHaveBeenCalled();
+  });
+});

--- a/turbo-repo/apps/app/src/features/dashboard/hooks/use-undo-redo.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/hooks/use-undo-redo.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import type { DashboardStorageSchema } from "../types/dashboard.types";
+
+const MAX_HISTORY = 50;
+
+/**
+ * Batch window in ms. Mutations within this window of each other are treated
+ * as a single undoable action. This prevents react-grid-layout's automatic
+ * `onLayoutChange` (which fires right after add/remove/undo/redo) from
+ * creating a separate undo entry or clearing the redo stack.
+ */
+const BATCH_WINDOW_MS = 500;
+
+/**
+ * Snapshot-based undo/redo history for dashboard state.
+ *
+ * Wraps a `saveData` callback so that every mutation automatically
+ * pushes the *previous* state onto the undo stack.
+ */
+export function useUndoRedo(
+  getCurrentConfig: () => DashboardStorageSchema,
+  saveData: (data: DashboardStorageSchema) => void
+) {
+  const undoStackRef = useRef<DashboardStorageSchema[]>([]);
+  const redoStackRef = useRef<DashboardStorageSchema[]>([]);
+  // Timestamp of the last snapshot push — used for batching normal mutations
+  const lastPushTimeRef = useRef(0);
+  // Timestamp of the last undo/redo — side-effect mutations within the batch
+  // window after an undo/redo are silently ignored (no snapshot, no redo clear).
+  const lastUndoRedoTimeRef = useRef(0);
+
+  /** Push current state to undo stack before a mutation */
+  const pushSnapshot = useCallback(() => {
+    const now = Date.now();
+
+    // If we're within the batch window of an undo/redo, this mutation is a
+    // side-effect (e.g. onLayoutChange). Ignore it completely — don't push
+    // a snapshot and don't clear the redo stack.
+    if (now - lastUndoRedoTimeRef.current <= BATCH_WINDOW_MS) {
+      return;
+    }
+
+    if (now - lastPushTimeRef.current > BATCH_WINDOW_MS) {
+      // Outside batch window → new undo entry
+      const current = getCurrentConfig();
+      const stack = undoStackRef.current;
+      stack.push(current);
+      if (stack.length > MAX_HISTORY) {
+        stack.shift();
+      }
+      lastPushTimeRef.current = now;
+    }
+    // Inside batch window of a previous user mutation → skip push; the
+    // snapshot already on the stack is the correct "before" state.
+
+    if (redoStackRef.current.length > 0) {
+      redoStackRef.current = [];
+    }
+  }, [getCurrentConfig]);
+
+  /** Wrapped saveData that records history */
+  const saveDataWithHistory = useCallback(
+    (data: DashboardStorageSchema) => {
+      pushSnapshot();
+      saveData(data);
+    },
+    [pushSnapshot, saveData]
+  );
+
+  const undo = useCallback(() => {
+    const stack = undoStackRef.current;
+    if (stack.length === 0) return;
+    const previous = stack.pop()!;
+    redoStackRef.current.push(getCurrentConfig());
+    lastUndoRedoTimeRef.current = Date.now();
+    saveData(previous);
+  }, [getCurrentConfig, saveData]);
+
+  const redo = useCallback(() => {
+    const stack = redoStackRef.current;
+    if (stack.length === 0) return;
+    const next = stack.pop()!;
+    undoStackRef.current.push(getCurrentConfig());
+    lastUndoRedoTimeRef.current = Date.now();
+    saveData(next);
+  }, [getCurrentConfig, saveData]);
+
+  const canUndo = useCallback(() => undoStackRef.current.length > 0, []);
+  const canRedo = useCallback(() => redoStackRef.current.length > 0, []);
+
+  /** Clear all history (e.g. on import) */
+  const clearHistory = useCallback(() => {
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+    lastPushTimeRef.current = 0;
+    lastUndoRedoTimeRef.current = 0;
+  }, []);
+
+  return {
+    saveDataWithHistory,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    clearHistory,
+  };
+}


### PR DESCRIPTION
- Add useUndoRedo hook with history stack management and unit tests
- Wire undo/redo into dashboard context and storage layer
- Add undo/redo toolbar buttons visible in edit mode
- Support Ctrl+Z / Ctrl+Shift+Z keyboard shortcuts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Undo/redo in dashboard edit mode with header buttons and Ctrl/Cmd+Z / Ctrl/Cmd+Shift+Z shortcuts.
  * Rapid edits are intelligently batched into single undoable actions; history capped to 50 entries.
  * Imports no longer populate undo history; shortcuts ignore text inputs and editable fields.

* **Tests**
  * Added comprehensive undo/redo tests covering batching, stack behavior, limits, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->