### PR TITLE
feat(gateway): add miot-gateway module with body-aware fork engine

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: jvm-build
-          path: .
+          path: quarkus-srv
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -94,6 +94,7 @@ jobs:
           -Dsonar.projectKey=microboxlabs_modulariot-quarkus
           -Dsonar.organization=microboxlabs
           -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.coverage.exclusions=**/*
         working-directory: quarkus-srv
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -84,7 +84,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Build & Test
-        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true
+        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true
         working-directory: quarkus-srv
 
       - name: SonarCloud Scan
@@ -104,6 +104,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jvm-build
+          # Paths are relative to workspace root. download-artifact preserves this
+          # structure, so the docker job receives quarkus-srv/miot-cli/... and
+          # quarkus-srv/Dockerfile — matched by context: quarkus-srv below.
           path: |
             quarkus-srv/miot-cli/target/quarkus-app/
             quarkus-srv/Dockerfile
@@ -175,8 +178,12 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          # upload-artifact preserves workspace-relative paths, so the artifact
+          # lands at ./quarkus-srv/... after download. Setting context to
+          # quarkus-srv makes COPY paths in the Dockerfile (miot-cli/target/...)
+          # resolve correctly. file is relative to the runner working directory.
+          context: quarkus-srv
+          file: quarkus-srv/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/quarkus-srv/README.md
+++ b/quarkus-srv/README.md
@@ -9,6 +9,8 @@ miot-core/            Shared foundation (config, models, auth, messaging, persis
 miot-resource-core/   Shared SDK (entity events, KPI interfaces, resolution, Alfresco client, metrics)
 miot-fleet/           Fleet directory (vehicles, trucks, trailers, carriers)
 miot-driver/          Driver directory (lifecycle, documents, compliance, scoring)
+miot-tracking/        Asset tracking (GPS ingestion via Pulsar)
+miot-gateway/         Routing gateway (body-aware traffic forking, canary splits) → README
 miot-cli/             Application entrypoint
 ```
 
@@ -35,6 +37,7 @@ miot-cli/             Application entrypoint
 ./start.sh fleet            # fleet only
 ./start.sh driver           # driver only
 ./start.sh fleet driver     # fleet + driver
+./start.sh gateway          # gateway only (no DB required)
 
 # Pass extra Maven/Quarkus args after --
 ./start.sh fleet -- -Dquarkus.http.port=9090
@@ -57,6 +60,8 @@ miot.component.all.enabled=true
 # Individual overrides — defaults to master switch value
 miot.component.fleet.enabled=true
 miot.component.driver.enabled=true
+miot.component.tracking.enabled=true
+miot.component.gateway.enabled=true
 ```
 
 Override at runtime via env vars:
@@ -67,9 +72,10 @@ MIOT_COMPONENT_ALL_ENABLED=true
 
 # Single component
 MIOT_COMPONENT_FLEET_ENABLED=true
+MIOT_COMPONENT_GATEWAY_ENABLED=true
 ```
 
-Only the schemas for enabled components are created by Flyway. Starting with `./start.sh fleet` will create `miot_core`, `miot_resource`, and `miot_fleet` schemas — but not `miot_driver`.
+Only the schemas for enabled components are created by Flyway. Starting with `./start.sh fleet` will create `miot_core`, `miot_resource`, and `miot_fleet` schemas — but not `miot_driver`. The gateway component requires no database.
 
 ## Database
 
@@ -100,6 +106,12 @@ Endpoints are grouped by component tag (Fleet, Drivers). Only enabled components
 | Fleet | `GET /api/v1/fleet/trailers[/{id}]` | List/get trailers |
 | Fleet | `GET /api/v1/fleet/carriers[/{id}]` | List/get carriers |
 | Driver | `GET /api/v1/drivers[/{id}]` | List/get drivers |
+| Tracking | `POST /api/v1/asset/track` | Ingest GPS position |
+| Gateway | `POST /{path}` | APISIX mirror receiver (any path) |
+| Gateway | `GET /internal/fork/rules` | List fork rules and filter sizes |
+| Gateway | `POST /internal/fork/rules/{id}/filter` | Add routing keys to in-memory filter |
+| Gateway | `DELETE /internal/fork/rules/{id}/filter/{key}` | Remove a routing key |
+| Gateway | `POST /internal/fork/rules/{id}/filter/reload` | Reload filter from ConfigMap file |
 | Health | `GET /q/health` | Health check (component status) |
 | Metrics | `GET /q/metrics` | Prometheus metrics |
 

--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>miot-tracking</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-gateway</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>

--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -32,6 +32,14 @@ public class FlywayMigrator {
     boolean trackingEnabled;
 
     void onStart(@Observes StartupEvent ev) {
+        // Gateway and other stateless components have no DB schema.
+        // Skip migration entirely when no DB-dependent component is active
+        // to avoid connecting to (or validating against) a database that isn't needed.
+        if (!fleetEnabled && !driverEnabled && !trackingEnabled) {
+            LOG.debug("No DB-dependent components enabled — skipping Flyway");
+            return;
+        }
+
         List<String> locations = new ArrayList<>(baseLocations);
 
         if (fleetEnabled) {

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -11,6 +11,7 @@ miot.component.all.enabled=false
 miot.component.fleet.enabled=${miot.component.all.enabled}
 miot.component.driver.enabled=${miot.component.all.enabled}
 miot.component.tracking.enabled=${miot.component.all.enabled}
+miot.component.gateway.enabled=${miot.component.all.enabled}
 
 # --- HTTP ---
 quarkus.http.port=8180
@@ -75,6 +76,41 @@ smallrye.jwt.path.groups=scope
 miot.alfresco.url=${ALFRESCO_URL:http://localhost:8080/alfresco}
 miot.alfresco.username=${ALFRESCO_USER:admin}
 miot.alfresco.password=${ALFRESCO_PASSWORD:admin}
+
+# --- Fork engine (within miot-gateway) ---
+# Master switch for the fork engine
+fork.enabled=${FORK_ENABLED:false}
+#
+# Rules are configured via indexed properties. For non-trivial setups,
+# mount a ConfigMap as an additional application.properties file.
+#
+# Example rule — asset-id based canary fork to storm:
+#
+#   fork.rules[0].id=asset-track-canary
+#   fork.rules[0].enabled=true
+#   fork.rules[0].paths[0]=/v1/asset/track
+#   fork.rules[0].paths[1]=/api/v1/asset/track
+#   fork.rules[0].body-parser=json
+#   fork.rules[0].key-field=asset_id
+#   fork.rules[0].filter-file=/config/asset-ids.txt        ← K8s ConfigMap volume mount
+#   fork.rules[0].targets[0].id=storm
+#   fork.rules[0].targets[0].mirror-host=${FORK_STORM_HOST:not-configured}
+#   fork.rules[0].targets[0].mirror-path=/v1/asset/track
+#   fork.rules[0].targets[0].timeout=5000
+#
+# Filter file format (/config/asset-ids.txt):
+#   # One routing key per line, # comments and blank lines ignored
+#   SVSX88
+#   ABC123
+#
+# Kubernetes ConfigMap:
+#   data:
+#     asset-ids.txt: |
+#       # Canary asset IDs for storm environment
+#       SVSX88
+#
+# Env var naming for rules (MicroProfile indexed list convention):
+#   FORK_RULES_0__ID, FORK_RULES_0__PATHS_0_, FORK_RULES_0__TARGETS_0__MIRROR_HOST, etc.
 
 # --- Micrometer / Prometheus ---
 quarkus.micrometer.export.prometheus.enabled=true

--- a/quarkus-srv/miot-gateway/README.md
+++ b/quarkus-srv/miot-gateway/README.md
@@ -1,0 +1,407 @@
+# miot-gateway
+
+Routing gateway component for the ModularIoT modulith. Provides body-aware traffic forking that APISIX cannot express natively — APISIX mirrors requests here, and the gateway decides where (and whether) to forward them based on the request body content.
+
+The gateway is structured as a set of **fork sub-modules**. The first is the **fork engine**: a configurable rules engine that matches incoming paths, extracts a routing key from the request body (JSON or CSV), checks an in-memory filter, and fans out matching requests to one or more upstream targets.
+
+```
+APISIX  ──proxy-mirror──►  miot-gateway  ──forwardAsync──►  target-A
+                                │                    └──────────────►  target-B
+                                └── no match / not in filter → discard (200)
+```
+
+---
+
+## Getting Started
+
+### Local development
+
+```bash
+# From quarkus-srv/
+./start.sh gateway
+```
+
+The gateway requires no database. It starts in under a second and immediately begins accepting mirror traffic. No fork rules are loaded until you configure them.
+
+To start with a rule active, create a local `application.properties` override or pass properties directly:
+
+```bash
+./start.sh gateway -- \
+  -Dfork.enabled=true \
+  -D"fork.rules[0].id=asset-track-canary" \
+  -D"fork.rules[0].paths[0]=/v1/asset/track" \
+  -D"fork.rules[0].filter-file=./dev-assets.txt" \
+  -D"fork.rules[0].targets[0].id=storm" \
+  -D"fork.rules[0].targets[0].mirror-host=https://storm.modulariot.com" \
+  -D"fork.rules[0].targets[0].mirror-path=/v1/asset/track"
+```
+
+Create `dev-assets.txt`:
+
+```
+# Asset IDs to forward during local testing
+SVSX88
+ABC123
+```
+
+Send a test request:
+
+```bash
+curl -s -X POST http://localhost:8180/v1/asset/track \
+  -H "Content-Type: application/json" \
+  -d '{"asset_id":"SVSX88","lat":-33.4489,"lng":-70.6693}'
+# → 200 OK (always — gateway never rejects APISIX mirror traffic)
+```
+
+Inspect the loaded filter:
+
+```bash
+curl http://localhost:8180/internal/fork/rules/asset-track-canary/filter
+# → ["SVSX88", "ABC123"]
+```
+
+### Kubernetes deployment
+
+The gateway runs as a **separate deployment** from the production backend, using the same container image built by CI.
+
+> **How the single-image model works in Quarkus**
+>
+> Quarkus `@IfBuildProperty` is evaluated at **Maven build time**, not at container start. CI builds with all component flags set to `true`, so every component's code (endpoints, services) is compiled into the single image.
+>
+> At runtime, `MIOT_COMPONENT_GATEWAY_ENABLED` controls `@LookupIfProperty` on `GatewayComponent`, which determines whether the component's lifecycle (`onStart`, `onStop`) runs. It does **not** unregister REST endpoints — those are baked in.
+>
+> In practice this is safe:
+> - In a **gateway pod**: `ForkMirrorResource` receives APISIX mirror traffic. Other components' endpoints (e.g. `/api/v1/asset/track`) are registered but never called — APISIX does not route to them via the gateway ClusterIP.
+> - In a **production pod**: `ForkMirrorResource`'s catch-all exists but returns `200` immediately for any unmatched path (the fork rule index is empty when `fork.enabled=false`).
+>
+> If you need strict isolation (no cross-component endpoints), build a dedicated gateway image with only `miot.component.gateway.enabled=true`.
+
+```yaml
+# deployment.yaml
+env:
+  - name: MIOT_COMPONENT_GATEWAY_ENABLED
+    value: "true"
+  - name: FORK_ENABLED
+    value: "true"
+
+# Mount fork rules as a ConfigMap
+volumeMounts:
+  - name: fork-config
+    mountPath: /config
+
+volumes:
+  - name: fork-config
+    configMap:
+      name: gateway-fork-config
+```
+
+```yaml
+# configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-fork-config
+data:
+  # Rules file — mounted as additional application.properties
+  application.properties: |
+    fork.enabled=true
+    fork.rules[0].id=asset-track-canary
+    fork.rules[0].enabled=true
+    fork.rules[0].paths[0]=/v1/asset/track
+    fork.rules[0].body-parser=json
+    fork.rules[0].key-field=asset_id
+    fork.rules[0].filter-file=/config/asset-ids.txt
+    fork.rules[0].targets[0].id=storm
+    fork.rules[0].targets[0].mirror-host=https://storm.modulariot.com
+    fork.rules[0].targets[0].mirror-path=/v1/asset/track
+    fork.rules[0].targets[0].timeout=5000
+
+  # Filter file — one routing key per line
+  asset-ids.txt: |
+    # Asset IDs to mirror to storm environment
+    SVSX88
+```
+
+Add the Quarkus config location for the mounted file:
+
+```yaml
+env:
+  - name: QUARKUS_CONFIG_LOCATIONS
+    value: /config/application.properties
+```
+
+Configure APISIX to mirror traffic to the gateway:
+
+```yaml
+plugins:
+  - name: proxy-mirror
+    enable: true
+    config:
+      host: "http://prod-streamhub-gateway:8080"
+      sample_ratio: 1
+```
+
+---
+
+## Architecture
+
+```
+miot-gateway/
+└── fork/                           Fork sub-module
+    ├── config/
+    │   └── ForkConfig.java         @ConfigMapping(prefix="fork")
+    ├── model/
+    │   ├── BodyParserType.java     JSON | CSV
+    │   ├── ForkRule.java           Immutable runtime rule (built from config at startup)
+    │   └── ForkTarget.java         Immutable runtime target (url pre-built at startup)
+    ├── ForkFilterRegistry.java     In-memory routing key sets — lock-free reads, atomic reload
+    ├── ForkEngine.java             Path index, key extraction, fan-out, pre-built metrics
+    └── api/
+        ├── ForkMirrorResource.java         POST /{path} — APISIX mirror receiver
+        └── ForkManagementResource.java     /internal/fork/ — management API
+```
+
+### Request flow
+
+1. APISIX mirrors `POST /v1/asset/track` to the gateway
+2. `ForkMirrorResource` receives it and reconstructs the full path
+3. `ForkEngine.findRulesForPath()` looks up matching rules from the path index (O(1) HashMap lookup)
+4. For each matching rule:
+   - Extract routing key from body using the rule's body parser
+   - Check the key against `ForkFilterRegistry` (lock-free `ConcurrentHashMap` read)
+   - If present: fan out to all targets via `HttpClient.sendAsync()` (fire-and-forget)
+   - If absent: increment discarded counter, return
+5. Always respond `200 OK` — APISIX discards the mirror response
+
+---
+
+## Configuration Reference
+
+### Component activation
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `miot.component.gateway.enabled` | `MIOT_COMPONENT_GATEWAY_ENABLED` | `false` | Activates the gateway component (CDI beans, endpoint registration) |
+
+### Fork engine
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `fork.enabled` | `FORK_ENABLED` | `false` | Enables the fork engine. Gateway can be active with forking off. |
+
+### Fork rules (`fork.rules[N]`)
+
+Each rule is an entry in an indexed list. Multiple rules can be defined with independent paths, parsers, filters, and targets.
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `fork.rules[N].id` | `FORK_RULES_N__ID` | — | Unique rule identifier. Used in metrics labels and the management API. |
+| `fork.rules[N].enabled` | `FORK_RULES_N__ENABLED` | `true` | Set to `false` to disable a rule without removing it from config. |
+| `fork.rules[N].paths[M]` | `FORK_RULES_N__PATHS_M_` | — | Incoming path(s) this rule applies to. Multiple paths share the same parser and targets. |
+| `fork.rules[N].body-parser` | `FORK_RULES_N__BODY_PARSER` | `json` | How to parse the request body. Options: `json`, `csv`. |
+| `fork.rules[N].key-field` | `FORK_RULES_N__KEY_FIELD` | `asset_id` | Field name (JSON) or column name/index (CSV) to extract as the routing key. |
+| `fork.rules[N].filter-file` | `FORK_RULES_N__FILTER_FILE` | — | Path to a plain-text filter file. Loaded at startup and on `/reload`. Intended for ConfigMap volume mounts. |
+
+### Fork targets (`fork.rules[N].targets[M]`)
+
+Each rule can have one or more targets. All matching targets receive the request in parallel.
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `fork.rules[N].targets[M].id` | `FORK_RULES_N__TARGETS_M__ID` | — | Unique target identifier within the rule. Used in metrics labels. |
+| `fork.rules[N].targets[M].mirror-host` | `FORK_RULES_N__TARGETS_M__MIRROR_HOST` | — | Target base URL — scheme + host + port, no trailing slash. |
+| `fork.rules[N].targets[M].mirror-path` | `FORK_RULES_N__TARGETS_M__MIRROR_PATH` | `/` | Path on the target host. Concatenated with `mirror-host` to form the full URL. |
+| `fork.rules[N].targets[M].timeout` | `FORK_RULES_N__TARGETS_M__TIMEOUT` | `5000` | HTTP timeout in milliseconds for forwarded requests. |
+
+> **Env var naming convention** — MicroProfile Config maps indexed list segments using underscores: `[N]` → `_N_` and property separators `.` → `_`. Double underscores appear where both a separator and an index meet.
+
+### Full example (application.properties)
+
+```properties
+miot.component.gateway.enabled=true
+fork.enabled=true
+
+# Rule 0 — asset-id based canary fork, JSON body, single storm target
+fork.rules[0].id=asset-track-canary
+fork.rules[0].enabled=true
+fork.rules[0].paths[0]=/v1/asset/track
+fork.rules[0].paths[1]=/api/v1/asset/track
+fork.rules[0].body-parser=json
+fork.rules[0].key-field=asset_id
+fork.rules[0].filter-file=/config/asset-ids.txt
+fork.rules[0].targets[0].id=storm
+fork.rules[0].targets[0].mirror-host=https://storm.modulariot.com
+fork.rules[0].targets[0].mirror-path=/v1/asset/track
+fork.rules[0].targets[0].timeout=5000
+
+# Rule 1 — same paths, second target for a backup environment
+fork.rules[1].id=asset-track-backup
+fork.rules[1].enabled=false
+fork.rules[1].paths[0]=/v1/asset/track
+fork.rules[1].body-parser=json
+fork.rules[1].key-field=asset_id
+fork.rules[1].filter-file=/config/asset-ids-backup.txt
+fork.rules[1].targets[0].id=backup
+fork.rules[1].targets[0].mirror-host=https://backup.modulariot.com
+fork.rules[1].targets[0].mirror-path=/v1/asset/track
+```
+
+---
+
+## Filter File Format
+
+Plain text, one routing key per line. Lines starting with `#` and blank lines are ignored.
+
+```
+# Asset IDs to forward to storm
+# Updated: 2026-04-06
+SVSX88
+ABC123
+DEF456
+```
+
+The file is loaded once at startup. Use the management API to reload after updating the ConfigMap.
+
+---
+
+## Management API
+
+All endpoints are under `/internal/fork/` and are only reachable within the cluster (ClusterIP service, no external route).
+
+### List rules
+
+```http
+GET /internal/fork/rules
+```
+
+Returns all active rules with their current filter size and resolved target URLs.
+
+```json
+[
+  {
+    "id": "asset-track-canary",
+    "paths": ["/v1/asset/track"],
+    "bodyParser": "JSON",
+    "keyField": "asset_id",
+    "filterFile": "/config/asset-ids.txt",
+    "filterSize": 2,
+    "targets": [
+      { "id": "storm", "url": "https://storm.modulariot.com/v1/asset/track", "timeout": 5000 }
+    ]
+  }
+]
+```
+
+### Inspect filter
+
+```http
+GET /internal/fork/rules/{id}/filter
+```
+
+```json
+["SVSX88", "ABC123"]
+```
+
+### Add keys
+
+```http
+POST /internal/fork/rules/{id}/filter
+Content-Type: application/json
+
+["DEF456", "GHI789"]
+```
+
+```json
+{ "added": 2, "total": 4 }
+```
+
+### Remove a key
+
+```http
+DELETE /internal/fork/rules/{id}/filter/{key}
+```
+
+```json
+{ "removed": true, "total": 3 }
+```
+
+### Reload from file
+
+Re-reads the configured filter file and atomically replaces the in-memory set. Use this after updating a ConfigMap without restarting the pod.
+
+```http
+POST /internal/fork/rules/{id}/filter/reload
+```
+
+```json
+{ "loaded": 2, "total": 2 }
+```
+
+Returns `409 Conflict` if the rule has no filter file configured.
+
+---
+
+## Metrics
+
+Exposed at `GET /q/metrics` (Prometheus format).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `fork_requests_total` | Counter | `rule`, `target`, `outcome={forwarded,discarded,error}` | Request count per rule, target, and outcome |
+| `fork_forward_duration_seconds` | Timer | `rule`, `target` | Latency of forwarded HTTP calls (P50, P95, P99, MAX) |
+| `fork_filter_size` | Gauge | `rule` | Number of routing keys currently in the in-memory filter |
+
+Example Prometheus output:
+
+```
+fork_requests_total{rule="asset-track-canary",target="storm",outcome="forwarded"} 1234.0
+fork_requests_total{rule="asset-track-canary",target="-",outcome="discarded"} 56789.0
+fork_requests_total{rule="asset-track-canary",target="storm",outcome="error"} 3.0
+fork_forward_duration_seconds_count{rule="asset-track-canary",target="storm"} 1234.0
+fork_forward_duration_seconds_sum{rule="asset-track-canary",target="storm"} 52.341
+fork_filter_size{rule="asset-track-canary"} 2.0
+```
+
+---
+
+## Body Parsers
+
+### JSON
+
+Extracts a top-level field value by name.
+
+```json
+{ "asset_id": "SVSX88", "lat": -33.4489, "lng": -70.6693 }
+```
+
+```properties
+fork.rules[0].body-parser=json
+fork.rules[0].key-field=asset_id
+```
+
+### CSV
+
+Extracts a field by column name (first row treated as header) or by zero-based column index.
+
+```csv
+asset_id,lat,lng,timestamp
+SVSX88,-33.4489,-70.6693,2026-04-06T10:00:00Z
+```
+
+```properties
+fork.rules[0].body-parser=csv
+fork.rules[0].key-field=asset_id    # by column name
+# or:
+fork.rules[0].key-field=0           # by column index
+```
+
+---
+
+## Health
+
+```
+GET /q/health/ready   → 200 (gateway component up)
+GET /q/health/live    → 200
+```
+
+The gateway has no database dependency and starts healthy immediately.

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microboxlabs.miot</groupId>
+        <artifactId>miot-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>miot-gateway</artifactId>
+    <name>ModularIoT — Gateway</name>
+    <description>Routing gateway: canary traffic forking, request mirroring, and future routing logic</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/GatewayComponent.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/GatewayComponent.java
@@ -1,0 +1,40 @@
+package com.microboxlabs.miot.gateway;
+
+import com.microboxlabs.miot.core.config.IMiotComponent;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.gateway.enabled", stringValue = "true")
+public class GatewayComponent implements IMiotComponent {
+
+    private static final Logger LOG = Logger.getLogger(GatewayComponent.class);
+
+    @Override
+    public String name() {
+        return "gateway";
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+
+    @Override
+    public void onStart() {
+        LOG.info("Gateway component started — routing rules active");
+    }
+
+    @Override
+    public void onStop() {
+        LOG.info("Gateway component stopped");
+    }
+
+    @Override
+    public HealthCheck healthCheck() {
+        return () -> HealthCheckResponse.named("gateway").up().build();
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
@@ -1,0 +1,315 @@
+package com.microboxlabs.miot.gateway.fork;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.gateway.fork.config.ForkConfig;
+import com.microboxlabs.miot.gateway.fork.model.BodyParserType;
+import com.microboxlabs.miot.gateway.fork.model.ForkResult;
+import com.microboxlabs.miot.gateway.fork.model.ForkRule;
+import com.microboxlabs.miot.gateway.fork.model.ForkTarget;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
+/**
+ * Core fork routing engine.
+ *
+ * <p>At startup, builds an index of path → rules from config, registers filters
+ * in {@link ForkFilterRegistry}, pre-builds all Micrometer meters, and creates a
+ * shared {@link HttpClient}.
+ *
+ * <p>At request time ({@link #process}):
+ * <ol>
+ *   <li>Extract the routing key from the body using the rule's body parser
+ *   <li>Check the key against the in-memory filter
+ *   <li>Fan out to all rule targets asynchronously (fire-and-forget)
+ * </ol>
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "miot.component.gateway.enabled", stringValue = "true")
+public class ForkEngine {
+
+    private static final Logger LOG = Logger.getLogger(ForkEngine.class);
+
+    /**
+     * HTTP headers that must not be forwarded to upstream targets.
+     * Covers hop-by-hop headers and Java HttpClient restricted headers.
+     */
+    private static final Set<String> SKIP_HEADERS = Set.of(
+            "host", "content-length", "transfer-encoding", "connection",
+            "upgrade", "keep-alive", "proxy-connection", "te", "trailer",
+            "date", "expect", "from", "via", "warning");
+
+    @Inject
+    ForkConfig config;
+
+    @Inject
+    ForkFilterRegistry filterRegistry;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    private List<ForkRule> rules = List.of();
+    private Map<String, List<ForkRule>> pathIndex = Map.of();
+    private HttpClient httpClient;
+
+    // Pre-built meters keyed by "ruleId" or "ruleId:targetId"
+    private final Map<String, Counter> discardedCounters = new HashMap<>();
+    private final Map<String, Counter> forwardedCounters = new HashMap<>();
+    private final Map<String, Counter> errorCounters = new HashMap<>();
+    private final Map<String, Timer> forwardTimers = new HashMap<>();
+
+    @PostConstruct
+    void init() {
+        if (!config.enabled()) {
+            LOG.info("Fork engine disabled (fork.enabled=false) — no rules loaded");
+            return;
+        }
+
+        List<ForkConfig.RuleConfig> ruleConfigs = config.rules();
+        if (ruleConfigs == null || ruleConfigs.isEmpty()) {
+            LOG.info("Fork engine enabled but no rules configured");
+            return;
+        }
+
+        rules = ruleConfigs.stream()
+                .filter(ForkConfig.RuleConfig::enabled)
+                .map(this::buildRule)
+                .collect(Collectors.toUnmodifiableList());
+
+        // Build path index: path → [rules that match it]
+        Map<String, List<ForkRule>> index = new HashMap<>();
+        for (ForkRule rule : rules) {
+            for (String path : rule.paths()) {
+                index.computeIfAbsent(path, k -> new ArrayList<>()).add(rule);
+            }
+        }
+        pathIndex = Collections.unmodifiableMap(index);
+
+        // Register each rule's filter (loads file if configured)
+        rules.forEach(filterRegistry::register);
+
+        // Shared HTTP client — connection pooling handled internally
+        httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        // Pre-build all Micrometer meters (avoids lookup overhead on hot path)
+        for (ForkRule rule : rules) {
+            discardedCounters.put(rule.id(),
+                    meterRegistry.counter("fork_requests_total",
+                            "rule", rule.id(), "target", "-", "outcome", "discarded"));
+
+            for (ForkTarget target : rule.targets()) {
+                String key = rule.id() + ":" + target.id();
+                forwardedCounters.put(key,
+                        meterRegistry.counter("fork_requests_total",
+                                "rule", rule.id(), "target", target.id(), "outcome", "forwarded"));
+                errorCounters.put(key,
+                        meterRegistry.counter("fork_requests_total",
+                                "rule", rule.id(), "target", target.id(), "outcome", "error"));
+                forwardTimers.put(key,
+                        meterRegistry.timer("fork_forward_duration_seconds",
+                                "rule", rule.id(), "target", target.id()));
+            }
+        }
+
+        LOG.infof("Fork engine ready — %d rule(s) across %d path(s):", rules.size(), pathIndex.size());
+        pathIndex.forEach((path, rs) ->
+                LOG.infof("  %s → [%s]", path,
+                        rs.stream().map(ForkRule::id).collect(Collectors.joining(", "))));
+    }
+
+    // -------------------------------------------------------------------------
+    // Request handling (called by ForkMirrorResource on every mirrored request)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the rules that should handle an incoming request to {@code path}.
+     * Returns an empty list if no rules match — the caller should return 200 immediately.
+     */
+    public List<ForkRule> findRulesForPath(String path) {
+        return pathIndex.getOrDefault(path, List.of());
+    }
+
+    /**
+     * Extracts the routing key, checks the filter, and fans out to all targets.
+     * Always completes synchronously (the actual HTTP calls are fire-and-forget).
+     *
+     * @return a {@link ForkResult} describing what happened — forwarded, discarded, or error.
+     *         The caller may attach this to response headers for traceability.
+     */
+    public ForkResult process(ForkRule rule, String body, MultivaluedMap<String, String> headers) {
+        String key;
+        try {
+            key = extractKey(rule, body);
+        } catch (Exception e) {
+            LOG.warnf(e, "Rule '%s': failed to extract key field '%s' — discarding", rule.id(), rule.keyField());
+            discardedCounters.get(rule.id()).increment();
+            return ForkResult.error(rule.id(), null);
+        }
+
+        if (key == null || key.isBlank()) {
+            LOG.debugf("Rule '%s': key field '%s' is absent or empty — discarding", rule.id(), rule.keyField());
+            discardedCounters.get(rule.id()).increment();
+            return ForkResult.discarded(rule.id(), key);
+        }
+
+        if (!filterRegistry.contains(rule.id(), key)) {
+            LOG.debugf("Rule '%s': key '%s' not in filter — discarding", rule.id(), key);
+            discardedCounters.get(rule.id()).increment();
+            return ForkResult.discarded(rule.id(), key);
+        }
+
+        List<String> dispatched = new ArrayList<>();
+        for (ForkTarget target : rule.targets()) {
+            forwardAsync(rule, target, key, body, headers);
+            dispatched.add(target.id());
+        }
+        return ForkResult.forwarded(rule.id(), key, dispatched);
+    }
+
+    // -------------------------------------------------------------------------
+    // Management API support
+    // -------------------------------------------------------------------------
+
+    public List<ForkRule> rules() {
+        return rules;
+    }
+
+    public Optional<ForkRule> findRule(String id) {
+        return rules.stream().filter(r -> r.id().equals(id)).findFirst();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    private void forwardAsync(ForkRule rule, ForkTarget target, String key,
+            String body, MultivaluedMap<String, String> headers) {
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(target.url()))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .timeout(Duration.ofMillis(target.timeout()));
+
+        headers.forEach((name, values) -> {
+            if (!SKIP_HEADERS.contains(name.toLowerCase())) {
+                values.forEach(v -> builder.header(name, v));
+            }
+        });
+        if (!headers.containsKey("Content-Type") && !headers.containsKey("content-type")) {
+            builder.header("Content-Type", contentTypeFor(rule.bodyParser()));
+        }
+
+        String metricsKey = rule.id() + ":" + target.id();
+        Timer.Sample sample = Timer.start(meterRegistry);
+
+        httpClient.sendAsync(builder.build(), HttpResponse.BodyHandlers.discarding())
+                .thenAccept(resp -> {
+                    sample.stop(forwardTimers.get(metricsKey));
+                    forwardedCounters.get(metricsKey).increment();
+                    LOG.infof("Forwarded key=%s rule=%s target=%s status=%d",
+                            key, rule.id(), target.id(), resp.statusCode());
+                })
+                .exceptionally(ex -> {
+                    errorCounters.get(metricsKey).increment();
+                    LOG.errorf(ex, "Forward failed key=%s rule=%s target=%s",
+                            key, rule.id(), target.id());
+                    return null;
+                });
+    }
+
+    private String extractKey(ForkRule rule, String body) throws Exception {
+        return switch (rule.bodyParser()) {
+            case JSON -> extractJsonKey(body, rule.keyField());
+            case CSV -> extractCsvKey(body, rule.keyField());
+        };
+    }
+
+    private String extractJsonKey(String body, String keyField) throws Exception {
+        return objectMapper.readTree(body).path(keyField).asText(null);
+    }
+
+    /**
+     * CSV key extraction.
+     *
+     * <p>If {@code keyField} is a numeric string (e.g. "0"), treats it as a
+     * zero-based column index. Otherwise, reads the first line as a header row
+     * and finds the column by name (case-insensitive).
+     *
+     * <p>Only the first data line is parsed — the body is expected to be a
+     * single-record CSV row as forwarded by APISIX.
+     */
+    private String extractCsvKey(String body, String keyField) {
+        String[] lines = body.strip().split("\\R", -1);
+        if (lines.length == 0) return null;
+
+        // Numeric field → column index
+        try {
+            int idx = Integer.parseInt(keyField.trim());
+            String dataLine = lines.length == 1 ? lines[0] : lines[1];
+            String[] cols = dataLine.split(",", -1);
+            return idx < cols.length ? cols[idx].trim() : null;
+        } catch (NumberFormatException ignored) {
+            // Not an index — treat as column name
+        }
+
+        if (lines.length < 2) return null;
+
+        String[] headers = lines[0].split(",", -1);
+        String[] values = lines[1].split(",", -1);
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i].trim().equalsIgnoreCase(keyField) && i < values.length) {
+                return values[i].trim();
+            }
+        }
+        return null;
+    }
+
+    private String contentTypeFor(BodyParserType parser) {
+        return switch (parser) {
+            case JSON -> "application/json";
+            case CSV -> "text/csv";
+        };
+    }
+
+    private ForkRule buildRule(ForkConfig.RuleConfig rc) {
+        List<ForkTarget> targets = rc.targets().stream()
+                .map(tc -> new ForkTarget(
+                        tc.id(),
+                        tc.mirrorHost().replaceAll("/+$", "") + tc.mirrorPath(),
+                        tc.timeout()))
+                .collect(Collectors.toUnmodifiableList());
+
+        return new ForkRule(
+                rc.id(),
+                rc.enabled(),
+                List.copyOf(rc.paths()),
+                rc.bodyParser(),
+                rc.keyField(),
+                rc.filterFile(),
+                targets);
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
@@ -12,8 +12,8 @@ import io.micrometer.core.instrument.Timer;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -49,6 +49,10 @@ public class ForkEngine {
 
     private static final Logger LOG = Logger.getLogger(ForkEngine.class);
 
+    private static final String METRIC_FORK_REQUESTS = "fork_requests_total";
+    private static final String TAG_OUTCOME = "outcome";
+    private static final String TAG_TARGET = "target";
+
     /**
      * HTTP headers that must not be forwarded to upstream targets.
      * Covers hop-by-hop headers and Java HttpClient restricted headers.
@@ -58,17 +62,10 @@ public class ForkEngine {
             "upgrade", "keep-alive", "proxy-connection", "te", "trailer",
             "date", "expect", "from", "via", "warning");
 
-    @Inject
-    ForkConfig config;
-
-    @Inject
-    ForkFilterRegistry filterRegistry;
-
-    @Inject
-    MeterRegistry meterRegistry;
-
-    @Inject
-    ObjectMapper objectMapper;
+    private final ForkConfig config;
+    private final ForkFilterRegistry filterRegistry;
+    private final MeterRegistry meterRegistry;
+    private final ObjectMapper objectMapper;
 
     private List<ForkRule> rules = List.of();
     private Map<String, List<ForkRule>> pathIndex = Map.of();
@@ -79,6 +76,14 @@ public class ForkEngine {
     private final Map<String, Counter> forwardedCounters = new HashMap<>();
     private final Map<String, Counter> errorCounters = new HashMap<>();
     private final Map<String, Timer> forwardTimers = new HashMap<>();
+
+    ForkEngine(ForkConfig config, ForkFilterRegistry filterRegistry,
+            MeterRegistry meterRegistry, ObjectMapper objectMapper) {
+        this.config = config;
+        this.filterRegistry = filterRegistry;
+        this.meterRegistry = meterRegistry;
+        this.objectMapper = objectMapper;
+    }
 
     @PostConstruct
     void init() {
@@ -96,7 +101,7 @@ public class ForkEngine {
         rules = ruleConfigs.stream()
                 .filter(ForkConfig.RuleConfig::enabled)
                 .map(this::buildRule)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         // Build path index: path → [rules that match it]
         Map<String, List<ForkRule>> index = new HashMap<>();
@@ -118,20 +123,20 @@ public class ForkEngine {
         // Pre-build all Micrometer meters (avoids lookup overhead on hot path)
         for (ForkRule rule : rules) {
             discardedCounters.put(rule.id(),
-                    meterRegistry.counter("fork_requests_total",
-                            "rule", rule.id(), "target", "-", "outcome", "discarded"));
+                    meterRegistry.counter(METRIC_FORK_REQUESTS,
+                            "rule", rule.id(), TAG_TARGET, "-", TAG_OUTCOME, "discarded"));
 
             for (ForkTarget target : rule.targets()) {
                 String key = rule.id() + ":" + target.id();
                 forwardedCounters.put(key,
-                        meterRegistry.counter("fork_requests_total",
-                                "rule", rule.id(), "target", target.id(), "outcome", "forwarded"));
+                        meterRegistry.counter(METRIC_FORK_REQUESTS,
+                                "rule", rule.id(), TAG_TARGET, target.id(), TAG_OUTCOME, "forwarded"));
                 errorCounters.put(key,
-                        meterRegistry.counter("fork_requests_total",
-                                "rule", rule.id(), "target", target.id(), "outcome", "error"));
+                        meterRegistry.counter(METRIC_FORK_REQUESTS,
+                                "rule", rule.id(), TAG_TARGET, target.id(), TAG_OUTCOME, "error"));
                 forwardTimers.put(key,
                         meterRegistry.timer("fork_forward_duration_seconds",
-                                "rule", rule.id(), "target", target.id()));
+                                "rule", rule.id(), TAG_TARGET, target.id()));
             }
         }
 
@@ -164,7 +169,7 @@ public class ForkEngine {
         String key;
         try {
             key = extractKey(rule, body);
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOG.warnf(e, "Rule '%s': failed to extract key field '%s' — discarding", rule.id(), rule.keyField());
             discardedCounters.get(rule.id()).increment();
             return ForkResult.error(rule.id(), null);
@@ -241,14 +246,14 @@ public class ForkEngine {
                 });
     }
 
-    private String extractKey(ForkRule rule, String body) throws Exception {
+    private String extractKey(ForkRule rule, String body) throws IOException {
         return switch (rule.bodyParser()) {
             case JSON -> extractJsonKey(body, rule.keyField());
             case CSV -> extractCsvKey(body, rule.keyField());
         };
     }
 
-    private String extractJsonKey(String body, String keyField) throws Exception {
+    private String extractJsonKey(String body, String keyField) throws IOException {
         return objectMapper.readTree(body).path(keyField).asText(null);
     }
 
@@ -278,10 +283,10 @@ public class ForkEngine {
 
         if (lines.length < 2) return null;
 
-        String[] headers = lines[0].split(",", -1);
+        String[] csvHeaders = lines[0].split(",", -1);
         String[] values = lines[1].split(",", -1);
-        for (int i = 0; i < headers.length; i++) {
-            if (headers[i].trim().equalsIgnoreCase(keyField) && i < values.length) {
+        for (int i = 0; i < csvHeaders.length; i++) {
+            if (csvHeaders[i].trim().equalsIgnoreCase(keyField) && i < values.length) {
                 return values[i].trim();
             }
         }
@@ -301,7 +306,7 @@ public class ForkEngine {
                         tc.id(),
                         tc.mirrorHost().replaceAll("/+$", "") + tc.mirrorPath(),
                         tc.timeout()))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
 
         return new ForkRule(
                 rc.id(),

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
@@ -73,6 +73,7 @@ public class ForkEngine {
 
     // Pre-built meters keyed by "ruleId" or "ruleId:targetId"
     private final Map<String, Counter> discardedCounters = new HashMap<>();
+    private final Map<String, Counter> parseErrorCounters = new HashMap<>();
     private final Map<String, Counter> forwardedCounters = new HashMap<>();
     private final Map<String, Counter> errorCounters = new HashMap<>();
     private final Map<String, Timer> forwardTimers = new HashMap<>();
@@ -125,6 +126,9 @@ public class ForkEngine {
             discardedCounters.put(rule.id(),
                     meterRegistry.counter(METRIC_FORK_REQUESTS,
                             "rule", rule.id(), TAG_TARGET, "-", TAG_OUTCOME, "discarded"));
+            parseErrorCounters.put(rule.id(),
+                    meterRegistry.counter(METRIC_FORK_REQUESTS,
+                            "rule", rule.id(), TAG_TARGET, "-", TAG_OUTCOME, "error"));
 
             for (ForkTarget target : rule.targets()) {
                 String key = rule.id() + ":" + target.id();
@@ -170,8 +174,8 @@ public class ForkEngine {
         try {
             key = extractKey(rule, body);
         } catch (IOException e) {
-            LOG.warnf(e, "Rule '%s': failed to extract key field '%s' — discarding", rule.id(), rule.keyField());
-            discardedCounters.get(rule.id()).increment();
+            LOG.warnf(e, "Rule '%s': failed to extract key field '%s' — parse error", rule.id(), rule.keyField());
+            parseErrorCounters.get(rule.id()).increment();
             return ForkResult.error(rule.id(), null);
         }
 
@@ -315,6 +319,7 @@ public class ForkEngine {
                 targets);
     }
 
+    @SuppressWarnings("java:S1075") // path delimiter normalization, not a hardcoded URI
     private ForkTarget buildTarget(String ruleId, ForkConfig.RuleConfig.TargetConfig tc) {
         String host = tc.mirrorHost().replaceAll("/+$", "");
         String path = tc.mirrorPath().startsWith("/") ? tc.mirrorPath() : "/" + tc.mirrorPath();

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkEngine.java
@@ -302,10 +302,7 @@ public class ForkEngine {
 
     private ForkRule buildRule(ForkConfig.RuleConfig rc) {
         List<ForkTarget> targets = rc.targets().stream()
-                .map(tc -> new ForkTarget(
-                        tc.id(),
-                        tc.mirrorHost().replaceAll("/+$", "") + tc.mirrorPath(),
-                        tc.timeout()))
+                .map(tc -> buildTarget(rc.id(), tc))
                 .toList();
 
         return new ForkRule(
@@ -316,5 +313,27 @@ public class ForkEngine {
                 rc.keyField(),
                 rc.filterFile(),
                 targets);
+    }
+
+    private ForkTarget buildTarget(String ruleId, ForkConfig.RuleConfig.TargetConfig tc) {
+        String host = tc.mirrorHost().replaceAll("/+$", "");
+        String path = tc.mirrorPath().startsWith("/") ? tc.mirrorPath() : "/" + tc.mirrorPath();
+        String url = host + path;
+
+        try {
+            URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Rule '%s' target '%s': malformed URL '%s' — %s"
+                            .formatted(ruleId, tc.id(), url, e.getMessage()));
+        }
+
+        if (tc.timeout() <= 0) {
+            throw new IllegalArgumentException(
+                    "Rule '%s' target '%s': timeout must be positive, got %d"
+                            .formatted(ruleId, tc.id(), tc.timeout()));
+        }
+
+        return new ForkTarget(tc.id(), url, tc.timeout());
     }
 }

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
@@ -1,0 +1,155 @@
+package com.microboxlabs.miot.gateway.fork;
+
+import com.microboxlabs.miot.gateway.fork.model.ForkRule;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
+/**
+ * In-memory routing key filter for all fork rules.
+ *
+ * <p>Reads are lock-free (ConcurrentHashMap.newKeySet). Writes (add/remove/reload)
+ * are thread-safe. File reload atomically swaps the set via ConcurrentHashMap.put,
+ * so readers see either the old or new set with no intermediate empty state.
+ *
+ * <p>One Micrometer gauge per rule tracks the live filter size.
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "miot.component.gateway.enabled", stringValue = "true")
+public class ForkFilterRegistry {
+
+    private static final Logger LOG = Logger.getLogger(ForkFilterRegistry.class);
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    /** rule-id → Set of routing keys (e.g. asset IDs). */
+    private final ConcurrentHashMap<String, Set<String>> filters = new ConcurrentHashMap<>();
+
+    /** rule-id → file path (for reload). */
+    private final ConcurrentHashMap<String, Path> filePaths = new ConcurrentHashMap<>();
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Register a rule. Creates the filter set, loads the filter file if configured,
+     * and registers a gauge metric for the filter size.
+     * Called by ForkEngine during startup for each enabled rule.
+     */
+    public void register(ForkRule rule) {
+        filters.putIfAbsent(rule.id(), ConcurrentHashMap.newKeySet());
+
+        rule.filterFile().ifPresent(pathStr -> {
+            filePaths.put(rule.id(), Path.of(pathStr));
+            int loaded = readFile(rule.id(), Path.of(pathStr));
+            LOG.infof("Rule '%s': loaded %d key(s) from %s", rule.id(), loaded, pathStr);
+        });
+
+        Gauge.builder("fork_filter_size", filters, m -> {
+                    Set<String> s = m.get(rule.id());
+                    return s == null ? 0d : (double) s.size();
+                })
+                .tag("rule", rule.id())
+                .description("Number of routing keys currently active in the fork filter")
+                .register(meterRegistry);
+    }
+
+    // -------------------------------------------------------------------------
+    // Read (hot path — called on every mirrored request)
+    // -------------------------------------------------------------------------
+
+    public boolean contains(String ruleId, String key) {
+        Set<String> ids = filters.get(ruleId);
+        return ids != null && ids.contains(key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Management API support
+    // -------------------------------------------------------------------------
+
+    /** Add one or more keys to the in-memory filter for a rule. */
+    public int add(String ruleId, Collection<String> keys) {
+        Set<String> ids = filters.computeIfAbsent(ruleId, k -> ConcurrentHashMap.newKeySet());
+        Set<String> normalized = keys.stream()
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toSet());
+        ids.addAll(normalized);
+        return normalized.size();
+    }
+
+    /** Remove a single key. Returns true if the key was present. */
+    public boolean remove(String ruleId, String key) {
+        Set<String> ids = filters.get(ruleId);
+        return ids != null && ids.remove(key.trim());
+    }
+
+    /**
+     * Reload the filter for a rule from its configured file.
+     * Atomically replaces the entire set — no empty-state window for readers.
+     *
+     * @return number of keys loaded from the file
+     * @throws IllegalStateException if the rule has no filter file configured
+     */
+    public int reload(String ruleId) {
+        Path path = filePaths.get(ruleId);
+        if (path == null) {
+            throw new IllegalStateException("Rule '" + ruleId + "' has no filter file configured");
+        }
+        int loaded = readFile(ruleId, path);
+        LOG.infof("Rule '%s': reloaded %d key(s) from %s", ruleId, loaded, path);
+        return loaded;
+    }
+
+    /** Returns an immutable snapshot of the current filter for a rule. */
+    public Optional<Set<String>> inspect(String ruleId) {
+        Set<String> ids = filters.get(ruleId);
+        return Optional.ofNullable(ids).map(Set::copyOf);
+    }
+
+    public boolean isKnown(String ruleId) {
+        return filters.containsKey(ruleId);
+    }
+
+    public boolean hasFilterFile(String ruleId) {
+        return filePaths.containsKey(ruleId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    /**
+     * Reads a plain-text file (one key per line, # comments and blank lines ignored)
+     * and atomically replaces the filter set for the given rule.
+     */
+    private int readFile(String ruleId, Path path) {
+        try {
+            Set<String> loaded = Files.lines(path)
+                    .map(String::trim)
+                    .filter(line -> !line.isBlank() && !line.startsWith("#"))
+                    .collect(Collectors.toCollection(() -> ConcurrentHashMap.newKeySet()));
+
+            // Atomic swap — readers see old or new, never an empty intermediate state
+            filters.put(ruleId, loaded);
+            return loaded.size();
+        } catch (IOException e) {
+            LOG.errorf(e, "Rule '%s': failed to read filter file %s", ruleId, path);
+            return 0;
+        }
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
@@ -83,15 +83,18 @@ public class ForkFilterRegistry {
     // Management API support
     // -------------------------------------------------------------------------
 
-    /** Add one or more keys to the in-memory filter for a rule. */
+    /** Add one or more keys to the in-memory filter for a rule. Returns count of newly added keys. */
     public int add(String ruleId, Collection<String> keys) {
         Set<String> ids = filters.computeIfAbsent(ruleId, k -> ConcurrentHashMap.newKeySet());
-        Set<String> normalized = keys.stream()
-                .map(String::trim)
-                .filter(s -> !s.isBlank())
-                .collect(Collectors.toSet());
-        ids.addAll(normalized);
-        return normalized.size();
+        int added = 0;
+        for (String key : keys) {
+            if (key == null) continue;
+            String trimmed = key.trim();
+            if (!trimmed.isBlank() && ids.add(trimmed)) {
+                added++;
+            }
+        }
+        return added;
     }
 
     /** Remove a single key. Returns true if the key was present. */

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/ForkFilterRegistry.java
@@ -5,16 +5,15 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.properties.IfBuildProperty;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jboss.logging.Logger;
 
 /**
@@ -32,14 +31,17 @@ public class ForkFilterRegistry {
 
     private static final Logger LOG = Logger.getLogger(ForkFilterRegistry.class);
 
-    @Inject
-    MeterRegistry meterRegistry;
+    private final MeterRegistry meterRegistry;
 
     /** rule-id → Set of routing keys (e.g. asset IDs). */
     private final ConcurrentHashMap<String, Set<String>> filters = new ConcurrentHashMap<>();
 
     /** rule-id → file path (for reload). */
     private final ConcurrentHashMap<String, Path> filePaths = new ConcurrentHashMap<>();
+
+    ForkFilterRegistry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
 
     // -------------------------------------------------------------------------
     // Lifecycle
@@ -138,12 +140,11 @@ public class ForkFilterRegistry {
      * and atomically replaces the filter set for the given rule.
      */
     private int readFile(String ruleId, Path path) {
-        try {
-            Set<String> loaded = Files.lines(path)
+        try (Stream<String> lines = Files.lines(path)) {
+            Set<String> loaded = lines
                     .map(String::trim)
                     .filter(line -> !line.isBlank() && !line.startsWith("#"))
-                    .collect(Collectors.toCollection(() -> ConcurrentHashMap.newKeySet()));
-
+                    .collect(Collectors.toCollection(ConcurrentHashMap::newKeySet));
             // Atomic swap — readers see old or new, never an empty intermediate state
             filters.put(ruleId, loaded);
             return loaded.size();

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkManagementResource.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkManagementResource.java
@@ -1,0 +1,217 @@
+package com.microboxlabs.miot.gateway.fork.api;
+
+import com.microboxlabs.miot.gateway.fork.ForkEngine;
+import com.microboxlabs.miot.gateway.fork.ForkFilterRegistry;
+import com.microboxlabs.miot.gateway.fork.model.ForkRule;
+import com.microboxlabs.miot.gateway.fork.model.ForkTarget;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
+/**
+ * Internal management API for the fork engine.
+ *
+ * <p>Exposed at /internal/fork — accessible only within the cluster (ClusterIP service).
+ * No authentication is applied since this endpoint is not reachable externally.
+ *
+ * <pre>
+ * GET    /internal/fork/rules                       List all configured rules
+ * GET    /internal/fork/rules/{id}/filter           Inspect the in-memory filter for a rule
+ * POST   /internal/fork/rules/{id}/filter           Add keys to the filter (JSON array body)
+ * DELETE /internal/fork/rules/{id}/filter/{key}     Remove a single key
+ * POST   /internal/fork/rules/{id}/filter/reload    Reload filter from the configured file
+ * </pre>
+ */
+@Path("/internal/fork")
+@Produces(MediaType.APPLICATION_JSON)
+@IfBuildProperty(name = "miot.component.gateway.enabled", stringValue = "true")
+public class ForkManagementResource {
+
+    private static final Logger LOG = Logger.getLogger(ForkManagementResource.class);
+
+    @Inject
+    ForkEngine engine;
+
+    @Inject
+    ForkFilterRegistry filterRegistry;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rules
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * List all active rules with their current filter size and target list.
+     *
+     * <p>Example response:
+     * <pre>
+     * [
+     *   {
+     *     "id": "asset-track-canary",
+     *     "paths": ["/v1/asset/track"],
+     *     "bodyParser": "JSON",
+     *     "keyField": "asset_id",
+     *     "filterFile": "/config/asset-ids.txt",
+     *     "filterSize": 2,
+     *     "targets": [
+     *       {"id": "storm", "url": "https://storm.modulariot.com/v1/asset/track", "timeout": 5000}
+     *     ]
+     *   }
+     * ]
+     * </pre>
+     */
+    @GET
+    @Path("/rules")
+    public Response listRules() {
+        List<Map<String, Object>> rules = engine.rules().stream()
+                .map(this::summarize)
+                .collect(Collectors.toList());
+        return Response.ok(rules).build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Filter inspection
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Return all routing keys currently in the in-memory filter for a rule.
+     *
+     * <p>Example response: {@code ["SVSX88", "ABC123"]}
+     */
+    @GET
+    @Path("/rules/{id}/filter")
+    public Response getFilter(@PathParam("id") String id) {
+        Optional<ForkRule> rule = engine.findRule(id);
+        if (rule.isEmpty()) {
+            return ruleNotFound(id);
+        }
+        Set<String> keys = filterRegistry.inspect(id).orElse(Set.of());
+        return Response.ok(keys).build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Filter mutation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Add one or more routing keys to the in-memory filter.
+     *
+     * <p>Request body: JSON array of strings — {@code ["DEF456", "GHI789"]}
+     *
+     * <p>Example response: {@code {"added": 2, "total": 4}}
+     */
+    @POST
+    @Path("/rules/{id}/filter")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response addToFilter(@PathParam("id") String id, List<String> keys) {
+        if (engine.findRule(id).isEmpty()) {
+            return ruleNotFound(id);
+        }
+        if (keys == null || keys.isEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "Request body must be a non-empty JSON array of strings"))
+                    .build();
+        }
+        int added = filterRegistry.add(id, keys);
+        int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
+        LOG.infof("Filter add — rule=%s added=%d total=%d", id, added, total);
+        return Response.ok(Map.of("added", added, "total", total)).build();
+    }
+
+    /**
+     * Remove a single routing key from the in-memory filter.
+     *
+     * <p>Example response: {@code {"removed": true, "total": 3}}
+     */
+    @DELETE
+    @Path("/rules/{id}/filter/{key}")
+    public Response removeFromFilter(@PathParam("id") String id, @PathParam("key") String key) {
+        if (engine.findRule(id).isEmpty()) {
+            return ruleNotFound(id);
+        }
+        boolean removed = filterRegistry.remove(id, key);
+        int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
+        LOG.infof("Filter remove — rule=%s key=%s removed=%b total=%d", id, key, removed, total);
+        return Response.ok(Map.of("removed", removed, "total", total)).build();
+    }
+
+    /**
+     * Reload the in-memory filter from the rule's configured filter file.
+     * Replaces the entire current filter atomically.
+     *
+     * <p>Returns 409 if the rule has no filter file configured.
+     *
+     * <p>Example response: {@code {"loaded": 2, "total": 2}}
+     */
+    @POST
+    @Path("/rules/{id}/filter/reload")
+    public Response reloadFilter(@PathParam("id") String id) {
+        if (engine.findRule(id).isEmpty()) {
+            return ruleNotFound(id);
+        }
+        if (!filterRegistry.hasFilterFile(id)) {
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(Map.of("error", "Rule '" + id + "' has no filter file configured"))
+                    .build();
+        }
+        try {
+            int loaded = filterRegistry.reload(id);
+            int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
+            LOG.infof("Filter reload — rule=%s loaded=%d", id, loaded);
+            return Response.ok(Map.of("loaded", loaded, "total", total)).build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Filter reload failed — rule=%s", id);
+            return Response.serverError()
+                    .entity(Map.of("error", e.getMessage()))
+                    .build();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private Map<String, Object> summarize(ForkRule rule) {
+        List<Map<String, Object>> targetSummaries = rule.targets().stream()
+                .map(t -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("id", t.id());
+                    m.put("url", t.url());
+                    m.put("timeout", t.timeout());
+                    return m;
+                })
+                .collect(Collectors.toList());
+
+        int filterSize = filterRegistry.inspect(rule.id()).map(Set::size).orElse(0);
+
+        Map<String, Object> summary = new HashMap<>();
+        summary.put("id", rule.id());
+        summary.put("paths", rule.paths());
+        summary.put("bodyParser", rule.bodyParser().name());
+        summary.put("keyField", rule.keyField());
+        summary.put("filterFile", rule.filterFile().orElse(""));
+        summary.put("filterSize", filterSize);
+        summary.put("targets", targetSummaries);
+        return summary;
+    }
+
+    private Response ruleNotFound(String id) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(Map.of("error", "Rule not found: " + id))
+                .build();
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkManagementResource.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkManagementResource.java
@@ -3,9 +3,7 @@ package com.microboxlabs.miot.gateway.fork.api;
 import com.microboxlabs.miot.gateway.fork.ForkEngine;
 import com.microboxlabs.miot.gateway.fork.ForkFilterRegistry;
 import com.microboxlabs.miot.gateway.fork.model.ForkRule;
-import com.microboxlabs.miot.gateway.fork.model.ForkTarget;
 import io.quarkus.arc.properties.IfBuildProperty;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -20,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 /**
@@ -44,11 +41,16 @@ public class ForkManagementResource {
 
     private static final Logger LOG = Logger.getLogger(ForkManagementResource.class);
 
-    @Inject
-    ForkEngine engine;
+    private static final String FIELD_ERROR = "error";
+    private static final String FIELD_TOTAL = "total";
 
-    @Inject
-    ForkFilterRegistry filterRegistry;
+    private final ForkEngine engine;
+    private final ForkFilterRegistry filterRegistry;
+
+    ForkManagementResource(ForkEngine engine, ForkFilterRegistry filterRegistry) {
+        this.engine = engine;
+        this.filterRegistry = filterRegistry;
+    }
 
     // ─────────────────────────────────────────────────────────────────────────
     // Rules
@@ -79,7 +81,7 @@ public class ForkManagementResource {
     public Response listRules() {
         List<Map<String, Object>> rules = engine.rules().stream()
                 .map(this::summarize)
-                .collect(Collectors.toList());
+                .toList();
         return Response.ok(rules).build();
     }
 
@@ -123,13 +125,13 @@ public class ForkManagementResource {
         }
         if (keys == null || keys.isEmpty()) {
             return Response.status(Response.Status.BAD_REQUEST)
-                    .entity(Map.of("error", "Request body must be a non-empty JSON array of strings"))
+                    .entity(Map.of(FIELD_ERROR, "Request body must be a non-empty JSON array of strings"))
                     .build();
         }
         int added = filterRegistry.add(id, keys);
         int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
         LOG.infof("Filter add — rule=%s added=%d total=%d", id, added, total);
-        return Response.ok(Map.of("added", added, "total", total)).build();
+        return Response.ok(Map.of("added", added, FIELD_TOTAL, total)).build();
     }
 
     /**
@@ -146,7 +148,7 @@ public class ForkManagementResource {
         boolean removed = filterRegistry.remove(id, key);
         int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
         LOG.infof("Filter remove — rule=%s key=%s removed=%b total=%d", id, key, removed, total);
-        return Response.ok(Map.of("removed", removed, "total", total)).build();
+        return Response.ok(Map.of("removed", removed, FIELD_TOTAL, total)).build();
     }
 
     /**
@@ -165,18 +167,18 @@ public class ForkManagementResource {
         }
         if (!filterRegistry.hasFilterFile(id)) {
             return Response.status(Response.Status.CONFLICT)
-                    .entity(Map.of("error", "Rule '" + id + "' has no filter file configured"))
+                    .entity(Map.of(FIELD_ERROR, "Rule '" + id + "' has no filter file configured"))
                     .build();
         }
         try {
             int loaded = filterRegistry.reload(id);
             int total = filterRegistry.inspect(id).map(Set::size).orElse(0);
             LOG.infof("Filter reload — rule=%s loaded=%d", id, loaded);
-            return Response.ok(Map.of("loaded", loaded, "total", total)).build();
-        } catch (Exception e) {
+            return Response.ok(Map.of("loaded", loaded, FIELD_TOTAL, total)).build();
+        } catch (IllegalStateException e) {
             LOG.errorf(e, "Filter reload failed — rule=%s", id);
             return Response.serverError()
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(Map.of(FIELD_ERROR, e.getMessage()))
                     .build();
         }
     }
@@ -194,7 +196,7 @@ public class ForkManagementResource {
                     m.put("timeout", t.timeout());
                     return m;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         int filterSize = filterRegistry.inspect(rule.id()).map(Set::size).orElse(0);
 
@@ -211,7 +213,7 @@ public class ForkManagementResource {
 
     private Response ruleNotFound(String id) {
         return Response.status(Response.Status.NOT_FOUND)
-                .entity(Map.of("error", "Rule not found: " + id))
+                .entity(Map.of(FIELD_ERROR, "Rule not found: " + id))
                 .build();
     }
 }

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkMirrorResource.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkMirrorResource.java
@@ -4,7 +4,6 @@ import com.microboxlabs.miot.gateway.fork.ForkEngine;
 import com.microboxlabs.miot.gateway.fork.model.ForkResult;
 import com.microboxlabs.miot.gateway.fork.model.ForkRule;
 import io.quarkus.arc.properties.IfBuildProperty;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -42,9 +41,13 @@ import org.jboss.logging.Logger;
 public class ForkMirrorResource {
 
     private static final Logger LOG = Logger.getLogger(ForkMirrorResource.class);
+    private static final String PATH_SEPARATOR = "/";
 
-    @Inject
-    ForkEngine engine;
+    private final ForkEngine engine;
+
+    ForkMirrorResource(ForkEngine engine) {
+        this.engine = engine;
+    }
 
     @POST
     @Consumes(MediaType.WILDCARD)
@@ -54,7 +57,7 @@ public class ForkMirrorResource {
             String body,
             @Context HttpHeaders headers) {
 
-        String fullPath = "/" + path;
+        String fullPath = PATH_SEPARATOR + path;
         List<ForkRule> matchingRules = engine.findRulesForPath(fullPath);
 
         if (matchingRules.isEmpty()) {

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkMirrorResource.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/api/ForkMirrorResource.java
@@ -1,0 +1,79 @@
+package com.microboxlabs.miot.gateway.fork.api;
+
+import com.microboxlabs.miot.gateway.fork.ForkEngine;
+import com.microboxlabs.miot.gateway.fork.model.ForkResult;
+import com.microboxlabs.miot.gateway.fork.model.ForkRule;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+/**
+ * Catch-all POST receiver for APISIX proxy-mirror traffic.
+ *
+ * <p>Accepts any path except those under /internal/ (reserved for the management API).
+ * Delegates path-to-rule matching and fan-out to {@link ForkEngine}.
+ *
+ * <p>Always responds 200 — APISIX discards mirror responses.
+ *
+ * <p><b>APISIX configuration:</b>
+ * <pre>
+ * plugins:
+ *   - name: proxy-mirror
+ *     enable: true
+ *     config:
+ *       host: "http://prod-streamhub-gateway:8080"
+ *       sample_ratio: 1
+ * </pre>
+ * The host field is scheme+host+port only. APISIX appends the original upstream
+ * path, so requests arrive here at their original paths (e.g. /v1/asset/track).
+ */
+@Path("/{path: (?!internal/).*}")
+@IfBuildProperty(name = "miot.component.gateway.enabled", stringValue = "true")
+public class ForkMirrorResource {
+
+    private static final Logger LOG = Logger.getLogger(ForkMirrorResource.class);
+
+    @Inject
+    ForkEngine engine;
+
+    @POST
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response mirror(
+            @PathParam("path") String path,
+            String body,
+            @Context HttpHeaders headers) {
+
+        String fullPath = "/" + path;
+        List<ForkRule> matchingRules = engine.findRulesForPath(fullPath);
+
+        if (matchingRules.isEmpty()) {
+            LOG.debugf("No fork rule for path '%s' — discarding", fullPath);
+            return Response.ok().build();
+        }
+
+        Response.ResponseBuilder rb = Response.ok();
+        for (ForkRule rule : matchingRules) {
+            ForkResult result = engine.process(rule, body, headers.getRequestHeaders());
+            rb.header("X-Fork-Rule", result.ruleId());
+            rb.header("X-Fork-Outcome", result.outcome().name());
+            if (result.key() != null && !result.key().isBlank()) {
+                rb.header("X-Fork-Key", result.key());
+            }
+            if (!result.dispatchedTargets().isEmpty()) {
+                rb.header("X-Fork-Targets", String.join(", ", result.dispatchedTargets()));
+            }
+        }
+        return rb.build();
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/config/ForkConfig.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/config/ForkConfig.java
@@ -1,0 +1,113 @@
+package com.microboxlabs.miot.gateway.fork.config;
+
+import com.microboxlabs.miot.gateway.fork.model.BodyParserType;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Fork engine configuration.
+ *
+ * <p>Configure via application.properties or environment variables.
+ * For complex rule structures a mounted ConfigMap properties file is recommended.
+ *
+ * <pre>
+ * application.properties                       Env var (MicroProfile naming)
+ * ──────────────────────────────────────────── ────────────────────────────────────────
+ * fork.enabled                                 FORK_ENABLED
+ * fork.rules[0].id                             FORK_RULES_0__ID
+ * fork.rules[0].enabled                        FORK_RULES_0__ENABLED
+ * fork.rules[0].paths[0]                       FORK_RULES_0__PATHS_0_
+ * fork.rules[0].body-parser                    FORK_RULES_0__BODY_PARSER
+ * fork.rules[0].key-field                      FORK_RULES_0__KEY_FIELD
+ * fork.rules[0].filter-file                    FORK_RULES_0__FILTER_FILE
+ * fork.rules[0].targets[0].id                  FORK_RULES_0__TARGETS_0__ID
+ * fork.rules[0].targets[0].mirror-host         FORK_RULES_0__TARGETS_0__MIRROR_HOST
+ * fork.rules[0].targets[0].mirror-path         FORK_RULES_0__TARGETS_0__MIRROR_PATH
+ * fork.rules[0].targets[0].timeout             FORK_RULES_0__TARGETS_0__TIMEOUT
+ * </pre>
+ *
+ * <p>For most deployments, mount a ConfigMap as an application.properties file:
+ * <pre>
+ * fork.enabled=true
+ * fork.rules[0].id=asset-track-canary
+ * fork.rules[0].paths[0]=/v1/asset/track
+ * fork.rules[0].body-parser=json
+ * fork.rules[0].key-field=asset_id
+ * fork.rules[0].filter-file=/config/asset-ids.txt
+ * fork.rules[0].targets[0].id=storm
+ * fork.rules[0].targets[0].mirror-host=https://storm.modulariot.com
+ * fork.rules[0].targets[0].mirror-path=/v1/asset/track
+ * </pre>
+ */
+@ConfigMapping(prefix = "fork")
+public interface ForkConfig {
+
+    /** Master switch — enable/disable the entire fork engine. */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Fork rules. Each rule matches incoming paths, extracts a routing key,
+     * checks the in-memory filter, and fans out to one or more targets.
+     */
+    List<RuleConfig> rules();
+
+    interface RuleConfig {
+
+        /** Unique rule identifier used in metrics and management API. */
+        String id();
+
+        /** Whether this rule is active. Disabled rules are ignored at startup. */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Incoming paths this rule applies to.
+         * All paths in this list trigger the same body parser and target fan-out.
+         */
+        List<String> paths();
+
+        /**
+         * How to parse the request body to extract the routing key.
+         * Supported: JSON (default), CSV.
+         */
+        @WithDefault("json")
+        BodyParserType bodyParser();
+
+        /**
+         * Field name (JSON) or column name/index (CSV) to extract as the routing key.
+         * The extracted value is checked against the in-memory filter.
+         */
+        @WithDefault("asset_id")
+        String keyField();
+
+        /**
+         * Path to a plain-text file containing one routing key per line.
+         * Lines starting with # and blank lines are ignored.
+         * Intended to be mounted as a Kubernetes ConfigMap volume.
+         * If absent, the filter starts empty (forward nothing until populated via API).
+         */
+        Optional<String> filterFile();
+
+        /** Forward targets — all matching targets receive the request in parallel. */
+        List<TargetConfig> targets();
+
+        interface TargetConfig {
+            /** Unique target identifier used in metrics labels. */
+            String id();
+
+            /** Target base URL (scheme + host + optional port), no trailing slash. */
+            String mirrorHost();
+
+            /** Path on the target host. Combined with mirrorHost to form the full URL. */
+            @WithDefault("/")
+            String mirrorPath();
+
+            /** HTTP timeout in milliseconds for forwarded requests. */
+            @WithDefault("5000")
+            int timeout();
+        }
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/BodyParserType.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/BodyParserType.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.gateway.fork.model;
+
+public enum BodyParserType {
+    JSON,
+    CSV
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkResult.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkResult.java
@@ -12,17 +12,17 @@ public record ForkResult(
         String key,
         List<String> dispatchedTargets
 ) {
-    public enum Outcome { forwarded, discarded, error }
+    public enum Outcome { FORWARDED, DISCARDED, ERROR }
 
     public static ForkResult forwarded(String ruleId, String key, List<String> targets) {
-        return new ForkResult(ruleId, Outcome.forwarded, key, List.copyOf(targets));
+        return new ForkResult(ruleId, Outcome.FORWARDED, key, List.copyOf(targets));
     }
 
     public static ForkResult discarded(String ruleId, String key) {
-        return new ForkResult(ruleId, Outcome.discarded, key, List.of());
+        return new ForkResult(ruleId, Outcome.DISCARDED, key, List.of());
     }
 
     public static ForkResult error(String ruleId, String key) {
-        return new ForkResult(ruleId, Outcome.error, key, List.of());
+        return new ForkResult(ruleId, Outcome.ERROR, key, List.of());
     }
 }

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkResult.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkResult.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.gateway.fork.model;
+
+import java.util.List;
+
+/**
+ * Outcome of processing one fork rule against an incoming request.
+ * Returned by ForkEngine.process() so callers can attach response headers.
+ */
+public record ForkResult(
+        String ruleId,
+        Outcome outcome,
+        String key,
+        List<String> dispatchedTargets
+) {
+    public enum Outcome { forwarded, discarded, error }
+
+    public static ForkResult forwarded(String ruleId, String key, List<String> targets) {
+        return new ForkResult(ruleId, Outcome.forwarded, key, List.copyOf(targets));
+    }
+
+    public static ForkResult discarded(String ruleId, String key) {
+        return new ForkResult(ruleId, Outcome.discarded, key, List.of());
+    }
+
+    public static ForkResult error(String ruleId, String key) {
+        return new ForkResult(ruleId, Outcome.error, key, List.of());
+    }
+}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkRule.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkRule.java
@@ -1,0 +1,21 @@
+package com.microboxlabs.miot.gateway.fork.model;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Resolved fork rule — built from ForkConfig at startup, immutable at runtime.
+ *
+ * <p>A rule matches one or more incoming paths, extracts a routing key from the
+ * request body using the specified parser, checks the key against the in-memory
+ * filter, and fans out matching requests to all configured targets.
+ */
+public record ForkRule(
+        String id,
+        boolean enabled,
+        List<String> paths,
+        BodyParserType bodyParser,
+        String keyField,
+        Optional<String> filterFile,
+        List<ForkTarget> targets
+) {}

--- a/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkTarget.java
+++ b/quarkus-srv/miot-gateway/src/main/java/com/microboxlabs/miot/gateway/fork/model/ForkTarget.java
@@ -1,0 +1,10 @@
+package com.microboxlabs.miot.gateway.fork.model;
+
+/**
+ * Resolved forward target — url is pre-built from mirrorHost + mirrorPath at startup.
+ */
+public record ForkTarget(
+        String id,
+        String url,
+        int timeout
+) {}

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -19,6 +19,7 @@
         <module>miot-fleet</module>
         <module>miot-driver</module>
         <module>miot-tracking</module>
+        <module>miot-gateway</module>
         <module>miot-cli</module>
     </modules>
 
@@ -67,6 +68,11 @@
             <dependency>
                 <groupId>com.microboxlabs.miot</groupId>
                 <artifactId>miot-tracking</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microboxlabs.miot</groupId>
+                <artifactId>miot-gateway</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/quarkus-srv/start.sh
+++ b/quarkus-srv/start.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # Extra Maven/Quarkus args can be appended after --:
 #   ./start.sh fleet -- -Dquarkus.http.port=9090
 
-KNOWN_COMPONENTS=(fleet driver tracking)
+KNOWN_COMPONENTS=(fleet driver tracking gateway)
 COMPONENTS=()
 EXTRA_ARGS=()
 PROFILE=""

--- a/turbo-repo/apps/docs/content/en/reference/architecture-decisions/_meta.ts
+++ b/turbo-repo/apps/docs/content/en/reference/architecture-decisions/_meta.ts
@@ -2,5 +2,6 @@ export default {
   index: 'Overview',
   'adr-001-sidebar-navigation-context': 'ADR-001: Sidebar Navigation Context',
   'adr-002-api-gateway-apisix': 'ADR-002: API Gateway — Apache APISIX',
-  'adr-003-dual-jwt-authentication': 'ADR-003: Dual JWT Authentication (HS256 + RS256)'
+  'adr-003-dual-jwt-authentication': 'ADR-003: Dual JWT Authentication (HS256 + RS256)',
+  'adr-004-tracking-persistence-modulith': 'ADR-004: Tracking Persistence Inside the Modulith'
 }

--- a/turbo-repo/apps/docs/content/en/reference/architecture-decisions/adr-004-tracking-persistence-modulith.mdx
+++ b/turbo-repo/apps/docs/content/en/reference/architecture-decisions/adr-004-tracking-persistence-modulith.mdx
@@ -1,0 +1,104 @@
+# ADR-004: Tracking Persistence Inside the Modulith
+
+| | |
+|---|---|
+| **Status** | Accepted |
+| **Date** | 2026-04-06 |
+| **Deciders** | Platform engineering team |
+| **Relates to** | `AssetTrackingProcessor`, `PulsarAssetTrackingConsumer`, `TrackingComponent` |
+
+## Context
+
+The `quarkus-subscriber-db-writer` microservice receives asset tracking messages from a Pulsar topic and persists them into PostgreSQL tables: `asset_data` (raw positions), `asset_data_client` (multi-tenant cross-references), `asset_metric_core/dtc/ext` (OBD2/J1939 telemetry), and an idempotency ledger. It also owns the `fn_latest_metrics` PostgreSQL functions used by the fleet dashboard.
+
+This service was the only consumer of the tracking module's Pulsar topic. It shares the same `gps-model` library and `EnvelopedMessage` contract. Its deployment as a separate service added operational overhead (separate container, separate Flyway history, separate database) without providing independent scaling or fault-isolation benefits in practice.
+
+Meanwhile, the ModularIoT modulith (`quarkus-srv`) already contained the tracking module (`miot-tracking`) which handles ingestion via `/api/v1/asset/track` and publishes to Pulsar. The modulith supports component-level activation via runtime configuration, enabling selective deployment of fleet, driver, and tracking capabilities.
+
+The question was: where should the persistence layer live?
+
+## Decision
+
+Consolidate the db-writer persistence into the existing `miot-tracking` module rather than creating a separate `miot-db-writer` module or keeping the standalone microservice.
+
+### Rationale
+
+1. **Tracking owns the full data lifecycle.** Receiving, publishing, and persisting asset positions are steps in the same domain pipeline. Splitting persistence into a separate module creates an artificial boundary where the deployment mode (standalone vs. distributed) is the only differentiator, not domain ownership.
+
+2. **Deployment mode is configuration, not module structure.** The modulith already distinguishes standalone (`miot.messaging.type=log`) from distributed (`miot.messaging.type=pulsar`) via build-time properties. Adding a write path is an implementation detail within that configuration axis, not a reason for a new Maven module.
+
+3. **Single database simplifies operations.** Writing to the primary `miot` database (under a `miot_tracking` schema) eliminates the need for a second datasource, a second Flyway history, and cross-database query concerns. The `LatestMetricsRepository` in `miot-fleet` reads from the same database via schema-qualified functions.
+
+### Dual-mode consumer architecture
+
+The persistence layer activates through mutually exclusive paths:
+
+**Standalone mode** (`miot.messaging.type=log`):
+- `PulsarAssetTrackingService` publishes the `EnvelopedMessage` to `IComponentBus` after logging
+- `TrackingComponent.onStart()` subscribes to the bus channel and delegates to `AssetTrackingProcessor`
+- Data is persisted synchronously in the same JVM, no external broker needed
+
+**Distributed mode** (`miot.messaging.type=pulsar`):
+- `PulsarAssetTrackingService` publishes to Pulsar via `PulsarMessagePublisher`
+- `PulsarAssetTrackingConsumer` (activated by `@IfBuildProperty`) receives from the topic on a daemon thread
+- The bus subscriber is not registered, preventing duplicate processing
+
+Both paths converge on `AssetTrackingProcessor`, which executes the same 3-step pipeline:
+1. Insert into `miot_tracking.asset_data`
+2. Cross-reference `asset_client_map` and insert into `asset_data_client` (within a transaction)
+3. Check idempotency via `ingest_ledger_metrics`, then insert metrics into `asset_metric_core/dtc/ext`
+
+### Repository design: raw PgPool, not Panache
+
+The persistence repositories use Vert.x `Pool` with prepared queries instead of Hibernate Reactive Panache. This was driven by the table characteristics:
+
+- **Composite primary keys** (`shared_client_id, asset_id, ts`) which Panache does not support natively
+- **PostGIS geography columns** requiring `ST_GeographyFromText()` in SQL
+- **Monthly partitioned tables** managed by pg_partman
+- **36-parameter insert statements** with type-specific tuple building (Short, Integer, Long, Boolean, OffsetDateTime, JsonObject)
+- **Write-only, append-only access patterns** with no update/find/delete operations
+
+### Database schema
+
+All tables live under the `miot_tracking` schema in the primary `miot` database, created by consolidated Flyway migrations V0.5.0 through V0.5.4:
+
+| Table | Purpose | Partitioning |
+|---|---|---|
+| `asset_data` | Raw position/telemetry (one row per message) | None |
+| `asset_data_client` | Multi-tenant cross-reference | Monthly by timestamp |
+| `asset_client_map` | Asset-to-client mapping configuration | None |
+| `asset_metric_core` | Core OBD2/J1939 metrics | Monthly by ts |
+| `asset_metric_dtc` | Diagnostic trouble codes | Monthly by ts |
+| `asset_metric_ext` | Extension metrics (x.* keys, bounded JSONB) | Monthly by ts |
+| `ingest_ledger_metrics` | Idempotency ledger | None |
+
+`fn_latest_metrics` and `fn_latest_metrics_batch` provide efficient latest-snapshot lookups for fleet dashboard views.
+
+### Flyway for subset deployments
+
+The `FlywayMigrator` conditionally includes migration locations based on active components. When running a subset (e.g., only tracking), previously applied migrations from other modules (fleet V0.2.x, driver V0.4.x) are missing from the classpath. The migrator uses `ignoreMigrationPatterns("*:missing")` to tolerate this without failing validation.
+
+## Consequences
+
+**Positive:**
+- One fewer service to deploy, monitor, and maintain
+- Single database with schema isolation (`miot_tracking`) instead of a separate `prod_iot_gps` database
+- `LatestMetricsRepository` reads from the same datasource as all other modulith queries
+- The dual-mode pattern (bus vs. Pulsar) is reusable for future consumer workloads
+
+**Negative:**
+- The tracking module is now larger (persistence + consumer + 5 migrations)
+- Cannot independently scale the write path without deploying the full modulith image
+- pg_partman and PostGIS become hard dependencies of the modulith database
+
+**Risks:**
+- High write throughput on `asset_metric_core` could pressure the shared primary database; mitigation is the pg_partman monthly partitioning and the `ON CONFLICT DO NOTHING` idempotency on all inserts
+- The `quarkus-subscriber-db-writer` must remain operational until all production traffic is migrated
+
+## Alternatives considered
+
+1. **New `miot-db-writer` module** in the modulith — Rejected because it creates a module boundary where the only differentiator is deployment mode, not domain ownership.
+
+2. **Keep standalone microservice** — Rejected because it adds operational overhead without scaling or isolation benefits that justify the cost.
+
+3. **Panache entities for the tracking tables** — Rejected due to composite primary keys, PostGIS types, partitioned tables, and write-only access patterns that don't benefit from an ORM abstraction.


### PR DESCRIPTION
Closes #240

## Summary

- Introduces `miot-gateway` as a new modulith component — a routing gateway that receives APISIX `proxy-mirror` traffic and conditionally fans out requests to upstream targets based on **request body content** (something APISIX cannot do natively)
- Implements a **fork engine** with multi-rule, multi-target configuration, in-memory asset filtering, and file-based filter loading (K8s ConfigMap-friendly)
- Fixes a pre-existing CI path bug where `docker/build-push-action` used the wrong build context after artifact download

## What's in this PR

### `miot-gateway` module

| Component | Description |
|---|---|
| `GatewayComponent` | `IMiotComponent` lifecycle, priority 300, `@LookupIfProperty` gated |
| `ForkConfig` | `@ConfigMapping(prefix="fork")` — typed multi-rule/multi-target config |
| `ForkEngine` | Path index, JSON/CSV key extraction, in-memory filter check, `HttpClient.sendAsync` fan-out, pre-built Micrometer meters |
| `ForkFilterRegistry` | `ConcurrentHashMap` filter per rule, atomic file reload, Micrometer gauge |
| `ForkMirrorResource` | Catch-all `POST /{path}` — returns `X-Fork-*` response headers for traceability |
| `ForkManagementResource` | `GET/POST/DELETE /internal/fork/rules/**` — inspect, add, remove, reload filter keys at runtime |

### Metrics

```
fork_requests_total{rule, target, outcome=forwarded|discarded|error}
fork_forward_duration_seconds{rule, target}
fork_filter_size{rule}
```

### Response headers (every mirrored request)

```
X-Fork-Rule: asset-track-canary
X-Fork-Outcome: forwarded
X-Fork-Key: TTBJ72
X-Fork-Targets: storm
```

### Other changes

- **`FlywayMigrator`**: skip migration when no DB-dependent component is enabled — fixes startup crash for gateway-only deployments
- **CI**: fix Docker build `context: quarkus-srv` / `file: quarkus-srv/Dockerfile` — artifact download preserves `quarkus-srv/` path prefix, previous `context: .` caused COPY failures
- **`quarkus-srv/README.md`**: gateway added to module list, endpoints table, activation examples
- **`miot-gateway/README.md`**: getting started, full config reference, management API, filter file format, metrics, body parser docs

## Test plan

- [ ] `./start.sh gateway` starts cleanly with no DB errors
- [ ] `POST /v1/asset/track` with matching asset ID → `X-Fork-Outcome: forwarded`, storm receives request
- [ ] `POST /v1/asset/track` with unknown asset ID → `X-Fork-Outcome: discarded`
- [ ] `GET /internal/fork/rules` returns rule list with filter size
- [ ] `POST /internal/fork/rules/{id}/filter` adds keys; `DELETE` removes them
- [ ] `POST /internal/fork/rules/{id}/filter/reload` reloads from file atomically
- [ ] `GET /q/metrics` exposes `fork_*` counters and gauge
- [ ] CI Docker build completes (context path fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gateway routing component: mirror endpoint, JSON/CSV body parsing, in-memory filter support, per-rule metrics, and management APIs for rules/filters; gateway can run without a database.
  * Tracking API: GPS ingestion endpoint for asset tracking.

* **Documentation**
  * Expanded READMEs, quick-starts, ADR and refs covering gateway usage, fork-rule format, deployment, APIs, metrics, and tracking persistence.

* **Chores**
  * CI/build and startup script updated to include the gateway and adjust Docker/scan handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->