### PR TITLE
fix(auth/cli): split JWT issuer config and guard Flyway

### DIFF
--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -32,12 +32,25 @@ public class FlywayMigrator {
     @ConfigProperty(name = "miot.component.tracking.enabled", defaultValue = "false")
     boolean trackingEnabled;
 
+    @ConfigProperty(name = "quarkus.datasource.active", defaultValue = "true")
+    boolean dataSourceActive;
+
     void onStart(@Observes StartupEvent ev) {
         // Gateway and other stateless components have no DB schema.
         // Skip migration entirely when no DB-dependent component is active
         // to avoid connecting to (or validating against) a database that isn't needed.
         if (!fleetEnabled && !driverEnabled && !trackingEnabled) {
             LOG.debug("No DB-dependent components enabled — skipping Flyway");
+            return;
+        }
+
+        if (!dataSourceActive) {
+            LOG.warn("Datasource is deactivated — skipping Flyway migration");
+            return;
+        }
+
+        if (dataSourceInstance.isUnsatisfied() || !dataSourceInstance.isResolvable()) {
+            LOG.warn("Datasource bean is not resolvable — skipping Flyway migration");
             return;
         }
 

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanism.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanism.java
@@ -46,7 +46,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String NOT_CONFIGURED = "not-configured";
 
-    private final String issuer;
+    private final String hs256Issuer;
+    private final String rs256Issuer;
     private final String jwksUrl;
     private final String hs256Secret;
     private final String hs256Audience;
@@ -57,8 +58,10 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
     private List<String> m2mPathPrefixes;
 
     DualJwtAuthMechanism(
-            @ConfigProperty(name = "mp.jwt.verify.issuer", defaultValue = "https://placeholder.auth0.com/")
-                    String issuer,
+            @ConfigProperty(name = "miot.auth.hs256-issuer", defaultValue = "https://placeholder.auth0.com/")
+                    String hs256Issuer,
+            @ConfigProperty(name = "miot.auth.rs256-issuer", defaultValue = "https://placeholder.auth0.com/")
+                    String rs256Issuer,
             @ConfigProperty(name = "miot.auth.jwks-url", defaultValue = NOT_CONFIGURED)
                     String jwksUrl,
             @ConfigProperty(name = "miot.auth.hs256-secret", defaultValue = NOT_CONFIGURED)
@@ -67,7 +70,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
                     String hs256Audience,
             @ConfigProperty(name = "miot.auth.rs256-audience", defaultValue = NOT_CONFIGURED)
                     String rs256Audience) {
-        this.issuer = issuer;
+        this.hs256Issuer = hs256Issuer;
+        this.rs256Issuer = rs256Issuer;
         this.jwksUrl = jwksUrl;
         this.hs256Secret = hs256Secret;
         this.hs256Audience = hs256Audience;
@@ -81,7 +85,7 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
         if (!NOT_CONFIGURED.equals(hs256Secret)) {
             var hs256Builder = new JwtConsumerBuilder()
                     .setVerificationKey(new HmacKey(hs256Secret.getBytes()))
-                    .setExpectedIssuer(issuer)
+                    .setExpectedIssuer(hs256Issuer)
                     .setRequireExpirationTime();
             if (!NOT_CONFIGURED.equals(hs256Audience)) {
                 hs256Builder.setExpectedAudience(hs256Audience);
@@ -89,14 +93,15 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
                 hs256Builder.setSkipDefaultAudienceValidation();
             }
             hs256Consumer = hs256Builder.build();
-            LOG.infof("HS256 verification configured for @M2MAuth paths: %s", m2mPathPrefixes);
+            LOG.infof("HS256 verification configured for @M2MAuth paths: %s issuer=%s",
+                    m2mPathPrefixes, hs256Issuer);
         }
 
         if (!NOT_CONFIGURED.equals(jwksUrl)) {
             HttpsJwks httpsJwks = new HttpsJwks(jwksUrl);
             var rs256Builder = new JwtConsumerBuilder()
                     .setVerificationKeyResolver(new HttpsJwksVerificationKeyResolver(httpsJwks))
-                    .setExpectedIssuer(issuer)
+                    .setExpectedIssuer(rs256Issuer)
                     .setRequireExpirationTime();
             if (!NOT_CONFIGURED.equals(rs256Audience)) {
                 rs256Builder.setExpectedAudience(rs256Audience);
@@ -104,7 +109,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
                 rs256Builder.setSkipDefaultAudienceValidation();
             }
             rs256Consumer = rs256Builder.build();
-            LOG.info("RS256 verification configured via JWKS for web paths");
+            LOG.infof("RS256 verification configured via JWKS for web paths issuer=%s jwks=%s",
+                    rs256Issuer, jwksUrl);
         }
     }
 


### PR DESCRIPTION
## Summary
- split JWT issuer configuration so HS256 and RS256 verification can use different issuers
- use the matching issuer in each verification path and include issuer details in auth setup logs
- skip Flyway startup when the datasource is deactivated or the datasource bean is not resolvable

## Issue
- closes #272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration property to control whether database migrations run at startup; migrations can now be conditionally disabled
  * Enhanced JWT authentication to support independent issuer configuration for different token algorithm types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->