### PR TITLE
fix(dashboard): fix overflow scrolling and planner section sizing

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
@@ -77,6 +77,11 @@ function SectionLayout({
 }: Readonly<SectionLayoutProps>) {
   const { headerHeightClass, headerInteractiveClass, contentMaxHeightClass } =
     classes;
+  const [animationDone, setAnimationDone] = useState(false);
+
+  if (!active && animationDone) {
+    setAnimationDone(false);
+  }
   const backButtonClass = active
     ? "opacity-100 w-10"
     : "opacity-0 w-0 pointer-events-none";
@@ -130,7 +135,8 @@ function SectionLayout({
         </Button>
       </div>
       <div
-        className={`${contentMaxHeightClass} transition-all duration-300 overflow-hidden`}
+        className={`${contentMaxHeightClass} transition-all duration-300 ${animationDone ? "overflow-y-auto" : "overflow-hidden"}`}
+        onTransitionEnd={() => { if (active) setAnimationDone(true); }}
       >
         {children}
       </div>
@@ -764,7 +770,7 @@ export default function DashboardSettingsDropdown() {
       </Button>
 
       {open && (
-        <div className="absolute z-50 right-0 top-full mt-2 h-fit bg-white dark:bg-gray-800 overflow-hidden border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg min-w-[360px] w-[440px]">
+        <div className="absolute z-50 right-0 top-full mt-2 h-fit bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg min-w-[360px] w-[440px]">
           <SettingsSection
             option="rename"
             selected={selected}
@@ -829,7 +835,7 @@ export default function DashboardSettingsDropdown() {
             setSelected={setSelected}
             title="Request Planner"
             description="Define shared data queries"
-            maxHeight="max-h-[600px]"
+            maxHeight="max-h-[60vh]"
           >
             <PlannerManagerForm />
           </SettingsSection>

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
@@ -79,9 +79,11 @@ function SectionLayout({
     classes;
   const [animationDone, setAnimationDone] = useState(false);
 
-  if (!active && animationDone) {
-    setAnimationDone(false);
-  }
+  useEffect(() => {
+    if (!active && animationDone) {
+      setAnimationDone(false);
+    }
+  }, [active, animationDone]);
   const backButtonClass = active
     ? "opacity-100 w-10"
     : "opacity-0 w-0 pointer-events-none";


### PR DESCRIPTION
- Defer overflow-y-auto until expand animation completes to prevent visual glitches
- Remove overflow-hidden from dropdown container to avoid clipping nested content
- Change planner section max-height from fixed 600px to 60vh for better responsiveness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrolling now becomes available only after layout animations finish, preventing content cutoff during transitions.
  * Request Planner section now scales with viewport height (uses vh) for more responsive sizing.
  * Dropdown panel overflow/styling adjusted for improved visual presentation and smoother interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->