### PR TITLE
feat(tracking): wire persistence pipeline and dual-mode consumer

### DIFF
--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -28,6 +28,9 @@ public class FlywayMigrator {
     @ConfigProperty(name = "miot.component.driver.enabled", defaultValue = "false")
     boolean driverEnabled;
 
+    @ConfigProperty(name = "miot.component.tracking.enabled", defaultValue = "false")
+    boolean trackingEnabled;
+
     void onStart(@Observes StartupEvent ev) {
         List<String> locations = new ArrayList<>(baseLocations);
 
@@ -36,6 +39,9 @@ public class FlywayMigrator {
         }
         if (driverEnabled) {
             locations.add("db/migration/driver");
+        }
+        if (trackingEnabled) {
+            locations.add("db/migration/tracking");
         }
 
         LOG.infof("Flyway locations: %s", locations);

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -109,3 +109,4 @@ miot.reconciliation.cron=0 */15 * * * ?
 miot.messaging.type=${MIOT_MESSAGING_TYPE:log}
 pulsar.client.serviceUrl=${PULSAR_URL:pulsar://localhost:6650}
 miot.tracking.pulsar.topic=${MIOT_TRACKING_TOPIC:not-configured}
+miot.tracking.pulsar.subscription=${MIOT_TRACKING_SUBSCRIPTION:asset-positions-sub}

--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/metrics/LatestMetricsRepository.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/metrics/LatestMetricsRepository.java
@@ -33,15 +33,14 @@ public class LatestMetricsRepository {
     private static final Logger logger = Logger.getLogger(LatestMetricsRepository.class);
 
     private static final String SQL_SINGLE =
-            "SELECT fn_latest_metrics($1, $2)";
+            "SELECT miot_tracking.fn_latest_metrics($1, $2)";
 
     private static final String SQL_BATCH =
-            "SELECT asset_id, metrics FROM fn_latest_metrics_batch($1, $2)";
+            "SELECT asset_id, metrics FROM miot_tracking.fn_latest_metrics_batch($1, $2)";
 
     private final Pool metricsClient;
 
-    LatestMetricsRepository(
-            @io.quarkus.reactive.datasource.ReactiveDataSource("metrics") Pool metricsClient) {
+    LatestMetricsRepository(Pool metricsClient) {
         this.metricsClient = metricsClient;
     }
 

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>miot-gps-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.geometry</groupId>
+            <artifactId>s2-geometry</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/TrackingComponent.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/TrackingComponent.java
@@ -1,8 +1,14 @@
 package com.microboxlabs.miot.tracking;
 
+import cl.streamhub.gps.model.EnvelopedMessage;
 import com.microboxlabs.miot.core.config.IMiotComponent;
+import com.microboxlabs.miot.core.messaging.IComponentBus;
+import com.microboxlabs.miot.tracking.consumer.PulsarAssetTrackingConsumer;
+import com.microboxlabs.miot.tracking.persistence.AssetTrackingProcessor;
+import com.microboxlabs.miot.tracking.service.impl.PulsarAssetTrackingService;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jboss.logging.Logger;
@@ -12,6 +18,17 @@ import org.jboss.logging.Logger;
 public class TrackingComponent implements IMiotComponent {
 
     private static final Logger LOG = Logger.getLogger(TrackingComponent.class);
+
+    private final IComponentBus componentBus;
+    private final AssetTrackingProcessor processor;
+    private final Instance<PulsarAssetTrackingConsumer> pulsarConsumer;
+
+    TrackingComponent(IComponentBus componentBus, AssetTrackingProcessor processor,
+            Instance<PulsarAssetTrackingConsumer> pulsarConsumer) {
+        this.componentBus = componentBus;
+        this.processor = processor;
+        this.pulsarConsumer = pulsarConsumer;
+    }
 
     @Override
     public String name() {
@@ -25,6 +42,20 @@ public class TrackingComponent implements IMiotComponent {
 
     @Override
     public void onStart() {
+        // Subscribe to in-process bus for standalone mode persistence
+        componentBus.subscribe(PulsarAssetTrackingService.BUS_CHANNEL, EnvelopedMessage.class,
+                msg -> processor.process(msg)
+                        .subscribe().with(
+                                v -> LOG.debugf("Persisted asset tracking for %s",
+                                        msg.getPayload().getAssetId()),
+                                e -> LOG.errorf(e, "Failed to persist asset tracking for %s",
+                                        msg.getPayload().getAssetId())));
+
+        // Start Pulsar consumer if available (distributed mode)
+        if (pulsarConsumer.isResolvable()) {
+            pulsarConsumer.get().start();
+        }
+
         LOG.info("Tracking component started");
     }
 

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/consumer/PulsarAssetTrackingConsumer.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/consumer/PulsarAssetTrackingConsumer.java
@@ -75,24 +75,35 @@ public class PulsarAssetTrackingConsumer {
     }
 
     private void consumeLoop() {
-        try {
-            Consumer<String> c = getConsumer();
-            while (running.get()) {
-                try {
-                    Message<String> msg = c.receive(1, TimeUnit.SECONDS);
-                    if (msg == null) continue;
+        Consumer<String> c = initConsumer();
+        if (c == null) return;
 
-                    long startTime = System.currentTimeMillis();
-                    processMessage(c, msg, startTime);
-                } catch (PulsarClientException e) {
-                    if (running.get()) {
-                        LOG.errorf(e, "Pulsar receive error, retrying in 5s");
-                        sleep(5000);
-                    }
-                }
-            }
+        while (running.get()) {
+            receiveAndProcess(c);
+        }
+    }
+
+    private Consumer<String> initConsumer() {
+        try {
+            return getConsumer();
         } catch (PulsarClientException e) {
             LOG.errorf(e, "Failed to create Pulsar consumer");
+            return null;
+        }
+    }
+
+    private void receiveAndProcess(Consumer<String> c) {
+        try {
+            Message<String> msg = c.receive(1, TimeUnit.SECONDS);
+            if (msg == null) return;
+
+            long startTime = System.currentTimeMillis();
+            processMessage(c, msg, startTime);
+        } catch (PulsarClientException e) {
+            if (running.get()) {
+                LOG.errorf(e, "Pulsar receive error, retrying in 5s");
+                sleep(5000);
+            }
         }
     }
 
@@ -102,32 +113,37 @@ public class PulsarAssetTrackingConsumer {
 
             processor.process(envelope)
                     .subscribe().with(
-                            v -> {
-                                try {
-                                    c.acknowledge(msg);
-                                    long ackTime = System.currentTimeMillis();
-                                    LOG.infof("TOTAL_ACK_TIME: %d ms", ackTime - startTime);
-                                } catch (PulsarClientException e) {
-                                    LOG.errorf(e, "Failed to ACK message");
-                                }
-                            },
-                            e -> {
-                                long errorTime = System.currentTimeMillis();
-                                LOG.errorf(e, "PROCESSING_ERROR after %d ms. Error: %s",
-                                        errorTime - startTime, e.getMessage());
-                                try {
-                                    c.reconsumeLater(msg, 30, TimeUnit.SECONDS);
-                                } catch (PulsarClientException nackEx) {
-                                    LOG.errorf(nackEx, "Failed to NACK message");
-                                }
-                            });
+                            v -> acknowledgeMessage(c, msg, startTime),
+                            e -> nackOnProcessingError(c, msg, startTime, e));
         } catch (Exception e) {
             LOG.errorf(e, "MESSAGE_PARSE_ERROR");
-            try {
-                c.reconsumeLater(msg, 30, TimeUnit.SECONDS);
-            } catch (PulsarClientException nackEx) {
-                LOG.errorf(nackEx, "Failed to NACK unparseable message");
-            }
+            nackMessage(c, msg);
+        }
+    }
+
+    private void acknowledgeMessage(Consumer<String> c, Message<String> msg, long startTime) {
+        try {
+            c.acknowledge(msg);
+            long ackTime = System.currentTimeMillis();
+            LOG.infof("TOTAL_ACK_TIME: %d ms", ackTime - startTime);
+        } catch (PulsarClientException e) {
+            LOG.errorf(e, "Failed to ACK message");
+        }
+    }
+
+    private void nackOnProcessingError(Consumer<String> c, Message<String> msg,
+            long startTime, Throwable e) {
+        long errorTime = System.currentTimeMillis();
+        LOG.errorf(e, "PROCESSING_ERROR after %d ms. Error: %s",
+                errorTime - startTime, e.getMessage());
+        nackMessage(c, msg);
+    }
+
+    private void nackMessage(Consumer<String> c, Message<String> msg) {
+        try {
+            c.reconsumeLater(msg, 30, TimeUnit.SECONDS);
+        } catch (PulsarClientException nackEx) {
+            LOG.errorf(nackEx, "Failed to NACK message");
         }
     }
 

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/consumer/PulsarAssetTrackingConsumer.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/consumer/PulsarAssetTrackingConsumer.java
@@ -1,0 +1,192 @@
+package com.microboxlabs.miot.tracking.consumer;
+
+import cl.streamhub.gps.model.EnvelopedMessage;
+import com.microboxlabs.miot.tracking.persistence.AssetTrackingProcessor;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Pulsar consumer for distributed mode. Receives asset tracking messages
+ * from the Pulsar topic and delegates to {@link AssetTrackingProcessor}.
+ *
+ * <p>Activated only when {@code miot.messaging.type=pulsar}.
+ * Follows the same lazy-initialization pattern as {@code PulsarMessagePublisher}.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "miot.messaging.type", stringValue = "pulsar")
+public class PulsarAssetTrackingConsumer {
+
+    private static final Logger LOG = Logger.getLogger(PulsarAssetTrackingConsumer.class);
+
+    private final AssetTrackingProcessor processor;
+    private final String serviceUrl;
+    private final String topic;
+    private final String subscription;
+
+    private final ReentrantLock clientLock = new ReentrantLock();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private PulsarClient client;
+    private Consumer<String> consumer;
+    private Thread consumerThread;
+
+    PulsarAssetTrackingConsumer(
+            AssetTrackingProcessor processor,
+            @ConfigProperty(name = "pulsar.client.serviceUrl", defaultValue = "pulsar://localhost:6650")
+                    String serviceUrl,
+            @ConfigProperty(name = "miot.tracking.pulsar.topic",
+                    defaultValue = "persistent://streamhub/tracking/asset-positions")
+                    String topic,
+            @ConfigProperty(name = "miot.tracking.pulsar.subscription",
+                    defaultValue = "asset-positions-sub")
+                    String subscription) {
+        this.processor = processor;
+        this.serviceUrl = serviceUrl;
+        this.topic = topic;
+        this.subscription = subscription;
+    }
+
+    /**
+     * Starts the consumer loop on a daemon thread.
+     * Called from {@code TrackingComponent.onStart()} when in distributed mode.
+     */
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            LOG.warn("Pulsar consumer already running");
+            return;
+        }
+
+        consumerThread = new Thread(this::consumeLoop, "pulsar-tracking-consumer");
+        consumerThread.setDaemon(true);
+        consumerThread.start();
+        LOG.infof("Pulsar consumer started — topic: %s, subscription: %s", topic, subscription);
+    }
+
+    private void consumeLoop() {
+        try {
+            Consumer<String> c = getConsumer();
+            while (running.get()) {
+                try {
+                    Message<String> msg = c.receive(1, TimeUnit.SECONDS);
+                    if (msg == null) continue;
+
+                    long startTime = System.currentTimeMillis();
+                    processMessage(c, msg, startTime);
+                } catch (PulsarClientException e) {
+                    if (running.get()) {
+                        LOG.errorf(e, "Pulsar receive error, retrying in 5s");
+                        sleep(5000);
+                    }
+                }
+            }
+        } catch (PulsarClientException e) {
+            LOG.errorf(e, "Failed to create Pulsar consumer");
+        }
+    }
+
+    private void processMessage(Consumer<String> c, Message<String> msg, long startTime) {
+        try {
+            EnvelopedMessage envelope = EnvelopedMessage.fromJson(msg.getValue());
+
+            processor.process(envelope)
+                    .subscribe().with(
+                            v -> {
+                                try {
+                                    c.acknowledge(msg);
+                                    long ackTime = System.currentTimeMillis();
+                                    LOG.infof("TOTAL_ACK_TIME: %d ms", ackTime - startTime);
+                                } catch (PulsarClientException e) {
+                                    LOG.errorf(e, "Failed to ACK message");
+                                }
+                            },
+                            e -> {
+                                long errorTime = System.currentTimeMillis();
+                                LOG.errorf(e, "PROCESSING_ERROR after %d ms. Error: %s",
+                                        errorTime - startTime, e.getMessage());
+                                try {
+                                    c.reconsumeLater(msg, 30, TimeUnit.SECONDS);
+                                } catch (PulsarClientException nackEx) {
+                                    LOG.errorf(nackEx, "Failed to NACK message");
+                                }
+                            });
+        } catch (Exception e) {
+            LOG.errorf(e, "MESSAGE_PARSE_ERROR");
+            try {
+                c.reconsumeLater(msg, 30, TimeUnit.SECONDS);
+            } catch (PulsarClientException nackEx) {
+                LOG.errorf(nackEx, "Failed to NACK unparseable message");
+            }
+        }
+    }
+
+    private Consumer<String> getConsumer() throws PulsarClientException {
+        clientLock.lock();
+        try {
+            if (consumer == null) {
+                if (client == null) {
+                    client = PulsarClient.builder()
+                            .serviceUrl(serviceUrl)
+                            .connectionTimeout(5, TimeUnit.SECONDS)
+                            .operationTimeout(10, TimeUnit.SECONDS)
+                            .build();
+                    LOG.infof("Pulsar client connected to %s", serviceUrl);
+                }
+                consumer = client.newConsumer(Schema.STRING)
+                        .topic(topic)
+                        .subscriptionName(subscription)
+                        .subscriptionType(SubscriptionType.Shared)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.Latest)
+                        .deadLetterPolicy(org.apache.pulsar.client.api.DeadLetterPolicy.builder()
+                                .maxRedeliverCount(2)
+                                .build())
+                        .subscribe();
+                LOG.infof("Pulsar consumer subscribed to %s", topic);
+            }
+            return consumer;
+        } finally {
+            clientLock.unlock();
+        }
+    }
+
+    @PreDestroy
+    void close() {
+        running.set(false);
+        if (consumerThread != null) {
+            consumerThread.interrupt();
+        }
+        if (consumer != null) {
+            try {
+                consumer.close();
+            } catch (PulsarClientException e) {
+                LOG.warn("Error closing Pulsar consumer", e);
+            }
+        }
+        if (client != null) {
+            try {
+                client.close();
+            } catch (PulsarClientException e) {
+                LOG.warn("Error closing Pulsar client", e);
+            }
+        }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataClientRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataClientRepository.java
@@ -1,0 +1,112 @@
+package com.microboxlabs.miot.tracking.persistence;
+
+import cl.streamhub.gps.model.EnvelopedMessage;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.RowSet;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.tracking.enabled", stringValue = "true")
+public class AssetDataClientRepository {
+
+    private static final Logger logger = Logger.getLogger(AssetDataClientRepository.class);
+
+    private static final String GET_CLIENT_MAPPINGS_QUERY = """
+            SELECT shared_client_id
+            FROM miot_tracking.asset_client_map
+            WHERE asset_id = $1 AND active = true
+            AND NOW() BETWEEN valid_from AND valid_to
+            """;
+
+    private static final String INSERT_CLIENT_QUERY = """
+            INSERT INTO miot_tracking.asset_data_client (
+            asset_data_id, asset_id, shared_client_id, timestamp)
+            VALUES ($1, $2, $3, $4)
+            """;
+
+    private final PgPool client;
+
+    AssetDataClientRepository(PgPool client) {
+        this.client = client;
+    }
+
+    public Uni<CrossReferenceResult> crossReferenceAndSave(EnvelopedMessage message, Long assetDataId) {
+        String assetId = message.getPayload().getAssetId();
+
+        return getClientMappings(assetId)
+                .chain(clientMappings -> saveClientData(message, assetDataId, clientMappings)
+                        .map(result -> new CrossReferenceResult(result, clientMappings)));
+    }
+
+    public Uni<List<String>> getClientMappings(String assetId) {
+        return client.preparedQuery(GET_CLIENT_MAPPINGS_QUERY)
+                .execute(Tuple.of(assetId))
+                .onFailure()
+                .invoke(failure -> logger.errorf(failure,
+                        "Failed to get client mappings for assetId: %s. Error: %s",
+                        assetId, failure.getMessage()))
+                .map(rowSet -> {
+                    List<String> clientIds = new ArrayList<>();
+                    for (Row row : rowSet) {
+                        clientIds.add(row.getString("shared_client_id"));
+                    }
+                    return clientIds;
+                });
+    }
+
+    private Uni<String> saveClientData(EnvelopedMessage message, Long assetDataId,
+            List<String> clientMappings) {
+        var asset = message.getPayload();
+        String assetId = asset.getAssetId();
+
+        if (clientMappings.isEmpty()) {
+            return Uni.createFrom().item(assetId);
+        }
+
+        List<Uni<RowSet<Row>>> insertOperations = new ArrayList<>();
+
+        for (String clientId : clientMappings) {
+            Tuple tuple = Tuple.from(new Object[]{
+                    assetDataId,
+                    assetId,
+                    clientId,
+                    asset.getTimestamp().toOffsetDateTime()
+            });
+
+            insertOperations.add(
+                    client.preparedQuery(INSERT_CLIENT_QUERY).execute(tuple)
+                            .onFailure()
+                            .invoke(failure -> logger.errorf(failure,
+                                    "Failed to insert into asset_data_client - assetDataId: %d, assetId: %s, clientId: %s. Error: %s",
+                                    assetDataId, assetId, clientId, failure.getMessage())));
+        }
+
+        return Uni.combine().all().unis(insertOperations)
+                .combinedWith(results -> assetId);
+    }
+
+    public static class CrossReferenceResult {
+        private final String result;
+        private final List<String> sharedClientIds;
+
+        public CrossReferenceResult(String result, List<String> sharedClientIds) {
+            this.result = result;
+            this.sharedClientIds = sharedClientIds;
+        }
+
+        public String getResult() {
+            return result;
+        }
+
+        public List<String> getSharedClientIds() {
+            return sharedClientIds;
+        }
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataClientRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataClientRepository.java
@@ -3,7 +3,7 @@ package com.microboxlabs.miot.tracking.persistence;
 import cl.streamhub.gps.model.EnvelopedMessage;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
@@ -31,9 +31,9 @@ public class AssetDataClientRepository {
             VALUES ($1, $2, $3, $4)
             """;
 
-    private final PgPool client;
+    private final Pool client;
 
-    AssetDataClientRepository(PgPool client) {
+    AssetDataClientRepository(Pool client) {
         this.client = client;
     }
 
@@ -88,8 +88,8 @@ public class AssetDataClientRepository {
                                     assetDataId, assetId, clientId, failure.getMessage())));
         }
 
-        return Uni.combine().all().unis(insertOperations)
-                .combinedWith(results -> assetId);
+        return Uni.join().all(insertOperations).andCollectFailures()
+                .map(results -> assetId);
     }
 
     public static class CrossReferenceResult {

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
@@ -1,0 +1,152 @@
+package com.microboxlabs.miot.tracking.persistence;
+
+import cl.streamhub.gps.model.Contact;
+import cl.streamhub.gps.model.EnvelopedMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.tracking.enabled", stringValue = "true")
+public class AssetDataRepository {
+
+    private static final Logger logger = Logger.getLogger(AssetDataRepository.class);
+
+    private static final String INSERT_QUERY = """
+            INSERT INTO miot_tracking.asset_data (
+            request_id, request_timestamp, client_id,
+            asset_id, type, owner, year, timestamp, location, altitude, speed, heading,
+            telcom_iccid, telcom_imsi, telcom_operator, telcom_mcc, telcom_mnc,
+            telcom_cell_id, telcom_lac, telcom_signal_strength, telcom_gps_provider,
+            driver_info_driver_id, driver_info_name, driver_info_license_number,
+            driver_info_contact_phone, driver_info_contact_email,
+            driver_info_id_button,
+            co_driver_info_driver_id, co_driver_info_name, co_driver_info_license_number,
+            co_driver_info_contact_phone, co_driver_info_contact_email,
+            sensors, peripherals, events, s2tokens)
+            VALUES (
+            $1, $2, $3,
+            $4, $5, $6, $7, $8, ST_GeographyFromText($9), $10, $11, $12,
+            $13, $14, $15, $16, $17,
+            $18, $19, $20, $21,
+            $22, $23, $24,
+            $25, $26,
+            $27,
+            $28, $29, $30,
+            $31, $32,
+            $33::jsonb, $34::jsonb, $35::jsonb, $36::jsonb)
+            RETURNING id
+            """;
+
+    private final PgPool client;
+    private final ObjectMapper objectMapper;
+
+    AssetDataRepository(PgPool client, ObjectMapper objectMapper) {
+        this.client = client;
+        this.objectMapper = objectMapper;
+    }
+
+    public Uni<Long> save(EnvelopedMessage message) {
+        var asset = message.getPayload();
+
+        final String clientId = message.getClientId() != null
+                ? message.getClientId().replace("@clients", "")
+                : null;
+        if (clientId == null) {
+            throw new IllegalArgumentException("ClientId cannot be null");
+        }
+
+        String pointWkt = null;
+        if (asset.getGps() != null) {
+            pointWkt = String.format(Locale.US, "SRID=4326;POINT(%f %f)",
+                    asset.getGps().getLongitude(),
+                    asset.getGps().getLatitude());
+        }
+
+        try {
+            JsonObject sensorsJson = asset.getSensors() != null
+                    ? new JsonObject(objectMapper.writeValueAsString(asset.getSensors()))
+                    : null;
+            JsonObject peripheralsJson = asset.getPeripherals() != null
+                    ? new JsonObject(objectMapper.writeValueAsString(asset.getPeripherals()))
+                    : null;
+            JsonArray eventsJson = asset.getEvents() != null
+                    ? new JsonArray(objectMapper.writeValueAsString(asset.getEvents()))
+                    : null;
+
+            String s2Token = S2Util.tokenAtLevel(
+                    asset.getGps().getLatitude(),
+                    asset.getGps().getLongitude(), 12);
+            JsonObject s2Json = new JsonObject();
+            s2Json.put("level_12", s2Token);
+
+            return client.preparedQuery(INSERT_QUERY)
+                    .execute(Tuple.from(new Object[]{
+                            message.getRequestId(),
+                            message.getTimestamp().atOffset(ZoneOffset.UTC),
+                            clientId,
+                            asset.getAssetId(),
+                            asset.getType(),
+                            asset.getOwner(),
+                            asset.getYear(),
+                            asset.getTimestamp().toOffsetDateTime(),
+                            pointWkt,
+                            asset.getGps().getAltitude(),
+                            asset.getGps().getSpeed(),
+                            asset.getGps().getHeading(),
+
+                            asset.getTelecom() != null ? asset.getTelecom().getIccid() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getImsi() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getOperator() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getMcc() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getMnc() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getCellId() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getLac() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getSignalStrength() : null,
+                            asset.getTelecom() != null ? asset.getTelecom().getGpsProvider() : null,
+
+                            asset.getDriverInfo() != null ? asset.getDriverInfo().getDriverId() : null,
+                            asset.getDriverInfo() != null ? asset.getDriverInfo().getName() : null,
+                            asset.getDriverInfo() != null ? asset.getDriverInfo().getLicenseNumber() : null,
+                            asset.getDriverInfo() != null ? getPhone(asset.getDriverInfo().getContact()) : null,
+                            asset.getDriverInfo() != null ? getEmail(asset.getDriverInfo().getContact()) : null,
+                            asset.getDriverInfo() != null ? asset.getDriverInfo().getIdButton() : null,
+
+                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getDriverId() : null,
+                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getName() : null,
+                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getLicenseNumber() : null,
+                            asset.getCoDriverInfo() != null ? getPhone(asset.getCoDriverInfo().getContact()) : null,
+                            asset.getCoDriverInfo() != null ? getEmail(asset.getCoDriverInfo().getContact()) : null,
+                            sensorsJson,
+                            peripheralsJson,
+                            eventsJson,
+                            s2Json
+                    }))
+                    .onFailure()
+                    .invoke(failure -> logger.errorf(failure,
+                            "Failed to insert into asset_data - assetId: %s, requestId: %s, clientId: %s. Error: %s",
+                            asset.getAssetId(), message.getRequestId(), clientId,
+                            failure.getMessage()))
+                    .map(rows -> rows.iterator().next().getLong("id"));
+        } catch (JsonProcessingException e) {
+            return Uni.createFrom().failure(e);
+        }
+    }
+
+    private static String getEmail(Contact contact) {
+        return contact == null ? null : contact.getEmail();
+    }
+
+    private static String getPhone(Contact contact) {
+        return contact == null ? null : contact.getPhone();
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
@@ -106,9 +106,9 @@ public class AssetDataRepository {
                 asset.getGps().getLatitude(), asset.getGps().getLongitude(), 12);
         JsonObject s2Json = new JsonObject().put("level_12", s2Token);
 
-        var t = asset.getTelecom();
-        var d = asset.getDriverInfo();
-        var cd = asset.getCoDriverInfo();
+        Object[] telecomParams = telecomParams(asset.getTelecom());
+        Object[] driverParams = driverInfoParams(asset.getDriverInfo());
+        Object[] coDriverParams = driverInfoParams(asset.getCoDriverInfo());
 
         return new Object[]{
                 message.getRequestId(),
@@ -118,24 +118,30 @@ public class AssetDataRepository {
                 asset.getTimestamp().toOffsetDateTime(),
                 pointWkt,
                 asset.getGps().getAltitude(), asset.getGps().getSpeed(), asset.getGps().getHeading(),
-                // telecom
-                t != null ? t.getIccid() : null, t != null ? t.getImsi() : null,
-                t != null ? t.getOperator() : null, t != null ? t.getMcc() : null,
-                t != null ? t.getMnc() : null, t != null ? t.getCellId() : null,
-                t != null ? t.getLac() : null, t != null ? t.getSignalStrength() : null,
-                t != null ? t.getGpsProvider() : null,
-                // driver
-                d != null ? d.getDriverId() : null, d != null ? d.getName() : null,
-                d != null ? d.getLicenseNumber() : null,
-                d != null ? getPhone(d.getContact()) : null,
-                d != null ? getEmail(d.getContact()) : null,
-                d != null ? d.getIdButton() : null,
-                // co-driver
-                cd != null ? cd.getDriverId() : null, cd != null ? cd.getName() : null,
-                cd != null ? cd.getLicenseNumber() : null,
-                cd != null ? getPhone(cd.getContact()) : null,
-                cd != null ? getEmail(cd.getContact()) : null,
+                telecomParams[0], telecomParams[1], telecomParams[2], telecomParams[3],
+                telecomParams[4], telecomParams[5], telecomParams[6], telecomParams[7],
+                telecomParams[8],
+                driverParams[0], driverParams[1], driverParams[2],       // $22-$24
+                driverParams[3], driverParams[4], driverParams[5],       // $25-$27
+                coDriverParams[0], coDriverParams[1], coDriverParams[2], // $28-$30
+                coDriverParams[3], coDriverParams[4],                    // $31-$32
                 sensorsJson, peripheralsJson, eventsJson, s2Json
+        };
+    }
+
+    private static Object[] telecomParams(cl.streamhub.gps.model.Telecom t) {
+        if (t == null) return new Object[9];
+        return new Object[]{
+                t.getIccid(), t.getImsi(), t.getOperator(), t.getMcc(), t.getMnc(),
+                t.getCellId(), t.getLac(), t.getSignalStrength(), t.getGpsProvider()
+        };
+    }
+
+    private static Object[] driverInfoParams(cl.streamhub.gps.model.DriverInfo d) {
+        if (d == null) return new Object[6];
+        return new Object[]{
+                d.getDriverId(), d.getName(), d.getLicenseNumber(),
+                getPhone(d.getContact()), getEmail(d.getContact()), d.getIdButton()
         };
     }
 

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetDataRepository.java
@@ -8,7 +8,7 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.ZoneOffset;
@@ -47,10 +47,10 @@ public class AssetDataRepository {
             RETURNING id
             """;
 
-    private final PgPool client;
+    private final Pool client;
     private final ObjectMapper objectMapper;
 
-    AssetDataRepository(PgPool client, ObjectMapper objectMapper) {
+    AssetDataRepository(Pool client, ObjectMapper objectMapper) {
         this.client = client;
         this.objectMapper = objectMapper;
     }
@@ -58,79 +58,14 @@ public class AssetDataRepository {
     public Uni<Long> save(EnvelopedMessage message) {
         var asset = message.getPayload();
 
-        final String clientId = message.getClientId() != null
-                ? message.getClientId().replace("@clients", "")
-                : null;
-        if (clientId == null) {
-            throw new IllegalArgumentException("ClientId cannot be null");
-        }
-
-        String pointWkt = null;
-        if (asset.getGps() != null) {
-            pointWkt = String.format(Locale.US, "SRID=4326;POINT(%f %f)",
-                    asset.getGps().getLongitude(),
-                    asset.getGps().getLatitude());
-        }
+        final String clientId = extractClientId(message);
+        String pointWkt = buildPointWkt(asset);
 
         try {
-            JsonObject sensorsJson = asset.getSensors() != null
-                    ? new JsonObject(objectMapper.writeValueAsString(asset.getSensors()))
-                    : null;
-            JsonObject peripheralsJson = asset.getPeripherals() != null
-                    ? new JsonObject(objectMapper.writeValueAsString(asset.getPeripherals()))
-                    : null;
-            JsonArray eventsJson = asset.getEvents() != null
-                    ? new JsonArray(objectMapper.writeValueAsString(asset.getEvents()))
-                    : null;
-
-            String s2Token = S2Util.tokenAtLevel(
-                    asset.getGps().getLatitude(),
-                    asset.getGps().getLongitude(), 12);
-            JsonObject s2Json = new JsonObject();
-            s2Json.put("level_12", s2Token);
+            Object[] params = buildInsertParams(message, asset, clientId, pointWkt);
 
             return client.preparedQuery(INSERT_QUERY)
-                    .execute(Tuple.from(new Object[]{
-                            message.getRequestId(),
-                            message.getTimestamp().atOffset(ZoneOffset.UTC),
-                            clientId,
-                            asset.getAssetId(),
-                            asset.getType(),
-                            asset.getOwner(),
-                            asset.getYear(),
-                            asset.getTimestamp().toOffsetDateTime(),
-                            pointWkt,
-                            asset.getGps().getAltitude(),
-                            asset.getGps().getSpeed(),
-                            asset.getGps().getHeading(),
-
-                            asset.getTelecom() != null ? asset.getTelecom().getIccid() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getImsi() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getOperator() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getMcc() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getMnc() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getCellId() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getLac() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getSignalStrength() : null,
-                            asset.getTelecom() != null ? asset.getTelecom().getGpsProvider() : null,
-
-                            asset.getDriverInfo() != null ? asset.getDriverInfo().getDriverId() : null,
-                            asset.getDriverInfo() != null ? asset.getDriverInfo().getName() : null,
-                            asset.getDriverInfo() != null ? asset.getDriverInfo().getLicenseNumber() : null,
-                            asset.getDriverInfo() != null ? getPhone(asset.getDriverInfo().getContact()) : null,
-                            asset.getDriverInfo() != null ? getEmail(asset.getDriverInfo().getContact()) : null,
-                            asset.getDriverInfo() != null ? asset.getDriverInfo().getIdButton() : null,
-
-                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getDriverId() : null,
-                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getName() : null,
-                            asset.getCoDriverInfo() != null ? asset.getCoDriverInfo().getLicenseNumber() : null,
-                            asset.getCoDriverInfo() != null ? getPhone(asset.getCoDriverInfo().getContact()) : null,
-                            asset.getCoDriverInfo() != null ? getEmail(asset.getCoDriverInfo().getContact()) : null,
-                            sensorsJson,
-                            peripheralsJson,
-                            eventsJson,
-                            s2Json
-                    }))
+                    .execute(Tuple.from(params))
                     .onFailure()
                     .invoke(failure -> logger.errorf(failure,
                             "Failed to insert into asset_data - assetId: %s, requestId: %s, clientId: %s. Error: %s",
@@ -140,6 +75,72 @@ public class AssetDataRepository {
         } catch (JsonProcessingException e) {
             return Uni.createFrom().failure(e);
         }
+    }
+
+    private static String extractClientId(EnvelopedMessage message) {
+        String raw = message.getClientId();
+        String clientId = raw != null ? raw.replace("@clients", "") : null;
+        if (clientId == null) {
+            throw new IllegalArgumentException("ClientId cannot be null");
+        }
+        return clientId;
+    }
+
+    private static String buildPointWkt(cl.streamhub.gps.model.AssetTrackingData asset) {
+        if (asset.getGps() == null) return null;
+        return String.format(Locale.US, "SRID=4326;POINT(%f %f)",
+                asset.getGps().getLongitude(), asset.getGps().getLatitude());
+    }
+
+    private Object[] buildInsertParams(EnvelopedMessage message,
+            cl.streamhub.gps.model.AssetTrackingData asset,
+            String clientId, String pointWkt) throws JsonProcessingException {
+
+        JsonObject sensorsJson = toJsonObject(asset.getSensors());
+        JsonObject peripheralsJson = toJsonObject(asset.getPeripherals());
+        JsonArray eventsJson = asset.getEvents() != null
+                ? new JsonArray(objectMapper.writeValueAsString(asset.getEvents()))
+                : null;
+
+        String s2Token = S2Util.tokenAtLevel(
+                asset.getGps().getLatitude(), asset.getGps().getLongitude(), 12);
+        JsonObject s2Json = new JsonObject().put("level_12", s2Token);
+
+        var t = asset.getTelecom();
+        var d = asset.getDriverInfo();
+        var cd = asset.getCoDriverInfo();
+
+        return new Object[]{
+                message.getRequestId(),
+                message.getTimestamp().atOffset(ZoneOffset.UTC),
+                clientId,
+                asset.getAssetId(), asset.getType(), asset.getOwner(), asset.getYear(),
+                asset.getTimestamp().toOffsetDateTime(),
+                pointWkt,
+                asset.getGps().getAltitude(), asset.getGps().getSpeed(), asset.getGps().getHeading(),
+                // telecom
+                t != null ? t.getIccid() : null, t != null ? t.getImsi() : null,
+                t != null ? t.getOperator() : null, t != null ? t.getMcc() : null,
+                t != null ? t.getMnc() : null, t != null ? t.getCellId() : null,
+                t != null ? t.getLac() : null, t != null ? t.getSignalStrength() : null,
+                t != null ? t.getGpsProvider() : null,
+                // driver
+                d != null ? d.getDriverId() : null, d != null ? d.getName() : null,
+                d != null ? d.getLicenseNumber() : null,
+                d != null ? getPhone(d.getContact()) : null,
+                d != null ? getEmail(d.getContact()) : null,
+                d != null ? d.getIdButton() : null,
+                // co-driver
+                cd != null ? cd.getDriverId() : null, cd != null ? cd.getName() : null,
+                cd != null ? cd.getLicenseNumber() : null,
+                cd != null ? getPhone(cd.getContact()) : null,
+                cd != null ? getEmail(cd.getContact()) : null,
+                sensorsJson, peripheralsJson, eventsJson, s2Json
+        };
+    }
+
+    private JsonObject toJsonObject(Object value) throws JsonProcessingException {
+        return value != null ? new JsonObject(objectMapper.writeValueAsString(value)) : null;
     }
 
     private static String getEmail(Contact contact) {

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetTrackingProcessor.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/AssetTrackingProcessor.java
@@ -1,0 +1,81 @@
+package com.microboxlabs.miot.tracking.persistence;
+
+import cl.streamhub.gps.model.EnvelopedMessage;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+/**
+ * Three-step processing pipeline for asset tracking data persistence.
+ *
+ * <ol>
+ *   <li>Insert raw position data into {@code asset_data}</li>
+ *   <li>Cross-reference via {@code asset_client_map} and insert into {@code asset_data_client}</li>
+ *   <li>Persist metrics (core / extension / DTC) with idempotency check</li>
+ * </ol>
+ */
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.tracking.enabled", stringValue = "true")
+public class AssetTrackingProcessor {
+
+    private static final Logger logger = Logger.getLogger(AssetTrackingProcessor.class);
+
+    private final AssetDataRepository assetDataRepository;
+    private final AssetDataClientRepository assetDataClientRepository;
+    private final MetricsRepository metricsRepository;
+
+    AssetTrackingProcessor(AssetDataRepository assetDataRepository,
+            AssetDataClientRepository assetDataClientRepository,
+            MetricsRepository metricsRepository) {
+        this.assetDataRepository = assetDataRepository;
+        this.assetDataClientRepository = assetDataClientRepository;
+        this.metricsRepository = metricsRepository;
+    }
+
+    public Uni<Void> process(EnvelopedMessage message) {
+        String assetId = message.getPayload().getAssetId();
+        long processStart = System.currentTimeMillis();
+
+        // Step 1: Insert into asset_data
+        return assetDataRepository.save(message)
+                .chain(assetDataId -> {
+                    long assetDataTime = System.currentTimeMillis();
+                    logger.infof("asset_data insert: %d ms - assetId: %s",
+                            assetDataTime - processStart, assetId);
+
+                    // Step 2: Cross-reference and save to asset_data_client
+                    return assetDataClientRepository.crossReferenceAndSave(message, assetDataId)
+                            .chain(crossRefResult -> {
+                                long clientDataTime = System.currentTimeMillis();
+                                logger.infof("client_data insert: %d ms - assetId: %s",
+                                        clientDataTime - assetDataTime, assetId);
+
+                                // Step 3: Metrics persistence
+                                List<String> sharedClientIds = crossRefResult.getSharedClientIds();
+                                if (!metricsRepository.hasMetrics(message)) {
+                                    logger.infof("no metrics to process: assetId: %s", assetId);
+                                    return Uni.createFrom().voidItem();
+                                }
+                                if (sharedClientIds.isEmpty()) {
+                                    logger.infof("no shared clients found: assetId: %s", assetId);
+                                    return Uni.createFrom().voidItem();
+                                }
+
+                                return metricsRepository
+                                        .saveMetrics(
+                                                message.getPayload().getMetrics(),
+                                                sharedClientIds,
+                                                assetDataId,
+                                                message)
+                                        .replaceWithVoid()
+                                        .invoke(() -> {
+                                            long metricsTime = System.currentTimeMillis();
+                                            logger.infof("metrics insert: %d ms - assetId: %s",
+                                                    metricsTime - clientDataTime, assetId);
+                                        });
+                            });
+                });
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/MetricsRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/MetricsRepository.java
@@ -1,0 +1,457 @@
+package com.microboxlabs.miot.tracking.persistence;
+
+import cl.streamhub.gps.model.EnvelopedMessage;
+import cl.streamhub.gps.model.metrics.MetricItem;
+import cl.streamhub.gps.model.metrics.MetricRegistry;
+import cl.streamhub.gps.model.metrics.MetricValidationResult;
+import cl.streamhub.gps.model.metrics.MetricsEnvelope;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.tracking.enabled", stringValue = "true")
+public class MetricsRepository {
+
+    private static final Logger logger = Logger.getLogger(MetricsRepository.class);
+
+    private static final String COL_DTC_CODES = "dtc_codes";
+    private static final String COL_ENGINE_FREEZE_FRAME = "engine_freeze_frame";
+
+    private final Map<String, BiConsumer<Object, Map<String, Object>>> metricMappers = buildMetricMappers();
+
+    private final PgPool client;
+    private final ObjectMapper objectMapper;
+
+    MetricsRepository(PgPool client, ObjectMapper objectMapper) {
+        this.client = client;
+        this.objectMapper = objectMapper;
+    }
+
+    private Map<String, BiConsumer<Object, Map<String, Object>>> buildMetricMappers() {
+        Map<String, BiConsumer<Object, Map<String, Object>>> m = new HashMap<>();
+        // --- POWERTRAIN ---
+        m.put("engine.rpm",            (v, r) -> r.put("engine_rpm", getIntegerValue(v)));
+        m.put("vehicle.speed",         (v, r) -> r.put("vehicle_speed_kph", getIntegerValue(v)));
+        m.put("engine.load",           (v, r) -> r.put("engine_load_pct", getShortValue(v)));
+        m.put("throttle.position",     (v, r) -> r.put("throttle_pos_pct", getShortValue(v)));
+        m.put("engine.coolant_temp",   (v, r) -> r.put("coolant_temp_c", getShortValue(v)));
+        m.put("engine.intake_air_temp",(v, r) -> r.put("intake_air_temp_c", getShortValue(v)));
+        m.put("engine.runtime",        (v, r) -> r.put("engine_runtime_s", getIntegerValue(v)));
+        m.put("engine.total_runtime",  (v, r) -> r.put("engine_total_runtime_h", getIntegerValue(v)));
+        // --- FUEL ---
+        m.put("fuel.level",            (v, r) -> r.put("fuel_level_pct", getShortValue(v)));
+        m.put("fuel.volume",           (v, r) -> r.put("fuel_volume_ml", getFuelVolumeMilliliters(v)));
+        m.put("fuel.rate",             (v, r) -> r.put("fuel_rate_mlph", getIntegerValue(v)));
+        m.put("fuel.used",             (v, r) -> r.put("fuel_used_ml", getLongValue(v)));
+        m.put("battery.voltage",       (v, r) -> r.put("battery_voltage_mv", getBatteryVoltageMillivolts(v)));
+        m.put("engine.torque_pct",     (v, r) -> r.put("engine_torque_pct", getShortValue(v)));
+        // --- MOTION ---
+        m.put("vehicle.odometer",      (v, r) -> r.put("odometer_km", getLongValue(v)));
+        m.put("idle.state",            (v, r) -> r.put("idle_state", getBooleanValue(v)));
+        m.put("accelerator.position",  (v, r) -> r.put("accelerator_pos_pct", getShortValue(v)));
+        m.put("brake.state",           (v, r) -> r.put("brake_state", getBooleanValue(v)));
+        // --- DIAGNOSTIC ---
+        m.put("dtc.mil_on",            (v, r) -> r.put("mil_on", getBooleanValue(v)));
+        m.put("dtc.codes",             (v, r) -> r.put(COL_DTC_CODES, v));
+        m.put("dtc.count",             (v, r) -> r.put("dtc_count", getIntegerValue(v)));
+        m.put("engine.freeze_frame",   (v, r) -> r.put(COL_ENGINE_FREEZE_FRAME, v));
+        // --- EMISSIONS ---
+        m.put("fuel.trim.short",       (v, r) -> r.put("fuel_trim_short_pct", getShortValue(v)));
+        m.put("fuel.trim.long",        (v, r) -> r.put("fuel_trim_long_pct", getShortValue(v)));
+        m.put("emissions.lambda",      (v, r) -> r.put("lambda_ratio", v));
+        m.put("catalyst.temp",         (v, r) -> r.put("catalyst_temp_c", getShortValue(v)));
+        // --- ELECTRICAL ---
+        m.put("battery.current",       (v, r) -> r.put("battery_current_ma", getIntegerValue(v)));
+        m.put("pto.state",             (v, r) -> r.put("pto_state", getBooleanValue(v)));
+        m.put("engine.fan.state",      (v, r) -> r.put("engine_fan_state", getBooleanValue(v)));
+        // --- IDENTITY ---
+        m.put("vehicle.vin",           (v, r) -> r.put("vehicle_vin", v));
+        m.put("vehicle.protocol",      (v, r) -> r.put("vehicle_protocol", v));
+        m.put("vehicle.ecu",           (v, r) -> r.put("vehicle_ecu", v));
+        return Map.copyOf(m);
+    }
+
+    private static final String INSERT_INDEMP_LEDGER = """
+            INSERT INTO miot_tracking.ingest_ledger_metrics (
+                client_id, device_id, request_id, request_timestamp
+            ) VALUES ($1, $2, $3, $4)
+            ON CONFLICT (client_id, device_id, request_id) DO NOTHING
+            RETURNING 1
+            """;
+
+    private static final String INSERT_METRICS_CORE_QUERY = """
+            INSERT INTO miot_tracking.asset_metric_core (
+                shared_client_id, asset_id, device_id, ts, asset_data_id,
+                engine_rpm, vehicle_speed_kph, engine_load_pct, throttle_pos_pct, coolant_temp_c,
+                intake_air_temp_c, engine_runtime_s, engine_total_runtime_h, fuel_level_pct,
+                fuel_volume_ml, fuel_rate_mlph, fuel_used_ml, battery_voltage_mv, engine_torque_pct,
+                odometer_km, idle_state, accelerator_pos_pct, brake_state, mil_on, dtc_count,
+                fuel_trim_short_pct, fuel_trim_long_pct, lambda_ratio, catalyst_temp_c,
+                battery_current_ma, pto_state, engine_fan_state, payload_schema, src, quality, seq, request_id, request_timestamp
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
+                $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38
+            )
+            ON CONFLICT (shared_client_id, asset_id, ts) DO NOTHING
+            RETURNING 1
+            """;
+
+    private static final String INSERT_METRICS_EXT_QUERY = """
+            INSERT INTO miot_tracking.asset_metric_ext (
+                shared_client_id, asset_id, device_id, ts, asset_data_id,
+                ext, payload_schema, src, request_id, request_timestamp
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (shared_client_id, asset_id, ts) DO NOTHING
+            RETURNING 1
+            """;
+
+    private static final String INSERT_METRICS_DTC_QUERY = """
+            INSERT INTO miot_tracking.asset_metric_dtc (
+                shared_client_id, asset_id, device_id, ts, asset_data_id,
+                dtc_codes, engine_freeze_frame,
+                payload_schema, src, request_id, request_timestamp
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (shared_client_id, asset_id, ts) DO NOTHING
+            RETURNING 1
+            """;
+
+    public boolean hasMetrics(EnvelopedMessage message) {
+        try {
+            List<MetricItem> metrics = message.getPayload().getMetrics().getItems();
+            return metrics != null && !metrics.isEmpty();
+        } catch (Exception e) {
+            logger.debug("Failed to check for metrics", e);
+            return false;
+        }
+    }
+
+    public Uni<String> saveMetrics(MetricsEnvelope metrics, List<String> sharedClientIds,
+            Long assetDataId, EnvelopedMessage envelopedMessage) {
+        long metricsStart = System.currentTimeMillis();
+
+        return processIdempotencyLedger(
+                envelopedMessage.getClientId(),
+                envelopedMessage.getPayload().getAssetId(),
+                envelopedMessage.getRequestId(),
+                envelopedMessage.getTimestamp().atOffset(ZoneOffset.UTC))
+                .chain(isNew -> {
+                    if (Boolean.FALSE.equals(isNew)) {
+                        return Uni.createFrom().item(
+                                "Metrics already processed for asset: "
+                                        + envelopedMessage.getPayload().getAssetId());
+                    }
+                    return saveMetricsInternal(metrics, sharedClientIds, assetDataId, envelopedMessage)
+                            .map(result -> {
+                                long metricsEnd = System.currentTimeMillis();
+                                logger.infof("METRICS_SAVE_TOTAL: %d ms - assetId: %s",
+                                        metricsEnd - metricsStart,
+                                        envelopedMessage.getPayload().getAssetId());
+                                return result;
+                            });
+                });
+    }
+
+    private Uni<String> saveMetricsInternal(MetricsEnvelope metrics, List<String> sharedClientIds,
+            Long assetDataId, EnvelopedMessage envelopedMessage) {
+        Map<String, Object> row = new HashMap<>();
+        List<MetricItem> metricItems = metrics.getItems();
+
+        List<MetricItem> coreMetrics = metricItems.stream()
+                .filter(item -> {
+                    MetricValidationResult validationResult = MetricRegistry.validate(item);
+                    boolean isExtension = MetricRegistry.isExtensionKey(item.getK());
+                    if (!validationResult.isValid()) {
+                        logger.warnf("Metric validation FAILED for key '%s' (value=%s, unit=%s): [%s] %s",
+                                item.getK(), item.getV(), item.getU(),
+                                validationResult.getErrorCode(), validationResult.getMessage());
+                    }
+                    return validationResult.isValid() && !isExtension;
+                })
+                .toList();
+
+        List<MetricItem> extensionMetrics = metricItems.stream()
+                .filter(item -> {
+                    boolean isValid = MetricRegistry.validate(item).isValid();
+                    boolean isExtension = MetricRegistry.isExtensionKey(item.getK());
+                    return isValid && isExtension;
+                })
+                .toList();
+
+        OffsetDateTime gpsTimestamp = envelopedMessage.getPayload().getTimestamp() != null
+                ? envelopedMessage.getPayload().getTimestamp().toOffsetDateTime()
+                        .atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+                : envelopedMessage.getTimestamp().atOffset(ZoneOffset.UTC);
+
+        for (MetricItem item : coreMetrics) {
+            mapMetricToColumn(item, row, gpsTimestamp);
+        }
+
+        Uni<String> result = Uni.createFrom().item("No metrics saved");
+
+        for (String sharedClientId : sharedClientIds) {
+            result = processCoreMetrics(sharedClientId, envelopedMessage, assetDataId, metrics, row, coreMetrics)
+                    .chain(coreResult -> processExtensionMetrics(sharedClientId, envelopedMessage,
+                            assetDataId, metrics, extensionMetrics)
+                            .onItem().transform(extResult -> coreResult + "; " + extResult))
+                    .chain(prevResult -> processDtcMetrics(sharedClientId, envelopedMessage,
+                            assetDataId, metrics, row)
+                            .onItem().transform(dtcResult -> prevResult + "; " + dtcResult));
+        }
+
+        return result;
+    }
+
+    private Uni<String> processCoreMetrics(String sharedClientId, EnvelopedMessage envelopedMessage,
+            Long assetDataId, MetricsEnvelope metrics, Map<String, Object> row,
+            List<MetricItem> coreMetrics) {
+
+        if (coreMetrics.isEmpty()) {
+            return Uni.createFrom().item("No core metrics to process");
+        }
+
+        logger.infof("Row map values for asset %s: %s", envelopedMessage.getPayload().getAssetId(), row);
+        Tuple tuple = Tuple.tuple();
+
+        tuple.addString(sharedClientId);                                     // $1
+        tuple.addString(envelopedMessage.getPayload().getAssetId());         // $2
+        tuple.addString(envelopedMessage.getPayload().getAssetId());         // $3 device_id
+        tuple.addOffsetDateTime((OffsetDateTime) row.get("ts"));             // $4
+        tuple.addLong(assetDataId);                                          // $5
+
+        // POWERTRAIN
+        tuple.addInteger((Integer) row.get("engine_rpm"));                   // $6
+        tuple.addInteger((Integer) row.get("vehicle_speed_kph"));            // $7
+        tuple.addShort((Short) row.get("engine_load_pct"));                  // $8
+        tuple.addShort((Short) row.get("throttle_pos_pct"));                 // $9
+        tuple.addShort((Short) row.get("coolant_temp_c"));                   // $10
+        tuple.addShort((Short) row.get("intake_air_temp_c"));                // $11
+        tuple.addInteger((Integer) row.get("engine_runtime_s"));             // $12
+        tuple.addInteger((Integer) row.get("engine_total_runtime_h"));       // $13
+
+        // FUEL
+        tuple.addShort((Short) row.get("fuel_level_pct"));                   // $14
+        tuple.addInteger((Integer) row.get("fuel_volume_ml"));               // $15
+        tuple.addInteger((Integer) row.get("fuel_rate_mlph"));               // $16
+        tuple.addLong((Long) row.get("fuel_used_ml"));                       // $17
+        tuple.addInteger((Integer) row.get("battery_voltage_mv"));           // $18
+        tuple.addShort((Short) row.get("engine_torque_pct"));                // $19
+
+        // MOTION
+        tuple.addLong((Long) row.get("odometer_km"));                        // $20
+        tuple.addBoolean((Boolean) row.get("idle_state"));                   // $21
+        tuple.addShort((Short) row.get("accelerator_pos_pct"));              // $22
+        tuple.addBoolean((Boolean) row.get("brake_state"));                  // $23
+
+        // DIAGNOSTICS
+        tuple.addBoolean((Boolean) row.get("mil_on"));                       // $24
+        tuple.addInteger((Integer) row.get("dtc_count"));                    // $25
+
+        // EMISSIONS
+        tuple.addShort((Short) row.get("fuel_trim_short_pct"));              // $26
+        tuple.addShort((Short) row.get("fuel_trim_long_pct"));               // $27
+        tuple.addDouble((Double) row.get("lambda_ratio"));                   // $28
+        tuple.addShort((Short) row.get("catalyst_temp_c"));                  // $29
+
+        // ELECTRICAL
+        tuple.addInteger((Integer) row.get("battery_current_ma"));           // $30
+        tuple.addBoolean((Boolean) row.get("pto_state"));                    // $31
+        tuple.addBoolean((Boolean) row.get("engine_fan_state"));             // $32
+
+        tuple.addString(metrics.getSchema());                                // $33
+        tuple.addString((String) row.get("src"));                            // $34
+        tuple.addString((String) row.get("quality"));                        // $35
+        tuple.addLong(metrics.getSeq());                                     // $36
+        tuple.addString(envelopedMessage.getRequestId());                    // $37
+        tuple.addOffsetDateTime(envelopedMessage.getTimestamp().atOffset(ZoneOffset.UTC)); // $38
+
+        return client.preparedQuery(INSERT_METRICS_CORE_QUERY)
+                .execute(tuple)
+                .onFailure()
+                .invoke(failure -> logger.errorf(failure,
+                        "Failed to insert core metrics - shared_client_id: %s, asset_id: %s, requestId: %s. Error: %s",
+                        sharedClientId, envelopedMessage.getPayload().getAssetId(),
+                        envelopedMessage.getRequestId(), failure.getMessage()))
+                .onItem().transformToUni(
+                        rowSet -> Uni.createFrom()
+                                .item("Core metrics saved for shared_client_id: " + sharedClientId));
+    }
+
+    private Uni<String> processExtensionMetrics(String sharedClientId,
+            EnvelopedMessage envelopedMessage, Long assetDataId,
+            MetricsEnvelope metrics, List<MetricItem> extensionMetrics) {
+
+        if (extensionMetrics.isEmpty()) {
+            return Uni.createFrom().item("No extension metrics to process");
+        }
+
+        Uni<String> result = Uni.createFrom().item("Extension metrics processed: ");
+
+        for (MetricItem extensionMetric : extensionMetrics) {
+            result = result.chain(currentResult -> {
+                try {
+                    JsonObject valueJson = new JsonObject(objectMapper.writeValueAsString(extensionMetric));
+
+                    Tuple tuple = Tuple.tuple()
+                            .addString(sharedClientId)
+                            .addString(envelopedMessage.getPayload().getAssetId())
+                            .addString(envelopedMessage.getPayload().getAssetId())
+                            .addOffsetDateTime(extensionMetric.getTs().toOffsetDateTime()
+                                    .atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime())
+                            .addLong(assetDataId)
+                            .addJsonObject(valueJson)
+                            .addString(metrics.getSchema())
+                            .addString(extensionMetric.getSrc())
+                            .addString(envelopedMessage.getRequestId())
+                            .addOffsetDateTime(envelopedMessage.getTimestamp().atOffset(ZoneOffset.UTC));
+
+                    return client.preparedQuery(INSERT_METRICS_EXT_QUERY)
+                            .execute(tuple)
+                            .onFailure()
+                            .invoke(failure -> logger.errorf(failure,
+                                    "Failed to insert extension metric '%s' - shared_client_id: %s, asset_id: %s, requestId: %s. Error: %s",
+                                    extensionMetric.getK(), sharedClientId,
+                                    envelopedMessage.getPayload().getAssetId(),
+                                    envelopedMessage.getRequestId(), failure.getMessage()))
+                            .onItem().transform(rowSet -> currentResult + extensionMetric.getK() + " ");
+                } catch (Exception e) {
+                    logger.errorf("Failed to serialize extension metric %s: %s",
+                            extensionMetric.getK(), e.getMessage());
+                    return Uni.createFrom()
+                            .item(currentResult + "[ERROR:" + extensionMetric.getK() + "] ");
+                }
+            });
+        }
+
+        return result.onItem()
+                .transform(finalResult -> finalResult + "for shared_client_id: " + sharedClientId);
+    }
+
+    private Uni<String> processDtcMetrics(String sharedClientId,
+            EnvelopedMessage envelopedMessage, Long assetDataId,
+            MetricsEnvelope metrics, Map<String, Object> row) {
+
+        if (row.isEmpty()) {
+            return Uni.createFrom().item("No core metrics to process");
+        }
+
+        Map<String, Object> dtcMetrics = row.entrySet().stream()
+                .filter(entry -> {
+                    String k = entry.getKey();
+                    return COL_DTC_CODES.equals(k) || COL_ENGINE_FREEZE_FRAME.equals(k);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (dtcMetrics.isEmpty()) {
+            return Uni.createFrom().item("No DTC metrics to process");
+        }
+
+        Tuple tuple = Tuple.tuple()
+                .addString(sharedClientId)
+                .addString(envelopedMessage.getPayload().getAssetId())
+                .addString(envelopedMessage.getPayload().getAssetId())
+                .addOffsetDateTime((OffsetDateTime) row.get("ts"))
+                .addLong(assetDataId)
+                .addArrayOfString(dtcMetrics.get(COL_DTC_CODES) instanceof List<?> list
+                        ? list.stream().map(Object::toString).toArray(String[]::new)
+                        : (String[]) dtcMetrics.get(COL_DTC_CODES))
+                .addString(dtcMetrics.get(COL_ENGINE_FREEZE_FRAME) != null
+                        ? dtcMetrics.get(COL_ENGINE_FREEZE_FRAME).toString()
+                        : null)
+                .addString(metrics.getSchema())
+                .addString((String) row.get("src"))
+                .addString(envelopedMessage.getRequestId())
+                .addOffsetDateTime(envelopedMessage.getTimestamp().atOffset(ZoneOffset.UTC));
+
+        return client.preparedQuery(INSERT_METRICS_DTC_QUERY)
+                .execute(tuple)
+                .onFailure()
+                .invoke(failure -> logger.errorf(failure,
+                        "Failed to insert DTC metric - shared_client_id: %s, asset_id: %s, requestId: %s. Error: %s",
+                        sharedClientId, envelopedMessage.getPayload().getAssetId(),
+                        envelopedMessage.getRequestId(), failure.getMessage()))
+                .onItem().transform(rowSet ->
+                        "DTC metrics saved for shared_client_id: " + sharedClientId);
+    }
+
+    private void mapMetricToColumn(MetricItem item, Map<String, Object> row,
+            OffsetDateTime fallbackTimestamp) {
+        BiConsumer<Object, Map<String, Object>> mapper = metricMappers.get(item.getK());
+        if (mapper != null) {
+            mapper.accept(item.getV(), row);
+        }
+        OffsetDateTime ts = item.getTs() != null
+                ? item.getTs().toOffsetDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+                : fallbackTimestamp;
+        row.put("ts", ts);
+        row.put("src", item.getSrc());
+        row.put("quality", item.getQ());
+    }
+
+    public Uni<Boolean> processIdempotencyLedger(String clientId, String deviceId,
+            String requestId, OffsetDateTime requestTs) {
+        Tuple tuple = Tuple.tuple()
+                .addString(clientId.replace("@clients", ""))
+                .addString(deviceId)
+                .addString(requestId)
+                .addOffsetDateTime(requestTs);
+
+        return client.preparedQuery(INSERT_INDEMP_LEDGER)
+                .execute(tuple)
+                .onFailure()
+                .invoke(failure -> logger.errorf(failure,
+                        "Failed to insert into ingest_ledger_metrics - clientId: %s, deviceId: %s, requestId: %s. Error: %s",
+                        clientId, deviceId, requestId, failure.getMessage()))
+                .onItem().transform(rowSet -> rowSet.rowCount() > 0);
+    }
+
+    // --- Value conversion helpers ---
+
+    private static Integer getIntegerValue(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return ((Number) value).intValue();
+        try { return Integer.parseInt(value.toString()); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Short getShortValue(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return ((Number) value).shortValue();
+        try { return Short.parseShort(value.toString()); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Long getLongValue(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return ((Number) value).longValue();
+        try { return Long.parseLong(value.toString()); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Boolean getBooleanValue(Object value) {
+        if (value == null) return null;
+        if (value instanceof Boolean) return (Boolean) value;
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    private static Integer getBatteryVoltageMillivolts(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return (int) (((Number) value).doubleValue() * 1000);
+        try { return (int) (Double.parseDouble(value.toString()) * 1000); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Integer getFuelVolumeMilliliters(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return (int) Math.round(((Number) value).doubleValue() * 1000);
+        try { return (int) Math.round(Double.parseDouble(value.toString()) * 1000); } catch (NumberFormatException e) { return null; }
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/MetricsRepository.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/MetricsRepository.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.OffsetDateTime;
@@ -32,10 +32,10 @@ public class MetricsRepository {
 
     private final Map<String, BiConsumer<Object, Map<String, Object>>> metricMappers = buildMetricMappers();
 
-    private final PgPool client;
+    private final Pool client;
     private final ObjectMapper objectMapper;
 
-    MetricsRepository(PgPool client, ObjectMapper objectMapper) {
+    MetricsRepository(Pool client, ObjectMapper objectMapper) {
         this.client = client;
         this.objectMapper = objectMapper;
     }
@@ -420,38 +420,38 @@ public class MetricsRepository {
     // --- Value conversion helpers ---
 
     private static Integer getIntegerValue(Object value) {
+        if (value instanceof Number number) return number.intValue();
         if (value == null) return null;
-        if (value instanceof Number) return ((Number) value).intValue();
         try { return Integer.parseInt(value.toString()); } catch (NumberFormatException e) { return null; }
     }
 
     private static Short getShortValue(Object value) {
+        if (value instanceof Number number) return number.shortValue();
         if (value == null) return null;
-        if (value instanceof Number) return ((Number) value).shortValue();
         try { return Short.parseShort(value.toString()); } catch (NumberFormatException e) { return null; }
     }
 
     private static Long getLongValue(Object value) {
+        if (value instanceof Number number) return number.longValue();
         if (value == null) return null;
-        if (value instanceof Number) return ((Number) value).longValue();
         try { return Long.parseLong(value.toString()); } catch (NumberFormatException e) { return null; }
     }
 
     private static Boolean getBooleanValue(Object value) {
-        if (value == null) return null;
-        if (value instanceof Boolean) return (Boolean) value;
+        if (value instanceof Boolean bool) return bool;
+        if (value == null) return Boolean.FALSE;
         return Boolean.parseBoolean(value.toString());
     }
 
     private static Integer getBatteryVoltageMillivolts(Object value) {
+        if (value instanceof Number number) return (int) (number.doubleValue() * 1000);
         if (value == null) return null;
-        if (value instanceof Number) return (int) (((Number) value).doubleValue() * 1000);
         try { return (int) (Double.parseDouble(value.toString()) * 1000); } catch (NumberFormatException e) { return null; }
     }
 
     private static Integer getFuelVolumeMilliliters(Object value) {
+        if (value instanceof Number number) return (int) Math.round(number.doubleValue() * 1000);
         if (value == null) return null;
-        if (value instanceof Number) return (int) Math.round(((Number) value).doubleValue() * 1000);
         try { return (int) Math.round(Double.parseDouble(value.toString()) * 1000); } catch (NumberFormatException e) { return null; }
     }
 }

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/S2Util.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/persistence/S2Util.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.tracking.persistence;
+
+import com.google.common.geometry.S2CellId;
+import com.google.common.geometry.S2LatLng;
+
+/**
+ * S2 geometry token generation for spatial indexing.
+ */
+public final class S2Util {
+
+    private S2Util() {}
+
+    /** Returns the compact hex S2 token at the given level. */
+    public static String tokenAtLevel(double lat, double lon, int level) {
+        validate(lat, lon, level);
+        S2LatLng ll = S2LatLng.fromDegrees(lat, lon);
+        return S2CellId.fromLatLng(ll).parent(level).toToken();
+    }
+
+    private static void validate(double lat, double lon, int level) {
+        if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+            throw new IllegalArgumentException("lat/lon out of range");
+        }
+        if (level < 0 || level > 30) {
+            throw new IllegalArgumentException("level must be between 0 and 30");
+        }
+    }
+}

--- a/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/service/impl/PulsarAssetTrackingService.java
+++ b/quarkus-srv/miot-tracking/src/main/java/com/microboxlabs/miot/tracking/service/impl/PulsarAssetTrackingService.java
@@ -3,6 +3,7 @@ package com.microboxlabs.miot.tracking.service.impl;
 import cl.streamhub.gps.model.AssetTrackingData;
 import cl.streamhub.gps.model.EnvelopedMessage;
 import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.core.messaging.IComponentBus;
 import com.microboxlabs.miot.core.messaging.IMessagePublisher;
 import com.microboxlabs.miot.tracking.errors.PublishPulsarError;
 import com.microboxlabs.miot.tracking.service.AssetTrackingService;
@@ -19,18 +20,23 @@ public class PulsarAssetTrackingService implements AssetTrackingService {
 
     private static final Logger logger = Logger.getLogger(PulsarAssetTrackingService.class);
 
+    public static final String BUS_CHANNEL = "tracking.asset-positions";
+
     private final TenantContext tenantContext;
     private final IMessagePublisher publisher;
+    private final IComponentBus componentBus;
     private final String topic;
 
     PulsarAssetTrackingService(
             TenantContext tenantContext,
             IMessagePublisher publisher,
+            IComponentBus componentBus,
             @ConfigProperty(name = "miot.tracking.pulsar.topic",
                     defaultValue = "persistent://streamhub/tracking/asset-positions")
                     String topic) {
         this.tenantContext = tenantContext;
         this.publisher = publisher;
+        this.componentBus = componentBus;
         this.topic = topic;
     }
 
@@ -49,8 +55,10 @@ public class PulsarAssetTrackingService implements AssetTrackingService {
         envelope.setClientId(clientId);
 
         return publisher.publish(topic, envelope)
-                .thenAccept(v -> logger.debugf(
-                        "Asset tracking sent. Request ID: %s, Client ID: %s",
-                        requestId, clientId));
+                .thenAccept(v -> {
+                    logger.debugf("Asset tracking sent. Request ID: %s, Client ID: %s",
+                            requestId, clientId);
+                    componentBus.publish(BUS_CHANNEL, envelope);
+                });
     }
 }

--- a/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.0__create_tracking_schema.sql
+++ b/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.0__create_tracking_schema.sql
@@ -1,0 +1,7 @@
+-- Tracking persistence schema
+CREATE SCHEMA IF NOT EXISTS miot_tracking;
+
+-- Required extensions (idempotent)
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE SCHEMA IF NOT EXISTS partman;
+CREATE EXTENSION IF NOT EXISTS pg_partman WITH SCHEMA partman;

--- a/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.1__create_asset_data.sql
+++ b/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.1__create_asset_data.sql
@@ -1,0 +1,48 @@
+-- Raw incoming asset position/telemetry data (one row per message).
+-- Consolidated from db-writer V1 through V1.32.x.
+CREATE TABLE miot_tracking.asset_data (
+    id                          BIGSERIAL PRIMARY KEY,
+    request_id                  VARCHAR(32),
+    request_timestamp           TIMESTAMPTZ,
+    client_id                   VARCHAR(32) NOT NULL,
+    asset_id                    VARCHAR(255) NOT NULL,
+    type                        VARCHAR(255),
+    owner                       VARCHAR(255),
+    year                        INTEGER,
+    timestamp                   TIMESTAMPTZ,
+    location                    geography(point, 4326),
+    altitude                    DOUBLE PRECISION,
+    speed                       DOUBLE PRECISION,
+    heading                     DOUBLE PRECISION,
+    telcom_iccid                VARCHAR(255),
+    telcom_imsi                 VARCHAR(255),
+    telcom_operator             VARCHAR(255),
+    telcom_mcc                  VARCHAR(255),
+    telcom_mnc                  VARCHAR(255),
+    telcom_cell_id              VARCHAR(255),
+    telcom_lac                  VARCHAR(255),
+    telcom_signal_strength      INTEGER,
+    telcom_gps_provider         VARCHAR(255),
+    driver_info_driver_id       VARCHAR(255),
+    driver_info_name            VARCHAR(255),
+    driver_info_license_number  VARCHAR(255),
+    driver_info_contact_phone   VARCHAR(255),
+    driver_info_contact_email   VARCHAR(255),
+    driver_info_id_button       VARCHAR(255),
+    co_driver_info_driver_id    VARCHAR(255),
+    co_driver_info_name         VARCHAR(255),
+    co_driver_info_license_number VARCHAR(255),
+    co_driver_info_contact_phone  VARCHAR(255),
+    co_driver_info_contact_email  VARCHAR(255),
+    sensors                     JSONB,
+    peripherals                 JSONB,
+    events                      JSONB,
+    s2tokens                    JSONB,
+    created_datetime            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_asset_data_location ON miot_tracking.asset_data USING GIST (location);
+CREATE INDEX idx_asset_data_request_id ON miot_tracking.asset_data (request_id);
+CREATE INDEX idx_asset_data_request_timestamp ON miot_tracking.asset_data (request_timestamp);
+CREATE INDEX idx_asset_data_created_datetime ON miot_tracking.asset_data (created_datetime);
+CREATE INDEX idx_asset_data_timestamp_asset ON miot_tracking.asset_data (timestamp, asset_id);

--- a/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.2__create_multi_client_tables.sql
+++ b/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.2__create_multi_client_tables.sql
@@ -1,0 +1,45 @@
+-- Multi-client mapping tables.
+-- Consolidated from db-writer V1.29.0 and V1.29.1.
+
+-- asset_data_client: one row per asset-client pair per message (partitioned monthly)
+CREATE TABLE miot_tracking.asset_data_client (
+    asset_data_id       INT8 NOT NULL,
+    asset_id            TEXT NOT NULL,
+    shared_client_id    TEXT NOT NULL,
+    timestamp           TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT asset_data_client_pkey PRIMARY KEY (asset_data_id, shared_client_id, timestamp)
+) PARTITION BY RANGE (timestamp);
+
+CREATE INDEX idx_adc_shared_client_timestamp
+    ON miot_tracking.asset_data_client (shared_client_id, timestamp DESC);
+CREATE INDEX idx_adc_timestamp_asset
+    ON miot_tracking.asset_data_client (shared_client_id, asset_id, timestamp DESC);
+
+-- asset_client_map: configuration table mapping assets to shared clients
+CREATE TABLE miot_tracking.asset_client_map (
+    asset_id            TEXT NOT NULL,
+    shared_client_id    TEXT NOT NULL,
+    active              BOOLEAN NOT NULL DEFAULT TRUE,
+    valid_from          TIMESTAMPTZ DEFAULT NOW(),
+    valid_to            TIMESTAMPTZ DEFAULT NOW() + INTERVAL '1 year',
+    CONSTRAINT asset_client_map_pkey PRIMARY KEY (asset_id, shared_client_id)
+);
+
+CREATE INDEX idx_acm_asset_active
+    ON miot_tracking.asset_client_map (asset_id) WHERE active = TRUE;
+CREATE INDEX idx_acm_client
+    ON miot_tracking.asset_client_map (shared_client_id);
+
+-- pg_partman configuration for asset_data_client
+SELECT partman.create_parent(
+    p_parent_table := 'miot_tracking.asset_data_client',
+    p_control      := 'timestamp',
+    p_type         := 'range',
+    p_interval     := '1 month',
+    p_start_partition := '2026-01-01'
+);
+
+UPDATE partman.part_config
+SET premake = 1
+WHERE parent_table = 'miot_tracking.asset_data_client';

--- a/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.3__create_metric_tables.sql
+++ b/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.3__create_metric_tables.sql
@@ -1,0 +1,174 @@
+-- Metric tables for vehicle telemetry persistence.
+-- Consolidated from db-writer V1.30.0-V1.30.3, V1.34.0, V1.35.0.
+
+-- ============================================================================
+-- asset_metric_core: core OBD2/J1939 telemetry (partitioned monthly)
+-- ============================================================================
+CREATE TABLE miot_tracking.asset_metric_core (
+    id                      BIGSERIAL NOT NULL,
+    shared_client_id        VARCHAR(32) NOT NULL,
+    asset_id                VARCHAR(255) NOT NULL,
+    device_id               VARCHAR(255),
+    ts                      TIMESTAMPTZ NOT NULL,
+    asset_data_id           BIGINT,
+
+    -- POWERTRAIN
+    engine_rpm              INT4,
+    vehicle_speed_kph       INT2,
+    engine_load_pct         INT2,
+    throttle_pos_pct        INT2,
+    coolant_temp_c          INT2,
+    intake_air_temp_c       INT2,
+    engine_runtime_s        INT4,
+    engine_total_runtime_h  INT4,
+
+    -- FUEL
+    fuel_level_pct          INT2,
+    fuel_volume_ml          INT4,
+    fuel_rate_mlph          INT4,
+    fuel_used_ml            INT8,
+    battery_voltage_mv      INT4,
+    engine_torque_pct       INT2,
+
+    -- MOTION
+    odometer_km             INT8,
+    idle_state              BOOLEAN,
+    accelerator_pos_pct     INT2,
+    brake_state             BOOLEAN,
+
+    -- DIAGNOSTICS
+    mil_on                  BOOLEAN,
+    dtc_count               INT2,
+
+    -- EMISSIONS
+    fuel_trim_short_pct     INT2,
+    fuel_trim_long_pct      INT2,
+    lambda_ratio            INT2,
+    catalyst_temp_c         INT2,
+
+    -- ELECTRICAL
+    battery_current_ma      INT4,
+    pto_state               BOOLEAN,
+    engine_fan_state        BOOLEAN,
+
+    -- PROVENANCE
+    payload_schema          VARCHAR(32) NOT NULL DEFAULT 'miot.metrics@1.0',
+    src                     VARCHAR(16),
+    quality                 VARCHAR(16),
+    seq                     INT8,
+    request_id              VARCHAR(32),
+    request_timestamp       TIMESTAMPTZ NOT NULL,
+    created_datetime        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (shared_client_id, asset_id, ts)
+) PARTITION BY RANGE (ts);
+
+CREATE INDEX ON miot_tracking.asset_metric_core (shared_client_id, asset_id, ts DESC);
+
+COMMENT ON TABLE miot_tracking.asset_metric_core IS 'Core vehicle telemetry metrics — append only, monthly partitions';
+
+SELECT partman.create_parent(
+    p_parent_table := 'miot_tracking.asset_metric_core',
+    p_control      := 'ts',
+    p_type         := 'range',
+    p_interval     := '1 month',
+    p_start_partition := '2026-02-01'
+);
+
+UPDATE partman.part_config
+SET premake = 1
+WHERE parent_table = 'miot_tracking.asset_metric_core';
+
+-- ============================================================================
+-- asset_metric_dtc: diagnostic trouble codes (partitioned monthly)
+-- ============================================================================
+CREATE TABLE miot_tracking.asset_metric_dtc (
+    id                  BIGSERIAL NOT NULL,
+    shared_client_id    VARCHAR(32) NOT NULL,
+    asset_id            VARCHAR(255) NOT NULL,
+    device_id           VARCHAR(255),
+    ts                  TIMESTAMPTZ NOT NULL,
+    asset_data_id       BIGINT,
+    dtc_codes           TEXT[],
+    engine_freeze_frame TEXT,
+    payload_schema      VARCHAR(32) NOT NULL DEFAULT 'miot.metrics@1.0',
+    src                 VARCHAR(16),
+    request_id          VARCHAR(32),
+    request_timestamp   TIMESTAMPTZ NOT NULL,
+    created_datetime    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (shared_client_id, asset_id, ts)
+) PARTITION BY RANGE (ts);
+
+ALTER TABLE miot_tracking.asset_metric_dtc
+    ADD CONSTRAINT dtc_codes_size_limit CHECK (array_length(dtc_codes, 1) <= 100);
+
+CREATE INDEX ON miot_tracking.asset_metric_dtc (shared_client_id, asset_id, ts DESC);
+
+COMMENT ON TABLE miot_tracking.asset_metric_dtc IS 'Diagnostic Trouble Code events — sparse, insert only on change';
+
+SELECT partman.create_parent(
+    p_parent_table := 'miot_tracking.asset_metric_dtc',
+    p_control      := 'ts',
+    p_type         := 'range',
+    p_interval     := '1 month',
+    p_start_partition := '2026-02-01'
+);
+
+UPDATE partman.part_config
+SET premake = 1
+WHERE parent_table = 'miot_tracking.asset_metric_dtc';
+
+-- ============================================================================
+-- asset_metric_ext: extension metrics (x.* keys) with bounded JSONB
+-- ============================================================================
+CREATE TABLE miot_tracking.asset_metric_ext (
+    id                  BIGSERIAL NOT NULL,
+    shared_client_id    VARCHAR(32) NOT NULL,
+    asset_id            VARCHAR(255) NOT NULL,
+    device_id           VARCHAR(255),
+    ts                  TIMESTAMPTZ NOT NULL,
+    asset_data_id       BIGINT,
+    ext                 JSONB NOT NULL,
+    payload_schema      VARCHAR(32) NOT NULL DEFAULT 'miot.metrics@1.0',
+    src                 VARCHAR(16),
+    request_id          VARCHAR(32),
+    request_timestamp   TIMESTAMPTZ NOT NULL,
+    created_datetime    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (shared_client_id, asset_id, ts)
+) PARTITION BY RANGE (ts);
+
+ALTER TABLE miot_tracking.asset_metric_ext
+    ADD CONSTRAINT ext_size_limit CHECK (octet_length(ext::text) <= 4096);
+
+CREATE INDEX ON miot_tracking.asset_metric_ext (shared_client_id, asset_id, ts DESC);
+
+COMMENT ON TABLE miot_tracking.asset_metric_ext IS 'Extension metrics (x.* keys) — bounded JSONB, sparse writes';
+
+SELECT partman.create_parent(
+    p_parent_table := 'miot_tracking.asset_metric_ext',
+    p_control      := 'ts',
+    p_type         := 'range',
+    p_interval     := '1 month',
+    p_start_partition := '2026-02-01'
+);
+
+UPDATE partman.part_config
+SET premake = 1
+WHERE parent_table = 'miot_tracking.asset_metric_ext';
+
+-- ============================================================================
+-- ingest_ledger_metrics: idempotency ledger
+-- ============================================================================
+CREATE TABLE miot_tracking.ingest_ledger_metrics (
+    client_id           VARCHAR(32) NOT NULL,
+    device_id           VARCHAR(255) NOT NULL,
+    request_id          VARCHAR(32) NOT NULL,
+    request_timestamp   TIMESTAMPTZ,
+    created_datetime    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (client_id, device_id, request_id)
+);
+
+COMMENT ON TABLE miot_tracking.ingest_ledger_metrics IS 'Idempotency ledger for metrics ingestion — check before insert';

--- a/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.4__fn_latest_metrics.sql
+++ b/quarkus-srv/miot-tracking/src/main/resources/db/migration/tracking/V0.5.4__fn_latest_metrics.sql
@@ -1,0 +1,63 @@
+-- Latest metrics lookup functions.
+-- Migrated from db-writer V1.36.0.
+
+-- Single asset: returns latest metric snapshot as JSONB.
+CREATE OR REPLACE FUNCTION miot_tracking.fn_latest_metrics(
+    p_shared_client_id TEXT,
+    p_asset_id         TEXT
+)
+RETURNS JSONB
+LANGUAGE SQL STABLE PARALLEL SAFE
+AS $$
+    SELECT to_jsonb(m)
+        - 'id'
+        - 'asset_data_id'
+        - 'request_id'
+        - 'payload_schema'
+        - 'seq'
+        - 'request_timestamp'
+        - 'created_datetime'
+    FROM (
+        SELECT DISTINCT ON (asset_id) *
+        FROM miot_tracking.asset_metric_core
+        WHERE shared_client_id = p_shared_client_id
+          AND asset_id         = p_asset_id
+        ORDER BY asset_id, ts DESC
+    ) m
+$$;
+
+-- Batch: returns latest metrics for multiple assets in one round-trip.
+CREATE OR REPLACE FUNCTION miot_tracking.fn_latest_metrics_batch(
+    p_shared_client_id TEXT,
+    p_asset_ids        TEXT[]
+)
+RETURNS TABLE(asset_id TEXT, metrics JSONB)
+LANGUAGE SQL STABLE PARALLEL SAFE
+AS $$
+    SELECT
+        m.asset_id::TEXT,
+        to_jsonb(m)
+            - 'id'
+            - 'asset_data_id'
+            - 'request_id'
+            - 'payload_schema'
+            - 'seq'
+            - 'request_timestamp'
+            - 'created_datetime'
+    FROM (
+        SELECT DISTINCT ON (asset_id) *
+        FROM miot_tracking.asset_metric_core
+        WHERE shared_client_id = p_shared_client_id
+          AND asset_id = ANY(p_asset_ids)
+        ORDER BY asset_id, ts DESC
+    ) m
+$$;
+
+COMMENT ON FUNCTION miot_tracking.fn_latest_metrics IS
+    'Latest metric snapshot for one asset as JSONB. '
+    'Implementation: DISTINCT ON asset_metric_core. '
+    'Escalation path: swap body for last_metric_data lookup if p95 > 100ms at scale.';
+
+COMMENT ON FUNCTION miot_tracking.fn_latest_metrics_batch IS
+    'Latest metric snapshot for multiple assets — one DB round-trip. '
+    'Use for fleet list views. Same escalation path as fn_latest_metrics.';


### PR DESCRIPTION
## Summary

Connects `miot-tracking` to a full persistence pipeline so GPS tracking messages are written to PostgreSQL in addition to being published to Pulsar.

**Persistence pipeline (new)**
- `AssetTrackingProcessor` — three-step orchestrator: `asset_data` → `asset_data_client` → metrics tables
- `AssetDataRepository` — reactive write of raw position data with S2 cell encoding for spatial indexing
- `AssetDataClientRepository` — cross-references `asset_client_map` to resolve which shared clients own each asset, then writes to `asset_data_client` (partitioned monthly)
- `MetricsRepository` — persists OBD2/sensor metrics to three typed tables (`asset_metric_core`, `asset_metric_ext`, `asset_metric_dtc`) with idempotency via `ingest_ledger_metrics`
- `S2Util` — S2 geometry cell encoding (`s2-geometry 2.0.0`) for spatial indexing on raw asset positions

**Dual-mode consumer**
- `TrackingComponent` subscribes to the in-process `IComponentBus` for standalone mode persistence
- `PulsarAssetTrackingConsumer` starts when available for distributed/multi-instance mode
- `PulsarAssetTrackingService` publishes to `IComponentBus` after Pulsar send — decouples transport from persistence

**Database migrations (V0.5.x)**
- `V0.5.0` — `miot_tracking` schema
- `V0.5.1` — `asset_data` table with PostGIS geometry and S2 cell columns
- `V0.5.2` — `asset_client_map` + `asset_data_client` (partitioned monthly, pg_partman managed)
- `V0.5.3` — `asset_metric_core`, `asset_metric_ext`, `asset_metric_dtc`, `ingest_ledger_metrics`
- `V0.5.4` — `fn_latest_metrics` and `fn_latest_metrics_batch` functions
- `FlywayMigrator` conditionally loads `db/migration/tracking` when `miot.component.tracking.enabled=true`

**Bug fixes**
- `LatestMetricsRepository` — schema-qualify function calls to `miot_tracking.*`, drop `@ReactiveDataSource("metrics")` in favour of default datasource

**Known issue (investigated this session)**
- `asset_client_map` must have a row for each `asset_id` before metrics are persisted. If the map is empty, `AssetTrackingProcessor:61` short-circuits after step 2. Seed data required per environment (`quarkus-srv/scripts/seed/gama-mobility.sql` provides Gama fleet seed).

## Pre-Landing Review
No prior eng review — diff is 1,468 lines. No SQL injection risks (parameterised queries throughout). No LLM trust boundary changes.

## Test Coverage
No test framework changes in this diff. Persistence layer is integration-tested against a live DB via the existing dev environment.

## Plan Completion
No plan file detected.

## Verification Results
Skipped — no plan verification section.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] `POST /api/v1/asset/track` with a valid payload inserts into `asset_data`
- [x] With `asset_client_map` row for the asset: inserts into `asset_data_client` and `asset_metric_core`
- [x] Repeat call with same `x-request-id` is idempotent (no duplicate metrics rows)
- [x] Quarkus starts cleanly with `miot.component.tracking.enabled=true`
- [x] Flyway migrations apply without errors on fresh schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset tracking: persistent storage of positions, telemetry, multi-client cross-references, and monthly-partitioned metrics
  * Real-time ingestion via Pulsar with optional consumer mode and component bus publishing
  * Geospatial enhancements: location storage, spatial indexing, and S2-based spatial tokens
  * Idempotent metric ingest and latest-metrics lookup functions

* **Configuration**
  * New setting to enable/disable tracking feature
  * New Pulsar subscription setting for tracking messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->