### PR TITLE
feat(resource-client): support fleet truck realtime metrics

### DIFF
--- a/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckMetricCatalog.java
+++ b/quarkus-srv/miot-fleet/src/main/java/com/microboxlabs/miot/fleet/service/TruckMetricCatalog.java
@@ -17,6 +17,7 @@ public class TruckMetricCatalog {
     private static final String DEFAULT_VIEW = "card";
     private static final String TIMESTAMP = "timestamp";
     private static final String FUEL_LEVEL_PCT = "fuel_level_pct";
+    private static final String FUEL_VOLUME_ML = "fuel_volume_ml";
     private static final String ODOMETER_KM = "odometer_km";
     private static final String BATTERY_VOLTAGE_MV = "battery_voltage_mv";
     private static final String VEHICLE_SPEED_KPH = "vehicle_speed_kph";
@@ -28,6 +29,7 @@ public class TruckMetricCatalog {
         Map<String, MetricSource> fields = new LinkedHashMap<>();
         fields.put(TIMESTAMP, MetricSource.CORE_TIMESTAMP);
         fields.put(FUEL_LEVEL_PCT, MetricSource.CORE);
+        fields.put(FUEL_VOLUME_ML, MetricSource.CORE);
         fields.put(ODOMETER_KM, MetricSource.CORE);
         fields.put(BATTERY_VOLTAGE_MV, MetricSource.CORE);
         fields.put(VEHICLE_SPEED_KPH, MetricSource.CORE);

--- a/turbo-repo/apps/app/src/app/api/fleet/trucks/[id]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/fleet/trucks/[id]/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "../../../utils/alfresco-crud-client";
 import { createResourceClient } from "../../../utils/miot-resource-api-client";
-import { MiotResourceApiError } from "@microboxlabs/miot-resource-client";
+import {
+  MiotResourceApiError,
+  type TruckMetricView,
+} from "@microboxlabs/miot-resource-client";
 import { logger } from "@/lib/logger";
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const authResult = await requireAuth();
@@ -16,10 +19,18 @@ export async function GET(
   if (Number.isNaN(numericId)) {
     return NextResponse.json({ error: "Invalid truck ID" }, { status: 400 });
   }
+  const { searchParams } = new URL(request.url);
+  const includeMetrics = searchParams.get("includeMetrics");
+  const metricView = searchParams.get("metricView");
+  const metricFields = searchParams.get("metricFields");
 
   try {
     const client = createResourceClient(authResult.session);
-    const truck = await client.fleet.getTruck(numericId);
+    const truck = await client.fleet.getTruck(numericId, {
+      includeMetrics: includeMetrics === null ? undefined : includeMetrics === "true",
+      metricView: metricView ? (metricView as TruckMetricView) : undefined,
+      metricFields: metricFields ?? undefined,
+    });
     return NextResponse.json(truck);
   } catch (error) {
     const status = error instanceof MiotResourceApiError ? error.status : 500;

--- a/turbo-repo/apps/app/src/app/api/fleet/trucks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/fleet/trucks/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { createResourceClient } from "../../utils/miot-resource-api-client";
 import { parsePageParams, isPageParamsError } from "../../utils/page-params";
-import { MiotResourceApiError } from "@microboxlabs/miot-resource-client";
+import {
+  MiotResourceApiError,
+  type TruckMetricView,
+  type TruckQueryParams,
+} from "@microboxlabs/miot-resource-client";
 import { logger } from "@/lib/logger";
 
 export async function GET(request: Request) {
@@ -13,10 +17,24 @@ export async function GET(request: Request) {
   const pageParams = parsePageParams(searchParams);
   if (isPageParamsError(pageParams)) return pageParams.error;
   const { page, size } = pageParams;
+  const includeMetrics = searchParams.get("includeMetrics");
+  const metricView = searchParams.get("metricView");
+  const metricFields = searchParams.get("metricFields");
+
+  const truckQuery: TruckQueryParams = { page, size };
+  if (includeMetrics !== null) {
+    truckQuery.includeMetrics = includeMetrics === "true";
+  }
+  if (metricView) {
+    truckQuery.metricView = metricView as TruckMetricView;
+  }
+  if (metricFields) {
+    truckQuery.metricFields = metricFields;
+  }
 
   try {
     const client = createResourceClient(authResult.session);
-    const trucks = await client.fleet.listTrucks({ page, size });
+    const trucks = await client.fleet.listTrucks(truckQuery);
     return NextResponse.json(trucks);
   } catch (error) {
     const status = error instanceof MiotResourceApiError ? error.status : 500;

--- a/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
@@ -32,7 +32,11 @@ export default function FleetManagementPage({
   const router = useRouter();
   const pathname = usePathname();
 
-  const { trucks, isLoading } = useFleetTrucks({ size: 100 });
+  const { trucks, isLoading } = useFleetTrucks({
+    size: 100,
+    includeMetrics: true,
+    metricView: "card",
+  });
 
   const vehicles = useMemo(() => trucks.map(truckToVehicle), [trucks]);
 

--- a/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
@@ -35,7 +35,7 @@ export default function FleetManagementPage({
   const { trucks, isLoading } = useFleetTrucks({
     size: 100,
     includeMetrics: true,
-    metricView: "card",
+    metricFields: "timestamp,odometer_km,fuel_volume_ml,fuel_level_pct",
   });
 
   const vehicles = useMemo(() => trucks.map(truckToVehicle), [trucks]);

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
@@ -110,23 +110,23 @@ export default function VehicleCard({
     </>
   );
 
-  if (isInteractive) {
+  if (!isInteractive) {
     return (
-      <button
-        type="button"
-        tabIndex={0}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        className={`${baseClasses} ${interactiveClasses}`}
-      >
+      <div className={baseClasses}>
         {cardContent}
-      </button>
+      </div>
     );
   }
 
   return (
-    <div className={baseClasses}>
+    <button
+      type="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={`${baseClasses} ${interactiveClasses}`}
+    >
       {cardContent}
-    </div>
+    </button>
   );
 }

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
@@ -29,9 +29,9 @@ export default function VehicleCard({
   isDetailed,
   onSelect,
 }: VehicleCardProps) {
-  const fuelValue = vehicle.fuelVolumeLiters !== undefined
-    ? `${vehicle.fuelVolumeLiters.toFixed(1)} L`
-    : `${vehicle.fuelLevel}%`;
+  const fuelValue = vehicle.fuelVolumeLiters === undefined
+    ? `${vehicle.fuelLevel}%`
+    : `${vehicle.fuelVolumeLiters.toFixed(1)} L`;
 
   const handleClick = () => {
     onSelect?.(vehicle.plate);

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-grid/vehicle-card.tsx
@@ -29,6 +29,10 @@ export default function VehicleCard({
   isDetailed,
   onSelect,
 }: VehicleCardProps) {
+  const fuelValue = vehicle.fuelVolumeLiters !== undefined
+    ? `${vehicle.fuelVolumeLiters.toFixed(1)} L`
+    : `${vehicle.fuelLevel}%`;
+
   const handleClick = () => {
     onSelect?.(vehicle.plate);
   };
@@ -88,7 +92,7 @@ export default function VehicleCard({
             <VehicleStatItem
               icon={HiOutlineFire}
               label={tr("vehicleGrid.fuel", dict)}
-              value={`${vehicle.fuelLevel}%`}
+              value={fuelValue}
             />
             <VehicleStatItem
               icon={HiOutlineCalendarDays}

--- a/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
@@ -21,6 +21,8 @@ function metricString(truck: Truck, key: string): string | undefined {
 
 export function truckToVehicle(truck: Truck): Vehicle {
   const fuelLevel = metricNumber(truck, "fuel_level_pct") ?? 0;
+  const fuelVolumeMl = metricNumber(truck, "fuel_volume_ml");
+  const fuelVolumeLiters = fuelVolumeMl !== undefined ? fuelVolumeMl / 1000 : undefined;
   const kmTraveled = metricNumber(truck, "odometer_km") ?? 0;
   const lastSignal = metricString(truck, "timestamp");
 
@@ -35,6 +37,7 @@ export function truckToVehicle(truck: Truck): Vehicle {
     lastLocation: "—",
     transportist: "—",
     fuelLevel,
+    fuelVolumeLiters,
     nextMaintenance: "—",
     kmTraveled,
     lastSignal,

--- a/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
@@ -9,7 +9,21 @@ function statusToVehicleStatus(status: string, active: boolean): VehicleStatus {
   return "active";
 }
 
+function metricNumber(truck: Truck, key: string): number | undefined {
+  const value = truck.latestMetrics?.[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function metricString(truck: Truck, key: string): string | undefined {
+  const value = truck.latestMetrics?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
 export function truckToVehicle(truck: Truck): Vehicle {
+  const fuelLevel = metricNumber(truck, "fuel_level_pct") ?? 0;
+  const kmTraveled = metricNumber(truck, "odometer_km") ?? 0;
+  const lastSignal = metricString(truck, "timestamp");
+
   return {
     id: String(truck.id),
     plate: truck.licensePlate ?? truck.externalId ?? String(truck.id),
@@ -20,8 +34,10 @@ export function truckToVehicle(truck: Truck): Vehicle {
     driver: "—",
     lastLocation: "—",
     transportist: "—",
-    fuelLevel: 0,
+    fuelLevel,
     nextMaintenance: "—",
-    kmTraveled: 0,
+    kmTraveled,
+    lastSignal,
+    assetId: truck.assetId,
   };
 }

--- a/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/data/fleet-adapters.ts
@@ -22,7 +22,7 @@ function metricString(truck: Truck, key: string): string | undefined {
 export function truckToVehicle(truck: Truck): Vehicle {
   const fuelLevel = metricNumber(truck, "fuel_level_pct") ?? 0;
   const fuelVolumeMl = metricNumber(truck, "fuel_volume_ml");
-  const fuelVolumeLiters = fuelVolumeMl !== undefined ? fuelVolumeMl / 1000 : undefined;
+  const fuelVolumeLiters = fuelVolumeMl === undefined ? undefined : fuelVolumeMl / 1000;
   const kmTraveled = metricNumber(truck, "odometer_km") ?? 0;
   const lastSignal = metricString(truck, "timestamp");
 

--- a/turbo-repo/apps/app/src/features/fleet-management/hooks/use-fleet-trucks.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/hooks/use-fleet-trucks.ts
@@ -1,5 +1,8 @@
 import useSWR from "swr";
-import type { Truck } from "@microboxlabs/miot-resource-client";
+import type {
+  Truck,
+  TruckMetricView,
+} from "@microboxlabs/miot-resource-client";
 
 const fetcher = (url: string): Promise<Truck[]> =>
   fetch(url).then((r) => {
@@ -9,10 +12,21 @@ const fetcher = (url: string): Promise<Truck[]> =>
 
 const EMPTY: Truck[] = [];
 
-export function useFleetTrucks(params?: { page?: number; size?: number }) {
+export function useFleetTrucks(params?: {
+  page?: number;
+  size?: number;
+  includeMetrics?: boolean;
+  metricView?: TruckMetricView;
+  metricFields?: string;
+}) {
   const query = new URLSearchParams();
   if (params?.page !== undefined) query.set("page", String(params.page));
   if (params?.size !== undefined) query.set("size", String(params.size));
+  if (params?.includeMetrics !== undefined) {
+    query.set("includeMetrics", String(params.includeMetrics));
+  }
+  if (params?.metricView) query.set("metricView", params.metricView);
+  if (params?.metricFields) query.set("metricFields", params.metricFields);
   const qs = query.toString();
 
   const url = qs ? `/app/api/fleet/trucks?${qs}` : `/app/api/fleet/trucks`;

--- a/turbo-repo/apps/app/src/features/fleet-management/types/fleet.types.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/types/fleet.types.ts
@@ -50,6 +50,7 @@ export interface Vehicle {
   nextMaintenance: string;
   kmTraveled: number;
   lastSignal?: string;
+  assetId?: string;
   gamification?: VehicleGamification;
 }
 

--- a/turbo-repo/apps/app/src/features/fleet-management/types/fleet.types.ts
+++ b/turbo-repo/apps/app/src/features/fleet-management/types/fleet.types.ts
@@ -47,6 +47,7 @@ export interface Vehicle {
   brand: string;
   transportist: string;
   fuelLevel: number;
+  fuelVolumeLiters?: number;
   nextMaintenance: string;
   kmTraveled: number;
   lastSignal?: string;

--- a/turbo-repo/packages/miot-resource-client/src/__tests__/fleet.test.ts
+++ b/turbo-repo/packages/miot-resource-client/src/__tests__/fleet.test.ts
@@ -15,6 +15,8 @@ const sampleTruck: Truck = {
   active: true, createdAt: "2025-01-01T00:00:00Z", updatedAt: "2025-01-01T00:00:00Z",
   licensePlate: "ABC123", vin: "VIN123", brand: "Volvo", model: "FH16",
   year: 2022, maxWeight: 25000, volume: 100, truckType: "RIGID",
+  assetId: "TRUCK-1",
+  latestMetrics: { timestamp: "2025-01-01T00:00:00Z", fuel_level_pct: 97, odometer_km: 10550 },
 };
 
 const sampleTrailer: Trailer = {
@@ -61,6 +63,24 @@ describe("fleet", () => {
       expect(url.searchParams.get("size")).toBe("10");
     });
 
+    it("listTrucks passes metrics query params", async () => {
+      const { fn, call } = createMockFetch([]);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, organizationId: ORG_ID, fetch: fn });
+
+      await client.fleet.listTrucks({
+        page: 0,
+        size: 25,
+        includeMetrics: true,
+        metricView: "card",
+        metricFields: "fuel_level_pct,odometer_km",
+      });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("includeMetrics")).toBe("true");
+      expect(url.searchParams.get("metricView")).toBe("card");
+      expect(url.searchParams.get("metricFields")).toBe("fuel_level_pct,odometer_km");
+    });
+
     it("getTruck sends GET to /fleet/trucks/:id", async () => {
       const { fn, call } = createMockFetch(sampleTruck);
       const client = createMiotResourceClient({ baseUrl: BASE_URL, organizationId: ORG_ID, fetch: fn });
@@ -70,6 +90,20 @@ describe("fleet", () => {
       expect(call.init.method).toBe("GET");
       expect(call.url).toBe(`${BASE_URL}${FLEET}/trucks/1`);
       expect(result).toEqual(sampleTruck);
+    });
+
+    it("getTruck passes metrics query params", async () => {
+      const { fn, call } = createMockFetch(sampleTruck);
+      const client = createMiotResourceClient({ baseUrl: BASE_URL, organizationId: ORG_ID, fetch: fn });
+
+      await client.fleet.getTruck(1, {
+        includeMetrics: true,
+        metricFields: "fuel_level_pct,engine_rpm",
+      });
+
+      const url = new URL(call.url);
+      expect(url.searchParams.get("includeMetrics")).toBe("true");
+      expect(url.searchParams.get("metricFields")).toBe("fuel_level_pct,engine_rpm");
     });
 
     it("createTruck sends POST with body", async () => {

--- a/turbo-repo/packages/miot-resource-client/src/index.ts
+++ b/turbo-repo/packages/miot-resource-client/src/index.ts
@@ -6,6 +6,8 @@ export type {
   EntityEvent,
   StatusChangeRequest,
   PageParams,
+  TruckMetricView,
+  TruckQueryParams,
   Truck,
   CreateTruckRequest,
   Trailer,

--- a/turbo-repo/packages/miot-resource-client/src/resources/fleet.ts
+++ b/turbo-repo/packages/miot-resource-client/src/resources/fleet.ts
@@ -9,6 +9,7 @@ import type {
   StatusChangeRequest,
   Trailer,
   Truck,
+  TruckQueryParams,
 } from "../types.js";
 
 export function createFleetApi(fetcher: Fetcher, organizationId: string) {
@@ -17,12 +18,12 @@ export function createFleetApi(fetcher: Fetcher, organizationId: string) {
   return {
     // --- Trucks ---
 
-    listTrucks(params?: PageParams): Promise<Truck[]> {
+    listTrucks(params?: TruckQueryParams): Promise<Truck[]> {
       return fetcher("GET", `${BASE}/trucks`, { query: params });
     },
 
-    getTruck(id: number): Promise<Truck> {
-      return fetcher("GET", `${BASE}/trucks/${id}`);
+    getTruck(id: number, params?: Omit<TruckQueryParams, "page" | "size">): Promise<Truck> {
+      return fetcher("GET", `${BASE}/trucks/${id}`, { query: params });
     },
 
     createTruck(body: CreateTruckRequest): Promise<Truck> {

--- a/turbo-repo/packages/miot-resource-client/src/types.ts
+++ b/turbo-repo/packages/miot-resource-client/src/types.ts
@@ -35,6 +35,14 @@ export interface PageParams {
   [key: string]: string | number | boolean | undefined;
 }
 
+export type TruckMetricView = "card" | "detail" | "diagnostics";
+
+export interface TruckQueryParams extends PageParams {
+  includeMetrics?: boolean;
+  metricView?: TruckMetricView;
+  metricFields?: string;
+}
+
 // --- Fleet: Trucks ---
 
 export interface Truck {
@@ -56,6 +64,8 @@ export interface Truck {
   maxWeight: number;
   volume: number;
   truckType: string;
+  assetId?: string;
+  latestMetrics?: Record<string, string | number | boolean | null>;
 }
 
 export interface CreateTruckRequest {


### PR DESCRIPTION
## Summary
- update `@microboxlabs/miot-resource-client` to support truck realtime metrics query params and response fields
- pass fleet metrics through the app truck API routes and consume them in fleet-management
- display odometer plus fuel metrics in the fleet-management UI, including fuel volume when available
- extend the fleet backend metric catalog to expose `fuel_volume_ml`

## Issue
- closes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet view now shows vehicle fuel volume in liters (when available) alongside fuel level percentages.
  * Fleet data includes additional metrics: timestamp (last signal) and odometer readings.
  * API and app list/get endpoints support requesting metric projections and view types to optimize fetched metric data.
* **Bug Fixes / Improvements**
  * Vehicle cards display fuel value more clearly and support interactive selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->