### PR TITLE
Fixing search state values in fleet management

### DIFF
--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-searchbar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-searchbar.tsx
@@ -295,8 +295,8 @@ function SelectorParams({
         // Use dynamic options from localStorage for specific params, or fallback to param.options
         let options: { value: string; label: string }[] = [];
 
-        if (dynamicOptions.length > 0) {
-          // For symptom_name in symptoms page, use dynamic options from localStorage
+        if (param.param.key === "symptom_name" && dynamicOptions.length > 0) {
+          // For symptom_name selector only, use dynamic options from localStorage
           options = [
             { value: "", label: "-" },
             ...dynamicOptions.map((option) => ({
@@ -305,7 +305,7 @@ function SelectorParams({
             })),
           ];
         } else if (param.options && Array.isArray(param.options)) {
-          // For other selectors (like originType), use their predefined options
+          // For other selectors (like state, originType), use their predefined options
           options = param.options;
         } else {
           // Fallback to empty options


### PR DESCRIPTION
Fixed values in state filter on searchbar on fleet

<img width="408" height="375" alt="image" src="https://github.com/user-attachments/assets/ca116dff-b1dc-429c-a17b-a97d0152efc6" />

closes #308 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the search bar's option-selection logic to correctly apply locally stored dynamic options exclusively for symptom searches, preventing the previous behavior that would override predefined filtering options for other parameter types and improving search accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->