### PR TITLE
feat: add kiosk/fullscreen mode for dashboards

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -2,13 +2,21 @@
 
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { Button, ToggleSwitch } from "flowbite-react";
-import { HiPlus, HiArrowUturnLeft, HiArrowUturnRight } from "react-icons/hi2";
+import {
+  HiPlus,
+  HiArrowUturnLeft,
+  HiArrowUturnRight,
+  HiArrowsPointingOut,
+} from "react-icons/hi2";
 import {
   GridLayout,
   verticalCompactor,
   type Layout,
   type LayoutItem,
 } from "react-grid-layout";
+import Link from "next/link";
+import { useSearchParams, usePathname } from "next/navigation";
+import { KIOSK_PARAM } from "@/features/layout/hooks/use-kiosk-mode";
 import { useDashboard } from "../../context/dashboard-context";
 import { tr } from "@/features/i18n/tr.service";
 import { EmptyState } from "../empty-state";
@@ -29,6 +37,7 @@ export function DashboardView() {
   const {
     widgets,
     editMode,
+    isKiosk,
     isLoaded,
     dashboardName,
     dictionary,
@@ -39,6 +48,15 @@ export function DashboardView() {
     canUndo,
     canRedo,
   } = useDashboard();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const kioskUrl = useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(KIOSK_PARAM, "true");
+    return `${pathname}?${params.toString()}`;
+  }, [searchParams, pathname]);
+
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -161,48 +179,58 @@ export function DashboardView() {
   return (
     <div className="w-full">
       {/* Portal: renders DashboardFilterBar into the navbar search slot */}
-      <DashboardNavbarPortal />
+      {!isKiosk && <DashboardNavbarPortal />}
 
-      {/* Header */}
-      <div className="-mx-4 -mt-4 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex items-center justify-between gap-4 p-4">
-          <h1 className="shrink-0 text-xl font-semibold text-gray-900 dark:text-white">
-            {dashboardName}
-          </h1>
-          <div className="flex shrink-0 items-center gap-4">
-            {editMode && (
-              <div className="flex items-center gap-1">
-                <Button
-                  size="xs"
-                  color="light"
-                  onClick={undo}
-                  disabled={!canUndo()}
-                  title={`${tr("dashboard.undo", dictionary)} (Ctrl+Z)`}
-                >
-                  <HiArrowUturnLeft className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="xs"
-                  color="light"
-                  onClick={redo}
-                  disabled={!canRedo()}
-                  title={`${tr("dashboard.redo", dictionary)} (Ctrl+Shift+Z)`}
-                >
-                  <HiArrowUturnRight className="h-4 w-4" />
-                </Button>
-              </div>
-            )}
-            {hasWidgets && (
-              <ToggleSwitch
-                checked={editMode}
-                onChange={toggleEditMode}
-                label={tr("dashboard.editMode", dictionary)}
-              />
-            )}
-            <DashboardSettingsDropdown />
+      {/* Header (hidden in kiosk mode) */}
+      {!isKiosk && (
+        <div className="-mx-4 -mt-4 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-center justify-between gap-4 p-4">
+            <h1 className="shrink-0 text-xl font-semibold text-gray-900 dark:text-white">
+              {dashboardName}
+            </h1>
+            <div className="flex shrink-0 items-center gap-4">
+              {editMode && (
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="xs"
+                    color="light"
+                    onClick={undo}
+                    disabled={!canUndo()}
+                    title={`${tr("dashboard.undo", dictionary)} (Ctrl+Z)`}
+                  >
+                    <HiArrowUturnLeft className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="xs"
+                    color="light"
+                    onClick={redo}
+                    disabled={!canRedo()}
+                    title={`${tr("dashboard.redo", dictionary)} (Ctrl+Shift+Z)`}
+                  >
+                    <HiArrowUturnRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+              {hasWidgets && (
+                <ToggleSwitch
+                  checked={editMode}
+                  onChange={toggleEditMode}
+                  label={tr("dashboard.editMode", dictionary)}
+                />
+              )}
+              <DashboardSettingsDropdown />
+              <Link
+                href={kioskUrl}
+                target="_blank"
+                title={tr("dashboard.kioskMode", dictionary)}
+                className="inline-flex items-center rounded-lg border border-gray-200 bg-white p-2.5 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+              >
+                <HiArrowsPointingOut className="h-4 w-4" />
+              </Link>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Content */}
       <div ref={containerRef} className="w-full min-h-[200px] max-w-screen-2xl mx-auto">

--- a/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useCallback,
+  useEffect,
   useMemo,
   type PropsWithChildren,
 } from "react";
@@ -21,6 +22,7 @@ import { getNextPosition } from "../utils/get-next-position";
 import { PlannerProvider } from "./planner-context";
 import { DashboardFiltersProvider } from "./dashboard-filters-context";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { useKioskMode } from "@/features/layout/hooks/use-kiosk-mode";
 
 /** Context value type */
 interface DashboardContextValue {
@@ -28,6 +30,8 @@ interface DashboardContextValue {
   widgets: Widget[];
   /** Whether edit mode is active */
   editMode: boolean;
+  /** Whether kiosk (fullscreen) mode is active via ?kiosk=true */
+  isKiosk: boolean;
   /** Whether data has loaded from storage */
   isLoaded: boolean;
   /** Dictionary for internationalization */
@@ -148,6 +152,18 @@ export function DashboardProvider({
     canUndo,
     canRedo,
   } = useDashboardStorage(slug, defaultConfig, siteId);
+
+  const isKiosk = useKioskMode();
+
+  // Force edit mode off in kiosk mode
+  useEffect(() => {
+    if (isKiosk && preferences.editMode) {
+      setEditModeStorage(false);
+    }
+  }, [isKiosk, preferences.editMode, setEditModeStorage]);
+
+  // In kiosk mode, default to 30s refresh without persisting the change
+  const effectiveRefreshInterval = isKiosk && refreshInterval === 0 ? 30 : refreshInterval;
 
   const createWidget = useCallback(
     (
@@ -316,14 +332,16 @@ export function DashboardProvider({
   );
 
   const toggleEditMode = useCallback(() => {
+    if (isKiosk) return;
     setEditModeStorage(!preferences.editMode);
-  }, [preferences.editMode, setEditModeStorage]);
+  }, [isKiosk, preferences.editMode, setEditModeStorage]);
 
   const setEditMode = useCallback(
     (value: boolean) => {
+      if (isKiosk && value) return;
       setEditModeStorage(value);
     },
-    [setEditModeStorage]
+    [isKiosk, setEditModeStorage]
   );
 
   const setDashboardName = useCallback(
@@ -337,12 +355,13 @@ export function DashboardProvider({
     () => ({
       widgets,
       editMode: preferences.editMode,
+      isKiosk,
       isLoaded,
       dictionary,
       siteId,
       filters,
       setFilters,
-      refreshInterval,
+      refreshInterval: effectiveRefreshInterval,
       setRefreshInterval,
       dashboardName,
       createWidget,
@@ -370,12 +389,13 @@ export function DashboardProvider({
     [
       widgets,
       preferences.editMode,
+      isKiosk,
       isLoaded,
       dictionary,
       siteId,
       filters,
       setFilters,
-      refreshInterval,
+      effectiveRefreshInterval,
       setRefreshInterval,
       dashboardName,
       createWidget,

--- a/turbo-repo/apps/app/src/features/layout/components/kiosk-shell.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/kiosk-shell.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Suspense, type PropsWithChildren } from "react";
+import { useKioskMode } from "../hooks/use-kiosk-mode";
+
+function KioskShellInner({ children }: Readonly<PropsWithChildren>) {
+  const isKiosk = useKioskMode();
+
+  if (!isKiosk) return <>{children}</>;
+
+  return (
+    <div data-kiosk="true" className="flex h-screen flex-col">
+      <style jsx global>{`
+        [data-kiosk] nav {
+          display: none !important;
+        }
+        [data-kiosk] [data-testid="content-with-sidebar"] {
+          margin-top: 0 !important;
+          margin-bottom: 0 !important;
+        }
+        [data-kiosk] [data-testid="content-with-sidebar"] > aside {
+          display: none !important;
+        }
+        [data-kiosk] footer {
+          display: none !important;
+        }
+      `}</style>
+      {children}
+    </div>
+  );
+}
+
+export function KioskShell({ children }: Readonly<PropsWithChildren>) {
+  return (
+    <Suspense fallback={<>{children}</>}>
+      <KioskShellInner>{children}</KioskShellInner>
+    </Suspense>
+  );
+}

--- a/turbo-repo/apps/app/src/features/layout/components/kiosk-shell.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/kiosk-shell.tsx
@@ -18,7 +18,7 @@ function KioskShellInner({ children }: Readonly<PropsWithChildren>) {
           margin-top: 0 !important;
           margin-bottom: 0 !important;
         }
-        [data-kiosk] [data-testid="content-with-sidebar"] > aside {
+        [data-kiosk] [data-testid="content-with-sidebar"] aside {
           display: none !important;
         }
         [data-kiosk] footer {

--- a/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
@@ -13,6 +13,7 @@ import FooterSecuredLayout from "./footer-secured/footer-secured";
 import SseListener from "@/features/sse/components/sse-listener/sse-listener";
 import { getPublicOrgLogo } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { RuntimeConfigProvider } from "@/features/runtime-config/runtime-config-context";
+import { KioskShell } from "./kiosk-shell";
 
 export default async function SecuredLayout({
   children,
@@ -26,25 +27,27 @@ export default async function SecuredLayout({
   return (
     <RuntimeConfigProvider>
     <SidebarProvider initialCollapsed={(await sidebarCookie.get()).isCollapsed}>
-      <SseListener dictionary={dictionary} tenantId={session!.user!.email} />
-      <SecuredNavbar
-        messages={navBarMessages}
-        dict={dictionary as I18nRecord}
-        initialOrgLogo={initialOrgLogo}
-      />
-      <div
-        data-testid="content-with-sidebar"
-        className="mt-16 mb-12 flex items-start flex-1 overflow-hidden"
-      >
-        <SecuredSidebar
-          dict={
-            ((dictionary.layout as I18nRecord)?.secured as I18nRecord)
-              ?.sidebar as I18nRecord
-          }
+      <KioskShell>
+        <SseListener dictionary={dictionary} tenantId={session!.user!.email} />
+        <SecuredNavbar
+          messages={navBarMessages}
+          dict={dictionary as I18nRecord}
+          initialOrgLogo={initialOrgLogo}
         />
-        <LayoutContent>{children}</LayoutContent>
-      </div>
-      <FooterSecuredLayout messages={dict} />
+        <div
+          data-testid="content-with-sidebar"
+          className="mt-16 mb-12 flex items-start flex-1 overflow-hidden"
+        >
+          <SecuredSidebar
+            dict={
+              ((dictionary.layout as I18nRecord)?.secured as I18nRecord)
+                ?.sidebar as I18nRecord
+            }
+          />
+          <LayoutContent>{children}</LayoutContent>
+        </div>
+        <FooterSecuredLayout messages={dict} />
+      </KioskShell>
     </SidebarProvider>
     </RuntimeConfigProvider>
   );

--- a/turbo-repo/apps/app/src/features/layout/hooks/use-kiosk-mode.ts
+++ b/turbo-repo/apps/app/src/features/layout/hooks/use-kiosk-mode.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export const KIOSK_PARAM = "kiosk";
+
+export function useKioskMode(): boolean {
+  const searchParams = useSearchParams();
+  return searchParams.get(KIOSK_PARAM) === "true";
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1467,6 +1467,7 @@
   },
   "dashboard": {
     "editMode": "Edit Mode",
+    "kioskMode": "Kiosk Mode",
     "landing": {
       "title": "Dashboards",
       "subtitle": "Create and manage custom dashboards with widgets, filters, and data visualizations.",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1492,6 +1492,7 @@
   },
   "dashboard": {
     "editMode": "Modo Edición",
+    "kioskMode": "Modo Kiosco",
     "landing": {
       "title": "Dashboards",
       "subtitle": "Crea y gestiona dashboards personalizados con widgets, filtros y visualizaciones de datos.",


### PR DESCRIPTION
- Add KioskShell layout that hides navbar/sidebar for fullscreen display
- Add useKioskMode hook to detect `?kiosk=true` search param
- Expose isKiosk flag from dashboard context to conditionally hide header, navbar portal, and settings
- Add fullscreen entry button with link to kiosk URL
- Support i18n labels for fullscreen mode (en/es)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Kiosk Mode — streamlined display that hides navigation, header controls (undo/redo, edit toggle, settings) and side chrome when active.
  * Added a dashboard header button to open the dashboard in Kiosk Mode in a new tab.
  * Kiosk Mode sets auto-refresh to 30 seconds by default when enabled.

* **Localization**
  * Added Kiosk Mode translations for English and Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->