### PR TITLE
[codex] Default canonical metric units when omitted

### DIFF
--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -31,6 +31,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus-srv/miot-gps-model/src/main/java/cl/streamhub/gps/model/metrics/MetricRegistry.java
+++ b/quarkus-srv/miot-gps-model/src/main/java/cl/streamhub/gps/model/metrics/MetricRegistry.java
@@ -426,6 +426,8 @@ public final class MetricRegistry {
         MetricDefinition def = DEFINITIONS.get(key);
         Object value = item.getV();
 
+        applyCanonicalUnitIfMissing(item, def);
+
         // 2. Validate value type
         if (!def.isValidValueType(value)) {
             return MetricValidationResult.error(MetricValidationResult.TYPE_MISMATCH,
@@ -452,6 +454,12 @@ public final class MetricRegistry {
         }
 
         return MetricValidationResult.ok();
+    }
+
+    private static void applyCanonicalUnitIfMissing(MetricItem item, MetricDefinition def) {
+        if (def.requiresUnit() && item.getU() == null) {
+            item.setU(def.getUnit());
+        }
     }
 
     private static String formatBounds(Double min, Double max) {

--- a/quarkus-srv/miot-gps-model/src/test/java/cl/streamhub/gps/model/metrics/MetricRegistryTest.java
+++ b/quarkus-srv/miot-gps-model/src/test/java/cl/streamhub/gps/model/metrics/MetricRegistryTest.java
@@ -1,0 +1,33 @@
+package cl.streamhub.gps.model.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MetricRegistryTest {
+
+    @Test
+    void validateDefaultsCanonicalUnitWhenMissing() {
+        MetricItem item = new MetricItem();
+        item.setK("vehicle.odometer");
+        item.setV(12345);
+
+        MetricValidationResult result = MetricRegistry.validate(item);
+
+        assertTrue(result.isValid());
+        assertEquals("km", item.getU());
+    }
+
+    @Test
+    void validateStillRejectsWrongUnit() {
+        MetricItem item = new MetricItem();
+        item.setK("battery.voltage");
+        item.setV(13.9);
+        item.setU("mV");
+
+        MetricValidationResult result = MetricRegistry.validate(item);
+
+        assertEquals(MetricValidationResult.UNIT_MISMATCH, result.getErrorCode());
+    }
+}


### PR DESCRIPTION
## Summary
Default canonical metric units during validation when clients omit `u` for known numeric metrics.

## What Changed
- Added a validator fallback that populates the canonical unit from `MetricRegistry` when a known metric requires a unit and `u` is missing
- Preserved rejection for explicitly incorrect units
- Added focused tests covering omitted-unit fallback and wrong-unit rejection
- Added the test dependency needed for the new model test

## Why
Asset tracking ingestion was rejecting valid canonical metrics such as `vehicle.odometer`, `battery.voltage`, and `fuel.level` when clients sent numeric values without an explicit unit, even though the registry already defines the canonical unit for those keys.

## Impact
Clients that omit `u` for known canonical numeric metrics will now be accepted and normalized to the registry unit. Clients that send the wrong explicit unit will still receive `UNIT_MISMATCH`.

## Validation
- `mvn -pl miot-gps-model test`

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Metric validation now automatically assigns default units when required units are missing, preventing validation failures for incomplete metric items.

* **Tests**
  * Added test coverage for metric validation scenarios including unit auto-assignment and unit mismatch detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->