### PR TITLE
Fixed icon not appearing on the background of count in clusters

### DIFF
--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
@@ -1,0 +1,60 @@
+import { LayerExtension } from "@deck.gl/core";
+
+const fs = `\
+#version 300 es
+#define SHADER_NAME text-background-layer-fragment-shader
+
+precision highp float;
+
+in vec4 vFillColor;
+in vec4 vLineColor;
+in float vLineWidth;
+in vec2 uv;
+in vec2 dimensions;
+
+out vec4 fragColor;
+
+float round_rect(vec2 p, vec2 size, vec4 radii) {
+    // from https://www.shadertoy.com/view/4llXD7
+    radii.xy = (p.x>0.0)?radii.xy : radii.zw;
+    radii.x  = (p.y>0.0)?radii.x  : radii.y;
+    vec2 q = abs(p)-size+radii.x;
+    return min(max(q.x,q.y),0.0) + length(max(q,0.0)) - radii.x;
+}
+
+void main(void) {
+  geometry.uv = uv;
+
+  // Convert UV to center-based coordinates [-0.5, 0.5]
+  vec2 pixelPosition = (uv - 0.5) * dimensions;
+
+  float maxBorderRadius = min(dimensions.x, dimensions.y) * 0.5;
+  vec4 borderRadius = vec4(min(20.0, maxBorderRadius)); // 14px border radius
+  float dist = round_rect(pixelPosition, dimensions * 0.5, borderRadius);
+
+  // Border Calculation - check vLineWidth directly for border
+  if (vLineWidth > 0.0) {
+    float distToEdge = -dist;
+    float isBorder = smoothstep(vLineWidth - 1.0, vLineWidth + 1.0, distToEdge);
+    fragColor = mix(vLineColor, vFillColor, isBorder);
+  } else {
+    fragColor = vFillColor;
+  }
+
+  // Smooth transition for the main shape
+  float shapeAlpha = smoothstep(1.0, -1.0, dist);
+  fragColor.a *= shapeAlpha;
+
+  DECKGL_FILTER_COLOR(fragColor, geometry);
+}
+`;
+
+export class BorderRadiusExtension extends LayerExtension {
+  static extensionName = "BorderRadiusExtension";
+
+  getShaders() {
+    return {
+      fs,
+    };
+  }
+}

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
@@ -55,7 +55,7 @@ void main(void) {
 `;
 
 export class BorderRadiusExtension extends LayerExtension {
-  static extensionName = "BorderRadiusExtension";
+  static readonly extensionName = "BorderRadiusExtension";
 
   getShaders() {
     return {

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/border-radius-extension.ts
@@ -29,8 +29,13 @@ void main(void) {
   vec2 pixelPosition = (uv - 0.5) * dimensions;
 
   float maxBorderRadius = min(dimensions.x, dimensions.y) * 0.5;
-  vec4 borderRadius = vec4(min(20.0, maxBorderRadius)); // 14px border radius
+  vec4 borderRadius = vec4(min(20.0, maxBorderRadius)); // 20px border radius
   float dist = round_rect(pixelPosition, dimensions * 0.5, borderRadius);
+
+  // Discard pixels outside the rounded rect
+  if (dist > 1.0) {
+    discard;
+  }
 
   // Border Calculation - check vLineWidth directly for border
   if (vLineWidth > 0.0) {

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_count.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_count.ts
@@ -1,6 +1,7 @@
-import { CompositeLayer, IconLayer, Layer, TextLayer } from "deck.gl";
+import { CompositeLayer, Layer, TextLayer } from "deck.gl";
 import type { CompositeLayerProps } from "@deck.gl/core";
-import { createSVGIcon, svgToDataURL } from "./map-visualization.utils";
+
+import { BorderRadiusExtension } from "./border-radius-extension";
 
 interface PinCountLayerProps extends CompositeLayerProps {
   data: Array<{
@@ -12,74 +13,80 @@ interface PinCountLayerProps extends CompositeLayerProps {
       coordinates: [number, number];
     };
   }>;
-  updateTriggers?: any;
+  updateTriggers?: Record<string, unknown>;
+}
+
+interface ClusterData {
+  properties: {
+    cluster?: boolean;
+    point_count?: number;
+  };
+  geometry: {
+    coordinates: [number, number];
+  };
 }
 
 export class PinCountLayer extends CompositeLayer<PinCountLayerProps> {
   renderLayers(): Layer[] {
-    const getScaledOffset: (d: any) => [number, number] = (d) => {
-      const count = d.properties.cluster ? d.properties.point_count : 1;
+    const getScaledOffset = (d: ClusterData): [number, number] => {
+      const count = d.properties.cluster ? (d.properties.point_count ?? 1) : 1;
       const baseOffset: [number, number] = [-20, 17];
       const scale = Math.min(100, count) / 100 + 1;
 
       return [baseOffset[0] * scale, baseOffset[1] * scale];
     };
 
-    const getScale = (d: any) => {
-      const count = d.properties.cluster ? d.properties.point_count : 1;
+    const getScale = (d: ClusterData) => {
+      const count = d.properties.cluster ? (d.properties.point_count ?? 1) : 1;
       return Math.min(100, count) / 100 + 1;
     };
 
     return [
-      new IconLayer({
-        id: "IconLayer-count-bg",
-        data: this.props.data,
-        getIcon: (d: any) => ({
-          url: svgToDataURL(
-            createSVGIcon(
-              (d.properties.cluster
-                ? d.properties.point_count.toString()
-                : "1") as string
-            )
-          ),
-          width: 480,
-          height: 480,
-        }),
-        sizeScale: 1.6,
-        getPixelOffset: getScaledOffset,
-        getSize: (d) => {
-          const baseSize = 35;
-          return baseSize * getScale(d);
-        },
-        getPosition: (d) => d.geometry.coordinates,
-        updateTriggers: {
-          getSize: this.props.updateTriggers?.getSize,
-          getPosition: this.props.updateTriggers,
-        },
-      }) as Layer,
-
+      // Text count with rounded background
       new TextLayer({
         id: "TextLayer-count",
         data: this.props.data,
-        getText: (d: any) =>
-          d.properties.cluster ? d.properties.point_count.toString() : "1",
-        getPosition: (d: any) => d.geometry.coordinates,
-        getSize: (d) => {
-          const baseSize = 10;
+        getText: (d: ClusterData) =>
+          d.properties.cluster
+            ? (d.properties.point_count ?? 1).toString()
+            : "1",
+        getPosition: (d: ClusterData) => d.geometry.coordinates,
+        getSize: (d: ClusterData) => {
+          const baseSize = 12;
           return baseSize * getScale(d);
         },
-        getColor: [0, 0, 0] as [number, number, number],
+        getColor: [0, 0, 0, 255] as [number, number, number, number],
         getTextAnchor: "middle",
         getAlignmentBaseline: "center",
+        background: true,
+        getBackgroundColor: [253, 224, 71, 255] as [
+          number,
+          number,
+          number,
+          number,
+        ],
+        backgroundPadding: [8, 7, 8, 5] as [number, number, number, number],
+        getBorderColor: [255, 255, 255, 255] as [
+          number,
+          number,
+          number,
+          number,
+        ],
+        getBorderWidth: 3,
+        extensions: [new BorderRadiusExtension()],
         updateTriggers: {
+          getText: this.props.data,
           getSize: this.props.updateTriggers?.getSize,
           getPosition: this.props.updateTriggers,
         },
-        getPixelOffset: ((d) => {
-          let offset = getScaledOffset(d);
+        getPixelOffset: (d: ClusterData): [number, number] => {
+          const offset = getScaledOffset(d);
           offset[1] += getScale(d);
           return offset;
-        }) as (d: any) => [number, number],
+        },
+        parameters: {
+          depthTest: false,
+        },
       }) as Layer,
     ];
   }

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_count.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_count.ts
@@ -85,7 +85,7 @@ export class PinCountLayer extends CompositeLayer<PinCountLayerProps> {
           return offset;
         },
         parameters: {
-          depthTest: false,
+          depthTest: true,
         },
       }) as Layer,
     ];

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_layer_clustered.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_layer_clustered.ts
@@ -229,6 +229,11 @@ export class PinLayer extends CompositeLayer<any> {
       return [];
     }
 
+    // Sort by latitude descending - pins with lower latitude (closer to camera) render last (on top)
+    const sortedClusters = [...clusters].sort(
+      (a, b) => b.geometry.coordinates[1] - a.geometry.coordinates[1]
+    );
+
     const getIconSize = (count: number) => {
       const baseSize = Math.min(70, count) / 70 + 1;
       return count > 1 ? baseSize * 70 : 50;
@@ -237,7 +242,7 @@ export class PinLayer extends CompositeLayer<any> {
     return [
       new IconLayer({
         id: "IconLayer-base",
-        data: clusters,
+        data: sortedClusters,
         getIcon: (d: any) => ({
           url: createSVGIcon(
             d.properties.cluster
@@ -259,7 +264,7 @@ export class PinLayer extends CompositeLayer<any> {
         updateTriggers: this.props.updateTriggers,
         pickable: true,
         parameters: {
-          depthTest: false,
+          depthTest: true,
         },
       }) as Layer,
       new PinCountLayer({
@@ -311,6 +316,9 @@ export class PinLayer extends CompositeLayer<any> {
         getAngle: (d: ClusterFeature) =>
           !d.properties.cluster ? Math.round(360 + d.properties.heading) : 0,
         pickable: true,
+        parameters: {
+          depthTest: true,
+        },
       }) as Layer,
     ];
   }

--- a/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_layer_clustered.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/layers/pin_layer_clustered.ts
@@ -229,11 +229,6 @@ export class PinLayer extends CompositeLayer<any> {
       return [];
     }
 
-    // Sort by latitude descending - pins with lower latitude (closer to camera) render last (on top)
-    const sortedClusters = [...clusters].sort(
-      (a, b) => b.geometry.coordinates[1] - a.geometry.coordinates[1]
-    );
-
     const getIconSize = (count: number) => {
       const baseSize = Math.min(70, count) / 70 + 1;
       return count > 1 ? baseSize * 70 : 50;
@@ -242,7 +237,7 @@ export class PinLayer extends CompositeLayer<any> {
     return [
       new IconLayer({
         id: "IconLayer-base",
-        data: sortedClusters,
+        data: clusters,
         getIcon: (d: any) => ({
           url: createSVGIcon(
             d.properties.cluster
@@ -316,9 +311,6 @@ export class PinLayer extends CompositeLayer<any> {
         getAngle: (d: ClusterFeature) =>
           !d.properties.cluster ? Math.round(360 + d.properties.heading) : 0,
         pickable: true,
-        parameters: {
-          depthTest: true,
-        },
       }) as Layer,
     ];
   }

--- a/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization.tsx
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization.tsx
@@ -19,15 +19,6 @@ import MapStyleSelector from "./map-style-selector";
 import { MapRef } from "react-map-gl";
 import MapVisualizationGeneric from "@/features/map-visualization/map-visualization";
 
-const mapboxStyles = {
-  streets: "mapbox://styles/mapbox/streets-v9",
-  satellite: "mapbox://styles/mapbox/satellite-streets-v11",
-  dark: "mapbox://styles/mapbox/dark-v10",
-  light: "mapbox://styles/mapbox/light-v10",
-  outdoors: "mapbox://styles/mapbox/outdoors-v11",
-  hybrid: "mapbox://styles/mapbox/hybrid-v10",
-};
-
 type MapVisualizationProps = {
   mapPositions: MapPosition[] | null;
   dict: I18nRecord;


### PR DESCRIPTION
Fixed icon sometimes not appearing in the background of the counter in clustered items.

### Before:
<img width="483" height="176" alt="image" src="https://github.com/user-attachments/assets/265d7585-4932-428b-82b7-4539e65abd7e" />

### After:
<img width="521" height="291" alt="image" src="https://github.com/user-attachments/assets/581e9dd9-fdee-4248-9213-6e43206e1eaa" />

The old method used a svg rendered manually behind the number, making it sometimes not fit properly, now instead of that we use a background color in text with a custom shader that allows the usage of rounded edges (since deckgl don't allow default rounded borders).

Closes #307 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rounded rectangular backgrounds for cluster counts on the map, with smoother edges and consistent border handling.

* **Refactor**
  * Cluster count rendering switched to a text-based layer for clearer, more consistent labels.
  * Improved pin layering and depth handling for more reliable visual stacking of map markers.
  * Removed an unused local map style configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->