### PR TITLE
feat: add "open in same tab" option for dashboard dashlet view-more l…

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Label } from "flowbite-react";
+import { Label, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import {
   type DashletConfig,
@@ -68,6 +68,7 @@ export function DashletSettings({
   const [verMasUrl, setVerMasUrl] = useState(
     config.verMasUrl ?? defaultConfig.verMasUrl
   );
+  const [openInSameTab, setOpenInSameTab] = useState(config.openInSameTab ?? false);
   const [label, setLabel] = useState(config.label ?? defaultConfig.label);
   const [borderColor, setBorderColor] = useState<LabelBorderColor>(
     config.borderColor ?? defaultConfig.borderColor ?? "gray"
@@ -101,6 +102,7 @@ export function DashletSettings({
     setName(config.name ?? defaultConfig.name);
     setDescription(config.description ?? defaultConfig.description);
     setVerMasUrl(config.verMasUrl ?? defaultConfig.verMasUrl);
+    setOpenInSameTab(config.openInSameTab ?? false);
     setLabel(config.label ?? defaultConfig.label);
     setBorderColor(config.borderColor ?? defaultConfig.borderColor ?? "gray");
     setDataMode(config.dataMode || "static");
@@ -115,6 +117,7 @@ export function DashletSettings({
       name: name?.trim() || tr("dashboard.defaults.untitled", dictionary),
       description: description?.trim() || "",
       verMasUrl: verMasUrl?.trim() || "",
+      openInSameTab,
       label: label?.trim() || tr("dashboard.defaults.group", dictionary),
       borderColor,
       // Data fields
@@ -201,6 +204,14 @@ export function DashletSettings({
             onChange={setVerMasUrl}
             placeholder="https://example.com"
           />
+          {verMasUrl && (
+            <div className="flex items-center justify-between">
+              <Label className="text-sm">
+                {tr("dashboard.settings.openInSameTab", dictionary)}
+              </Label>
+              <ToggleSwitch checked={openInSameTab} onChange={setOpenInSameTab} />
+            </div>
+          )}
         </>
       ) : (
         <>

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.tsx
@@ -315,9 +315,9 @@ export function Dashlet({
   const handleVerMasClick = () => {
     if (config.verMasUrl) {
       if (config.openInSameTab) {
-        window.location.href = config.verMasUrl;
+        globalThis.location.href = config.verMasUrl;
       } else {
-        window.open(config.verMasUrl, "_blank", "noopener,noreferrer");
+        globalThis.open(config.verMasUrl, "_blank", "noopener,noreferrer");
       }
     }
   };

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.tsx
@@ -77,6 +77,8 @@ export interface DashletConfig {
   description?: string;
   /** URL for "Ver más" button in bento-box variant */
   verMasUrl?: string;
+  /** Whether to open the "Ver más" link in the same tab instead of a new one */
+  openInSameTab?: boolean;
 
   // Labeled Group specific fields
   /** Label text for labeled-group variant */
@@ -312,7 +314,11 @@ export function Dashlet({
 
   const handleVerMasClick = () => {
     if (config.verMasUrl) {
-      window.open(config.verMasUrl, "_blank", "noopener,noreferrer");
+      if (config.openInSameTab) {
+        window.location.href = config.verMasUrl;
+      } else {
+        window.open(config.verMasUrl, "_blank", "noopener,noreferrer");
+      }
     }
   };
 

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/info_card/dashlet.settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { Label, ToggleSwitch } from "flowbite-react";
 import type { DashletSettingsProps } from "../types";
 import type { DashletConfig, InfoCardIcon } from "./dashlet";
 import { ICON_OPTIONS } from "./dashlet";
@@ -62,6 +63,7 @@ export function DashletSettings({
     config.aiPlaceholder || "AI summary will appear here"
   );
   const [viewMoreUrl, setViewMoreUrl] = useState(config.viewMoreUrl || "");
+  const [openInSameTab, setOpenInSameTab] = useState(config.openInSameTab ?? false);
   const [dataMode, setDataMode] = useState<SimpleDataMode>(
     config.dataMode === "static" || config.dataMode === "pgrest" || config.dataMode === "planner"
       ? config.dataMode
@@ -79,17 +81,18 @@ export function DashletSettings({
       .dataProvider || DEFAULT_DATA_ENTRIES
   );
 
-  const staticSnapshot = useRef({ title, value, descriptor, aiPlaceholder, viewMoreUrl });
+  const staticSnapshot = useRef({ title, value, descriptor, aiPlaceholder, viewMoreUrl, openInSameTab });
 
   const handleDataModeChange = (mode: SimpleDataMode) => {
     if (isRemoteDataMode(mode) && dataMode === "static") {
-      staticSnapshot.current = { title, value, descriptor, aiPlaceholder, viewMoreUrl };
+      staticSnapshot.current = { title, value, descriptor, aiPlaceholder, viewMoreUrl, openInSameTab };
     } else if (mode === "static" && isRemoteDataMode(dataMode)) {
       setTitle(staticSnapshot.current.title);
       setValue(staticSnapshot.current.value);
       setDescriptor(staticSnapshot.current.descriptor);
       setAiPlaceholder(staticSnapshot.current.aiPlaceholder);
       setViewMoreUrl(staticSnapshot.current.viewMoreUrl);
+      setOpenInSameTab(staticSnapshot.current.openInSameTab);
     }
     setDataMode(mode);
   };
@@ -115,6 +118,7 @@ export function DashletSettings({
       descriptor,
       aiPlaceholder,
       viewMoreUrl,
+      openInSameTab,
       dataProvider: dp.getCleanEntries(),
       dataMode,
       pgrestFunctionName: pg.pgrestFunctionName,
@@ -184,6 +188,14 @@ export function DashletSettings({
         onChange={setViewMoreUrl}
         placeholder="https://example.com/details"
       />
+      {viewMoreUrl && (
+        <div className="flex items-center justify-between">
+          <Label className="text-sm">
+            {tr("dashboard.settings.openInSameTab", dictionary)}
+          </Label>
+          <ToggleSwitch checked={openInSameTab} onChange={setOpenInSameTab} />
+        </div>
+      )}
     </>
   );
 

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/info_card/dashlet.tsx
@@ -83,6 +83,8 @@ export interface DashletConfig extends PgrestDashletFields {
   aiPlaceholder: string;
   /** Optional URL for "View more" button */
   viewMoreUrl: string;
+  /** Whether to open the "View more" link in the same tab instead of a new one */
+  openInSameTab?: boolean;
   /** Data provider entries for dynamic values */
   dataProvider?: DataProviderEntry[];
 }
@@ -156,7 +158,11 @@ export function Dashlet({
       try {
         const url = new URL(compiledViewMoreUrl, globalThis.location.href);
         if (url.protocol === "http:" || url.protocol === "https:") {
-          globalThis.open(compiledViewMoreUrl, "_blank", "noopener,noreferrer");
+          if (config.openInSameTab) {
+            globalThis.location.href = url.href;
+          } else {
+            globalThis.open(compiledViewMoreUrl, "_blank", "noopener,noreferrer");
+          }
         }
       } catch {
         // Invalid URL, do nothing

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1532,6 +1532,7 @@
       "descriptor": "Descriptor",
       "aiPlaceholder": "AI Placeholder",
       "viewMoreUrl": "View More URL (optional)",
+      "openInSameTab": "Open in same tab",
       "key": "Key",
       "addEntry": "+ Add Entry",
       "dynamicValuesHint": "Use {code} syntax for dynamic values",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1557,6 +1557,7 @@
       "descriptor": "Descriptor",
       "aiPlaceholder": "Texto IA",
       "viewMoreUrl": "URL Ver Más (opcional)",
+      "openInSameTab": "Abrir en la misma pestaña",
       "key": "Clave",
       "addEntry": "+ Agregar Entrada",
       "dynamicValuesHint": "Usa la sintaxis {code} para valores dinámicos",


### PR DESCRIPTION
…inks

- Add openInSameTab toggle to container and info_card dashlet settings
- Conditionally use window.location.href instead of window.open when enabled
- Show toggle only when a view-more URL is configured
- Add i18n keys for the new setting in en.json and es.json