### PR TITLE
feat(app): add storm environment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ apps/app/.env.local.dev
 
 # Aura
 .aura
+turbo-repo/apps/app/.env.storm

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",
+    "storm": "dotenv -e .env.storm -- next dev --port 3050",
     "build": "NODE_OPTIONS=--enable-source-maps next build",
     "start": "next start",
     "lint": "eslint .",
@@ -99,6 +100,7 @@
     "@vitest/coverage-v8": "^4.0.10",
     "@vitest/ui": "^4.0.10",
     "autoprefixer": "^10.4.19",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "jsdom": "^24.0.0",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -100,6 +100,7 @@
         "@vitest/coverage-v8": "^4.0.10",
         "@vitest/ui": "^4.0.10",
         "autoprefixer": "^10.4.19",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "jsdom": "^24.0.0",
@@ -12262,6 +12263,51 @@
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
       "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/turbo-repo/package.json
+++ b/turbo-repo/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "storm": "turbo run storm",
     "lint": "turbo run lint --filter='!@modulariot/web-admin'",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types --filter='!@modulariot/web-admin'",

--- a/turbo-repo/turbo.json
+++ b/turbo-repo/turbo.json
@@ -36,6 +36,10 @@
       "cache": false,
       "persistent": true
     },
+    "storm": {
+      "cache": false,
+      "persistent": true
+    },
     "test": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

- Add `storm` script to `apps/app/package.json` using `dotenv-cli` to load `.env.storm` before starting Next.js on port 3050
- Add `storm` task to `turbo.json` (`cache: false`, `persistent: true`)
- Add `storm` script to root `package.json` (`turbo run storm`)
- Add `dotenv-cli` as a devDependency in `apps/app`

## Usage

```bash
npm run storm        # from repo root or apps/app
turbo run storm      # from turbo-repo/
```

Closes #203

## Test plan

- [x] Run `npm run storm` from repo root and verify Next.js starts on port 3050 with `.env.storm` variables loaded
- [x] Confirm `STREAMHUB_URL` and other storm-specific vars are picked up correctly
- [x] Confirm `npm run dev` still works unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new development task enabling alternative environment configuration
  * Configured persistent execution across the monorepo workspace
  * Introduced environment-specific development script with custom environment variable support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->