### PR TITLE
feat: add CSV export for dashboard data table and data list dashlets

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/action-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/action-dropdown.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { HiEllipsisVertical, HiArrowTopRightOnSquare, HiLink } from "react-icons/hi2";
 import type { ActionItem } from "./action-types";
+import { usePortalDropdown } from "./use-portal-dropdown";
 
 interface ResolvedAction {
   action: ActionItem;
@@ -16,55 +16,8 @@ interface ActionDropdownProps {
 }
 
 export function ActionDropdown({ items, ariaLabel }: Readonly<ActionDropdownProps>) {
-  const [open, setOpen] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0 });
-
-  const close = useCallback(() => setOpen(false), []);
-
-  // Compute position when opening
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-    const rect = buttonRef.current.getBoundingClientRect();
-    setPos({
-      top: rect.bottom + 4,
-      left: rect.right,
-    });
-  }, [open]);
-
-  // Close on click outside
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (
-        buttonRef.current?.contains(target) ||
-        menuRef.current?.contains(target)
-      ) return;
-      close();
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open, close]);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [open, close]);
-
-  // Close on scroll of any ancestor (the table container scrolls)
-  useEffect(() => {
-    if (!open) return;
-    const handler = () => close();
-    window.addEventListener("scroll", handler, true);
-    return () => window.removeEventListener("scroll", handler, true);
-  }, [open, close]);
+  const { open, pos, buttonRef, menuRef, close, toggle } =
+    usePortalDropdown();
 
   if (items.length === 0) return null;
 
@@ -73,7 +26,7 @@ export function ActionDropdown({ items, ariaLabel }: Readonly<ActionDropdownProp
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={toggle}
         aria-label={ariaLabel}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/dashlet-title-bar.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/dashlet-title-bar.tsx
@@ -8,22 +8,29 @@ import type { TableColumn } from "./column-types";
 import { buildCsvContent, downloadCsv } from "./export-csv";
 import { ExportDropdown } from "./export-dropdown";
 
-interface DashletTitleBarProps {
+type ResolveValueFn = (
+  key: string,
+  row: Record<string, string>,
+  rowIdx: number,
+  totalRows: number
+) => string;
+
+type ResolveLabelFn = (key: string) => string;
+
+export interface DashletTitleBarData {
   title: string;
   showRowCount: boolean;
   showExport: boolean;
-  /** Rendered text for the row count (each dashlet uses different i18n keys). */
-  rowCountLabel: ReactNode;
   columns: TableColumn[];
   displayRows: Record<string, string>[];
-  resolveValue: (
-    key: string,
-    row: Record<string, string>,
-    rowIdx: number,
-    totalRows: number
-  ) => string;
-  resolveLabel: (key: string) => string;
+  resolveValue: ResolveValueFn;
+  resolveLabel: ResolveLabelFn;
   dictionary: I18nRecord;
+}
+
+interface DashletTitleBarProps extends DashletTitleBarData {
+  /** Rendered text for the row count (each dashlet uses different i18n keys). */
+  rowCountLabel: ReactNode;
 }
 
 export function DashletTitleBar({
@@ -63,4 +70,21 @@ export function DashletTitleBar({
       </div>
     </div>
   );
+}
+
+/**
+ * Helper to collect the common props shared by every dashlet that
+ * uses DashletTitleBar, so the call-site stays one-liner + rowCountLabel.
+ */
+export function buildTitleBarData(opts: {
+  title: string;
+  showRowCount: boolean;
+  showExport: boolean;
+  columns: TableColumn[];
+  displayRows: Record<string, string>[];
+  resolveValue: ResolveValueFn;
+  resolveLabel: ResolveLabelFn;
+  dictionary: I18nRecord;
+}): DashletTitleBarData {
+  return opts;
 }

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/dashlet-title-bar.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/dashlet-title-bar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import type { TableColumn } from "./column-types";
+import { buildCsvContent, downloadCsv } from "./export-csv";
+import { ExportDropdown } from "./export-dropdown";
+
+interface DashletTitleBarProps {
+  title: string;
+  showRowCount: boolean;
+  showExport: boolean;
+  /** Rendered text for the row count (each dashlet uses different i18n keys). */
+  rowCountLabel: ReactNode;
+  columns: TableColumn[];
+  displayRows: Record<string, string>[];
+  resolveValue: (
+    key: string,
+    row: Record<string, string>,
+    rowIdx: number,
+    totalRows: number
+  ) => string;
+  resolveLabel: (key: string) => string;
+  dictionary: I18nRecord;
+}
+
+export function DashletTitleBar({
+  title,
+  showRowCount,
+  showExport,
+  rowCountLabel,
+  columns,
+  displayRows,
+  resolveValue,
+  resolveLabel,
+  dictionary,
+}: Readonly<DashletTitleBarProps>) {
+  const handleExportCsv = useCallback(() => {
+    const csv = buildCsvContent(columns, displayRows, resolveValue, resolveLabel);
+    downloadCsv(csv, `${title}.csv`);
+  }, [columns, displayRows, resolveValue, resolveLabel, title]);
+
+  return (
+    <div className="flex shrink-0 items-start justify-between">
+      <h3 className="text-xl font-bold text-gray-900 dark:text-white">
+        {title}
+      </h3>
+      <div className="flex items-center gap-2">
+        {showRowCount && (
+          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+            {rowCountLabel}
+          </span>
+        )}
+        {showExport && displayRows.length > 0 && (
+          <ExportDropdown
+            ariaLabel={tr("dashboard.settings.exportCsv", dictionary)}
+            csvLabel="CSV"
+            onExportCsv={handleExportCsv}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-csv.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-csv.ts
@@ -1,0 +1,68 @@
+import type { TableColumn } from "./column-types";
+
+type ResolveValueFn = (
+  key: string,
+  row: Record<string, string>,
+  rowIdx: number,
+  totalRows: number
+) => string;
+
+type ResolveLabelFn = (key: string) => string;
+
+const DELIMITER = ";";
+
+/** Escape a cell value for CSV: wrap in quotes if it contains the delimiter, quotes, or newlines. */
+function escapeCell(value: string): string {
+  if (
+    value.includes(DELIMITER) ||
+    value.includes('"') ||
+    value.includes("\n") ||
+    value.includes("\r")
+  ) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Build a semicolon-delimited CSV string from dashlet columns and rows.
+ * Uses the same `resolveValue` / `resolveLabel` functions provided by `useCompiledColumns`,
+ * so Handlebars templates are resolved to their display values.
+ */
+export function buildCsvContent(
+  columns: TableColumn[],
+  rows: Record<string, string>[],
+  resolveValue: ResolveValueFn,
+  resolveLabel: ResolveLabelFn
+): string {
+  if (rows.length === 0) return "";
+
+  const headerLine = columns
+    .map((col) => escapeCell(resolveLabel(col.key)))
+    .join(DELIMITER);
+
+  const dataLines = rows.map((row, rowIdx) =>
+    columns
+      .map((col) =>
+        escapeCell(resolveValue(col.key, row, rowIdx, rows.length))
+      )
+      .join(DELIMITER)
+  );
+
+  return [headerLine, ...dataLines].join("\n");
+}
+
+/** Trigger a CSV file download in the browser. */
+export function downloadCsv(csvContent: string, filename: string): void {
+  const safeName = filename.replace(/[/\\:*?"<>|]/g, "_");
+  const bom = "\uFEFF";
+  const blob = new Blob([bom + csvContent], {
+    type: "text/csv;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = safeName;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-csv.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-csv.ts
@@ -19,7 +19,7 @@ function escapeCell(value: string): string {
     value.includes("\n") ||
     value.includes("\r")
   ) {
-    return `"${value.replace(/"/g, '""')}"`;
+    return `"${value.replaceAll('"', '""')}"`;
   }
   return value;
 }
@@ -54,7 +54,7 @@ export function buildCsvContent(
 
 /** Trigger a CSV file download in the browser. */
 export function downloadCsv(csvContent: string, filename: string): void {
-  const safeName = filename.replace(/[/\\:*?"<>|]/g, "_");
+  const safeName = filename.replaceAll(/[/\\:*?"<>|]/g, "_");
   const bom = "\uFEFF";
   const blob = new Blob([bom + csvContent], {
     type: "text/csv;charset=utf-8;",

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-dropdown.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { HiArrowDownTray } from "react-icons/hi2";
+import { RiFileChartLine } from "react-icons/ri";
+
+interface ExportDropdownProps {
+  ariaLabel: string;
+  csvLabel: string;
+  onExportCsv: () => void;
+}
+
+export function ExportDropdown({
+  ariaLabel,
+  csvLabel,
+  onExportCsv,
+}: Readonly<ExportDropdownProps>) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, left: rect.right });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        buttonRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      )
+        return;
+      close();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = () => close();
+    window.addEventListener("scroll", handler, true);
+    return () => window.removeEventListener("scroll", handler, true);
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="no-drag shrink-0 cursor-pointer rounded p-1 text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+      >
+        <HiArrowDownTray className="h-4 w-4" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[9999] min-w-[140px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+            style={{
+              top: pos.top,
+              left: pos.left,
+              transform: "translateX(-100%)",
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                onExportCsv();
+                close();
+              }}
+              className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              <RiFileChartLine className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+              <span>{csvLabel}</span>
+            </button>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/export-dropdown.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { HiArrowDownTray } from "react-icons/hi2";
 import { RiFileChartLine } from "react-icons/ri";
+import { usePortalDropdown } from "./use-portal-dropdown";
 
 interface ExportDropdownProps {
   ariaLabel: string;
@@ -16,56 +16,15 @@ export function ExportDropdown({
   csvLabel,
   onExportCsv,
 }: Readonly<ExportDropdownProps>) {
-  const [open, setOpen] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0 });
-
-  const close = useCallback(() => setOpen(false), []);
-
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-    const rect = buttonRef.current.getBoundingClientRect();
-    setPos({ top: rect.bottom + 4, left: rect.right });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (
-        buttonRef.current?.contains(target) ||
-        menuRef.current?.contains(target)
-      )
-        return;
-      close();
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open, close]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [open, close]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = () => close();
-    window.addEventListener("scroll", handler, true);
-    return () => window.removeEventListener("scroll", handler, true);
-  }, [open, close]);
+  const { open, pos, buttonRef, menuRef, close, toggle } =
+    usePortalDropdown();
 
   return (
     <>
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={toggle}
         aria-label={ariaLabel}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -163,3 +163,5 @@ export { ThresholdEditor } from "./threshold-editor";
 export { useThresholdSettings } from "./use-threshold-settings";
 export { buildCsvContent, downloadCsv } from "./export-csv";
 export { ExportDropdown } from "./export-dropdown";
+export { usePortalDropdown } from "./use-portal-dropdown";
+export { DashletTitleBar } from "./dashlet-title-bar";

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/index.ts
@@ -161,3 +161,5 @@ export {
 export { type ThresholdResult, useThreshold, useRowThreshold } from "./use-threshold";
 export { ThresholdEditor } from "./threshold-editor";
 export { useThresholdSettings } from "./use-threshold-settings";
+export { buildCsvContent, downloadCsv } from "./export-csv";
+export { ExportDropdown } from "./export-dropdown";

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
@@ -10,6 +10,11 @@ interface SortPillRowProps {
   onSortClick: (key: string) => void;
 }
 
+function SortIcon({ dir }: Readonly<{ dir: "asc" | "desc" }>) {
+  if (dir === "asc") return <HiArrowUp className="h-3 w-3" />;
+  return <HiArrowDown className="h-3 w-3" />;
+}
+
 export function SortPillRow({
   label,
   columns,
@@ -29,15 +34,7 @@ export function SortPillRow({
           label={getColumnLabel(key)}
           active={sortKey === key}
           onClick={() => onSortClick(key)}
-          icon={
-            sortKey === key ? (
-              sortDir === "asc" ? (
-                <HiArrowUp className="h-3 w-3" />
-              ) : (
-                <HiArrowDown className="h-3 w-3" />
-              )
-            ) : undefined
-          }
+          icon={sortKey === key ? <SortIcon dir={sortDir} /> : undefined}
         />
       ))}
     </div>

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
@@ -1,0 +1,45 @@
+import { HiArrowUp, HiArrowDown } from "react-icons/hi2";
+import { Pill } from "./pill";
+
+interface SortPillRowProps {
+  label: string;
+  columns: string[];
+  sortKey: string;
+  sortDir: "asc" | "desc";
+  getColumnLabel: (key: string) => string;
+  onSortClick: (key: string) => void;
+}
+
+export function SortPillRow({
+  label,
+  columns,
+  sortKey,
+  sortDir,
+  getColumnLabel,
+  onSortClick,
+}: Readonly<SortPillRowProps>) {
+  if (columns.length === 0) return null;
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+      <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
+      {columns.map((key) => (
+        <Pill
+          key={key}
+          label={getColumnLabel(key)}
+          active={sortKey === key}
+          onClick={() => onSortClick(key)}
+          icon={
+            sortKey === key ? (
+              sortDir === "asc" ? (
+                <HiArrowUp className="h-3 w-3" />
+              ) : (
+                <HiArrowDown className="h-3 w-3" />
+              )
+            ) : undefined
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/sort-pill-row.tsx
@@ -4,7 +4,7 @@ import { Pill } from "./pill";
 interface SortPillRowProps {
   label: string;
   columns: string[];
-  sortKey: string;
+  sortKey: string | null;
   sortDir: "asc" | "desc";
   getColumnLabel: (key: string) => string;
   onSortClick: (key: string) => void;

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-portal-dropdown.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-portal-dropdown.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+/**
+ * Shared state and event-handling logic for portal-based dropdown menus.
+ * Used by ActionDropdown, ExportDropdown, and any future dropdown that
+ * renders its menu via createPortal.
+ */
+export function usePortalDropdown() {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+
+  const close = useCallback(() => setOpen(false), []);
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  // Compute position when opening
+  useEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, left: rect.right });
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        buttonRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      )
+        return;
+      close();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, close]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, close]);
+
+  // Close on scroll of any ancestor (the table/dashboard container scrolls)
+  useEffect(() => {
+    if (!open) return;
+    const handler = () => close();
+    window.addEventListener("scroll", handler, true);
+    return () => window.removeEventListener("scroll", handler, true);
+  }, [open, close]);
+
+  return { open, pos, buttonRef, menuRef, close, toggle };
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.settings.tsx
@@ -70,6 +70,8 @@ export function DashletSettings({
     cl.footerColumns
   );
 
+  const [showExport, setShowExport] = useState(config.showExport ?? true);
+
   const [dataSourceId, setDataSourceId] = useState<string>(
     config.dataSourceId ?? ""
   );
@@ -122,6 +124,7 @@ export function DashletSettings({
     onSave({
       title: s.title,
       showRowCount: s.showRowCount,
+      showExport,
       dataMode: s.dataMode,
       columns: savedColumns,
       rows,
@@ -160,6 +163,20 @@ export function DashletSettings({
         syncColumnsFromKeys(keys, s, autoPopulateCardLayout)
       }
     />
+  );
+
+  const exportToggle = (
+    <div className="flex items-center justify-between py-0.5">
+      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        {tr("dashboard.settings.showExport", dictionary)}
+      </label>
+      <input
+        type="checkbox"
+        checked={showExport}
+        onChange={(e) => setShowExport(e.target.checked)}
+        className="no-drag h-4 w-4 rounded border-gray-300 text-blue-600 dark:border-gray-600"
+      />
+    </div>
   );
 
   // Card layout section (inserted between ColumnEditor and FilterEditor)
@@ -258,6 +275,7 @@ export function DashletSettings({
       handlebarsColorKeys
       refreshSelect={refresh.selectNode}
       title={dashletName}
+      displayOptionsChildren={exportToggle}
     >
       {cardLayoutSection}
     </TableListSettingsShell>

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { HiArrowUp, HiArrowDown, HiEllipsisVertical } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import { useDashboard } from "../../context/dashboard-context";
@@ -17,6 +17,8 @@ import { normalizeFilterConfig } from "../common/filter-helpers";
 import { FilterPillRow } from "../common/filter-pill-row";
 import { useFilterAndSort } from "../common/use-filter-and-sort";
 import { useCompiledColumns } from "../common/use-compiled-columns";
+import { buildCsvContent, downloadCsv } from "../common/export-csv";
+import { ExportDropdown } from "../common/export-dropdown";
 
 export type {
   DataMode,
@@ -60,6 +62,8 @@ export interface DashletConfig {
   sort: SortConfig;
   cardLayout: CardLayoutConfig;
   plannerVariableName?: string;
+  /** Show the export dropdown in the title bar */
+  showExport?: boolean;
 }
 
 // ============================================================================
@@ -334,6 +338,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     sort = defaultSort,
     cardLayout = defaultCardLayout,
     plannerVariableName,
+    showExport = true,
   } = config;
   const filter = useMemo(
     () => normalizeFilterConfig(config.filter, defaultFilter),
@@ -401,25 +406,40 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
+  // ── CSV export ──────────────────────────────────────────────────────────────
+  const handleExportCsv = useCallback(() => {
+    const csv = buildCsvContent(columns, displayRows, resolveValue, resolveLabel);
+    downloadCsv(csv, `${title}.csv`);
+  }, [columns, displayRows, resolveValue, resolveLabel, title]);
+
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
-      {/* Title + row count */}
+      {/* Title + row count + export */}
       <div className="flex shrink-0 items-start justify-between">
         <h3 className="text-xl font-bold text-gray-900 dark:text-white">
           {title}
         </h3>
-        {showRowCount && (
-          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
-            {displayRows.length === 1
-              ? tr("dashboard.dashlets.data_list.itemTotal", dictionary)
-              : tr("dashboard.dashlets.data_list.itemsTotal", dictionary, {
-                  count: String(displayRows.length),
-                })}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {showRowCount && (
+            <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+              {displayRows.length === 1
+                ? tr("dashboard.dashlets.data_list.itemTotal", dictionary)
+                : tr("dashboard.dashlets.data_list.itemsTotal", dictionary, {
+                    count: String(displayRows.length),
+                  })}
+            </span>
+          )}
+          {showExport && displayRows.length > 0 && (
+            <ExportDropdown
+              ariaLabel={tr("dashboard.settings.exportCsv", dictionary)}
+              csvLabel="CSV"
+              onExportCsv={handleExportCsv}
+            />
+          )}
+        </div>
       </div>
 
       {/* Filter cards */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { HiArrowUp, HiArrowDown, HiEllipsisVertical } from "react-icons/hi2";
+import { HiEllipsisVertical } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import { useDashboard } from "../../context/dashboard-context";
 import { tr } from "@/features/i18n/tr.service";
@@ -9,12 +9,12 @@ import type { DataMode, TableColumn, SortConfig } from "../common/column-types";
 import type { FilterConfig, FilterItemConfig } from "../common/filter-types";
 import type { PgrestParam, PgrestHttpMethod } from "../common/pgrest-types";
 import { renderCell } from "../common/cell-renderers";
-import { Pill } from "../common/pill";
 import { useDynamicRows } from "../common/use-dynamic-rows";
 import { useDashletData } from "../common/use-dashlet-data";
 import { useEffectiveRefreshInterval } from "../../hooks/use-effective-refresh-interval";
 import { normalizeFilterConfig } from "../common/filter-helpers";
 import { FilterPillRow } from "../common/filter-pill-row";
+import { SortPillRow } from "../common/sort-pill-row";
 import { useFilterAndSort } from "../common/use-filter-and-sort";
 import { useCompiledColumns } from "../common/use-compiled-columns";
 import {
@@ -395,13 +395,6 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     handleSortClick,
   } = useFilterAndSort(filter, sort, allRows, columns);
 
-  const getSortIcon = (dir: "asc" | "desc") =>
-    dir === "asc" ? (
-      <HiArrowUp className="h-3 w-3" />
-    ) : (
-      <HiArrowDown className="h-3 w-3" />
-    );
-
   // ── Handlebars template compilation ────────────────────────────────────────
   const { resolveValue, resolveLabel, resolveType } = useCompiledColumns(
     columns,
@@ -449,21 +442,15 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
         })}
 
       {/* Sort card */}
-      {sort.enabled && sort.columns.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
-          <span className="text-sm text-gray-500 dark:text-gray-400">
-            {tr("dashboard.dashlets.data_list.sortBy", dictionary)}
-          </span>
-          {sort.columns.map((key) => (
-            <Pill
-              key={key}
-              label={getColumnLabel(key)}
-              active={sortKey === key}
-              onClick={() => handleSortClick(key)}
-              icon={sortKey === key ? getSortIcon(sortDir) : undefined}
-            />
-          ))}
-        </div>
+      {sort.enabled && (
+        <SortPillRow
+          label={tr("dashboard.dashlets.data_list.sortBy", dictionary)}
+          columns={sort.columns}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          getColumnLabel={getColumnLabel}
+          onSortClick={handleSortClick}
+        />
       )}
 
       {/* Cards list */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
@@ -17,7 +17,10 @@ import { normalizeFilterConfig } from "../common/filter-helpers";
 import { FilterPillRow } from "../common/filter-pill-row";
 import { useFilterAndSort } from "../common/use-filter-and-sort";
 import { useCompiledColumns } from "../common/use-compiled-columns";
-import { DashletTitleBar } from "../common/dashlet-title-bar";
+import {
+  DashletTitleBar,
+  buildTitleBarData,
+} from "../common/dashlet-title-bar";
 
 export type {
   DataMode,
@@ -405,15 +408,19 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
+  // ── Title bar data ──────────────────────────────────────────────────────────
+  const titleBarData = buildTitleBarData({
+    title, showRowCount, showExport, columns,
+    displayRows, resolveValue, resolveLabel, dictionary,
+  });
+
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
       <DashletTitleBar
-        title={title}
-        showRowCount={showRowCount}
-        showExport={showExport}
+        {...titleBarData}
         rowCountLabel={
           displayRows.length === 1
             ? tr("dashboard.dashlets.data_list.itemTotal", dictionary)
@@ -421,11 +428,6 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
                 count: String(displayRows.length),
               })
         }
-        columns={columns}
-        displayRows={displayRows}
-        resolveValue={resolveValue}
-        resolveLabel={resolveLabel}
-        dictionary={dictionary}
       />
 
       {/* Filter cards */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo } from "react";
 import { HiArrowUp, HiArrowDown, HiEllipsisVertical } from "react-icons/hi2";
 import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
 import { useDashboard } from "../../context/dashboard-context";
@@ -17,8 +17,7 @@ import { normalizeFilterConfig } from "../common/filter-helpers";
 import { FilterPillRow } from "../common/filter-pill-row";
 import { useFilterAndSort } from "../common/use-filter-and-sort";
 import { useCompiledColumns } from "../common/use-compiled-columns";
-import { buildCsvContent, downloadCsv } from "../common/export-csv";
-import { ExportDropdown } from "../common/export-dropdown";
+import { DashletTitleBar } from "../common/dashlet-title-bar";
 
 export type {
   DataMode,
@@ -406,41 +405,28 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
-  // ── CSV export ──────────────────────────────────────────────────────────────
-  const handleExportCsv = useCallback(() => {
-    const csv = buildCsvContent(columns, displayRows, resolveValue, resolveLabel);
-    downloadCsv(csv, `${title}.csv`);
-  }, [columns, displayRows, resolveValue, resolveLabel, title]);
-
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
-      {/* Title + row count + export */}
-      <div className="flex shrink-0 items-start justify-between">
-        <h3 className="text-xl font-bold text-gray-900 dark:text-white">
-          {title}
-        </h3>
-        <div className="flex items-center gap-2">
-          {showRowCount && (
-            <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
-              {displayRows.length === 1
-                ? tr("dashboard.dashlets.data_list.itemTotal", dictionary)
-                : tr("dashboard.dashlets.data_list.itemsTotal", dictionary, {
-                    count: String(displayRows.length),
-                  })}
-            </span>
-          )}
-          {showExport && displayRows.length > 0 && (
-            <ExportDropdown
-              ariaLabel={tr("dashboard.settings.exportCsv", dictionary)}
-              csvLabel="CSV"
-              onExportCsv={handleExportCsv}
-            />
-          )}
-        </div>
-      </div>
+      <DashletTitleBar
+        title={title}
+        showRowCount={showRowCount}
+        showExport={showExport}
+        rowCountLabel={
+          displayRows.length === 1
+            ? tr("dashboard.dashlets.data_list.itemTotal", dictionary)
+            : tr("dashboard.dashlets.data_list.itemsTotal", dictionary, {
+                count: String(displayRows.length),
+              })
+        }
+        columns={columns}
+        displayRows={displayRows}
+        resolveValue={resolveValue}
+        resolveLabel={resolveLabel}
+        dictionary={dictionary}
+      />
 
       {/* Filter cards */}
       {filter.enabled &&

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.settings.tsx
@@ -50,6 +50,7 @@ export function DashletSettings({
   const [showColumnDividers, setShowColumnDividers] = useState(
     config.showColumnDividers ?? true
   );
+  const [showExport, setShowExport] = useState(config.showExport ?? true);
 
   const s = useSettingsState({
     title: config.title,
@@ -92,6 +93,7 @@ export function DashletSettings({
       title: s.title,
       showRowCount: s.showRowCount,
       showColumnDividers,
+      showExport,
       dataMode: s.dataMode as "static" | "pgrest" | "planner",
       columns: savedColumns,
       rows,
@@ -130,18 +132,31 @@ export function DashletSettings({
     />
   );
 
-  const columnDividersToggle = (
-    <div className="flex items-center justify-between py-0.5">
-      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        {tr("dashboard.settings.showColumnDividers", dictionary)}
-      </label>
-      <input
-        type="checkbox"
-        checked={showColumnDividers}
-        onChange={(e) => setShowColumnDividers(e.target.checked)}
-        className="no-drag h-4 w-4 rounded border-gray-300 text-blue-600 dark:border-gray-600"
-      />
-    </div>
+  const displayOptions = (
+    <>
+      <div className="flex items-center justify-between py-0.5">
+        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {tr("dashboard.settings.showColumnDividers", dictionary)}
+        </label>
+        <input
+          type="checkbox"
+          checked={showColumnDividers}
+          onChange={(e) => setShowColumnDividers(e.target.checked)}
+          className="no-drag h-4 w-4 rounded border-gray-300 text-blue-600 dark:border-gray-600"
+        />
+      </div>
+      <div className="flex items-center justify-between py-0.5">
+        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {tr("dashboard.settings.showExport", dictionary)}
+        </label>
+        <input
+          type="checkbox"
+          checked={showExport}
+          onChange={(e) => setShowExport(e.target.checked)}
+          className="no-drag h-4 w-4 rounded border-gray-300 text-blue-600 dark:border-gray-600"
+        />
+      </div>
+    </>
   );
 
   return (
@@ -157,7 +172,7 @@ export function DashletSettings({
       handlebarsColorKeys
       refreshSelect={refresh.selectNode}
       title={dashletName}
-      displayOptionsChildren={columnDividersToggle}
+      displayOptionsChildren={displayOptions}
     />
   );
 }

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -62,7 +62,10 @@ import {
 } from "@/features/dashboard/dashlets/common/action-helpers";
 import { resolveHandlebarsField } from "@/features/dashboard/dashlets/common/use-handlebars-templates";
 import { ActionDropdown } from "@/features/dashboard/dashlets/common/action-dropdown";
-import { DashletTitleBar } from "@/features/dashboard/dashlets/common/dashlet-title-bar";
+import {
+  DashletTitleBar,
+  buildTitleBarData,
+} from "@/features/dashboard/dashlets/common/dashlet-title-bar";
 
 export interface DashletConfig {
   title: string;
@@ -261,15 +264,19 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
+  // ── Title bar data ──────────────────────────────────────────────────────────
+  const titleBarData = buildTitleBarData({
+    title, showRowCount, showExport, columns,
+    displayRows, resolveValue, resolveLabel, dictionary,
+  });
+
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
       <DashletTitleBar
-        title={title}
-        showRowCount={showRowCount}
-        showExport={showExport}
+        {...titleBarData}
         rowCountLabel={tr(
           displayRows.length === 1
             ? "dashboard.settings.totalItemsSingular"
@@ -277,11 +284,6 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
           dictionary,
           { count: String(displayRows.length) }
         )}
-        columns={columns}
-        displayRows={displayRows}
-        resolveValue={resolveValue}
-        resolveLabel={resolveLabel}
-        dictionary={dictionary}
       />
 
       {/* Filter cards */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo } from "react";
 import { HiArrowUp, HiArrowDown } from "react-icons/hi2";
 import type {
   DashletComponentProps,
@@ -62,8 +62,7 @@ import {
 } from "@/features/dashboard/dashlets/common/action-helpers";
 import { resolveHandlebarsField } from "@/features/dashboard/dashlets/common/use-handlebars-templates";
 import { ActionDropdown } from "@/features/dashboard/dashlets/common/action-dropdown";
-import { buildCsvContent, downloadCsv } from "@/features/dashboard/dashlets/common/export-csv";
-import { ExportDropdown } from "@/features/dashboard/dashlets/common/export-dropdown";
+import { DashletTitleBar } from "@/features/dashboard/dashlets/common/dashlet-title-bar";
 
 export interface DashletConfig {
   title: string;
@@ -262,43 +261,28 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
-  // ── CSV export ──────────────────────────────────────────────────────────────
-  const handleExportCsv = useCallback(() => {
-    const csv = buildCsvContent(columns, displayRows, resolveValue, resolveLabel);
-    downloadCsv(csv, `${title}.csv`);
-  }, [columns, displayRows, resolveValue, resolveLabel, title]);
-
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
-      {/* Title + row count + export — outside any card */}
-      <div className="flex shrink-0 items-start justify-between">
-        <h3 className="text-xl font-bold text-gray-900 dark:text-white">
-          {title}
-        </h3>
-        <div className="flex items-center gap-2">
-          {showRowCount && (
-            <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
-              {tr(
-                displayRows.length === 1
-                  ? "dashboard.settings.totalItemsSingular"
-                  : "dashboard.settings.totalItems",
-                dictionary,
-                { count: String(displayRows.length) }
-              )}
-            </span>
-          )}
-          {showExport && displayRows.length > 0 && (
-            <ExportDropdown
-              ariaLabel={tr("dashboard.settings.exportCsv", dictionary)}
-              csvLabel="CSV"
-              onExportCsv={handleExportCsv}
-            />
-          )}
-        </div>
-      </div>
+      <DashletTitleBar
+        title={title}
+        showRowCount={showRowCount}
+        showExport={showExport}
+        rowCountLabel={tr(
+          displayRows.length === 1
+            ? "dashboard.settings.totalItemsSingular"
+            : "dashboard.settings.totalItems",
+          dictionary,
+          { count: String(displayRows.length) }
+        )}
+        columns={columns}
+        displayRows={displayRows}
+        resolveValue={resolveValue}
+        resolveLabel={resolveLabel}
+        dictionary={dictionary}
+      />
 
       {/* Filter cards */}
       {filter.enabled &&

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -299,7 +299,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
       {/* Sort card */}
       {sort.enabled && (
         <SortPillRow
-          label="Ordenar por:"
+          label={tr("dashboard.settings.sortBy", dictionary)}
           columns={validSortColumns}
           sortKey={sortKey}
           sortDir={sortDir}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo } from "react";
-import { HiArrowUp, HiArrowDown } from "react-icons/hi2";
 import type {
   DashletComponentProps,
   DashletLayoutDefaults,
@@ -18,6 +17,7 @@ import { renderCell } from "@/features/dashboard/dashlets/common/cell-renderers"
 import { Pill } from "@/features/dashboard/dashlets/common/pill";
 import { normalizeFilterConfig } from "@/features/dashboard/dashlets/common/filter-helpers";
 import { FilterPillRow } from "@/features/dashboard/dashlets/common/filter-pill-row";
+import { SortPillRow } from "@/features/dashboard/dashlets/common/sort-pill-row";
 import { useFilterAndSort } from "@/features/dashboard/dashlets/common/use-filter-and-sort";
 import { useDashletData } from "@/features/dashboard/dashlets/common/use-dashlet-data";
 import { useEffectiveRefreshInterval } from "../../hooks/use-effective-refresh-interval";
@@ -251,13 +251,6 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     handleSortClick,
   } = useFilterAndSort(filter, sort, allRows, columns);
 
-  const getSortIcon = (dir: "asc" | "desc") =>
-    dir === "asc" ? (
-      <HiArrowUp className="h-3 w-3" />
-    ) : (
-      <HiArrowDown className="h-3 w-3" />
-    );
-
   // ── Handlebars template compilation ────────────────────────────────────────
   const { resolveValue, resolveLabel, resolveType } = useCompiledColumns(
     columns,
@@ -305,21 +298,15 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
         })}
 
       {/* Sort card */}
-      {sort.enabled && validSortColumns.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
-          <span className="text-sm text-gray-500 dark:text-gray-400">
-            Ordenar por:
-          </span>
-          {validSortColumns.map((key) => (
-            <Pill
-              key={key}
-              label={getColumnLabel(key)}
-              active={sortKey === key}
-              onClick={() => handleSortClick(key)}
-              icon={sortKey === key ? getSortIcon(sortDir) : undefined}
-            />
-          ))}
-        </div>
+      {sort.enabled && (
+        <SortPillRow
+          label="Ordenar por:"
+          columns={validSortColumns}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          getColumnLabel={getColumnLabel}
+          onSortClick={handleSortClick}
+        />
       )}
 
       {/* Table card */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { HiArrowUp, HiArrowDown } from "react-icons/hi2";
 import type {
   DashletComponentProps,
@@ -62,6 +62,8 @@ import {
 } from "@/features/dashboard/dashlets/common/action-helpers";
 import { resolveHandlebarsField } from "@/features/dashboard/dashlets/common/use-handlebars-templates";
 import { ActionDropdown } from "@/features/dashboard/dashlets/common/action-dropdown";
+import { buildCsvContent, downloadCsv } from "@/features/dashboard/dashlets/common/export-csv";
+import { ExportDropdown } from "@/features/dashboard/dashlets/common/export-dropdown";
 
 export interface DashletConfig {
   title: string;
@@ -80,6 +82,8 @@ export interface DashletConfig {
   plannerVariableName?: string;
   rowColorRules?: ColorRulesConfig;
   actions?: ActionsConfig;
+  /** Show the export dropdown in the title bar */
+  showExport?: boolean;
 }
 
 // ============================================================================
@@ -192,6 +196,7 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     sort = defaultSort,
     dataSourceId,
     plannerVariableName,
+    showExport = true,
   } = config;
   const filter = useMemo(
     () => normalizeFilterConfig(config.filter, defaultFilter),
@@ -257,27 +262,42 @@ export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
     displayRows.length
   );
 
+  // ── CSV export ──────────────────────────────────────────────────────────────
+  const handleExportCsv = useCallback(() => {
+    const csv = buildCsvContent(columns, displayRows, resolveValue, resolveLabel);
+    downloadCsv(csv, `${title}.csv`);
+  }, [columns, displayRows, resolveValue, resolveLabel, title]);
+
   // ── Render ──────────────────────────────────────────────────────────────────
   const allLabel = tr("common.all", dictionary);
 
   return (
     <div className="flex h-full flex-col gap-3">
-      {/* Title + row count — outside any card */}
+      {/* Title + row count + export — outside any card */}
       <div className="flex shrink-0 items-start justify-between">
         <h3 className="text-xl font-bold text-gray-900 dark:text-white">
           {title}
         </h3>
-        {showRowCount && (
-          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
-            {tr(
-              displayRows.length === 1
-                ? "dashboard.settings.totalItemsSingular"
-                : "dashboard.settings.totalItems",
-              dictionary,
-              { count: String(displayRows.length) }
-            )}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {showRowCount && (
+            <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+              {tr(
+                displayRows.length === 1
+                  ? "dashboard.settings.totalItemsSingular"
+                  : "dashboard.settings.totalItems",
+                dictionary,
+                { count: String(displayRows.length) }
+              )}
+            </span>
+          )}
+          {showExport && displayRows.length > 0 && (
+            <ExportDropdown
+              ariaLabel={tr("dashboard.settings.exportCsv", dictionary)}
+              csvLabel="CSV"
+              onExportCsv={handleExportCsv}
+            />
+          )}
+        </div>
       </div>
 
       {/* Filter cards */}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx
@@ -14,7 +14,6 @@ import type {
   FilterConfig,
 } from "@/features/dashboard/dashlets/common/filter-types";
 import { renderCell } from "@/features/dashboard/dashlets/common/cell-renderers";
-import { Pill } from "@/features/dashboard/dashlets/common/pill";
 import { normalizeFilterConfig } from "@/features/dashboard/dashlets/common/filter-helpers";
 import { FilterPillRow } from "@/features/dashboard/dashlets/common/filter-pill-row";
 import { SortPillRow } from "@/features/dashboard/dashlets/common/sort-pill-row";

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1608,6 +1608,7 @@
       "addParameter": "Add parameter",
       "totalItems": "{count} items",
       "totalItemsSingular": "{count} item",
+      "sortBy": "Sort by:",
       "exportCsv": "Export CSV",
       "showExport": "Show export",
       "staticJson": "Static (JSON)",

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1608,6 +1608,8 @@
       "addParameter": "Add parameter",
       "totalItems": "{count} items",
       "totalItemsSingular": "{count} item",
+      "exportCsv": "Export CSV",
+      "showExport": "Show export",
       "staticJson": "Static (JSON)",
       "pgrest": "PGREST",
       "dynamicApi": "Dynamic (API)",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1634,6 +1634,7 @@
       "addParameter": "Agregar parámetro",
       "totalItems": "{count} elementos",
       "totalItemsSingular": "{count} elemento",
+      "sortBy": "Ordenar por:",
       "exportCsv": "Exportar CSV",
       "showExport": "Mostrar exportación",
       "staticJson": "Estático (JSON)",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1634,6 +1634,8 @@
       "addParameter": "Agregar parámetro",
       "totalItems": "{count} elementos",
       "totalItemsSingular": "{count} elemento",
+      "exportCsv": "Exportar CSV",
+      "showExport": "Mostrar exportación",
       "staticJson": "Estático (JSON)",
       "pgrest": "PGREST",
       "dynamicApi": "Dinámico (API)",


### PR DESCRIPTION
- Add export-csv utility with CSV building and download helpers
- Add ExportDropdown reusable component with portal-based menu
- Integrate CSV export into data_table and data_list dashlet settings and views
- Add i18n labels for export actions (en/es)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export: export dashlet data to CSV from a new title-bar dropdown.
  * Proper CSV formatting and download handling (escaped values, UTF‑8 BOM).
  * Toggle to show/hide export added to dashlet settings.
  * Updated title bar shows row count and export control.
  * Improved sort controls rendered as interactive sort "pills".

* **Localization**
  * Added English and Spanish labels for export UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->