### PR TITLE
feat(auth): org-scoped API endpoints with Alfresco membership validation

### DIFF
--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -43,6 +43,7 @@ public class FlywayMigrator {
         Flyway flyway = Flyway.configure()
                 .dataSource(dataSource)
                 .locations(locations.toArray(String[]::new))
+                .outOfOrder(true)
                 .load();
 
         flyway.migrate();

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/IAlfrescoMembershipClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/IAlfrescoMembershipClient.java
@@ -1,0 +1,20 @@
+package com.microboxlabs.miot.core.alfresco;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Checks user membership and roles in Alfresco groups/sites.
+ * Alfresco is the source of truth for organization membership and permissions.
+ *
+ * personId  — Alfresco person ID, typically the user's email address
+ * groupId   — Alfresco group ID (e.g., "GROUP_acme") or site shortname (e.g., "acme-logistics")
+ *
+ * Site roles: SITE_MANAGER, SITE_COLLABORATOR, SITE_CONTRIBUTOR, SITE_CONSUMER
+ * Group roles: GROUP_ADMIN, GROUP_MEMBER
+ */
+public interface IAlfrescoMembershipClient {
+
+    Uni<Boolean> isMember(String personId, String groupId);
+
+    Uni<String> getRole(String personId, String groupId);
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/StubAlfrescoMembershipClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/StubAlfrescoMembershipClient.java
@@ -1,0 +1,29 @@
+package com.microboxlabs.miot.core.alfresco;
+
+import io.quarkus.arc.DefaultBean;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+/**
+ * Stub implementation — always approves membership.
+ * Active by default until a real Alfresco REST client is registered.
+ */
+@ApplicationScoped
+@DefaultBean
+public class StubAlfrescoMembershipClient implements IAlfrescoMembershipClient {
+
+    private static final Logger LOG = Logger.getLogger(StubAlfrescoMembershipClient.class);
+
+    @Override
+    public Uni<Boolean> isMember(String personId, String groupId) {
+        LOG.warnf("STUB: membership check for '%s' in '%s' — always returning true", personId, groupId);
+        return Uni.createFrom().item(true);
+    }
+
+    @Override
+    public Uni<String> getRole(String personId, String groupId) {
+        LOG.warnf("STUB: role lookup for '%s' in '%s' — returning SITE_MANAGER", personId, groupId);
+        return Uni.createFrom().item("SITE_MANAGER");
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationContext.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationContext.java
@@ -1,0 +1,44 @@
+package com.microboxlabs.miot.core.auth;
+
+import jakarta.enterprise.context.RequestScoped;
+
+/**
+ * Holds the resolved organization for the current request.
+ * Populated by OrganizationRequestFilter from the URL path ({organizationId}).
+ * Only set for org-scoped endpoints: /api/v1/orgs/{organizationId}/...
+ */
+@RequestScoped
+public class OrganizationContext {
+
+    private String organizationId;
+    private String userEmail;
+    private String alfrescoRole;
+
+    public boolean isResolved() {
+        return organizationId != null;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
+    public String getAlfrescoRole() {
+        return alfrescoRole;
+    }
+
+    public void setAlfrescoRole(String alfrescoRole) {
+        this.alfrescoRole = alfrescoRole;
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
@@ -8,6 +8,7 @@ import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -26,8 +27,12 @@ import org.jboss.resteasy.reactive.server.ServerRequestFilter;
  *     - Validates that JWT aud/azp matches org.tenantClientId
  *     - No Alfresco check — the M2M token itself is proof of authorization
  *
- * In both cases TenantContext.clientId is set to org.tenantClientId so all
- * downstream services work unchanged.
+ * Hierarchy:
+ *   - Parent orgs (parent == null): effectiveClientIds = [own] + [all direct children]
+ *   - Child orgs (parent != null): effectiveClientIds = [own]
+ *
+ * In both cases TenantContext.clientId is set to org.tenantClientId (used for writes)
+ * and TenantContext.effectiveClientIds is set for read-scoped queries.
  *
  * Dev fallback: X-Organization-Id header + X-Client-Id header bypass JWT checks.
  */
@@ -54,7 +59,8 @@ public class OrganizationRequestFilter {
             return Uni.createFrom().voidItem();
         }
 
-        return Panache.withSession(() -> Organization.<Organization>find("slug = ?1 and active = true", orgSlug).firstResult())
+        return Panache.withSession(() ->
+            Organization.<Organization>find("slug = ?1 and active = true", orgSlug).firstResult()
                 .flatMap(org -> {
                     if (org == null) {
                         requestContext.abortWith(Response.status(Response.Status.NOT_FOUND)
@@ -65,27 +71,52 @@ public class OrganizationRequestFilter {
                     }
 
                     String email = resolveEmail(requestContext);
-                    if (email != null) {
-                        return handleWebUser(requestContext, org, email);
-                    }
-
                     String m2mClientId = resolveM2mClientId(requestContext);
-                    if (m2mClientId != null) {
-                        return handleM2mClient(requestContext, org, m2mClientId);
+
+                    Uni<String> accessValidation;
+                    if (email != null) {
+                        accessValidation = validateWebUser(requestContext, org, email);
+                    } else if (m2mClientId != null) {
+                        accessValidation = validateM2mClient(requestContext, org, m2mClientId);
+                    } else {
+                        requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
+                                .entity("{\"error\":\"Cannot resolve caller identity for organization request\"}")
+                                .type("application/json")
+                                .build());
+                        return Uni.createFrom().voidItem();
                     }
 
-                    requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
-                            .entity("{\"error\":\"Cannot resolve caller identity for organization request\"}")
-                            .type("application/json")
-                            .build());
-                    return Uni.createFrom().voidItem();
+                    return accessValidation.flatMap(role ->
+                        resolveEffectiveClientIds(org).invoke(ids -> applyContext(org, email, role, ids))
+                    ).replaceWithVoid();
+                })
+        );
+    }
+
+    /**
+     * For parent orgs: collects tenantClientId from all direct children.
+     * For child orgs: returns a single-element list.
+     */
+    private Uni<List<String>> resolveEffectiveClientIds(Organization org) {
+        List<String> ids = new ArrayList<>();
+        ids.add(org.tenantClientId);
+
+        if (org.parent != null) {
+            // This is a child org — no children of its own
+            return Uni.createFrom().item(ids);
+        }
+
+        // This is a parent org — load direct children
+        return Organization.<Organization>find("parent.id = ?1 and active = true", org.id).list()
+                .map(children -> {
+                    children.forEach(child -> ids.add(child.tenantClientId));
+                    return ids;
                 });
     }
 
-    private Uni<Void> handleWebUser(ContainerRequestContext requestContext, Organization org, String email) {
+    private Uni<String> validateWebUser(ContainerRequestContext requestContext, Organization org, String email) {
         if (org.alfrescoGroupId == null) {
-            applyContext(org, email, null);
-            return Uni.createFrom().voidItem();
+            return Uni.createFrom().nullItem();
         }
         return alfrescoMembership.isMember(email, org.alfrescoGroupId)
                 .flatMap(isMember -> {
@@ -94,35 +125,32 @@ public class OrganizationRequestFilter {
                                 .entity("{\"error\":\"User is not a member of organization: " + org.slug + "\"}")
                                 .type("application/json")
                                 .build());
-                        return Uni.createFrom().voidItem();
+                        return Uni.createFrom().nullItem();
                     }
-                    return alfrescoMembership.getRole(email, org.alfrescoGroupId)
-                            .invoke(role -> applyContext(org, email, role))
-                            .replaceWithVoid();
+                    return alfrescoMembership.getRole(email, org.alfrescoGroupId);
                 });
     }
 
-    private Uni<Void> handleM2mClient(ContainerRequestContext requestContext, Organization org, String m2mClientId) {
+    private Uni<String> validateM2mClient(ContainerRequestContext requestContext, Organization org, String m2mClientId) {
         if (!m2mClientId.equals(org.tenantClientId)) {
             requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
                     .entity("{\"error\":\"M2M client is not authorized for organization: " + org.slug + "\"}")
                     .type("application/json")
                     .build());
-            return Uni.createFrom().voidItem();
+            return Uni.createFrom().nullItem();
         }
-        applyContext(org, null, null);
-        LOG.debugf("M2M client authorized for org: slug=%s tenant=%s", org.slug, org.tenantClientId);
-        return Uni.createFrom().voidItem();
+        return Uni.createFrom().nullItem();
     }
 
-    private void applyContext(Organization org, String userEmail, String role) {
+    private void applyContext(Organization org, String userEmail, String role, List<String> effectiveClientIds) {
         tenantContext.setClientId(org.tenantClientId);
         tenantContext.setTenantCode(org.tenantClientId);
+        tenantContext.setEffectiveClientIds(effectiveClientIds);
         organizationContext.setOrganizationId(org.slug);
         organizationContext.setUserEmail(userEmail);
         organizationContext.setAlfrescoRole(role);
-        LOG.debugf("Organization resolved: slug=%s tenant=%s user=%s role=%s",
-                org.slug, org.tenantClientId, userEmail, role);
+        LOG.debugf("Organization resolved: slug=%s tenant=%s effectiveIds=%s user=%s role=%s",
+                org.slug, org.tenantClientId, effectiveClientIds, userEmail, role);
     }
 
     private String extractOrgSlug(String path) {

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
@@ -1,0 +1,160 @@
+package com.microboxlabs.miot.core.auth;
+
+import com.microboxlabs.miot.core.alfresco.IAlfrescoMembershipClient;
+import com.microboxlabs.miot.core.model.Organization;
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+
+/**
+ * Validates organization membership for all org-scoped endpoints.
+ * Intercepts requests to /api/v1/orgs/{organizationId}/... and:
+ *
+ *   Web users (JWT has email claim):
+ *     - Validates Alfresco group membership
+ *     - Role is read from Alfresco
+ *
+ *   M2M services (no email claim):
+ *     - Validates that JWT aud/azp matches org.tenantClientId
+ *     - No Alfresco check — the M2M token itself is proof of authorization
+ *
+ * In both cases TenantContext.clientId is set to org.tenantClientId so all
+ * downstream services work unchanged.
+ *
+ * Dev fallback: X-Organization-Id header + X-Client-Id header bypass JWT checks.
+ */
+public class OrganizationRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationRequestFilter.class);
+    private static final String ORG_PATH_PREFIX = "/api/v1/orgs/";
+    private static final String ORG_HEADER = "X-Organization-Id";
+
+    @Inject TenantContext tenantContext;
+    @Inject OrganizationContext organizationContext;
+    @Inject SecurityIdentity securityIdentity;
+    @Inject IAlfrescoMembershipClient alfrescoMembership;
+
+    @ConfigProperty(name = "miot.auth.client-id-claims", defaultValue = "aud,azp")
+    List<String> clientIdClaims;
+
+    @ServerRequestFilter
+    public Uni<Void> filter(ContainerRequestContext requestContext) {
+        String path = requestContext.getUriInfo().getPath();
+        String orgSlug = extractOrgSlug(path);
+
+        if (orgSlug == null) {
+            return Uni.createFrom().voidItem();
+        }
+
+        return Panache.withSession(() -> Organization.<Organization>find("slug = ?1 and active = true", orgSlug).firstResult())
+                .flatMap(org -> {
+                    if (org == null) {
+                        requestContext.abortWith(Response.status(Response.Status.NOT_FOUND)
+                                .entity("{\"error\":\"Organization not found: " + orgSlug + "\"}")
+                                .type("application/json")
+                                .build());
+                        return Uni.createFrom().voidItem();
+                    }
+
+                    String email = resolveEmail(requestContext);
+                    if (email != null) {
+                        return handleWebUser(requestContext, org, email);
+                    }
+
+                    String m2mClientId = resolveM2mClientId(requestContext);
+                    if (m2mClientId != null) {
+                        return handleM2mClient(requestContext, org, m2mClientId);
+                    }
+
+                    requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
+                            .entity("{\"error\":\"Cannot resolve caller identity for organization request\"}")
+                            .type("application/json")
+                            .build());
+                    return Uni.createFrom().voidItem();
+                });
+    }
+
+    private Uni<Void> handleWebUser(ContainerRequestContext requestContext, Organization org, String email) {
+        if (org.alfrescoGroupId == null) {
+            applyContext(org, email, null);
+            return Uni.createFrom().voidItem();
+        }
+        return alfrescoMembership.isMember(email, org.alfrescoGroupId)
+                .flatMap(isMember -> {
+                    if (!isMember) {
+                        requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
+                                .entity("{\"error\":\"User is not a member of organization: " + org.slug + "\"}")
+                                .type("application/json")
+                                .build());
+                        return Uni.createFrom().voidItem();
+                    }
+                    return alfrescoMembership.getRole(email, org.alfrescoGroupId)
+                            .invoke(role -> applyContext(org, email, role))
+                            .replaceWithVoid();
+                });
+    }
+
+    private Uni<Void> handleM2mClient(ContainerRequestContext requestContext, Organization org, String m2mClientId) {
+        if (!m2mClientId.equals(org.tenantClientId)) {
+            requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
+                    .entity("{\"error\":\"M2M client is not authorized for organization: " + org.slug + "\"}")
+                    .type("application/json")
+                    .build());
+            return Uni.createFrom().voidItem();
+        }
+        applyContext(org, null, null);
+        LOG.debugf("M2M client authorized for org: slug=%s tenant=%s", org.slug, org.tenantClientId);
+        return Uni.createFrom().voidItem();
+    }
+
+    private void applyContext(Organization org, String userEmail, String role) {
+        tenantContext.setClientId(org.tenantClientId);
+        tenantContext.setTenantCode(org.tenantClientId);
+        organizationContext.setOrganizationId(org.slug);
+        organizationContext.setUserEmail(userEmail);
+        organizationContext.setAlfrescoRole(role);
+        LOG.debugf("Organization resolved: slug=%s tenant=%s user=%s role=%s",
+                org.slug, org.tenantClientId, userEmail, role);
+    }
+
+    private String extractOrgSlug(String path) {
+        if (!path.startsWith(ORG_PATH_PREFIX)) return null;
+        String rest = path.substring(ORG_PATH_PREFIX.length());
+        int slash = rest.indexOf('/');
+        String slug = slash == -1 ? rest : rest.substring(0, slash);
+        return slug.isBlank() ? null : slug;
+    }
+
+    private String resolveEmail(ContainerRequestContext requestContext) {
+        if (securityIdentity != null && !securityIdentity.isAnonymous()) {
+            var principal = securityIdentity.getPrincipal();
+            if (principal instanceof JsonWebToken jwt) {
+                String email = jwt.getClaim("email");
+                if (email != null && !email.isBlank()) return email;
+            }
+        }
+        return requestContext.getHeaderString(ORG_HEADER);
+    }
+
+    private String resolveM2mClientId(ContainerRequestContext requestContext) {
+        if (securityIdentity != null && !securityIdentity.isAnonymous()) {
+            var principal = securityIdentity.getPrincipal();
+            if (principal instanceof JsonWebToken jwt) {
+                for (String claim : clientIdClaims) {
+                    Object val = jwt.getClaim(claim.trim());
+                    if (val instanceof List<?> list && !list.isEmpty()) return list.get(0).toString();
+                    if (val != null) return val.toString();
+                }
+            }
+        }
+        return tenantContext.getClientId();
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
@@ -180,7 +180,8 @@ public class OrganizationRequestFilter {
                 if (email != null && !email.isBlank()) return email;
             }
         }
-        return requestContext.getHeaderString(ORG_HEADER);
+        // Dev-only impersonation header — distinct from the org-slug header
+        return requestContext.getHeaderString("X-Dev-User-Email");
     }
 
     private String resolveM2mClientId() {

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
@@ -7,6 +7,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
 /**
  * Validates organization membership for all org-scoped endpoints.
- * Intercepts requests to /api/v1/orgs/{organizationId}/... and:
+ * Intercepts requests to {orgPathPrefix}{organizationId}/... and:
  *
  *   Web users (JWT has email claim):
  *     - Validates Alfresco group membership
@@ -34,21 +35,35 @@ import org.jboss.resteasy.reactive.server.ServerRequestFilter;
  * In both cases TenantContext.clientId is set to org.tenantClientId (used for writes)
  * and TenantContext.effectiveClientIds is set for read-scoped queries.
  *
- * Dev fallback: X-Organization-Id header + X-Client-Id header bypass JWT checks.
+ * Dev fallback: X-Organization-Id header bypasses JWT checks.
  */
 public class OrganizationRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(OrganizationRequestFilter.class);
-    private static final String ORG_PATH_PREFIX = "/api/v1/orgs/";
     private static final String ORG_HEADER = "X-Organization-Id";
 
-    @Inject TenantContext tenantContext;
-    @Inject OrganizationContext organizationContext;
-    @Inject SecurityIdentity securityIdentity;
-    @Inject IAlfrescoMembershipClient alfrescoMembership;
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final SecurityIdentity securityIdentity;
+    private final IAlfrescoMembershipClient alfrescoMembership;
+    private final List<String> clientIdClaims;
+    private final String orgPathPrefix;
 
-    @ConfigProperty(name = "miot.auth.client-id-claims", defaultValue = "aud,azp")
-    List<String> clientIdClaims;
+    @Inject
+    public OrganizationRequestFilter(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            SecurityIdentity securityIdentity,
+            IAlfrescoMembershipClient alfrescoMembership,
+            @ConfigProperty(name = "miot.auth.client-id-claims", defaultValue = "aud,azp") List<String> clientIdClaims,
+            @ConfigProperty(name = "miot.auth.org-path-prefix", defaultValue = "/api/v1/orgs/") String orgPathPrefix) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.securityIdentity = securityIdentity;
+        this.alfrescoMembership = alfrescoMembership;
+        this.clientIdClaims = clientIdClaims;
+        this.orgPathPrefix = orgPathPrefix;
+    }
 
     @ServerRequestFilter
     public Uni<Void> filter(ContainerRequestContext requestContext) {
@@ -60,54 +75,51 @@ public class OrganizationRequestFilter {
         }
 
         return Panache.withSession(() ->
-            Organization.<Organization>find("slug = ?1 and active = true", orgSlug).firstResult()
+            Organization.findBySlug(orgSlug)
                 .flatMap(org -> {
                     if (org == null) {
                         requestContext.abortWith(Response.status(Response.Status.NOT_FOUND)
                                 .entity("{\"error\":\"Organization not found: " + orgSlug + "\"}")
-                                .type("application/json")
+                                .type(MediaType.APPLICATION_JSON)
                                 .build());
                         return Uni.createFrom().voidItem();
                     }
-
-                    String email = resolveEmail(requestContext);
-                    String m2mClientId = resolveM2mClientId(requestContext);
-
-                    Uni<String> accessValidation;
-                    if (email != null) {
-                        accessValidation = validateWebUser(requestContext, org, email);
-                    } else if (m2mClientId != null) {
-                        accessValidation = validateM2mClient(requestContext, org, m2mClientId);
-                    } else {
-                        requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
-                                .entity("{\"error\":\"Cannot resolve caller identity for organization request\"}")
-                                .type("application/json")
-                                .build());
-                        return Uni.createFrom().voidItem();
-                    }
-
-                    return accessValidation.flatMap(role ->
-                        resolveEffectiveClientIds(org).invoke(ids -> applyContext(org, email, role, ids))
-                    ).replaceWithVoid();
+                    return validateAndApply(requestContext, org);
                 })
         );
     }
 
-    /**
-     * For parent orgs: collects tenantClientId from all direct children.
-     * For child orgs: returns a single-element list.
-     */
+    private Uni<Void> validateAndApply(ContainerRequestContext requestContext, Organization org) {
+        String email = resolveEmail(requestContext);
+        String m2mClientId = resolveM2mClientId();
+
+        Uni<String> accessValidation;
+        if (email != null) {
+            accessValidation = validateWebUser(requestContext, org, email);
+        } else if (m2mClientId != null) {
+            accessValidation = validateM2mClient(requestContext, org, m2mClientId);
+        } else {
+            requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
+                    .entity("{\"error\":\"Cannot resolve caller identity for organization request\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build());
+            return Uni.createFrom().voidItem();
+        }
+
+        return accessValidation.flatMap(role ->
+            resolveEffectiveClientIds(org).invoke(ids -> applyContext(org, email, role, ids))
+        ).replaceWithVoid();
+    }
+
     private Uni<List<String>> resolveEffectiveClientIds(Organization org) {
         List<String> ids = new ArrayList<>();
         ids.add(org.tenantClientId);
 
         if (org.parent != null) {
-            // This is a child org — no children of its own
             return Uni.createFrom().item(ids);
         }
 
-        // This is a parent org — load direct children
-        return Organization.<Organization>find("parent.id = ?1 and active = true", org.id).list()
+        return Organization.findByParent(org.id)
                 .map(children -> {
                     children.forEach(child -> ids.add(child.tenantClientId));
                     return ids;
@@ -120,10 +132,10 @@ public class OrganizationRequestFilter {
         }
         return alfrescoMembership.isMember(email, org.alfrescoGroupId)
                 .flatMap(isMember -> {
-                    if (!isMember) {
+                    if (!Boolean.TRUE.equals(isMember)) {
                         requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
                                 .entity("{\"error\":\"User is not a member of organization: " + org.slug + "\"}")
-                                .type("application/json")
+                                .type(MediaType.APPLICATION_JSON)
                                 .build());
                         return Uni.createFrom().nullItem();
                     }
@@ -135,9 +147,8 @@ public class OrganizationRequestFilter {
         if (!m2mClientId.equals(org.tenantClientId)) {
             requestContext.abortWith(Response.status(Response.Status.FORBIDDEN)
                     .entity("{\"error\":\"M2M client is not authorized for organization: " + org.slug + "\"}")
-                    .type("application/json")
+                    .type(MediaType.APPLICATION_JSON)
                     .build());
-            return Uni.createFrom().nullItem();
         }
         return Uni.createFrom().nullItem();
     }
@@ -154,8 +165,8 @@ public class OrganizationRequestFilter {
     }
 
     private String extractOrgSlug(String path) {
-        if (!path.startsWith(ORG_PATH_PREFIX)) return null;
-        String rest = path.substring(ORG_PATH_PREFIX.length());
+        if (!path.startsWith(orgPathPrefix)) return null;
+        String rest = path.substring(orgPathPrefix.length());
         int slash = rest.indexOf('/');
         String slug = slash == -1 ? rest : rest.substring(0, slash);
         return slug.isBlank() ? null : slug;
@@ -172,17 +183,21 @@ public class OrganizationRequestFilter {
         return requestContext.getHeaderString(ORG_HEADER);
     }
 
-    private String resolveM2mClientId(ContainerRequestContext requestContext) {
+    private String resolveM2mClientId() {
         if (securityIdentity != null && !securityIdentity.isAnonymous()) {
             var principal = securityIdentity.getPrincipal();
             if (principal instanceof JsonWebToken jwt) {
                 for (String claim : clientIdClaims) {
-                    Object val = jwt.getClaim(claim.trim());
-                    if (val instanceof List<?> list && !list.isEmpty()) return list.get(0).toString();
-                    if (val != null) return val.toString();
+                    String value = extractClaimValue(jwt.getClaim(claim.trim()));
+                    if (value != null) return value;
                 }
             }
         }
         return tenantContext.getClientId();
+    }
+
+    private static String extractClaimValue(Object val) {
+        if (val instanceof List<?> list && !list.isEmpty()) return list.get(0).toString();
+        return val != null ? val.toString() : null;
     }
 }

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/OrganizationRequestFilter.java
@@ -40,7 +40,6 @@ import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 public class OrganizationRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(OrganizationRequestFilter.class);
-    private static final String ORG_HEADER = "X-Organization-Id";
 
     private final TenantContext tenantContext;
     private final OrganizationContext organizationContext;

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/TenantContext.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/TenantContext.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.core.auth;
 
 import jakarta.enterprise.context.RequestScoped;
+import java.util.List;
 
 /**
  * Holds the resolved tenant for the current request.
@@ -12,6 +13,13 @@ public class TenantContext {
     private String clientId;
     private String tenantCode;
     private Long tenantId;
+    /**
+     * Effective client IDs for read-scoped queries.
+     * For child orgs: single element [own clientId].
+     * For parent orgs: [own clientId] + all direct children clientIds.
+     * Falls back to [clientId] when not explicitly set.
+     */
+    private List<String> effectiveClientIds;
 
     public String getClientId() {
         return clientId;
@@ -35,5 +43,13 @@ public class TenantContext {
 
     public void setTenantId(Long tenantId) {
         this.tenantId = tenantId;
+    }
+
+    public List<String> getEffectiveClientIds() {
+        return effectiveClientIds != null ? effectiveClientIds : List.of(clientId);
+    }
+
+    public void setEffectiveClientIds(List<String> effectiveClientIds) {
+        this.effectiveClientIds = effectiveClientIds;
     }
 }

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
@@ -1,0 +1,38 @@
+package com.microboxlabs.miot.core.model;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * An organization is the multi-tenant unit for web users.
+ * It maps a URL-friendly slug to:
+ *   - alfrescoGroupId: the Alfresco group/site used for membership and permission checks
+ *   - tenantClientId:  the Auth0 M2M client ID (= Tenant.code) that scopes all data queries
+ */
+@Entity
+@Table(name = "organizations", schema = "miot_core")
+public class Organization extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    @Column(nullable = false, unique = true)
+    public String slug;
+
+    @Column(nullable = false)
+    public String name;
+
+    @Column(name = "alfresco_group_id")
+    public String alfrescoGroupId;
+
+    @Column(name = "tenant_client_id", nullable = false)
+    public String tenantClientId;
+
+    public boolean active = true;
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.core.model;
 
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+import io.smallrye.mutiny.Uni;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 
 /**
  * An organization is the multi-tenant unit for web users.
@@ -42,5 +44,16 @@ public class Organization extends PanacheEntityBase {
     @JoinColumn(name = "parent_id")
     public Organization parent;
 
+    @Column(nullable = false)
     public boolean active = true;
+
+    // --- Named finders (avoids static access via inherited PanacheEntityBase) ---
+
+    public static Uni<Organization> findBySlug(String slug) {
+        return find("slug = ?1 and active = true", slug).firstResult();
+    }
+
+    public static Uni<List<Organization>> findByParent(Long parentId) {
+        return find("parent.id = ?1 and active = true", parentId).list();
+    }
 }

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/Organization.java
@@ -3,9 +3,12 @@ package com.microboxlabs.miot.core.model;
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 /**
@@ -33,6 +36,11 @@ public class Organization extends PanacheEntityBase {
 
     @Column(name = "tenant_client_id", nullable = false)
     public String tenantClientId;
+
+    /** Parent organization. Null means this org is a top-level (parent) org. Max 2 levels deep. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    public Organization parent;
 
     public boolean active = true;
 }

--- a/quarkus-srv/miot-core/src/main/resources/db/migration/core/V1.3.0__create_organizations.sql
+++ b/quarkus-srv/miot-core/src/main/resources/db/migration/core/V1.3.0__create_organizations.sql
@@ -1,0 +1,14 @@
+-- Organizations: multi-tenant units for web users
+-- Maps a URL slug to an Alfresco group (membership/permissions) and an Auth0 M2M client (data scope)
+CREATE TABLE miot_core.organizations (
+    id                BIGSERIAL    PRIMARY KEY,
+    slug              VARCHAR(100) NOT NULL UNIQUE,
+    name              VARCHAR(255) NOT NULL,
+    alfresco_group_id VARCHAR(255),          -- Alfresco GROUP_xxx or site shortname; null = skip membership check
+    tenant_client_id  VARCHAR(255) NOT NULL, -- Auth0 M2M client ID = Tenant.code
+    active            BOOLEAN      NOT NULL DEFAULT true,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_organizations_slug ON miot_core.organizations(slug) WHERE active = true;

--- a/quarkus-srv/miot-core/src/main/resources/db/migration/core/V1.4.0__add_organization_hierarchy.sql
+++ b/quarkus-srv/miot-core/src/main/resources/db/migration/core/V1.4.0__add_organization_hierarchy.sql
@@ -1,0 +1,5 @@
+-- Add parent/child hierarchy to organizations (max 2 levels: parent → children)
+ALTER TABLE miot_core.organizations
+    ADD COLUMN parent_id BIGINT REFERENCES miot_core.organizations(id);
+
+CREATE INDEX idx_organizations_parent ON miot_core.organizations(parent_id) WHERE active = true;

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
@@ -1,13 +1,11 @@
 package com.microboxlabs.miot.driver.api;
 
+import com.microboxlabs.miot.core.auth.OrganizationContext;
 import com.microboxlabs.miot.core.auth.TenantContext;
 import com.microboxlabs.miot.driver.dto.CreateDriverRequest;
 import com.microboxlabs.miot.driver.dto.UpdateDriverRequest;
 import com.microboxlabs.miot.driver.model.Driver;
-import com.microboxlabs.miot.driver.service.DriverBulkSyncService;
 import com.microboxlabs.miot.driver.service.DriverService;
-import com.microboxlabs.miot.resource.dto.BulkSyncRequest;
-import com.microboxlabs.miot.resource.dto.BulkSyncResponse;
 import com.microboxlabs.miot.resource.dto.StatusChangeRequest;
 import com.microboxlabs.miot.resource.event.EntityEvent;
 import com.microboxlabs.miot.resource.event.EntityEventService;
@@ -32,22 +30,23 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-@Path("/api/v1/drivers")
+@Path("/api/v1/orgs/{organizationId}/drivers")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Drivers", description = "Driver resource directory: lifecycle, documents, compliance, scoring")
+@Tag(name = "Drivers (org-scoped)", description = "Driver endpoints scoped to a web organization")
 @SecurityRequirement(name = "oidc")
 @IfBuildProperty(name = "miot.component.driver.enabled", stringValue = "true")
-public class DriverResource {
+public class OrgDriverResource {
 
     @Inject TenantContext tenantContext;
+    @Inject OrganizationContext organizationContext;
     @Inject DriverService driverService;
-    @Inject DriverBulkSyncService bulkSyncService;
     @Inject EntityEventService eventService;
 
     @GET
     @Operation(summary = "List drivers")
     public Uni<List<Driver>> listDrivers(
+            @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
         return driverService.list(tenantContext.getClientId(), page, size);
@@ -56,7 +55,9 @@ public class DriverResource {
     @GET
     @Path("/{id}")
     @Operation(summary = "Get driver by ID")
-    public Uni<Response> getDriver(@PathParam("id") Long id) {
+    public Uni<Response> getDriver(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id) {
         return driverService.findById(tenantContext.getClientId(), id)
                 .map(driver -> driver != null
                         ? Response.ok(driver).build()
@@ -65,16 +66,21 @@ public class DriverResource {
 
     @POST
     @Operation(summary = "Create a driver")
-    public Uni<Response> createDriver(CreateDriverRequest req) {
-        return driverService.create(tenantContext.getClientId(), req, "api")
+    public Uni<Response> createDriver(
+            @PathParam("organizationId") String organizationId,
+            CreateDriverRequest req) {
+        return driverService.create(tenantContext.getClientId(), req, organizationContext.getUserEmail())
                 .map(driver -> Response.status(Response.Status.CREATED).entity(driver).build());
     }
 
     @PUT
     @Path("/{id}")
     @Operation(summary = "Update a driver")
-    public Uni<Response> updateDriver(@PathParam("id") Long id, UpdateDriverRequest req) {
-        return driverService.update(tenantContext.getClientId(), id, req, "api")
+    public Uni<Response> updateDriver(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id,
+            UpdateDriverRequest req) {
+        return driverService.update(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
                 .map(driver -> Response.ok(driver).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(Response.Status.NOT_FOUND)
@@ -84,8 +90,11 @@ public class DriverResource {
     @PATCH
     @Path("/{id}/status")
     @Operation(summary = "Change driver status")
-    public Uni<Response> changeStatus(@PathParam("id") Long id, StatusChangeRequest req) {
-        return driverService.changeStatus(tenantContext.getClientId(), id, req, "api")
+    public Uni<Response> changeStatus(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id,
+            StatusChangeRequest req) {
+        return driverService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
                 .map(driver -> Response.ok(driver).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(Response.Status.NOT_FOUND)
@@ -96,6 +105,7 @@ public class DriverResource {
     @Path("/{id}/events")
     @Operation(summary = "Get driver event history")
     public Uni<List<EntityEvent>> getEvents(
+            @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
         return driverService.findById(tenantContext.getClientId(), id)
@@ -103,12 +113,5 @@ public class DriverResource {
                     if (driver == null) return Uni.createFrom().item(List.<EntityEvent>of());
                     return eventService.listByEntity(EntityType.DRIVER, driver.entityId, limit);
                 });
-    }
-
-    @POST
-    @Path("/bulk-sync")
-    @Operation(summary = "Bulk-sync drivers from source system")
-    public Uni<BulkSyncResponse> bulkSync(BulkSyncRequest request) {
-        return bulkSyncService.process(tenantContext.getClientId(), request);
     }
 }

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
@@ -38,10 +38,19 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @IfBuildProperty(name = "miot.component.driver.enabled", stringValue = "true")
 public class OrgDriverResource {
 
-    @Inject TenantContext tenantContext;
-    @Inject OrganizationContext organizationContext;
-    @Inject DriverService driverService;
-    @Inject EntityEventService eventService;
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final DriverService driverService;
+    private final EntityEventService eventService;
+
+    @Inject
+    public OrgDriverResource(TenantContext tenantContext, OrganizationContext organizationContext,
+            DriverService driverService, EntityEventService eventService) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.driverService = driverService;
+        this.eventService = eventService;
+    }
 
     @GET
     @Operation(summary = "List drivers")

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/api/v1/orgs/{organizationId}/drivers")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Drivers (org-scoped)", description = "Driver endpoints scoped to a web organization")
+@Tag(name = "Drivers", description = "Driver resource directory: lifecycle, documents, compliance, scoring")
 @SecurityRequirement(name = "oidc")
 @IfBuildProperty(name = "miot.component.driver.enabled", stringValue = "true")
 public class OrgDriverResource {

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/api/OrgDriverResource.java
@@ -49,7 +49,7 @@ public class OrgDriverResource {
             @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
-        return driverService.list(tenantContext.getClientId(), page, size);
+        return driverService.list(tenantContext.getEffectiveClientIds(), page, size);
     }
 
     @GET
@@ -58,7 +58,7 @@ public class OrgDriverResource {
     public Uni<Response> getDriver(
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id) {
-        return driverService.findById(tenantContext.getClientId(), id)
+        return driverService.findById(tenantContext.getEffectiveClientIds(), id)
                 .map(driver -> driver != null
                         ? Response.ok(driver).build()
                         : Response.status(Response.Status.NOT_FOUND).build());
@@ -80,7 +80,7 @@ public class OrgDriverResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             UpdateDriverRequest req) {
-        return driverService.update(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
+        return driverService.update(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(driver -> Response.ok(driver).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(Response.Status.NOT_FOUND)
@@ -94,7 +94,7 @@ public class OrgDriverResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             StatusChangeRequest req) {
-        return driverService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
+        return driverService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(driver -> Response.ok(driver).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(Response.Status.NOT_FOUND)
@@ -108,7 +108,7 @@ public class OrgDriverResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
-        return driverService.findById(tenantContext.getClientId(), id)
+        return driverService.findById(tenantContext.getEffectiveClientIds(), id)
                 .flatMap(driver -> {
                     if (driver == null) return Uni.createFrom().item(List.<EntityEvent>of());
                     return eventService.listByEntity(EntityType.DRIVER, driver.entityId, limit);

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 @ApplicationScoped
 public class DriverService {
 
-    private static final String FIND_BY_ID = FIND_BY_ID;
+    private static final String FIND_BY_ID = "id = ?1 and clientId in ?2";
 
     @Inject EntityEventService eventService;
     @Inject IAlfrescoClient alfrescoClient;

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
@@ -29,24 +29,24 @@ public class DriverService {
     @Inject IAlfrescoClient alfrescoClient;
 
     @WithSession
-    public Uni<List<Driver>> list(String clientId, int page, int size) {
-        return Driver.find("clientId = ?1 and active = true order by lastName, firstName", clientId)
+    public Uni<List<Driver>> list(List<String> clientIds, int page, int size) {
+        return Driver.find("clientId in ?1 and active = true order by lastName, firstName", clientIds)
                 .page(Page.of(page, size)).list();
     }
 
     @WithSession
-    public Uni<Long> count(String clientId) {
-        return Driver.count("clientId = ?1 and active = true", clientId);
+    public Uni<Long> count(List<String> clientIds) {
+        return Driver.count("clientId in ?1 and active = true", clientIds);
     }
 
     @WithSession
-    public Uni<Driver> findById(String clientId, Long id) {
-        return Driver.find("id = ?1 and clientId = ?2", id, clientId).firstResult();
+    public Uni<Driver> findById(List<String> clientIds, Long id) {
+        return Driver.find("id = ?1 and clientId in ?2", id, clientIds).firstResult();
     }
 
     @WithSession
-    public Uni<Driver> findByExternalId(String clientId, String externalId) {
-        return Driver.find("clientId = ?1 and externalId = ?2", clientId, externalId).firstResult();
+    public Uni<Driver> findByExternalId(List<String> clientIds, String externalId) {
+        return Driver.find("clientId in ?1 and externalId = ?2", clientIds, externalId).firstResult();
     }
 
     @WithTransaction
@@ -77,8 +77,8 @@ public class DriverService {
     }
 
     @WithTransaction
-    public Uni<Driver> update(String clientId, Long id, UpdateDriverRequest req, String actor) {
-        return Driver.<Driver>find("id = ?1 and clientId = ?2", id, clientId).firstResult()
+    public Uni<Driver> update(List<String> clientIds, Long id, UpdateDriverRequest req, String actor) {
+        return Driver.<Driver>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Driver not found: " + id))
                 .flatMap(driver -> {
                     Map<String, Object> changes = new HashMap<>();
@@ -111,7 +111,7 @@ public class DriverService {
                             : Uni.createFrom().voidItem();
 
                     return alfrescoUpdate
-                            .flatMap(v -> eventService.record(clientId, EntityType.DRIVER, driver.entityId,
+                            .flatMap(v -> eventService.record(driver.clientId, EntityType.DRIVER, driver.entityId,
                                     EventTypes.ENTITY_UPDATED, "api", actor,
                                     JsonUtil.toJson(Map.of("changes", changes))))
                             .replaceWith(driver);
@@ -119,8 +119,8 @@ public class DriverService {
     }
 
     @WithTransaction
-    public Uni<Driver> changeStatus(String clientId, Long id, StatusChangeRequest req, String actor) {
-        return Driver.<Driver>find("id = ?1 and clientId = ?2", id, clientId).firstResult()
+    public Uni<Driver> changeStatus(List<String> clientIds, Long id, StatusChangeRequest req, String actor) {
+        return Driver.<Driver>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Driver not found: " + id))
                 .flatMap(driver -> {
                     String oldStatus = driver.status;
@@ -131,7 +131,7 @@ public class DriverService {
                         driver.deactivatedAt = Instant.now();
                     }
 
-                    return eventService.record(clientId, EntityType.DRIVER, driver.entityId,
+                    return eventService.record(driver.clientId, EntityType.DRIVER, driver.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status(),
                                             "reason", JsonUtil.nvl(req.reason()))))

--- a/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
+++ b/quarkus-srv/miot-driver/src/main/java/com/microboxlabs/miot/driver/service/DriverService.java
@@ -25,6 +25,8 @@ import java.util.UUID;
 @ApplicationScoped
 public class DriverService {
 
+    private static final String FIND_BY_ID = FIND_BY_ID;
+
     @Inject EntityEventService eventService;
     @Inject IAlfrescoClient alfrescoClient;
 
@@ -41,7 +43,7 @@ public class DriverService {
 
     @WithSession
     public Uni<Driver> findById(List<String> clientIds, Long id) {
-        return Driver.find("id = ?1 and clientId in ?2", id, clientIds).firstResult();
+        return Driver.find(FIND_BY_ID, id, clientIds).firstResult();
     }
 
     @WithSession
@@ -78,7 +80,7 @@ public class DriverService {
 
     @WithTransaction
     public Uni<Driver> update(List<String> clientIds, Long id, UpdateDriverRequest req, String actor) {
-        return Driver.<Driver>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
+        return Driver.<Driver>find(FIND_BY_ID, id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Driver not found: " + id))
                 .flatMap(driver -> {
                     Map<String, Object> changes = new HashMap<>();
@@ -120,7 +122,7 @@ public class DriverService {
 
     @WithTransaction
     public Uni<Driver> changeStatus(List<String> clientIds, Long id, StatusChangeRequest req, String actor) {
-        return Driver.<Driver>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
+        return Driver.<Driver>find(FIND_BY_ID, id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Driver not found: " + id))
                 .flatMap(driver -> {
                     String oldStatus = driver.status;

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
@@ -37,7 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Path("/api/v1/orgs/{organizationId}/fleet")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Fleet (org-scoped)", description = "Fleet endpoints scoped to a web organization")
+@Tag(name = "Fleet", description = "Fleet resource directory: vehicles, trucks, trailers, carriers")
 @SecurityRequirement(name = "oidc")
 @IfBuildProperty(name = "miot.component.fleet.enabled", stringValue = "true")
 public class OrgFleetResource {

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
@@ -42,12 +42,26 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @IfBuildProperty(name = "miot.component.fleet.enabled", stringValue = "true")
 public class OrgFleetResource {
 
-    @Inject TenantContext tenantContext;
-    @Inject OrganizationContext organizationContext;
-    @Inject TruckService truckService;
-    @Inject TrailerService trailerService;
-    @Inject CarrierService carrierService;
-    @Inject EntityEventService eventService;
+    private static final String ERR_JSON_PREFIX = "{\"error\":\"";
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final TruckService truckService;
+    private final TrailerService trailerService;
+    private final CarrierService carrierService;
+    private final EntityEventService eventService;
+
+    @Inject
+    public OrgFleetResource(TenantContext tenantContext, OrganizationContext organizationContext,
+            TruckService truckService, TrailerService trailerService,
+            CarrierService carrierService, EntityEventService eventService) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.truckService = truckService;
+        this.trailerService = trailerService;
+        this.carrierService = carrierService;
+        this.eventService = eventService;
+    }
 
     // --- Trucks ---
 
@@ -91,7 +105,7 @@ public class OrgFleetResource {
         return truckService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
-                .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
+                .recoverWithItem(e -> Response.status(404).entity(ERR_JSON_PREFIX + e.getMessage() + "\"}").build());
     }
 
     @GET
@@ -148,7 +162,7 @@ public class OrgFleetResource {
         return trailerService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
-                .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
+                .recoverWithItem(e -> Response.status(404).entity(ERR_JSON_PREFIX + e.getMessage() + "\"}").build());
     }
 
     @GET
@@ -205,7 +219,7 @@ public class OrgFleetResource {
         return carrierService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(c -> Response.ok(c).build())
                 .onFailure(IllegalArgumentException.class)
-                .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
+                .recoverWithItem(e -> Response.status(404).entity(ERR_JSON_PREFIX + e.getMessage() + "\"}").build());
     }
 
     @GET

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.fleet.api;
 
+import com.microboxlabs.miot.core.auth.OrganizationContext;
 import com.microboxlabs.miot.core.auth.TenantContext;
 import com.microboxlabs.miot.fleet.dto.CreateCarrierRequest;
 import com.microboxlabs.miot.fleet.dto.CreateTrailerRequest;
@@ -7,7 +8,6 @@ import com.microboxlabs.miot.fleet.dto.CreateTruckRequest;
 import com.microboxlabs.miot.fleet.model.Carrier;
 import com.microboxlabs.miot.fleet.model.Trailer;
 import com.microboxlabs.miot.fleet.model.Truck;
-import com.microboxlabs.miot.fleet.model.Vehicle;
 import com.microboxlabs.miot.fleet.service.CarrierService;
 import com.microboxlabs.miot.fleet.service.TrailerService;
 import com.microboxlabs.miot.fleet.service.TruckService;
@@ -16,7 +16,6 @@ import com.microboxlabs.miot.resource.event.EntityEvent;
 import com.microboxlabs.miot.resource.event.EntityEventService;
 import com.microboxlabs.miot.resource.event.EntityType;
 import io.quarkus.arc.properties.IfBuildProperty;
-import io.quarkus.hibernate.reactive.panache.common.WithSession;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -35,29 +34,20 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-@Path("/api/v1/fleet")
+@Path("/api/v1/orgs/{organizationId}/fleet")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Fleet", description = "Fleet resource directory: vehicles, trucks, trailers, carriers")
+@Tag(name = "Fleet (org-scoped)", description = "Fleet endpoints scoped to a web organization")
 @SecurityRequirement(name = "oidc")
 @IfBuildProperty(name = "miot.component.fleet.enabled", stringValue = "true")
-public class FleetResource {
+public class OrgFleetResource {
 
     @Inject TenantContext tenantContext;
+    @Inject OrganizationContext organizationContext;
     @Inject TruckService truckService;
     @Inject TrailerService trailerService;
     @Inject CarrierService carrierService;
     @Inject EntityEventService eventService;
-
-    // --- Vehicles (legacy, read-only) ---
-
-    @GET
-    @Path("/vehicles")
-    @WithSession
-    @Operation(summary = "List all vehicles")
-    public Uni<List<Vehicle>> listVehicles() {
-        return Vehicle.listAll();
-    }
 
     // --- Trucks ---
 
@@ -65,6 +55,7 @@ public class FleetResource {
     @Path("/trucks")
     @Operation(summary = "List trucks")
     public Uni<List<Truck>> listTrucks(
+            @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
         return truckService.list(tenantContext.getClientId(), page, size);
@@ -73,7 +64,9 @@ public class FleetResource {
     @GET
     @Path("/trucks/{id}")
     @Operation(summary = "Get truck by ID")
-    public Uni<Response> getTruck(@PathParam("id") Long id) {
+    public Uni<Response> getTruck(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id) {
         return truckService.findById(tenantContext.getClientId(), id)
                 .map(t -> t != null ? Response.ok(t).build() : Response.status(404).build());
     }
@@ -81,16 +74,21 @@ public class FleetResource {
     @POST
     @Path("/trucks")
     @Operation(summary = "Create a truck")
-    public Uni<Response> createTruck(CreateTruckRequest req) {
-        return truckService.create(tenantContext.getClientId(), req, "api")
+    public Uni<Response> createTruck(
+            @PathParam("organizationId") String organizationId,
+            CreateTruckRequest req) {
+        return truckService.create(tenantContext.getClientId(), req, organizationContext.getUserEmail())
                 .map(t -> Response.status(201).entity(t).build());
     }
 
     @PATCH
     @Path("/trucks/{id}/status")
     @Operation(summary = "Change truck status")
-    public Uni<Response> changeTruckStatus(@PathParam("id") Long id, StatusChangeRequest req) {
-        return truckService.changeStatus(tenantContext.getClientId(), id, req, "api")
+    public Uni<Response> changeTruckStatus(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id,
+            StatusChangeRequest req) {
+        return truckService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -100,6 +98,7 @@ public class FleetResource {
     @Path("/trucks/{id}/events")
     @Operation(summary = "Get truck event history")
     public Uni<List<EntityEvent>> getTruckEvents(
+            @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
         return truckService.findById(tenantContext.getClientId(), id)
@@ -113,6 +112,7 @@ public class FleetResource {
     @Path("/trailers")
     @Operation(summary = "List trailers")
     public Uni<List<Trailer>> listTrailers(
+            @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
         return trailerService.list(tenantContext.getClientId(), page, size);
@@ -121,7 +121,9 @@ public class FleetResource {
     @GET
     @Path("/trailers/{id}")
     @Operation(summary = "Get trailer by ID")
-    public Uni<Response> getTrailer(@PathParam("id") Long id) {
+    public Uni<Response> getTrailer(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id) {
         return trailerService.findById(tenantContext.getClientId(), id)
                 .map(t -> t != null ? Response.ok(t).build() : Response.status(404).build());
     }
@@ -129,16 +131,21 @@ public class FleetResource {
     @POST
     @Path("/trailers")
     @Operation(summary = "Create a trailer")
-    public Uni<Response> createTrailer(CreateTrailerRequest req) {
-        return trailerService.create(tenantContext.getClientId(), req, "api")
+    public Uni<Response> createTrailer(
+            @PathParam("organizationId") String organizationId,
+            CreateTrailerRequest req) {
+        return trailerService.create(tenantContext.getClientId(), req, organizationContext.getUserEmail())
                 .map(t -> Response.status(201).entity(t).build());
     }
 
     @PATCH
     @Path("/trailers/{id}/status")
     @Operation(summary = "Change trailer status")
-    public Uni<Response> changeTrailerStatus(@PathParam("id") Long id, StatusChangeRequest req) {
-        return trailerService.changeStatus(tenantContext.getClientId(), id, req, "api")
+    public Uni<Response> changeTrailerStatus(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id,
+            StatusChangeRequest req) {
+        return trailerService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -148,6 +155,7 @@ public class FleetResource {
     @Path("/trailers/{id}/events")
     @Operation(summary = "Get trailer event history")
     public Uni<List<EntityEvent>> getTrailerEvents(
+            @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
         return trailerService.findById(tenantContext.getClientId(), id)
@@ -161,6 +169,7 @@ public class FleetResource {
     @Path("/carriers")
     @Operation(summary = "List carriers")
     public Uni<List<Carrier>> listCarriers(
+            @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
         return carrierService.list(tenantContext.getClientId(), page, size);
@@ -169,7 +178,9 @@ public class FleetResource {
     @GET
     @Path("/carriers/{id}")
     @Operation(summary = "Get carrier by ID")
-    public Uni<Response> getCarrier(@PathParam("id") Long id) {
+    public Uni<Response> getCarrier(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id) {
         return carrierService.findById(tenantContext.getClientId(), id)
                 .map(c -> c != null ? Response.ok(c).build() : Response.status(404).build());
     }
@@ -177,16 +188,21 @@ public class FleetResource {
     @POST
     @Path("/carriers")
     @Operation(summary = "Create a carrier")
-    public Uni<Response> createCarrier(CreateCarrierRequest req) {
-        return carrierService.create(tenantContext.getClientId(), req, "api")
+    public Uni<Response> createCarrier(
+            @PathParam("organizationId") String organizationId,
+            CreateCarrierRequest req) {
+        return carrierService.create(tenantContext.getClientId(), req, organizationContext.getUserEmail())
                 .map(c -> Response.status(201).entity(c).build());
     }
 
     @PATCH
     @Path("/carriers/{id}/status")
     @Operation(summary = "Change carrier status")
-    public Uni<Response> changeCarrierStatus(@PathParam("id") Long id, StatusChangeRequest req) {
-        return carrierService.changeStatus(tenantContext.getClientId(), id, req, "api")
+    public Uni<Response> changeCarrierStatus(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("id") Long id,
+            StatusChangeRequest req) {
+        return carrierService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
                 .map(c -> Response.ok(c).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -196,6 +212,7 @@ public class FleetResource {
     @Path("/carriers/{id}/events")
     @Operation(summary = "Get carrier event history")
     public Uni<List<EntityEvent>> getCarrierEvents(
+            @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
         return carrierService.findById(tenantContext.getClientId(), id)

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/api/OrgFleetResource.java
@@ -58,7 +58,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
-        return truckService.list(tenantContext.getClientId(), page, size);
+        return truckService.list(tenantContext.getEffectiveClientIds(), page, size);
     }
 
     @GET
@@ -67,7 +67,7 @@ public class OrgFleetResource {
     public Uni<Response> getTruck(
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id) {
-        return truckService.findById(tenantContext.getClientId(), id)
+        return truckService.findById(tenantContext.getEffectiveClientIds(), id)
                 .map(t -> t != null ? Response.ok(t).build() : Response.status(404).build());
     }
 
@@ -88,7 +88,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             StatusChangeRequest req) {
-        return truckService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
+        return truckService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -101,7 +101,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
-        return truckService.findById(tenantContext.getClientId(), id)
+        return truckService.findById(tenantContext.getEffectiveClientIds(), id)
                 .flatMap(t -> t == null ? Uni.createFrom().item(List.<EntityEvent>of())
                         : eventService.listByEntity(EntityType.TRUCK, t.entityId, limit));
     }
@@ -115,7 +115,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
-        return trailerService.list(tenantContext.getClientId(), page, size);
+        return trailerService.list(tenantContext.getEffectiveClientIds(), page, size);
     }
 
     @GET
@@ -124,7 +124,7 @@ public class OrgFleetResource {
     public Uni<Response> getTrailer(
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id) {
-        return trailerService.findById(tenantContext.getClientId(), id)
+        return trailerService.findById(tenantContext.getEffectiveClientIds(), id)
                 .map(t -> t != null ? Response.ok(t).build() : Response.status(404).build());
     }
 
@@ -145,7 +145,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             StatusChangeRequest req) {
-        return trailerService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
+        return trailerService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(t -> Response.ok(t).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -158,7 +158,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
-        return trailerService.findById(tenantContext.getClientId(), id)
+        return trailerService.findById(tenantContext.getEffectiveClientIds(), id)
                 .flatMap(t -> t == null ? Uni.createFrom().item(List.<EntityEvent>of())
                         : eventService.listByEntity(EntityType.TRAILER, t.entityId, limit));
     }
@@ -172,7 +172,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @QueryParam("page") @DefaultValue("0") int page,
             @QueryParam("size") @DefaultValue("25") int size) {
-        return carrierService.list(tenantContext.getClientId(), page, size);
+        return carrierService.list(tenantContext.getEffectiveClientIds(), page, size);
     }
 
     @GET
@@ -181,7 +181,7 @@ public class OrgFleetResource {
     public Uni<Response> getCarrier(
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id) {
-        return carrierService.findById(tenantContext.getClientId(), id)
+        return carrierService.findById(tenantContext.getEffectiveClientIds(), id)
                 .map(c -> c != null ? Response.ok(c).build() : Response.status(404).build());
     }
 
@@ -202,7 +202,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             StatusChangeRequest req) {
-        return carrierService.changeStatus(tenantContext.getClientId(), id, req, organizationContext.getUserEmail())
+        return carrierService.changeStatus(tenantContext.getEffectiveClientIds(), id, req, organizationContext.getUserEmail())
                 .map(c -> Response.ok(c).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(e -> Response.status(404).entity("{\"error\":\"" + e.getMessage() + "\"}").build());
@@ -215,7 +215,7 @@ public class OrgFleetResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("id") Long id,
             @QueryParam("limit") @DefaultValue("50") int limit) {
-        return carrierService.findById(tenantContext.getClientId(), id)
+        return carrierService.findById(tenantContext.getEffectiveClientIds(), id)
                 .flatMap(c -> c == null ? Uni.createFrom().item(List.<EntityEvent>of())
                         : eventService.listByEntity(EntityType.CARRIER, c.entityId, limit));
     }

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/CarrierService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/CarrierService.java
@@ -25,23 +25,23 @@ public class CarrierService {
     @Inject IAlfrescoClient alfrescoClient;
 
     @WithSession
-    public Uni<List<Carrier>> list(String clientId, int page, int size) {
-        return Carrier.find("clientId = ?1 and active = true", clientId).page(Page.of(page, size)).list();
+    public Uni<List<Carrier>> list(List<String> clientIds, int page, int size) {
+        return Carrier.find("clientId in ?1 and active = true", clientIds).page(Page.of(page, size)).list();
     }
 
     @WithSession
-    public Uni<Long> count(String clientId) {
-        return Carrier.count("clientId = ?1 and active = true", clientId);
+    public Uni<Long> count(List<String> clientIds) {
+        return Carrier.count("clientId in ?1 and active = true", clientIds);
     }
 
     @WithSession
-    public Uni<Carrier> findById(String clientId, Long id) {
-        return Carrier.find("id = ?1 and clientId = ?2", id, clientId).firstResult();
+    public Uni<Carrier> findById(List<String> clientIds, Long id) {
+        return Carrier.find("id = ?1 and clientId in ?2", id, clientIds).firstResult();
     }
 
     @WithSession
-    public Uni<Carrier> findByExternalId(String clientId, String externalId) {
-        return Carrier.find("clientId = ?1 and externalId = ?2", clientId, externalId).firstResult();
+    public Uni<Carrier> findByExternalId(List<String> clientIds, String externalId) {
+        return Carrier.find("clientId in ?1 and externalId = ?2", clientIds, externalId).firstResult();
     }
 
     @WithTransaction
@@ -65,15 +65,15 @@ public class CarrierService {
     }
 
     @WithTransaction
-    public Uni<Carrier> changeStatus(String clientId, Long id, StatusChangeRequest req, String actor) {
-        return Carrier.<Carrier>find("id = ?1 and clientId = ?2", id, clientId).firstResult()
+    public Uni<Carrier> changeStatus(List<String> clientIds, Long id, StatusChangeRequest req, String actor) {
+        return Carrier.<Carrier>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Carrier not found: " + id))
                 .flatMap(carrier -> {
                     String oldStatus = carrier.status;
                     carrier.status = req.status();
                     carrier.updatedAt = Instant.now();
                     if ("INACTIVE".equals(req.status())) carrier.active = false;
-                    return eventService.record(clientId, EntityType.CARRIER, carrier.entityId,
+                    return eventService.record(carrier.clientId, EntityType.CARRIER, carrier.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))
                             .replaceWith(carrier);

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TrailerService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TrailerService.java
@@ -25,23 +25,23 @@ public class TrailerService {
     @Inject IAlfrescoClient alfrescoClient;
 
     @WithSession
-    public Uni<List<Trailer>> list(String clientId, int page, int size) {
-        return Trailer.find("clientId = ?1 and active = true", clientId).page(Page.of(page, size)).list();
+    public Uni<List<Trailer>> list(List<String> clientIds, int page, int size) {
+        return Trailer.find("clientId in ?1 and active = true", clientIds).page(Page.of(page, size)).list();
     }
 
     @WithSession
-    public Uni<Long> count(String clientId) {
-        return Trailer.count("clientId = ?1 and active = true", clientId);
+    public Uni<Long> count(List<String> clientIds) {
+        return Trailer.count("clientId in ?1 and active = true", clientIds);
     }
 
     @WithSession
-    public Uni<Trailer> findById(String clientId, Long id) {
-        return Trailer.find("id = ?1 and clientId = ?2", id, clientId).firstResult();
+    public Uni<Trailer> findById(List<String> clientIds, Long id) {
+        return Trailer.find("id = ?1 and clientId in ?2", id, clientIds).firstResult();
     }
 
     @WithSession
-    public Uni<Trailer> findByExternalId(String clientId, String externalId) {
-        return Trailer.find("clientId = ?1 and externalId = ?2", clientId, externalId).firstResult();
+    public Uni<Trailer> findByExternalId(List<String> clientIds, String externalId) {
+        return Trailer.find("clientId in ?1 and externalId = ?2", clientIds, externalId).firstResult();
     }
 
     @WithTransaction
@@ -65,15 +65,15 @@ public class TrailerService {
     }
 
     @WithTransaction
-    public Uni<Trailer> changeStatus(String clientId, Long id, StatusChangeRequest req, String actor) {
-        return Trailer.<Trailer>find("id = ?1 and clientId = ?2", id, clientId).firstResult()
+    public Uni<Trailer> changeStatus(List<String> clientIds, Long id, StatusChangeRequest req, String actor) {
+        return Trailer.<Trailer>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Trailer not found: " + id))
                 .flatMap(trailer -> {
                     String oldStatus = trailer.status;
                     trailer.status = req.status();
                     trailer.updatedAt = Instant.now();
                     if ("INACTIVE".equals(req.status())) trailer.active = false;
-                    return eventService.record(clientId, EntityType.TRAILER, trailer.entityId,
+                    return eventService.record(trailer.clientId, EntityType.TRAILER, trailer.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))
                             .replaceWith(trailer);

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckService.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckService.java
@@ -25,23 +25,23 @@ public class TruckService {
     @Inject IAlfrescoClient alfrescoClient;
 
     @WithSession
-    public Uni<List<Truck>> list(String clientId, int page, int size) {
-        return Truck.find("clientId = ?1 and active = true", clientId).page(Page.of(page, size)).list();
+    public Uni<List<Truck>> list(List<String> clientIds, int page, int size) {
+        return Truck.find("clientId in ?1 and active = true", clientIds).page(Page.of(page, size)).list();
     }
 
     @WithSession
-    public Uni<Long> count(String clientId) {
-        return Truck.count("clientId = ?1 and active = true", clientId);
+    public Uni<Long> count(List<String> clientIds) {
+        return Truck.count("clientId in ?1 and active = true", clientIds);
     }
 
     @WithSession
-    public Uni<Truck> findById(String clientId, Long id) {
-        return Truck.find("id = ?1 and clientId = ?2", id, clientId).firstResult();
+    public Uni<Truck> findById(List<String> clientIds, Long id) {
+        return Truck.find("id = ?1 and clientId in ?2", id, clientIds).firstResult();
     }
 
     @WithSession
-    public Uni<Truck> findByExternalId(String clientId, String externalId) {
-        return Truck.find("clientId = ?1 and externalId = ?2", clientId, externalId).firstResult();
+    public Uni<Truck> findByExternalId(List<String> clientIds, String externalId) {
+        return Truck.find("clientId in ?1 and externalId = ?2", clientIds, externalId).firstResult();
     }
 
     @WithTransaction
@@ -69,15 +69,15 @@ public class TruckService {
     }
 
     @WithTransaction
-    public Uni<Truck> changeStatus(String clientId, Long id, StatusChangeRequest req, String actor) {
-        return Truck.<Truck>find("id = ?1 and clientId = ?2", id, clientId).firstResult()
+    public Uni<Truck> changeStatus(List<String> clientIds, Long id, StatusChangeRequest req, String actor) {
+        return Truck.<Truck>find("id = ?1 and clientId in ?2", id, clientIds).firstResult()
                 .onItem().ifNull().failWith(() -> new IllegalArgumentException("Truck not found: " + id))
                 .flatMap(truck -> {
                     String oldStatus = truck.status;
                     truck.status = req.status();
                     truck.updatedAt = Instant.now();
                     if ("INACTIVE".equals(req.status())) truck.active = false;
-                    return eventService.record(clientId, EntityType.TRUCK, truck.entityId,
+                    return eventService.record(truck.clientId, EntityType.TRUCK, truck.entityId,
                                     EventTypes.STATUS_CHANGED, "api", actor,
                                     JsonUtil.toJson(Map.of("old", oldStatus, "new", req.status())))
                             .replaceWith(truck);


### PR DESCRIPTION
## Summary

- Introduces `Organization` as a first-class concept so web users (Auth0 web OAuth) can be scoped to a tenant via URL without modifying Auth0 tokens
- All resources unified under `/api/v1/orgs/{organizationId}/...` — non-scoped endpoints removed
- Web users validated via Alfresco group membership; M2M services validated by matching JWT `aud`/`azp` against `org.tenantClientId`

## Changes

**miot-core**
- `Organization` entity: `slug` → `alfrescoGroupId` + `tenantClientId`
- `OrganizationContext`: request-scoped bean (org ID, user email, Alfresco role)
- `OrganizationRequestFilter`: `@ServerRequestFilter` handling both web and M2M auth paths
- `IAlfrescoMembershipClient` + `StubAlfrescoMembershipClient` (`@DefaultBean`)
- `V1.3.0__create_organizations.sql`: `miot_core.organizations` table

**miot-fleet / miot-driver**
- `FleetResource` → `OrgFleetResource` at `/api/v1/orgs/{organizationId}/fleet/...`
- `DriverResource` → `OrgDriverResource` at `/api/v1/orgs/{organizationId}/drivers/...`

**miot-cli**
- `FlywayMigrator`: `outOfOrder(true)` to support independent version ranges across modules

## Test plan

- [ ] M2M token with matching `aud` → `GET /api/v1/orgs/{slug}/fleet/trucks` returns 200
- [ ] M2M token with non-matching `aud` → 403
- [ ] Web token with valid Alfresco membership (stub always returns true) → 200
- [ ] Unknown org slug → 404
- [ ] Verify `miot_core.organizations` table created by Flyway on startup

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-organization support: org-scoped APIs, organization entity, and DB migrations
  * Per-request organization resolution with optional Alfresco membership/role checks (includes a default stub)

* **Bug Fixes / Maintenance**
  * Flyway configured to allow out-of-order migrations

* **Breaking Changes**
  * Driver and fleet APIs now require organization ID in URL path (/api/v1/orgs/{organizationId}/...)
  * Bulk driver synchronization endpoint removed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->