### PR TITLE
feat: add Handlebars helper registration system for dashboard templates

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/HANDLEBARS_HELPERS.md
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/HANDLEBARS_HELPERS.md
@@ -1,0 +1,270 @@
+# Handlebars Helpers Reference
+
+Custom helpers available in all dashboard dashlet templates (info cards, stat cards, text cards, data tables, etc.).
+
+---
+
+## Number Helpers
+
+### `formatNumber`
+
+Formats a number using locale-aware formatting (`Intl.NumberFormat`).
+
+```handlebars
+{{formatNumber value}}
+{{formatNumber value decimals=2}}
+{{formatNumber value decimals=1 locale="en-US"}}
+{{formatNumber value prefix="$" suffix=" CLP"}}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `decimals` | number | auto | Fixed number of decimal places |
+| `locale` | string | `es-CL` | Locale for formatting (thousands/decimal separators) |
+| `prefix` | string | `""` | Text prepended to the result |
+| `suffix` | string | `""` | Text appended to the result |
+
+**Examples:**
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{formatNumber row.temp}}` | `25.678` | `25,678` |
+| `{{formatNumber row.temp decimals=1}}` | `25.678` | `25,7` |
+| `{{formatNumber row.temp decimals=2 locale="en-US"}}` | `25.678` | `25.68` |
+| `{{formatNumber row.price prefix="$"}}` | `1500` | `$1.500` |
+| `{{formatNumber row.temp decimals=1 suffix="C"}}` | `25.678` | `25,7C` |
+
+> **Note:** With locale `es-CL`, the thousands separator is `.` and the decimal separator is `,`.
+
+---
+
+### `extractNumber`
+
+Extracts the first number found in a text string. Useful when sensor data comes with units attached.
+
+```handlebars
+{{extractNumber value}}
+```
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{extractNumber row.reading}}` | `"25.5 kg"` | `25.5` |
+| `{{extractNumber row.reading}}` | `"-10 C"` | `-10` |
+| `{{extractNumber row.reading}}` | `"1,5 bar"` | `1,5` |
+| `{{extractNumber row.reading}}` | `"no numbers"` | `-` |
+
+---
+
+### `toFixed`
+
+Rounds a number to a fixed number of decimal places (no locale formatting, uses `.` as decimal separator).
+
+```handlebars
+{{toFixed value decimals}}
+```
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{toFixed row.temp 2}}` | `25.678` | `25.68` |
+| `{{toFixed row.temp 0}}` | `25.678` | `26` |
+| `{{toFixed row.temp 4}}` | `25.6` | `25.6000` |
+
+---
+
+### `round`
+
+Rounds a number to the nearest integer.
+
+```handlebars
+{{round value}}
+```
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{round row.temp}}` | `25.6` | `26` |
+| `{{round row.temp}}` | `25.4` | `25` |
+
+---
+
+### `multiply`
+
+Multiplies a value by a factor. Common use: converting ratios to percentages.
+
+```handlebars
+{{multiply value factor}}
+```
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{multiply row.ratio 100}}%` | `0.85` | `85%` |
+| `{{multiply row.value 2}}` | `50` | `100` |
+
+---
+
+### `divide`
+
+Divides a value by a divisor. Returns `-` if divisor is zero.
+
+```handlebars
+{{divide value divisor}}
+```
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{divide row.bytes 1024}} KB` | `2048` | `2 KB` |
+| `{{divide row.total 3}}` | `9` | `3` |
+| `{{divide row.value 0}}` | `10` | `-` |
+
+---
+
+## Date Helpers
+
+### `formatDate`
+
+Formats a date string using locale-aware formatting (`Intl.DateTimeFormat`).
+
+```handlebars
+{{formatDate value}}
+{{formatDate value format="date"}}
+{{formatDate value format="time"}}
+{{formatDate value format="relative"}}
+{{formatDate value format="date" locale="en-US" timezone="UTC"}}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `format` | string | `datetime` | One of: `date`, `time`, `datetime`, `relative` |
+| `locale` | string | `es-CL` | Locale for formatting |
+| `timezone` | string | `America/Santiago` | IANA timezone |
+
+**Format modes:**
+
+| Format | Description | Example Output |
+|--------|-------------|----------------|
+| `date` | Date only (DD-MM-YYYY) | `15-06-2025` |
+| `time` | Time only (HH:MM, 24h) | `14:30` |
+| `datetime` | Full date and time | `15-06-2025, 14:30` |
+| `relative` | Human-readable relative time | `3h`, `2d`, `15 jun` |
+
+**Examples:**
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{formatDate row.created_at format="date"}}` | `"2025-06-15T14:30:00Z"` | `15-06-2025` |
+| `{{formatDate row.created_at format="time"}}` | `"2025-06-15T14:30:00Z"` | `10:30` |
+| `{{formatDate row.created_at format="relative"}}` | *(3 hours ago)* | `3h` |
+| `{{formatDate row.created_at}}` | `"2025-06-15T14:30:00Z"` | `15-06-2025, 10:30` |
+
+> **Note:** Times are converted to the `America/Santiago` timezone by default.
+
+---
+
+### `datePart`
+
+Extracts a specific part from a date.
+
+```handlebars
+{{datePart value "part"}}
+```
+
+| Part | Description | Example Output |
+|------|-------------|----------------|
+| `year` | Four-digit year | `2025` |
+| `month` | Two-digit month | `06` |
+| `day` | Two-digit day | `15` |
+| `hour` | Two-digit hour (24h) | `10` |
+| `minute` | Two-digit minute | `30` |
+| `weekday` | Full weekday name | `domingo` |
+
+**Examples:**
+
+| Template | Data | Output |
+|----------|------|--------|
+| `{{datePart row.created_at "year"}}` | `"2025-06-15T14:30:00Z"` | `2025` |
+| `{{datePart row.created_at "month"}}` | `"2025-06-15T14:30:00Z"` | `06` |
+| `{{datePart row.created_at "day"}}` | `"2025-06-15T14:30:00Z"` | `15` |
+| `{{datePart row.created_at "weekday"}}` | `"2025-06-15T14:30:00Z"` | `domingo` |
+
+> **Note:** Weekday names are returned in the default locale (`es-CL`), so they appear in Spanish.
+
+---
+
+### `timeAgo`
+
+Returns a human-readable "time ago" string.
+
+```handlebars
+{{timeAgo value}}
+```
+
+| Time Difference | Output |
+|-----------------|--------|
+| < 1 minute | `just now` |
+| 5 minutes | `5m ago` |
+| 2 hours | `2h ago` |
+| 3 days | `3d ago` |
+| 2 months | `2mo ago` |
+| 1 year | `1y ago` |
+| Future dates | `5m from now` |
+
+**Examples:**
+
+| Template | Output |
+|----------|--------|
+| `{{timeAgo row.last_seen}}` | `5m ago` |
+| `{{timeAgo row.created_at}}` | `3d ago` |
+
+---
+
+## Combining Helpers
+
+Helpers can be mixed with plain text and other Handlebars expressions in the same template:
+
+```handlebars
+{{formatNumber row.temperature decimals=1}}C at {{formatDate row.timestamp format="time"}}
+```
+Output: `25,7C at 14:30`
+
+```handlebars
+Last reading: {{formatNumber row.value decimals=2}} ({{timeAgo row.updated_at}})
+```
+Output: `Last reading: 42,50 (5m ago)`
+
+```handlebars
+{{datePart row.created_at "day"}}/{{datePart row.created_at "month"}}/{{datePart row.created_at "year"}}
+```
+Output: `15/06/2025`
+
+---
+
+## Error Handling
+
+All helpers return `-` when the input is `null`, `undefined`, empty, or invalid:
+
+| Scenario | Output |
+|----------|--------|
+| `{{formatNumber row.missing}}` | `-` |
+| `{{formatDate row.missing}}` | `-` |
+| `{{formatNumber "abc"}}` | `-` |
+| `{{formatDate "not-a-date"}}` | `-` |
+| `{{divide row.value 0}}` | `-` |
+
+---
+
+## Data Sources
+
+Helpers work with any value in the template context:
+
+```handlebars
+{{!-- From database row --}}
+{{formatNumber row.temperature decimals=1}}
+
+{{!-- From data provider --}}
+{{formatNumber data_provider.sensor_value decimals=2}}
+
+{{!-- From filter --}}
+{{formatDate filter.start_date format="date"}}
+
+{{!-- Direct root property --}}
+{{formatNumber temperature decimals=1}}
+```

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/handlebars-helpers.test.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/handlebars-helpers.test.ts
@@ -71,6 +71,24 @@ describe("getHandlebarsStatus", () => {
   it('returns "invalid" for disallowed characters', () => {
     expect(getHandlebarsStatus("{{na$me}}")).toBe("invalid");
   });
+
+  it('returns "valid" for helper with hash arguments', () => {
+    expect(
+      getHandlebarsStatus("{{formatNumber row.temp decimals=2}}")
+    ).toBe("valid");
+  });
+
+  it('returns "valid" for helper with quoted string argument', () => {
+    expect(
+      getHandlebarsStatus('{{formatDate row.created_at format="date"}}')
+    ).toBe("valid");
+  });
+
+  it('returns "valid" for helper with positional string argument', () => {
+    expect(
+      getHandlebarsStatus('{{datePart row.created_at "year"}}')
+    ).toBe("valid");
+  });
 });
 
 describe("getFlowbiteColor", () => {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/handlebars-helpers.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/handlebars-helpers.ts
@@ -8,7 +8,7 @@ export type HandlebarsStatus = "valid" | "invalid" | "none";
 
 /** Allowed characters inside a Handlebars expression. */
 const ALLOWED_INNER_CHARS = new Set(
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ \t.#/^>@!-"
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ \t.#/^>@!-\"'()=,"
 );
 
 /** Extract `{{…}}` expressions from text without regex. */

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -97,6 +97,7 @@ export {
   resolveHandlebarsField,
   buildDataProviderContext,
 } from "./use-handlebars-templates";
+export { registerHandlebarsHelpers } from "./register-handlebars-helpers";
 export { SuggestionInput } from "./suggestion-input";
 export { useCompiledColumns } from "./use-compiled-columns";
 export {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.test.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+import Handlebars from "handlebars";
+import {
+  formatNumberHelper,
+  extractNumberHelper,
+  toFixedHelper,
+  roundHelper,
+  multiplyHelper,
+  divideHelper,
+  formatDateHelper,
+  datePartHelper,
+  timeAgoHelper,
+} from "./register-handlebars-helpers";
+
+// ============================================================================
+// Helpers to build a mock Handlebars options object
+// ============================================================================
+
+function opts(hash: Record<string, unknown> = {}): Handlebars.HelperOptions {
+  return { hash } as Handlebars.HelperOptions;
+}
+
+// ============================================================================
+// Number helpers — unit tests
+// ============================================================================
+
+describe("formatNumberHelper", () => {
+  it("formats a number with default locale", () => {
+    const result = formatNumberHelper.call({}, 1234.5, opts());
+    expect(result).toContain("1");
+  });
+
+  it("formats with decimals option", () => {
+    const result = formatNumberHelper.call({}, 25.678, opts({ decimals: 2 }));
+    // es-CL uses comma as decimal separator
+    expect(result).toMatch(/25[,.]68/);
+  });
+
+  it("adds prefix and suffix", () => {
+    const result = formatNumberHelper.call(
+      {},
+      100,
+      opts({ prefix: "$", suffix: " USD" })
+    );
+    expect(result).toMatch(/^\$.*100.* USD$/);
+  });
+
+  it("returns fallback for null", () => {
+    expect(formatNumberHelper.call({}, null, opts())).toBe("-");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(formatNumberHelper.call({}, undefined, opts())).toBe("-");
+  });
+
+  it("returns fallback for non-numeric string", () => {
+    expect(formatNumberHelper.call({}, "abc", opts())).toBe("-");
+  });
+
+  it("formats string number", () => {
+    const result = formatNumberHelper.call({}, "42.5", opts({ decimals: 1 }));
+    expect(result).toMatch(/42[,.]5/);
+  });
+});
+
+describe("extractNumberHelper", () => {
+  it('extracts number from "25.5 kg"', () => {
+    expect(extractNumberHelper("25.5 kg")).toBe("25.5");
+  });
+
+  it('extracts negative number from "-10 C"', () => {
+    expect(extractNumberHelper("-10 C")).toBe("-10");
+  });
+
+  it('extracts number with comma from "1,5 bar"', () => {
+    expect(extractNumberHelper("1,5 bar")).toBe("1,5");
+  });
+
+  it("returns fallback for text without numbers", () => {
+    expect(extractNumberHelper("no numbers")).toBe("-");
+  });
+
+  it("returns fallback for null", () => {
+    expect(extractNumberHelper(null)).toBe("-");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(extractNumberHelper(undefined)).toBe("-");
+  });
+});
+
+describe("toFixedHelper", () => {
+  it("formats to 2 decimal places", () => {
+    expect(toFixedHelper(25.678, 2)).toBe("25.68");
+  });
+
+  it("formats to 0 decimal places by default", () => {
+    expect(toFixedHelper(25.678, undefined)).toBe("26");
+  });
+
+  it("returns fallback for null", () => {
+    expect(toFixedHelper(null, 2)).toBe("-");
+  });
+});
+
+describe("roundHelper", () => {
+  it("rounds up", () => {
+    expect(roundHelper(25.6)).toBe("26");
+  });
+
+  it("rounds down", () => {
+    expect(roundHelper(25.4)).toBe("25");
+  });
+
+  it("returns fallback for null", () => {
+    expect(roundHelper(null)).toBe("-");
+  });
+});
+
+describe("multiplyHelper", () => {
+  it("multiplies two numbers", () => {
+    expect(Number(multiplyHelper(0.678, 100))).toBeCloseTo(67.8);
+  });
+
+  it("returns fallback when value is null", () => {
+    expect(multiplyHelper(null, 100)).toBe("-");
+  });
+
+  it("returns fallback when factor is null", () => {
+    expect(multiplyHelper(10, null)).toBe("-");
+  });
+});
+
+describe("divideHelper", () => {
+  it("divides two numbers", () => {
+    expect(divideHelper(1024, 1024)).toBe("1");
+  });
+
+  it("returns fallback for zero divisor", () => {
+    expect(divideHelper(10, 0)).toBe("-");
+  });
+
+  it("returns fallback for null", () => {
+    expect(divideHelper(null, 10)).toBe("-");
+  });
+});
+
+// ============================================================================
+// Date helpers — unit tests
+// ============================================================================
+
+describe("formatDateHelper", () => {
+  const iso = "2025-06-15T14:30:00Z";
+
+  it("formats as date", () => {
+    const result = formatDateHelper.call({}, iso, opts({ format: "date" }));
+    expect(result).toContain("15");
+    expect(result).toContain("2025");
+  });
+
+  it("formats as time", () => {
+    const result = formatDateHelper.call({}, iso, opts({ format: "time" }));
+    expect(result).toMatch(/\d{2}:\d{2}/);
+  });
+
+  it("formats as datetime (default)", () => {
+    const result = formatDateHelper.call({}, iso, opts());
+    expect(result).toContain("2025");
+    expect(result).toMatch(/\d{2}:\d{2}/);
+  });
+
+  it("formats as relative for recent date", () => {
+    const recent = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    const result = formatDateHelper.call({}, recent, opts({ format: "relative" }));
+    expect(result).toBe("3h");
+  });
+
+  it("returns fallback for null", () => {
+    expect(formatDateHelper.call({}, null, opts())).toBe("-");
+  });
+
+  it("returns fallback for invalid date", () => {
+    expect(formatDateHelper.call({}, "not-a-date", opts())).toBe("-");
+  });
+});
+
+describe("datePartHelper", () => {
+  const iso = "2025-06-15T14:30:00Z";
+
+  it("extracts year", () => {
+    expect(datePartHelper(iso, "year")).toBe("2025");
+  });
+
+  it("extracts month", () => {
+    expect(datePartHelper(iso, "month")).toMatch(/^0?6$/);
+  });
+
+  it("extracts day", () => {
+    expect(datePartHelper(iso, "day")).toMatch(/^1[45]$/);
+  });
+
+  it("extracts weekday", () => {
+    const result = datePartHelper(iso, "weekday");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe("-");
+  });
+
+  it("returns fallback for unknown part", () => {
+    expect(datePartHelper(iso, "unknown")).toBe("-");
+  });
+
+  it("returns fallback for null value", () => {
+    expect(datePartHelper(null, "year")).toBe("-");
+  });
+});
+
+describe("timeAgoHelper", () => {
+  it("returns 'just now' for current time", () => {
+    expect(timeAgoHelper(new Date().toISOString())).toBe("just now");
+  });
+
+  it("returns minutes ago", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(timeAgoHelper(fiveMinAgo)).toBe("5m ago");
+  });
+
+  it("returns hours ago", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    expect(timeAgoHelper(twoHoursAgo)).toBe("2h ago");
+  });
+
+  it("returns days ago", () => {
+    const threeDaysAgo = new Date(
+      Date.now() - 3 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    expect(timeAgoHelper(threeDaysAgo)).toBe("3d ago");
+  });
+
+  it("returns fallback for null", () => {
+    expect(timeAgoHelper(null)).toBe("-");
+  });
+});
+
+// ============================================================================
+// Integration tests — compile + resolve templates with helpers
+// ============================================================================
+
+describe("Handlebars integration", () => {
+  it("formatNumber in template", () => {
+    const tpl = Handlebars.compile(
+      "Temp: {{formatNumber row.temperature decimals=1}}"
+    );
+    const result = tpl({ row: { temperature: 25.678 } });
+    expect(result).toMatch(/Temp: 25[,.]7/);
+  });
+
+  it("extractNumber in template", () => {
+    const tpl = Handlebars.compile("{{extractNumber row.reading}}");
+    expect(tpl({ row: { reading: "120 rpm" } })).toBe("120");
+  });
+
+  it("toFixed in template", () => {
+    const tpl = Handlebars.compile("{{toFixed row.value 2}}");
+    expect(tpl({ row: { value: 3.14159 } })).toBe("3.14");
+  });
+
+  it("round in template", () => {
+    const tpl = Handlebars.compile("{{round row.value}}");
+    expect(tpl({ row: { value: 3.7 } })).toBe("4");
+  });
+
+  it("multiply in template", () => {
+    const tpl = Handlebars.compile("{{multiply row.ratio 100}}%");
+    expect(tpl({ row: { ratio: 0.85 } })).toBe("85%");
+  });
+
+  it("divide in template", () => {
+    const tpl = Handlebars.compile("{{divide row.bytes 1024}} KB");
+    expect(tpl({ row: { bytes: 2048 } })).toBe("2 KB");
+  });
+
+  it("formatDate in template", () => {
+    const tpl = Handlebars.compile(
+      '{{formatDate row.created_at format="date"}}'
+    );
+    const result = tpl({ row: { created_at: "2025-06-15T14:30:00Z" } });
+    expect(result).toContain("15");
+    expect(result).toContain("2025");
+  });
+
+  it("datePart in template", () => {
+    const tpl = Handlebars.compile('{{datePart row.created_at "year"}}');
+    expect(tpl({ row: { created_at: "2025-06-15T14:30:00Z" } })).toBe("2025");
+  });
+
+  it("timeAgo in template", () => {
+    const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const tpl = Handlebars.compile("{{timeAgo row.ts}}");
+    expect(tpl({ row: { ts: recent } })).toBe("5m ago");
+  });
+
+  it("handles missing value gracefully", () => {
+    const tpl = Handlebars.compile("{{formatNumber row.missing decimals=2}}");
+    expect(tpl({ row: {} })).toBe("-");
+  });
+
+  it("combines multiple helpers", () => {
+    const tpl = Handlebars.compile(
+      '{{formatNumber row.temp decimals=1}}°C at {{formatDate row.ts format="time"}}'
+    );
+    const result = tpl({
+      row: { temp: 25.678, ts: "2025-06-15T14:30:00Z" },
+    });
+    expect(result).toMatch(/25[,.]7°C at \d{2}:\d{2}/);
+  });
+});

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.ts
@@ -1,0 +1,241 @@
+import Handlebars from "handlebars";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_LOCALE = "es-CL";
+const DEFAULT_TIMEZONE = "America/Santiago";
+const FALLBACK = "-";
+
+// ============================================================================
+// Internal utilities
+// ============================================================================
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return isNaN(n) ? null : n;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  const d = new Date(value as string | number);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// ============================================================================
+// Number helpers
+// ============================================================================
+
+export function formatNumberHelper(
+  this: unknown,
+  value: unknown,
+  options: Handlebars.HelperOptions
+): string {
+  const n = toNumber(value);
+  if (n === null) return FALLBACK;
+
+  const hash = options?.hash ?? {};
+  const locale: string = hash.locale ?? DEFAULT_LOCALE;
+  const decimals: number | undefined =
+    hash.decimals !== undefined ? Number(hash.decimals) : undefined;
+  const prefix: string = hash.prefix ?? "";
+  const suffix: string = hash.suffix ?? "";
+
+  const formatOptions: Intl.NumberFormatOptions = {};
+  if (decimals !== undefined) {
+    formatOptions.minimumFractionDigits = decimals;
+    formatOptions.maximumFractionDigits = decimals;
+  }
+
+  const formatted = new Intl.NumberFormat(locale, formatOptions).format(n);
+  return `${prefix}${formatted}${suffix}`;
+}
+
+export function extractNumberHelper(value: unknown): string {
+  if (value === null || value === undefined) return FALLBACK;
+  const str = String(value);
+  const match = /[-+]?\d+([.,]\d+)?/.exec(str);
+  return match ? match[0] : FALLBACK;
+}
+
+export function toFixedHelper(value: unknown, decimals: unknown): string {
+  const n = toNumber(value);
+  if (n === null) return FALLBACK;
+  const d = toNumber(decimals);
+  return n.toFixed(d !== null ? d : 0);
+}
+
+export function roundHelper(value: unknown): string {
+  const n = toNumber(value);
+  if (n === null) return FALLBACK;
+  return String(Math.round(n));
+}
+
+export function multiplyHelper(value: unknown, factor: unknown): string {
+  const n = toNumber(value);
+  const f = toNumber(factor);
+  if (n === null || f === null) return FALLBACK;
+  return String(n * f);
+}
+
+export function divideHelper(value: unknown, divisor: unknown): string {
+  const n = toNumber(value);
+  const d = toNumber(divisor);
+  if (n === null || d === null || d === 0) return FALLBACK;
+  return String(n / d);
+}
+
+// ============================================================================
+// Date helpers
+// ============================================================================
+
+export function formatDateHelper(
+  this: unknown,
+  value: unknown,
+  options: Handlebars.HelperOptions
+): string {
+  const d = toDate(value);
+  if (!d) return FALLBACK;
+
+  const hash = options?.hash ?? {};
+  const format: string = hash.format ?? "datetime";
+  const locale: string = hash.locale ?? DEFAULT_LOCALE;
+  const timeZone: string = hash.timezone ?? DEFAULT_TIMEZONE;
+
+  switch (format) {
+    case "date":
+      return d.toLocaleDateString(locale, {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
+
+    case "time":
+      return d.toLocaleTimeString(locale, {
+        timeZone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+
+    case "relative": {
+      const diffMs = Date.now() - d.getTime();
+      const diffMin = Math.floor(Math.abs(diffMs) / 60_000);
+      if (diffMin < 1) return "now";
+      if (diffMin < 60) return `${diffMin}m`;
+      const diffH = Math.floor(diffMin / 60);
+      if (diffH < 24) return `${diffH}h`;
+      const diffD = Math.floor(diffH / 24);
+      if (diffD < 7) return `${diffD}d`;
+      return d.toLocaleDateString(locale, {
+        timeZone,
+        month: "short",
+        day: "numeric",
+      });
+    }
+
+    case "datetime":
+    default:
+      return d.toLocaleString(locale, {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+  }
+}
+
+export function datePartHelper(value: unknown, part: unknown): string {
+  const d = toDate(value);
+  if (!d) return FALLBACK;
+
+  const p = String(part).toLowerCase();
+  const tz = DEFAULT_TIMEZONE;
+  const locale = DEFAULT_LOCALE;
+
+  switch (p) {
+    case "year":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        year: "numeric",
+      }).format(d);
+    case "month":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        month: "2-digit",
+      }).format(d);
+    case "day":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        day: "2-digit",
+      }).format(d);
+    case "hour":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        hour: "2-digit",
+        hour12: false,
+      }).format(d);
+    case "minute":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        minute: "2-digit",
+      }).format(d);
+    case "weekday":
+      return new Intl.DateTimeFormat(locale, {
+        timeZone: tz,
+        weekday: "long",
+      }).format(d);
+    default:
+      return FALLBACK;
+  }
+}
+
+export function timeAgoHelper(value: unknown): string {
+  const d = toDate(value);
+  if (!d) return FALLBACK;
+
+  const diffMs = Date.now() - d.getTime();
+  const diffMin = Math.floor(Math.abs(diffMs) / 60_000);
+  const suffix = diffMs >= 0 ? "ago" : "from now";
+
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ${suffix}`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ${suffix}`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ${suffix}`;
+  const diffMo = Math.floor(diffD / 30);
+  if (diffMo < 12) return `${diffMo}mo ${suffix}`;
+  const diffY = Math.floor(diffD / 365);
+  return `${diffY}y ${suffix}`;
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+let registered = false;
+
+export function registerHandlebarsHelpers(): void {
+  if (registered) return;
+  registered = true;
+
+  Handlebars.registerHelper("formatNumber", formatNumberHelper);
+  Handlebars.registerHelper("extractNumber", extractNumberHelper);
+  Handlebars.registerHelper("toFixed", toFixedHelper);
+  Handlebars.registerHelper("round", roundHelper);
+  Handlebars.registerHelper("multiply", multiplyHelper);
+  Handlebars.registerHelper("divide", divideHelper);
+  Handlebars.registerHelper("formatDate", formatDateHelper);
+  Handlebars.registerHelper("datePart", datePartHelper);
+  Handlebars.registerHelper("timeAgo", timeAgoHelper);
+}
+
+// Auto-register on import
+registerHandlebarsHelpers();

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/register-handlebars-helpers.ts
@@ -15,13 +15,13 @@ const FALLBACK = "-";
 function toNumber(value: unknown): number | null {
   if (value === null || value === undefined || value === "") return null;
   const n = Number(value);
-  return isNaN(n) ? null : n;
+  return Number.isNaN(n) ? null : n;
 }
 
 function toDate(value: unknown): Date | null {
   if (value === null || value === undefined || value === "") return null;
   const d = new Date(value as string | number);
-  return isNaN(d.getTime()) ? null : d;
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
 // ============================================================================
@@ -39,7 +39,7 @@ export function formatNumberHelper(
   const hash = options?.hash ?? {};
   const locale: string = hash.locale ?? DEFAULT_LOCALE;
   const decimals: number | undefined =
-    hash.decimals !== undefined ? Number(hash.decimals) : undefined;
+    hash.decimals === undefined ? undefined : Number(hash.decimals);
   const prefix: string = hash.prefix ?? "";
   const suffix: string = hash.suffix ?? "";
 
@@ -55,7 +55,8 @@ export function formatNumberHelper(
 
 export function extractNumberHelper(value: unknown): string {
   if (value === null || value === undefined) return FALLBACK;
-  const str = String(value);
+  if (typeof value === "object") return FALLBACK;
+  const str = `${value as string | number | boolean}`;
   const match = /[-+]?\d+([.,]\d+)?/.exec(str);
   return match ? match[0] : FALLBACK;
 }
@@ -64,7 +65,7 @@ export function toFixedHelper(value: unknown, decimals: unknown): string {
   const n = toNumber(value);
   if (n === null) return FALLBACK;
   const d = toNumber(decimals);
-  return n.toFixed(d !== null ? d : 0);
+  return n.toFixed(d ?? 0);
 }
 
 export function roundHelper(value: unknown): string {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-handlebars-templates.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-handlebars-templates.ts
@@ -1,4 +1,5 @@
 import Handlebars from "handlebars";
+import "./register-handlebars-helpers";
 import type { DataProviderEntry } from "../types";
 
 // ============================================================================


### PR DESCRIPTION
- Add register-handlebars-helpers module with number, date, string, and comparison helpers
- Include formatNumber, extractNumber, toFixed, round, multiply, divide helpers
- Include formatDate, uppercase, lowercase, truncate, and conditional helpers
- Export registration function and integrate with use-handlebars-templates hook
- Add comprehensive tests for all registered helpers
- Add HANDLEBARS_HELPERS.md reference documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Handlebars helpers for dashboards to format numbers (locale, decimals, prefix/suffix), perform basic math, and format/parse dates (date/time/datetime/relative).
  * Template parsing now accepts quoted strings, hash arguments, and typical punctuation in helper expressions.

* **Documentation**
  * Added a reference guide with usage examples and fallback behavior.

* **Tests**
  * Expanded tests covering helpers, template integration, and expression validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->