### PR TITLE
feat: add prev/next navigation to vehicle detail page

### DIFF
--- a/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/fleet-management-page.tsx
@@ -157,9 +157,11 @@ export default function FleetManagementPage({
 
   const handleSelectVehicle = useCallback(
     (plate: string) => {
-      router.push(`${pathname}/${encodeURIComponent(plate)}`);
+      const qs = searchParams.toString();
+      const base = `${pathname}/${encodeURIComponent(plate)}`;
+      router.push(qs ? `${base}?${qs}` : base);
     },
-    [router, pathname]
+    [router, pathname, searchParams]
   );
 
   return (

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail-page.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail-page.tsx
@@ -1,16 +1,35 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import { truckToVehicle } from "../data/fleet-adapters";
 import { useFleetTruck } from "../hooks/use-fleet-truck";
+import { useFleetTrucks } from "../hooks/use-fleet-trucks";
+import type { Vehicle } from "../types/fleet.types";
 import VehicleDetailView from "./vehicle-detail/vehicle-detail-view";
 
 interface VehicleDetailPageProps {
   readonly dict: I18nRecord;
   readonly plate: string;
+}
+
+/**
+ * Walk the vehicle list to find prev/next neighbors for the current plate.
+ * Returns null when the list is still loading or the plate isn't found.
+ */
+function computeNeighborNav(
+  list: Vehicle[],
+  plate: string
+): { prevPlate: string | null; nextPlate: string | null } | null {
+  if (list.length === 0) return null;
+  const idx = list.findIndex((v) => v.plate === plate);
+  if (idx === -1) return null;
+  return {
+    prevPlate: idx > 0 ? list[idx - 1].plate : null,
+    nextPlate: idx < list.length - 1 ? list[idx + 1].plate : null,
+  };
 }
 
 export default function VehicleDetailPage({
@@ -20,6 +39,7 @@ export default function VehicleDetailPage({
   const fleetDict = dict["fleetManagement"] as I18nRecord;
   const router = useRouter();
   const { lang } = useParams<{ lang: string }>();
+  const searchParams = useSearchParams();
 
   const { truck, notFound, error, isLoading } = useFleetTruck(plate, {
     includeMetrics: true,
@@ -27,14 +47,74 @@ export default function VehicleDetailPage({
       "timestamp,odometer_km,fuel_volume_ml,fuel_level_pct,latitude,longitude",
   });
 
+  // Pull the full list for prev/next navigation. SWR dedupes against the
+  // list page's call so there's no extra network cost when the user came
+  // here via a card click; direct URL hits pay one fetch for navigation.
+  const { trucks } = useFleetTrucks({
+    size: 9999,
+    includeMetrics: true,
+    metricFields:
+      "timestamp,odometer_km,fuel_volume_ml,fuel_level_pct,latitude,longitude",
+  });
+
+  const allVehicles = useMemo(() => trucks.map(truckToVehicle), [trucks]);
+
+  // Apply the same filters as the list page so navigation respects the
+  // current search/filter context carried via URL search params.
+  const filteredVehicles = useMemo(() => {
+    const plateFilter = (searchParams.get("licensePlate") ?? "")
+      .trim()
+      .toLowerCase();
+    const clientFilter = (searchParams.get("client") ?? "")
+      .trim()
+      .toLowerCase();
+    const stateFilter = (searchParams.get("state") ?? "")
+      .trim()
+      .toLowerCase();
+
+    if (!plateFilter && !clientFilter && !stateFilter) return allVehicles;
+
+    return allVehicles.filter((v) => {
+      if (plateFilter && !v.plate.toLowerCase().includes(plateFilter))
+        return false;
+      if (clientFilter && !v.transportist.toLowerCase().includes(clientFilter))
+        return false;
+      if (stateFilter && v.status !== stateFilter) return false;
+      return true;
+    });
+  }, [allVehicles, searchParams]);
+
   const vehicle = useMemo(
     () => (truck ? truckToVehicle(truck) : null),
     [truck]
   );
 
+  const navigation = useMemo(
+    () => computeNeighborNav(filteredVehicles, plate),
+    [filteredVehicles, plate]
+  );
+
   const handleBack = useCallback(() => {
-    router.push(`/${lang}/fleet-management`);
-  }, [router, lang]);
+    const qs = searchParams.toString();
+    const base = `/${lang}/fleet-management`;
+    router.push(qs ? `${base}?${qs}` : base);
+  }, [router, lang, searchParams]);
+
+  const handlePrevious = useCallback(() => {
+    if (navigation?.prevPlate) {
+      const qs = searchParams.toString();
+      const base = `/${lang}/fleet-management/${encodeURIComponent(navigation.prevPlate)}`;
+      router.push(qs ? `${base}?${qs}` : base);
+    }
+  }, [navigation, router, lang, searchParams]);
+
+  const handleNext = useCallback(() => {
+    if (navigation?.nextPlate) {
+      const qs = searchParams.toString();
+      const base = `/${lang}/fleet-management/${encodeURIComponent(navigation.nextPlate)}`;
+      router.push(qs ? `${base}?${qs}` : base);
+    }
+  }, [navigation, router, lang, searchParams]);
 
   if (isLoading) {
     return (
@@ -87,6 +167,14 @@ export default function VehicleDetailPage({
         vehicle={vehicle}
         dict={fleetDict}
         onBack={handleBack}
+        previous={{
+          hasPrevious: navigation?.prevPlate !== null && navigation !== null,
+          onPrevious: handlePrevious,
+        }}
+        next={{
+          hasNext: navigation?.nextPlate !== null && navigation !== null,
+          onNext: handleNext,
+        }}
       />
     </div>
   );

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail/vehicle-detail-header.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail/vehicle-detail-header.tsx
@@ -137,6 +137,7 @@ export default function VehicleDetailHeader({
         <div className="flex items-center gap-1 shrink-0">
           <button
             type="button"
+            disabled={!hasPrevious}
             onClick={onPrevious}
             className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             aria-label={tr("fleetManagement.previous", dict)}
@@ -145,6 +146,7 @@ export default function VehicleDetailHeader({
           </button>
           <button
             type="button"
+            disabled={!hasNext}
             onClick={onNext}
             className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             aria-label={tr("fleetManagement.next", dict)}

--- a/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail/vehicle-detail-view.tsx
+++ b/turbo-repo/apps/app/src/features/fleet-management/components/vehicle-detail/vehicle-detail-view.tsx
@@ -9,16 +9,28 @@ interface VehicleDetailViewProps {
   readonly vehicle: Vehicle;
   readonly dict: I18nRecord;
   readonly onBack: () => void;
+  readonly previous?: { hasPrevious: boolean; onPrevious: () => void };
+  readonly next?: { hasNext: boolean; onNext: () => void };
 }
 
 export default function VehicleDetailView({
   vehicle,
   dict,
   onBack,
+  previous,
+  next,
 }: VehicleDetailViewProps) {
   return (
     <div className="flex flex-col h-full items-center w-full">
-      <VehicleDetailHeader vehicle={vehicle} dict={dict} onBack={onBack} />
+      <VehicleDetailHeader
+        vehicle={vehicle}
+        dict={dict}
+        onBack={onBack}
+        onPrevious={previous?.onPrevious}
+        onNext={next?.onNext}
+        hasPrevious={previous?.hasPrevious ?? false}
+        hasNext={next?.hasNext ?? false}
+      />
       <div className="flex-1 min-h-0 overflow-y-auto w-[70vw] max-w-screen-2xl">
         <VehicleDetailAccordion vehicle={vehicle} dict={dict} />
       </div>


### PR DESCRIPTION
- preserve search params when navigating from list to detail
- compute prev/next neighbors using filtered vehicle list
- add navigation controls to vehicle detail header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added previous and next navigation buttons to vehicle detail pages, enabling users to browse through the filtered vehicle list without returning to the fleet management view
* Search filters and query parameters are now automatically preserved when navigating between individual vehicles in the list
* Navigation buttons intelligently disable when there are no previous or next vehicles available in the current filtered view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->