### PR TITLE
fix: stop double-parsing reasons array in task end endpoint

### DIFF
--- a/turbo-repo/apps/app/.gitignore
+++ b/turbo-repo/apps/app/.gitignore
@@ -28,6 +28,8 @@ yarn-error.log*
 # local env files
 .env*.local
 .env*.*
+!.env.example
+!.env.template
 
 # vercel
 .vercel

--- a/turbo-repo/apps/app/.gitignore
+++ b/turbo-repo/apps/app/.gitignore
@@ -27,7 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
-.env*.prod
+.env*.*
 
 # vercel
 .vercel

--- a/turbo-repo/apps/app/src/app/api/task/end/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.ts
@@ -103,13 +103,12 @@ function addNativeGenerationProperty(
  */
 function addMultiReasonProperties(
   payload: UpdateTaskRequest,
-  reasons: string
+  reasons: string[]
 ): boolean {
   try {
-    const reasonArray = JSON.parse(reasons) as string[];
-    if (reasonArray.length > 0) {
-      payload.prop_mintral_commentReasons = reasonArray;
-      payload.prop_mintral_commentPostTitle = `Multiple reasons: ${reasonArray.length} items`;
+    if (reasons.length > 0) {
+      payload.prop_mintral_commentReasons = reasons;
+      payload.prop_mintral_commentPostTitle = `Multiple reasons: ${reasons.length} items`;
       return true;
     }
   } catch {
@@ -124,16 +123,16 @@ function addMultiReasonProperties(
 function addReasonProperties(
   payload: UpdateTaskRequest,
   reason: string | undefined,
-  reasons: string | undefined,
+  reasons: string | string[] | undefined,
   isMultiReason: boolean
 ): void {
   if (isMultiReason && reasons) {
-    const success = addMultiReasonProperties(payload, reasons);
+    const success = addMultiReasonProperties(payload, Array.isArray(reasons) ? reasons : [reasons]);
     if (success) {
       return;
     }
     // Fallback to single reason
-    if (reasons.trim() !== "") {
+    if (typeof reasons === "string" && reasons.trim() !== "") {
       payload.prop_mintral_commentPostTitle = reasons;
     }
     return;


### PR DESCRIPTION
## Summary

- Fix `addMultiReasonProperties` which was calling `JSON.parse()` on an already-parsed `string[]`, causing silent failures
- Update `addReasonProperties` to accept `string | string[]` and normalize with `Array.isArray`
- Broaden `.gitignore` env pattern from `.env*.prod` to `.env*.*`

Closes #264

## Test plan

- [ ] Trigger task end with multiple reasons and verify `prop_mintral_commentReasons` is set correctly
- [ ] Verify single reason fallback still works
- [ ] Confirm env files matching `.env*.*` are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened environment file ignore patterns and preserved example/template env files.

* **Refactor**
  * Improved task API handling to accept and normalize single or multiple reason inputs, ensuring consistent comment reason and title assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->