### PR TITLE
fix: improve dashboard sort to handle empty values and support sort r…

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-filter-and-sort.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-filter-and-sort.ts
@@ -80,7 +80,7 @@ export function useFilterAndSort(
           if (aEmpty !== bEmpty) return aEmpty ? 1 : -1;
           if (aEmpty && bEmpty) return 0;
 
-          const cmp = aVal!.localeCompare(bVal!);
+          const cmp = aVal.localeCompare(bVal);
           return sortDir === "asc" ? cmp : -cmp;
         });
       }

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-filter-and-sort.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-filter-and-sort.ts
@@ -72,7 +72,15 @@ export function useFilterAndSort(
       const sortProp = resolveDataProperty(sortKey);
       if (sortProp) {
         result = [...result].sort((a, b) => {
-          const cmp = (a[sortProp] ?? "").localeCompare(b[sortProp] ?? "");
+          const aVal = a[sortProp];
+          const bVal = b[sortProp];
+          const aEmpty = aVal == null || aVal === "";
+          const bEmpty = bVal == null || bVal === "";
+
+          if (aEmpty !== bEmpty) return aEmpty ? 1 : -1;
+          if (aEmpty && bEmpty) return 0;
+
+          const cmp = aVal!.localeCompare(bVal!);
           return sortDir === "asc" ? cmp : -cmp;
         });
       }
@@ -95,7 +103,12 @@ export function useFilterAndSort(
 
   const handleSortClick = (key: string) => {
     if (sortKey === key) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      if (sortDir === "asc") {
+        setSortDir("desc");
+      } else {
+        setSortKey(null);
+        setSortDir("asc");
+      }
     } else {
       setSortKey(key);
       setSortDir("asc");


### PR DESCRIPTION
…eset

- Push rows with null/empty values to the bottom when sorting
- Cycle sort direction through asc → desc → none instead of toggling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sorting now treats empty or missing values consistently, placing them after non-empty values.
  * Sort column toggle behavior improved: repeated clicks cycle ascending → descending → no sort (reset), making it easy to clear sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->