### PR TITLE
feat: add batch import dashlet

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer-modal.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer-modal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import FormModal from "@/features/common/components/form-modal/form-modal";
+import type { DuplicateStrategy, SubmitFn } from "./engine/types";
+import {
+  BatchImporterView,
+  useBatchImporter,
+} from "./batch-importer";
+import { tr } from "@/features/i18n/tr.service";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  submit: SubmitFn;
+  sourceKey: string;
+  title: string;
+  defaultStrategy?: DuplicateStrategy;
+  sample?: string;
+  acceptedFileTypes?: string;
+  dictionary: I18nRecord;
+}
+
+export function BatchImporterModal({
+  isOpen,
+  onClose,
+  submit,
+  sourceKey,
+  title,
+  defaultStrategy,
+  sample,
+  acceptedFileTypes,
+  dictionary,
+}: Readonly<Props>) {
+  const state = useBatchImporter({ submit, sourceKey, defaultStrategy });
+
+  const submitLabel = state.importing
+    ? tr("dashboard.dashlets.batchImport.importing", dictionary)
+    : tr("dashboard.dashlets.batchImport.importN", dictionary, {
+        count: String(state.summary.unprocessed),
+      });
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      subtitle={tr("dashboard.dashlets.batchImport.subtitle", dictionary)}
+      size="7xl"
+      submitLabel={submitLabel}
+      cancelLabel={tr("common.close", dictionary)}
+      showCancelButton
+      isProcessing={state.importing || !state.importable}
+      onSubmit={state.onImport}
+    >
+      <BatchImporterView
+        state={state}
+        sample={sample}
+        acceptedFileTypes={acceptedFileTypes}
+        dictionary={dictionary}
+      />
+    </FormModal>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -77,12 +77,12 @@ export function useBatchImporter({
       const parsed = parseDocument(text);
       const cache = readCache(sourceKey);
       parsed.rows = parsed.rows.map((r) => {
-        const cached = cache.status[r.index];
+        const cached = cache.status[r.fingerprint];
         if (cached && (isResolved(cached) || cached === "failed")) {
           return {
             ...r,
             status: cached,
-            errorMessage: cache.errorlog[r.index],
+            errorMessage: cache.errorlog[r.fingerprint],
           };
         }
         return r;
@@ -120,10 +120,10 @@ export function useBatchImporter({
 
         updateRow(i, { ...row, status: "wait" });
         const result = await submit(row, strategy);
-        cache.status[row.index] = result.status;
+        cache.status[row.fingerprint] = result.status;
         if (result.errorMessage)
-          cache.errorlog[row.index] = result.errorMessage;
-        else delete cache.errorlog[row.index];
+          cache.errorlog[row.fingerprint] = result.errorMessage;
+        else delete cache.errorlog[row.fingerprint];
         writeCache(sourceKey, cache);
         updateRow(i, {
           ...row,

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { Button } from "flowbite-react";
+import type {
+  DuplicateStrategy,
+  ParsedDocument,
+  ParsedRow,
+  RowStatus,
+  SubmitFn,
+} from "./engine/types";
+import { parseDocument } from "./engine/parser";
+import {
+  clearCache,
+  clearFailed,
+  isResolved,
+  readCache,
+  writeCache,
+} from "./engine/importer";
+import { StatusIcon } from "./components/status-icon";
+import { tr } from "@/features/i18n/tr.service";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+
+const RESOLVED: RowStatus[] = ["processed", "updated", "skipped"];
+
+const ROW_BG: Record<RowStatus, string> = {
+  unprocessed: "",
+  wait: "bg-amber-50 dark:bg-amber-900/10",
+  processed: "bg-green-50 dark:bg-green-900/10",
+  updated: "bg-indigo-50 dark:bg-indigo-900/10",
+  skipped: "bg-gray-50 text-gray-500 dark:bg-gray-800/40 dark:text-gray-400",
+  failed: "bg-red-50 dark:bg-red-900/10",
+};
+
+export interface UseBatchImporterArgs {
+  submit: SubmitFn;
+  sourceKey: string;
+  defaultStrategy?: DuplicateStrategy;
+}
+
+export interface BatchImporterState {
+  raw: string;
+  doc: ParsedDocument | null;
+  importing: boolean;
+  strategy: DuplicateStrategy;
+  setStrategy: (s: DuplicateStrategy) => void;
+  summary: Record<RowStatus | "total", number>;
+  importable: boolean;
+  hasFailed: boolean;
+  hasResolved: boolean;
+  load: (text: string) => void;
+  loadFile: (file: File) => void;
+  onImport: () => Promise<void>;
+  onRetryFailed: () => void;
+  onReset: () => void;
+}
+
+export function useBatchImporter({
+  submit,
+  sourceKey,
+  defaultStrategy = "upsert",
+}: UseBatchImporterArgs): BatchImporterState {
+  const [raw, setRaw] = useState<string>("");
+  const [doc, setDoc] = useState<ParsedDocument | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [strategy, setStrategy] = useState<DuplicateStrategy>(defaultStrategy);
+
+  const load = useCallback(
+    (text: string) => {
+      setRaw(text);
+      const parsed = parseDocument(text);
+      const cache = readCache(sourceKey);
+      parsed.rows = parsed.rows.map((r) => {
+        const cached = cache.status[r.index];
+        if (cached && (isResolved(cached) || cached === "failed")) {
+          return {
+            ...r,
+            status: cached,
+            errorMessage: cache.errorlog[r.index],
+          };
+        }
+        return r;
+      });
+      setDoc(parsed);
+    },
+    [sourceKey],
+  );
+
+  const loadFile = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => load(String(reader.result ?? ""));
+      reader.readAsText(file);
+    },
+    [load],
+  );
+
+  const updateRow = useCallback((idx: number, row: ParsedRow) => {
+    setDoc((d) => {
+      if (!d) return d;
+      const next = { ...d, rows: [...d.rows] };
+      next.rows[idx] = row;
+      return next;
+    });
+  }, []);
+
+  const runImport = useCallback(
+    async (targetIndexes?: Set<number>) => {
+      if (!doc) return;
+      setImporting(true);
+      const cache = readCache(sourceKey);
+      for (let i = 0; i < doc.rows.length; i++) {
+        const row = doc.rows[i];
+        if (targetIndexes && !targetIndexes.has(row.index)) continue;
+        if (row.status !== "unprocessed") continue;
+
+        updateRow(i, { ...row, status: "wait" });
+        const result = await submit(row, strategy);
+        cache.status[row.index] = result.status;
+        if (result.errorMessage)
+          cache.errorlog[row.index] = result.errorMessage;
+        else delete cache.errorlog[row.index];
+        writeCache(sourceKey, cache);
+        updateRow(i, {
+          ...row,
+          status: result.status,
+          errorMessage: result.errorMessage,
+        });
+      }
+      setImporting(false);
+    },
+    [doc, sourceKey, strategy, submit, updateRow],
+  );
+
+  const onImport = useCallback(() => runImport(), [runImport]);
+
+  const onRetryFailed = useCallback(() => {
+    if (!doc) return;
+    clearFailed(sourceKey);
+    const failedIndexes = new Set<number>();
+    const resetRows = doc.rows.map((r) => {
+      if (r.status === "failed") {
+        failedIndexes.add(r.index);
+        return {
+          ...r,
+          status: "unprocessed" as RowStatus,
+          errorMessage: undefined,
+        };
+      }
+      return r;
+    });
+    setDoc({ ...doc, rows: resetRows });
+    queueMicrotask(() => runImport(failedIndexes));
+  }, [doc, sourceKey, runImport]);
+
+  const onReset = useCallback(() => {
+    clearCache(sourceKey);
+    if (raw) load(raw);
+  }, [sourceKey, raw, load]);
+
+  const summary = useMemo(() => {
+    const c: Record<RowStatus | "total", number> = {
+      total: 0,
+      unprocessed: 0,
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      wait: 0,
+    };
+    if (!doc) return c;
+    doc.rows.forEach((r) => {
+      c.total++;
+      c[r.status]++;
+    });
+    return c;
+  }, [doc]);
+
+  return {
+    raw,
+    doc,
+    importing,
+    strategy,
+    setStrategy,
+    summary,
+    importable: summary.unprocessed > 0,
+    hasFailed: summary.failed > 0,
+    hasResolved: RESOLVED.reduce((n, s) => n + summary[s], 0) > 0,
+    load,
+    loadFile,
+    onImport,
+    onRetryFailed,
+    onReset,
+  };
+}
+
+interface ViewProps {
+  state: BatchImporterState;
+  sample?: string;
+  acceptedFileTypes?: string;
+  dictionary: I18nRecord;
+}
+
+export function BatchImporterView({
+  state,
+  sample,
+  acceptedFileTypes,
+  dictionary,
+}: Readonly<ViewProps>) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const {
+    raw,
+    doc,
+    importing,
+    strategy,
+    setStrategy,
+    summary,
+    hasFailed,
+    hasResolved,
+    load,
+    loadFile,
+    onRetryFailed,
+    onReset,
+  } = state;
+
+  const statusLabel = (status: RowStatus) =>
+    tr(`dashboard.dashlets.batchImport.status.${status}`, dictionary);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 text-gray-900 dark:text-gray-100">
+      <div className="flex justify-end gap-2">
+        {sample && (
+          <Button size="xs" color="gray" onClick={() => load(sample)}>
+            {tr("dashboard.dashlets.batchImport.loadSample", dictionary)}
+          </Button>
+        )}
+        <Button
+          size="xs"
+          color="gray"
+          onClick={() => fileRef.current?.click()}
+        >
+          {tr("dashboard.dashlets.batchImport.loadFile", dictionary)}
+        </Button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept={acceptedFileTypes || ".tsv,.csv,.txt,text/plain,text/csv"}
+          className="hidden"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            const f = e.target.files?.[0];
+            if (f) loadFile(f);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      <label className="block">
+        <span className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+          {tr("dashboard.dashlets.batchImport.pasteHint", dictionary)}
+        </span>
+        <textarea
+          value={raw}
+          onChange={(e) => load(e.target.value)}
+          rows={4}
+          className="w-full rounded-md border border-gray-200 bg-white p-2 font-mono text-xs text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+        />
+      </label>
+
+      {doc?.headerError && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+          {tr(
+            `dashboard.dashlets.batchImport.headerError.${doc.headerError}`,
+            dictionary,
+          )}
+        </div>
+      )}
+
+      {doc && !doc.headerError && doc.headers.length > 0 && (
+        <>
+          <section className="flex flex-wrap items-center justify-between gap-2 rounded-t-md border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex flex-wrap gap-1.5">
+              <Badge label={statusLabel("unprocessed")} count={summary.unprocessed} tone="ok" />
+              <Badge label={statusLabel("processed")} count={summary.processed} tone="done" />
+              <Badge label={statusLabel("updated")} count={summary.updated} tone="info" />
+              <Badge label={statusLabel("skipped")} count={summary.skipped} tone="mute" />
+              <Badge label={statusLabel("failed")} count={summary.failed} tone="fail" />
+              <Badge label={tr("dashboard.dashlets.batchImport.total", dictionary)} count={summary.total} />
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300">
+                {tr("dashboard.dashlets.batchImport.duplicates", dictionary)}
+                <select
+                  value={strategy}
+                  disabled={importing}
+                  onChange={(e) =>
+                    setStrategy(e.target.value as DuplicateStrategy)
+                  }
+                  className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                >
+                  <option value="upsert">
+                    {tr("dashboard.dashlets.batchImport.strategy.upsert", dictionary)}
+                  </option>
+                  <option value="skip">
+                    {tr("dashboard.dashlets.batchImport.strategy.skip", dictionary)}
+                  </option>
+                  <option value="create">
+                    {tr("dashboard.dashlets.batchImport.strategy.create", dictionary)}
+                  </option>
+                </select>
+              </label>
+              <Button
+                size="xs"
+                color="gray"
+                onClick={onRetryFailed}
+                disabled={!hasFailed || importing}
+              >
+                {tr("dashboard.dashlets.batchImport.retryFailed", dictionary, { count: String(summary.failed) })}
+              </Button>
+              <Button
+                size="xs"
+                color="gray"
+                onClick={onReset}
+                disabled={importing || (!hasResolved && !hasFailed)}
+              >
+                {tr("dashboard.dashlets.batchImport.clearCache", dictionary)}
+              </Button>
+            </div>
+          </section>
+
+          <div className="min-h-0 flex-1 overflow-auto rounded-b-md border border-t-0 border-gray-200 dark:border-gray-700">
+            <table className="w-full border-collapse text-xs">
+              <thead className="sticky top-0 z-10 bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100">
+                <tr>
+                  <th className="w-14 border-b border-r border-gray-200 p-2 text-center dark:border-gray-700">
+                    {tr("dashboard.dashlets.batchImport.statusCol", dictionary)}
+                  </th>
+                  {doc.headers.map((h) => (
+                    <th
+                      key={h}
+                      className="min-w-[120px] border-b border-r border-gray-200 p-2 text-left font-semibold dark:border-gray-700"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {doc.rows.map((row) => (
+                  <tr key={row.index} className={ROW_BG[row.status]}>
+                    <td className="w-14 border-b border-r border-gray-200 p-2 text-center align-top dark:border-gray-700">
+                      <StatusIcon
+                        status={row.status}
+                        tooltip={row.errorMessage}
+                        label={statusLabel(row.status)}
+                      />
+                    </td>
+                    {doc.headers.map((h) => (
+                      <td
+                        key={h}
+                        className="border-b border-r border-gray-200 p-2 align-top dark:border-gray-700"
+                      >
+                        {row.fields[h] || (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+type BadgeTone = "ok" | "done" | "fail" | "info" | "mute";
+
+const BADGE_TONES: Record<BadgeTone, string> = {
+  ok: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  done: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  fail: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  info: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+  mute: "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300",
+};
+
+function Badge({
+  label,
+  count,
+  tone,
+}: Readonly<{ label: string; count: number; tone?: BadgeTone }>) {
+  const cls = tone ? BADGE_TONES[tone] : BADGE_TONES.mute;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] ${cls}`}>
+      <strong className="mr-1 font-semibold">{count}</strong>
+      {label}
+    </span>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -14,6 +14,7 @@ import type {
   ParsedRow,
   RowStatus,
   SubmitFn,
+  SubmitResult,
 } from "./engine/types";
 import { parseDocument } from "./engine/parser";
 import {
@@ -109,29 +110,50 @@ export function useBatchImporter({
   }, []);
 
   const runImport = useCallback(
-    async (targetIndexes?: Set<number>) => {
-      if (!doc) return;
+    async (targetIndexes?: Set<number>, rowsOverride?: ParsedRow[]) => {
+      const rows = rowsOverride ?? doc?.rows;
+      if (!rows) return;
       setImporting(true);
-      const cache = readCache(sourceKey);
-      for (let i = 0; i < doc.rows.length; i++) {
-        const row = doc.rows[i];
-        if (targetIndexes && !targetIndexes.has(row.index)) continue;
-        if (row.status !== "unprocessed") continue;
+      try {
+        const cache = readCache(sourceKey);
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          if (targetIndexes && !targetIndexes.has(row.index)) continue;
+          if (row.status !== "unprocessed") continue;
 
-        updateRow(i, { ...row, status: "wait" });
-        const result = await submit(row, strategy);
-        cache.status[row.fingerprint] = result.status;
-        if (result.errorMessage)
-          cache.errorlog[row.fingerprint] = result.errorMessage;
-        else delete cache.errorlog[row.fingerprint];
-        writeCache(sourceKey, cache);
-        updateRow(i, {
-          ...row,
-          status: result.status,
-          errorMessage: result.errorMessage,
-        });
+          updateRow(i, { ...row, status: "wait" });
+
+          let result: SubmitResult;
+          try {
+            result = await submit(row, strategy);
+          } catch (err) {
+            result = {
+              status: "failed",
+              errorMessage:
+                err instanceof Error ? err.message : "Submit threw",
+            };
+          }
+
+          cache.status[row.fingerprint] = result.status;
+          if (result.errorMessage)
+            cache.errorlog[row.fingerprint] = result.errorMessage;
+          else delete cache.errorlog[row.fingerprint];
+          try {
+            writeCache(sourceKey, cache);
+          } catch {
+            // LocalStorage write failed (quota / disabled). UI state still
+            // reflects the result; persistence across reloads is lost.
+          }
+
+          updateRow(i, {
+            ...row,
+            status: result.status,
+            errorMessage: result.errorMessage,
+          });
+        }
+      } finally {
+        setImporting(false);
       }
-      setImporting(false);
     },
     [doc, sourceKey, strategy, submit, updateRow],
   );
@@ -154,7 +176,9 @@ export function useBatchImporter({
       return r;
     });
     setDoc({ ...doc, rows: resetRows });
-    queueMicrotask(() => runImport(failedIndexes));
+    // Pass resetRows explicitly so the import loop doesn't read the stale
+    // closure's `doc` — setDoc hasn't committed yet when runImport starts.
+    void runImport(failedIndexes, resetRows);
   }, [doc, sourceKey, runImport]);
 
   const onReset = useCallback(() => {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -56,6 +57,9 @@ export interface BatchImporterState {
   hasFailed: boolean;
   hasResolved: boolean;
   load: (text: string) => void;
+  /** Debounced variant for the textarea: updates the visible buffer
+   *  immediately but delays the (non-trivial) parse until typing pauses. */
+  loadDebounced: (text: string) => void;
   loadFile: (file: File) => Promise<void>;
   onImport: () => Promise<void>;
   onRetryFailed: () => void;
@@ -72,9 +76,10 @@ export function useBatchImporter({
   const [importing, setImporting] = useState(false);
   const [strategy, setStrategy] = useState<DuplicateStrategy>(defaultStrategy);
 
-  const load = useCallback(
+  const parseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyParse = useCallback(
     (text: string) => {
-      setRaw(text);
       const parsed = parseDocument(text);
       const cache = readCache(sourceKey);
       parsed.rows = parsed.rows.map((r) => {
@@ -92,6 +97,36 @@ export function useBatchImporter({
     },
     [sourceKey],
   );
+
+  const cancelPendingParse = () => {
+    if (parseTimer.current) {
+      clearTimeout(parseTimer.current);
+      parseTimer.current = null;
+    }
+  };
+
+  const load = useCallback(
+    (text: string) => {
+      cancelPendingParse();
+      setRaw(text);
+      applyParse(text);
+    },
+    [applyParse],
+  );
+
+  const loadDebounced = useCallback(
+    (text: string) => {
+      setRaw(text);
+      cancelPendingParse();
+      parseTimer.current = setTimeout(() => {
+        parseTimer.current = null;
+        applyParse(text);
+      }, 250);
+    },
+    [applyParse],
+  );
+
+  useEffect(() => cancelPendingParse, []);
 
   const loadFile = useCallback(
     async (file: File) => {
@@ -209,6 +244,7 @@ export function useBatchImporter({
     hasFailed: summary.failed > 0,
     hasResolved: RESOLVED.reduce((n, s) => n + summary[s], 0) > 0,
     load,
+    loadDebounced,
     loadFile,
     onImport,
     onRetryFailed,
@@ -240,6 +276,7 @@ export function BatchImporterView({
     hasFailed,
     hasResolved,
     load,
+    loadDebounced,
     loadFile,
     onRetryFailed,
     onReset,
@@ -282,7 +319,7 @@ export function BatchImporterView({
         </span>
         <textarea
           value={raw}
-          onChange={(e) => load(e.target.value)}
+          onChange={(e) => loadDebounced(e.target.value)}
           rows={4}
           className="w-full rounded-md border border-gray-200 bg-white p-2 font-mono text-xs text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
         />

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -138,12 +138,7 @@ export function useBatchImporter({
           if (result.errorMessage)
             cache.errorlog[row.fingerprint] = result.errorMessage;
           else delete cache.errorlog[row.fingerprint];
-          try {
-            writeCache(sourceKey, cache);
-          } catch {
-            // LocalStorage write failed (quota / disabled). UI state still
-            // reflects the result; persistence across reloads is lost.
-          }
+          writeCache(sourceKey, cache);
 
           updateRow(i, {
             ...row,

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -55,7 +55,7 @@ export interface BatchImporterState {
   hasFailed: boolean;
   hasResolved: boolean;
   load: (text: string) => void;
-  loadFile: (file: File) => void;
+  loadFile: (file: File) => Promise<void>;
   onImport: () => Promise<void>;
   onRetryFailed: () => void;
   onReset: () => void;
@@ -93,10 +93,8 @@ export function useBatchImporter({
   );
 
   const loadFile = useCallback(
-    (file: File) => {
-      const reader = new FileReader();
-      reader.onload = () => load(String(reader.result ?? ""));
-      reader.readAsText(file);
+    async (file: File) => {
+      load(await file.text());
     },
     [load],
   );
@@ -174,8 +172,7 @@ export function useBatchImporter({
       failed: 0,
       wait: 0,
     };
-    if (!doc) return c;
-    doc.rows.forEach((r) => {
+    doc?.rows.forEach((r) => {
       c.total++;
       c[r.status]++;
     });
@@ -254,7 +251,7 @@ export function BatchImporterView({
           className="hidden"
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
             const f = e.target.files?.[0];
-            if (f) loadFile(f);
+            if (f) void loadFile(f);
             e.target.value = "";
           }}
         />

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/components/status-icon.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/components/status-icon.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { RowStatus } from "../engine/types";
+
+interface StatusStyle {
+  glyph: string;
+  className: string;
+}
+
+const STYLES: Record<RowStatus, StatusStyle> = {
+  unprocessed: {
+    glyph: "○",
+    className: "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300",
+  },
+  wait: {
+    glyph: "⟳",
+    className:
+      "bg-amber-100 text-amber-700 animate-spin dark:bg-amber-900/40 dark:text-amber-300",
+  },
+  processed: {
+    glyph: "✓",
+    className:
+      "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  },
+  updated: {
+    glyph: "↻",
+    className:
+      "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+  },
+  skipped: {
+    glyph: "⤼",
+    className: "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300",
+  },
+  failed: {
+    glyph: "✕",
+    className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  },
+};
+
+export function StatusIcon({
+  status,
+  tooltip,
+  label,
+}: Readonly<{ status: RowStatus; tooltip?: string; label: string }>) {
+  const style = STYLES[status];
+  return (
+    <span
+      className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-sm font-bold leading-none ${style.className}`}
+      title={tooltip || label}
+    >
+      {style.glyph}
+    </span>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.meta.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.meta.ts
@@ -1,0 +1,13 @@
+import { HiArrowUpTray } from "react-icons/hi2";
+import type { DashletMeta } from "../types";
+
+export const dashletMeta: DashletMeta = {
+  id: "batch_import",
+  name: "Batch Import",
+  description: "Import a large dataset via TSV/CSV with preview and validation",
+  icon: HiArrowUpTray,
+  category: "actions",
+  canNestIn: [],
+  hasSettings: true,
+  hasChildren: false,
+};

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.settings.tsx
@@ -74,7 +74,11 @@ export function DashletSettings({
           id="batch-import-datasource"
           label={tr("dashboard.settings.dataSource", dictionary)}
           value={dataSourceId}
-          onChange={setDataSourceId}
+          onChange={(v) => {
+            if (v === dataSourceId) return;
+            setDataSourceId(v);
+            setPgrestFunctionName("");
+          }}
           options={[
             {
               value: "",

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.settings.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.settings.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { Button, TextInput, Label } from "flowbite-react";
+import type { DashletSettingsProps } from "../types";
+import type { DashletConfig } from "./dashlet";
+import type { DuplicateStrategy } from "./engine/types";
+import { SettingsDrawer } from "../common/settings-drawer";
+import { SettingsSelectField } from "../common/settings-fields";
+import { PgrestFunctionAutocomplete } from "../common/pgrest-function-autocomplete";
+import { useDataSources } from "@/features/data-sources/hooks/use-data-sources";
+import { useDashboard } from "../../context/dashboard-context";
+import { tr } from "@/features/i18n/tr.service";
+
+const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
+
+export function DashletSettings({
+  isOpen,
+  onClose,
+  config,
+  onSave,
+  dictionary,
+}: Readonly<DashletSettingsProps<DashletConfig>>) {
+  const { siteId } = useDashboard();
+  const { dataSources } = useDataSources(siteId ?? undefined);
+  const activeProviders = dataSources.filter(
+    (ds) => ds.isActive === true && ds.lastTestResult === true,
+  );
+
+  const [title, setTitle] = useState(config.title || "");
+  const [pgrestFunctionName, setPgrestFunctionName] = useState(
+    config.pgrestFunctionName || "",
+  );
+  const [dataSourceId, setDataSourceId] = useState(config.dataSourceId || "");
+  const [defaultStrategy, setDefaultStrategy] = useState<DuplicateStrategy>(
+    config.defaultStrategy || "upsert",
+  );
+  const [cacheKey, setCacheKey] = useState(config.cacheKey || "");
+  const [acceptedFileTypes, setAcceptedFileTypes] = useState(
+    config.acceptedFileTypes || "",
+  );
+
+  const handleSave = () => {
+    onSave({
+      title: title.trim(),
+      pgrestFunctionName: pgrestFunctionName.trim(),
+      dataSourceId: dataSourceId || undefined,
+      defaultStrategy,
+      cacheKey: cacheKey.trim() || undefined,
+      acceptedFileTypes: acceptedFileTypes.trim() || undefined,
+    });
+    onClose();
+  };
+
+  return (
+    <SettingsDrawer open={isOpen} onClose={onClose}>
+      <div className="flex h-full flex-col gap-3">
+        <div>
+          <Label htmlFor="batch-import-title" className="mb-1 block text-sm">
+            {tr("dashboard.settings.batchImport.buttonLabel", dictionary)}
+          </Label>
+          <TextInput
+            id="batch-import-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={tr(
+              "dashboard.settings.batchImport.buttonLabelPlaceholder",
+              dictionary,
+            )}
+          />
+        </div>
+
+        <SettingsSelectField
+          id="batch-import-datasource"
+          label={tr("dashboard.settings.dataSource", dictionary)}
+          value={dataSourceId}
+          onChange={setDataSourceId}
+          options={[
+            {
+              value: "",
+              label: tr(
+                "dashboard.settings.batchImport.defaultEnv",
+                dictionary,
+              ),
+            },
+            ...activeProviders.map((ds) => ({ value: ds.id, label: ds.name })),
+          ]}
+        />
+
+        <div>
+          <Label className="mb-1 block text-sm">
+            {tr("dashboard.settings.batchImport.endpoint", dictionary)}
+          </Label>
+          <PgrestFunctionAutocomplete
+            value={pgrestFunctionName}
+            onChange={setPgrestFunctionName}
+            onSelect={setPgrestFunctionName}
+            dictionary={dictionary}
+            dataSourceId={dataSourceId || undefined}
+          />
+        </div>
+
+        <SettingsSelectField
+          id="batch-import-strategy"
+          label={tr(
+            "dashboard.settings.batchImport.defaultStrategy",
+            dictionary,
+          )}
+          value={defaultStrategy}
+          onChange={(v) => setDefaultStrategy(v as DuplicateStrategy)}
+          options={[
+            {
+              value: "upsert",
+              label: tr(
+                "dashboard.dashlets.batchImport.strategy.upsert",
+                dictionary,
+              ),
+            },
+            {
+              value: "skip",
+              label: tr(
+                "dashboard.dashlets.batchImport.strategy.skip",
+                dictionary,
+              ),
+            },
+            {
+              value: "create",
+              label: tr(
+                "dashboard.dashlets.batchImport.strategy.create",
+                dictionary,
+              ),
+            },
+          ]}
+        />
+
+        <div>
+          <Label
+            htmlFor="batch-import-accept"
+            className="mb-1 block text-sm"
+          >
+            {tr(
+              "dashboard.settings.batchImport.acceptedFileTypes",
+              dictionary,
+            )}
+          </Label>
+          <TextInput
+            id="batch-import-accept"
+            value={acceptedFileTypes}
+            onChange={(e) => setAcceptedFileTypes(e.target.value)}
+            placeholder=".csv,.tsv,.txt"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            {tr(
+              "dashboard.settings.batchImport.acceptedFileTypesHint",
+              dictionary,
+            )}
+          </p>
+        </div>
+
+        <div>
+          <Label htmlFor="batch-import-cachekey" className="mb-1 block text-sm">
+            {tr("dashboard.settings.batchImport.cacheKey", dictionary)}
+          </Label>
+          <TextInput
+            id="batch-import-cachekey"
+            value={cacheKey}
+            onChange={(e) => setCacheKey(e.target.value)}
+            placeholder={tr(
+              "dashboard.settings.batchImport.cacheKeyPlaceholder",
+              dictionary,
+            )}
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            {tr("dashboard.settings.batchImport.cacheKeyHint", dictionary)}
+          </p>
+        </div>
+
+        <div className="flex w-full justify-end gap-2">
+          <Button
+            color="gray"
+            onClick={onClose}
+            className="no-drag w-full"
+            onMouseDown={stopPropagation}
+          >
+            {tr("common.cancel", dictionary)}
+          </Button>
+          <Button
+            color="blue"
+            onClick={handleSave}
+            className="no-drag w-full"
+            onMouseDown={stopPropagation}
+          >
+            {tr("common.save", dictionary)}
+          </Button>
+        </div>
+      </div>
+    </SettingsDrawer>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "flowbite-react";
+import { HiArrowUpTray } from "react-icons/hi2";
+import type { DashletComponentProps, DashletLayoutDefaults } from "../types";
+import { useDashboard } from "../../context/dashboard-context";
+import { tr } from "@/features/i18n/tr.service";
+import { makePgrestSubmit } from "./engine/importer";
+import { BatchImporterModal } from "./batch-importer-modal";
+import { SAMPLE_TSV } from "./sample";
+import type { DuplicateStrategy } from "./engine/types";
+
+export interface DashletConfig {
+  title: string;
+  pgrestFunctionName: string;
+  dataSourceId?: string;
+  defaultStrategy: DuplicateStrategy;
+  cacheKey?: string;
+  acceptedFileTypes?: string;
+}
+
+export const defaultConfig: DashletConfig = {
+  title: "",
+  pgrestFunctionName: "",
+  defaultStrategy: "upsert",
+};
+
+export const layoutDefaults: DashletLayoutDefaults = {
+  minW: 3,
+  minH: 2,
+};
+
+export function getLayoutDefaults(): DashletLayoutDefaults {
+  return layoutDefaults;
+}
+
+export function Dashlet({ widget }: Readonly<DashletComponentProps>) {
+  const config = widget.config as unknown as DashletConfig;
+  const { dictionary } = useDashboard();
+  const [open, setOpen] = useState(false);
+
+  const isConfigured = !!config.pgrestFunctionName;
+  const title =
+    config.title?.trim() ||
+    tr("dashboard.dashlets.batchImport.defaultTitle", dictionary);
+
+  const submit = useMemo(
+    () =>
+      isConfigured
+        ? makePgrestSubmit(config.pgrestFunctionName, config.dataSourceId)
+        : null,
+    [isConfigured, config.pgrestFunctionName, config.dataSourceId],
+  );
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      {!isConfigured && (
+        <p className="text-sm text-gray-400">
+          {tr("dashboard.dashlets.batchImport.configureHint", dictionary)}
+        </p>
+      )}
+
+      {isConfigured && submit && (
+        <>
+          <Button color="blue" onClick={() => setOpen(true)}>
+            <HiArrowUpTray className="mr-2 h-5 w-5" />
+            {title}
+          </Button>
+          <BatchImporterModal
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            submit={submit}
+            sourceKey={config.cacheKey || `${widget.id}:${config.pgrestFunctionName}`}
+            title={title}
+            defaultStrategy={config.defaultStrategy}
+            sample={SAMPLE_TSV}
+            acceptedFileTypes={config.acceptedFileTypes}
+            dictionary={dictionary}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
@@ -1,0 +1,129 @@
+import type {
+  DuplicateStrategy,
+  ParsedRow,
+  RowStatus,
+  SubmitFn,
+  SubmitResult,
+} from "./types";
+import { buildPgrestFetch } from "../../common/pgrest-utils";
+import type { PgrestParam } from "../../common/pgrest-types";
+
+const CACHE_PREFIX = "batch-importer-cache:";
+const RESOLVED: RowStatus[] = ["processed", "updated", "skipped"];
+
+export function isResolved(status: RowStatus): boolean {
+  return RESOLVED.includes(status);
+}
+
+export interface CacheBlob {
+  status: Record<number, RowStatus>;
+  errorlog: Record<number, string>;
+}
+
+export function readCache(key: string): CacheBlob {
+  if (typeof localStorage === "undefined") return { status: {}, errorlog: {} };
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return { status: {}, errorlog: {} };
+    return JSON.parse(raw) as CacheBlob;
+  } catch {
+    return { status: {}, errorlog: {} };
+  }
+}
+
+export function writeCache(key: string, cache: CacheBlob) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(cache));
+}
+
+export function clearCache(key: string) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(CACHE_PREFIX + key);
+}
+
+export function clearFailed(key: string) {
+  const cache = readCache(key);
+  Object.keys(cache.status).forEach((k) => {
+    if (cache.status[Number(k)] === "failed") {
+      delete cache.status[Number(k)];
+      delete cache.errorlog[Number(k)];
+    }
+  });
+  writeCache(key, cache);
+}
+
+function rowToParams(
+  row: ParsedRow,
+  strategy: DuplicateStrategy,
+): PgrestParam[] {
+  const out: PgrestParam[] = Object.entries(row.fields).map(([key, value]) => ({
+    key,
+    value,
+  }));
+  out.push({ key: "_duplicateStrategy", value: strategy });
+  return out;
+}
+
+const SUCCESS_STATUSES: readonly RowStatus[] = [
+  "processed",
+  "updated",
+  "skipped",
+];
+
+function coerceStatus(
+  body: unknown,
+  fallback: RowStatus = "processed",
+): RowStatus {
+  if (body && typeof body === "object" && "status" in body) {
+    const s = (body as { status?: unknown }).status;
+    if (typeof s === "string" && SUCCESS_STATUSES.includes(s as RowStatus)) {
+      return s as RowStatus;
+    }
+  }
+  return fallback;
+}
+
+/**
+ * Build a row-level submit that POSTs each row as JSON to a PostgREST RPC.
+ *
+ * Contract with the backend:
+ *   - Body: `{ [header]: value, ..., _duplicateStrategy: "upsert"|"skip"|"create" }`
+ *   - 2xx → row is considered successful. If the response body includes
+ *     `{ "status": "processed" | "updated" | "skipped" }`, that value is
+ *     used; otherwise the row is marked `processed`.
+ *   - Non-2xx → row fails with the response body's `error` field or the
+ *     HTTP status text.
+ */
+export function makePgrestSubmit(
+  functionName: string,
+  dataSourceId?: string,
+): SubmitFn {
+  return async (row, strategy) => {
+    const { url, init } = buildPgrestFetch(
+      functionName,
+      "POST",
+      rowToParams(row, strategy),
+      dataSourceId,
+    );
+    try {
+      const res = await fetch(url, init);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }));
+        return {
+          status: "failed" as const,
+          errorMessage:
+            (body as { error?: string }).error ?? `HTTP ${res.status}`,
+        };
+      }
+      const body = await res.json().catch(() => null);
+      return { status: coerceStatus(body) };
+    } catch (err) {
+      return {
+        status: "failed" as const,
+        errorMessage: err instanceof Error ? err.message : "Network error",
+      };
+    }
+  };
+}
+
+export type { SubmitResult };

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
@@ -14,19 +14,34 @@ export function isResolved(status: RowStatus): boolean {
   return RESOLVED.has(status);
 }
 
+/** Bump when the shape changes; older blobs are ignored on read so stale
+ *  numeric-index caches from pre-fingerprint versions don't pollute lookups. */
+const CACHE_VERSION = 2 as const;
+
 export interface CacheBlob {
-  status: Record<number, RowStatus>;
-  errorlog: Record<number, string>;
+  version: typeof CACHE_VERSION;
+  status: Record<string, RowStatus>;
+  errorlog: Record<string, string>;
+}
+
+function emptyCache(): CacheBlob {
+  return { version: CACHE_VERSION, status: {}, errorlog: {} };
 }
 
 export function readCache(key: string): CacheBlob {
-  if (typeof localStorage === "undefined") return { status: {}, errorlog: {} };
+  if (typeof localStorage === "undefined") return emptyCache();
   try {
     const raw = localStorage.getItem(CACHE_PREFIX + key);
-    if (!raw) return { status: {}, errorlog: {} };
-    return JSON.parse(raw) as CacheBlob;
+    if (!raw) return emptyCache();
+    const parsed = JSON.parse(raw) as Partial<CacheBlob>;
+    if (parsed.version !== CACHE_VERSION) return emptyCache();
+    return {
+      version: CACHE_VERSION,
+      status: parsed.status ?? {},
+      errorlog: parsed.errorlog ?? {},
+    };
   } catch {
-    return { status: {}, errorlog: {} };
+    return emptyCache();
   }
 }
 
@@ -42,12 +57,12 @@ export function clearCache(key: string) {
 
 export function clearFailed(key: string) {
   const cache = readCache(key);
-  Object.keys(cache.status).forEach((k) => {
-    if (cache.status[Number(k)] === "failed") {
-      delete cache.status[Number(k)];
-      delete cache.errorlog[Number(k)];
+  for (const k of Object.keys(cache.status)) {
+    if (cache.status[k] === "failed") {
+      delete cache.status[k];
+      delete cache.errorlog[k];
     }
-  });
+  }
   writeCache(key, cache);
 }
 

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
@@ -9,6 +9,14 @@ import type { PgrestParam } from "../../common/pgrest-types";
 
 const CACHE_PREFIX = "batch-importer-cache:";
 const RESOLVED = new Set<RowStatus>(["processed", "updated", "skipped"]);
+const ALL_STATUSES = new Set<RowStatus>([
+  "unprocessed",
+  "processed",
+  "updated",
+  "skipped",
+  "failed",
+  "wait",
+]);
 
 export function isResolved(status: RowStatus): boolean {
   return RESOLVED.has(status);
@@ -28,18 +36,35 @@ function emptyCache(): CacheBlob {
   return { version: CACHE_VERSION, status: {}, errorlog: {} };
 }
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function sanitizeCache(raw: unknown): CacheBlob {
+  if (!isPlainObject(raw) || raw.version !== CACHE_VERSION) return emptyCache();
+  const status: Record<string, RowStatus> = {};
+  const errorlog: Record<string, string> = {};
+  if (isPlainObject(raw.status)) {
+    for (const [k, v] of Object.entries(raw.status)) {
+      if (typeof v === "string" && ALL_STATUSES.has(v as RowStatus)) {
+        status[k] = v as RowStatus;
+      }
+    }
+  }
+  if (isPlainObject(raw.errorlog)) {
+    for (const [k, v] of Object.entries(raw.errorlog)) {
+      if (typeof v === "string") errorlog[k] = v;
+    }
+  }
+  return { version: CACHE_VERSION, status, errorlog };
+}
+
 export function readCache(key: string): CacheBlob {
   if (typeof localStorage === "undefined") return emptyCache();
   try {
     const raw = localStorage.getItem(CACHE_PREFIX + key);
     if (!raw) return emptyCache();
-    const parsed = JSON.parse(raw) as Partial<CacheBlob>;
-    if (parsed.version !== CACHE_VERSION) return emptyCache();
-    return {
-      version: CACHE_VERSION,
-      status: parsed.status ?? {},
-      errorlog: parsed.errorlog ?? {},
-    };
+    return sanitizeCache(JSON.parse(raw));
   } catch {
     return emptyCache();
   }
@@ -47,7 +72,12 @@ export function readCache(key: string): CacheBlob {
 
 export function writeCache(key: string, cache: CacheBlob) {
   if (typeof localStorage === "undefined") return;
-  localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(cache));
+  try {
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(cache));
+  } catch {
+    // QuotaExceededError / private-mode / disabled storage. Persistence is
+    // best-effort; the in-memory UI state is authoritative within a session.
+  }
 }
 
 export function clearCache(key: string) {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/importer.ts
@@ -3,16 +3,15 @@ import type {
   ParsedRow,
   RowStatus,
   SubmitFn,
-  SubmitResult,
 } from "./types";
 import { buildPgrestFetch } from "../../common/pgrest-utils";
 import type { PgrestParam } from "../../common/pgrest-types";
 
 const CACHE_PREFIX = "batch-importer-cache:";
-const RESOLVED: RowStatus[] = ["processed", "updated", "skipped"];
+const RESOLVED = new Set<RowStatus>(["processed", "updated", "skipped"]);
 
 export function isResolved(status: RowStatus): boolean {
-  return RESOLVED.includes(status);
+  return RESOLVED.has(status);
 }
 
 export interface CacheBlob {
@@ -64,11 +63,11 @@ function rowToParams(
   return out;
 }
 
-const SUCCESS_STATUSES: readonly RowStatus[] = [
+const SUCCESS_STATUSES = new Set<RowStatus>([
   "processed",
   "updated",
   "skipped",
-];
+]);
 
 function coerceStatus(
   body: unknown,
@@ -76,7 +75,7 @@ function coerceStatus(
 ): RowStatus {
   if (body && typeof body === "object" && "status" in body) {
     const s = (body as { status?: unknown }).status;
-    if (typeof s === "string" && SUCCESS_STATUSES.includes(s as RowStatus)) {
+    if (typeof s === "string" && SUCCESS_STATUSES.has(s as RowStatus)) {
       return s as RowStatus;
     }
   }
@@ -126,4 +125,4 @@ export function makePgrestSubmit(
   };
 }
 
-export type { SubmitResult };
+export type { SubmitResult } from "./types";

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -6,31 +6,44 @@ function detectDelimiter(firstLine: string): string {
   return commas > tabs ? "," : "\t";
 }
 
+interface QuotedStep {
+  append: string;
+  advance: number;
+  endQuote: boolean;
+}
+
+function consumeQuotedChar(content: string, pos: number): QuotedStep {
+  const c = content[pos];
+  if (c === '"') {
+    if (content[pos + 1] === '"') {
+      return { append: '"', advance: 2, endQuote: false };
+    }
+    return { append: "", advance: 1, endQuote: true };
+  }
+  return { append: c, advance: 1, endQuote: false };
+}
+
+function newlineAdvance(content: string, pos: number): number {
+  return content[pos] === "\r" && content[pos + 1] === "\n" ? 2 : 1;
+}
+
 function tokenize(content: string, delimiter: string): string[][] {
   const rows: string[][] = [];
   let row: string[] = [];
   let cell = "";
   let inQuotes = false;
-  let i = 0;
   const len = content.length;
+  let i = 0;
 
   while (i < len) {
-    const c = content[i];
     if (inQuotes) {
-      if (c === '"') {
-        if (content[i + 1] === '"') {
-          cell += '"';
-          i += 2;
-          continue;
-        }
-        inQuotes = false;
-        i++;
-        continue;
-      }
-      cell += c;
-      i++;
+      const step = consumeQuotedChar(content, i);
+      cell += step.append;
+      i += step.advance;
+      if (step.endQuote) inQuotes = false;
       continue;
     }
+    const c = content[i];
     if (c === '"') {
       inQuotes = true;
       i++;
@@ -47,8 +60,7 @@ function tokenize(content: string, delimiter: string): string[][] {
       rows.push(row);
       row = [];
       cell = "";
-      if (c === "\r" && content[i + 1] === "\n") i += 2;
-      else i++;
+      i += newlineAdvance(content, i);
       continue;
     }
     cell += c;

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -111,8 +111,12 @@ export function parseDocument(content: string): ParsedDocument {
   return { headers, rows };
 }
 
+// Pinned-locale collator so fingerprints are reproducible across runtimes /
+// CI / user locales. Kept at module scope to avoid rebuilding per row.
+const FINGERPRINT_COLLATOR = new Intl.Collator("en", { sensitivity: "variant" });
+
 function fingerprintRow(fields: Record<string, string>): string {
-  const keys = Object.keys(fields).sort((a, b) => a.localeCompare(b));
+  const keys = Object.keys(fields).sort(FINGERPRINT_COLLATOR.compare);
   const sorted: Record<string, string> = {};
   for (const k of keys) sorted[k] = fields[k];
   return JSON.stringify(sorted);

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -1,0 +1,89 @@
+import type { ParsedDocument, ParsedRow } from "./types";
+
+function detectDelimiter(firstLine: string): string {
+  const tabs = (firstLine.match(/\t/g) || []).length;
+  const commas = (firstLine.match(/,/g) || []).length;
+  return commas > tabs ? "," : "\t";
+}
+
+function tokenize(content: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  let i = 0;
+  const len = content.length;
+
+  while (i < len) {
+    const c = content[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          cell += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      cell += c;
+      i++;
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+    if (c === delimiter) {
+      row.push(cell);
+      cell = "";
+      i++;
+      continue;
+    }
+    if (c === "\n" || c === "\r") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      if (c === "\r" && content[i + 1] === "\n") i += 2;
+      else i++;
+      continue;
+    }
+    cell += c;
+    i++;
+  }
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows.filter((r) => r.some((v) => v.trim().length > 0));
+}
+
+export function parseDocument(content: string): ParsedDocument {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? "";
+  const delimiter = detectDelimiter(firstLine);
+  const grid = tokenize(content, delimiter);
+
+  if (grid.length === 0) {
+    return { headers: [], rows: [], headerError: "empty" };
+  }
+
+  const [header, ...dataRows] = grid;
+  const headers = header.map((h) => h.trim()).filter((h) => h.length > 0);
+
+  if (headers.length === 0) {
+    return { headers: [], rows: [], headerError: "no_headers" };
+  }
+
+  const rows: ParsedRow[] = dataRows.map((cells, index) => {
+    const fields: Record<string, string> = {};
+    headers.forEach((key, ci) => {
+      fields[key] = (cells[ci] ?? "").trim();
+    });
+    return { index, status: "unprocessed", fields };
+  });
+
+  return { headers, rows };
+}

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -83,17 +83,23 @@ export function parseDocument(content: string): ParsedDocument {
   }
 
   const [header, ...dataRows] = grid;
-  const headers = header.map((h) => h.trim()).filter((h) => h.length > 0);
+  // Preserve each surviving header's original column index so downstream rows
+  // read from the correct cell even when the header row has empty columns.
+  const headerEntries = header
+    .map((h, index) => ({ name: h.trim(), index }))
+    .filter((e) => e.name.length > 0);
 
-  if (headers.length === 0) {
+  if (headerEntries.length === 0) {
     return { headers: [], rows: [], headerError: "no_headers" };
   }
 
+  const headers = headerEntries.map((e) => e.name);
+
   const rows: ParsedRow[] = dataRows.map((cells, index) => {
     const fields: Record<string, string> = {};
-    headers.forEach((key, ci) => {
-      fields[key] = (cells[ci] ?? "").trim();
-    });
+    for (const { name, index: originalIndex } of headerEntries) {
+      fields[name] = (cells[originalIndex] ?? "").trim();
+    }
     return {
       index,
       fingerprint: fingerprintRow(fields),

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -94,8 +94,20 @@ export function parseDocument(content: string): ParsedDocument {
     headers.forEach((key, ci) => {
       fields[key] = (cells[ci] ?? "").trim();
     });
-    return { index, status: "unprocessed", fields };
+    return {
+      index,
+      fingerprint: fingerprintRow(fields),
+      status: "unprocessed",
+      fields,
+    };
   });
 
   return { headers, rows };
+}
+
+function fingerprintRow(fields: Record<string, string>): string {
+  const keys = Object.keys(fields).sort();
+  const sorted: Record<string, string> = {};
+  for (const k of keys) sorted[k] = fields[k];
+  return JSON.stringify(sorted);
 }

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/parser.ts
@@ -112,7 +112,7 @@ export function parseDocument(content: string): ParsedDocument {
 }
 
 function fingerprintRow(fields: Record<string, string>): string {
-  const keys = Object.keys(fields).sort();
+  const keys = Object.keys(fields).sort((a, b) => a.localeCompare(b));
   const sorted: Record<string, string> = {};
   for (const k of keys) sorted[k] = fields[k];
   return JSON.stringify(sorted);

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/types.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/types.ts
@@ -1,0 +1,32 @@
+export type RowStatus =
+  | "unprocessed"
+  | "processed"
+  | "updated"
+  | "skipped"
+  | "failed"
+  | "wait";
+
+export type DuplicateStrategy = "create" | "upsert" | "skip";
+
+export interface ParsedRow {
+  index: number;
+  status: RowStatus;
+  errorMessage?: string;
+  fields: Record<string, string>;
+}
+
+export interface ParsedDocument {
+  headers: string[];
+  rows: ParsedRow[];
+  headerError?: string;
+}
+
+export interface SubmitResult {
+  status: RowStatus;
+  errorMessage?: string;
+}
+
+export type SubmitFn = (
+  row: ParsedRow,
+  strategy: DuplicateStrategy,
+) => Promise<SubmitResult>;

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/types.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/engine/types.ts
@@ -10,6 +10,11 @@ export type DuplicateStrategy = "create" | "upsert" | "skip";
 
 export interface ParsedRow {
   index: number;
+  /** Deterministic hash of the row's fields — stable across re-uploads of the
+   *  same content, independent of row position. Used as the cache key so the
+   *  "already processed" skip logic survives edits that reorder rows but is
+   *  also not fooled by a completely different document sharing a sourceKey. */
+  fingerprint: string;
   status: RowStatus;
   errorMessage?: string;
   fields: Record<string, string>;

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/index.ts
@@ -1,0 +1,17 @@
+import type { DashletDefinition } from "../types";
+import { Dashlet, defaultConfig, getLayoutDefaults } from "./dashlet";
+import { DashletSettings } from "./dashlet.settings";
+import { dashletMeta } from "./dashlet.meta";
+
+export const dashletDefinition: DashletDefinition = {
+  meta: dashletMeta,
+  Component: Dashlet,
+  SettingsModal: DashletSettings,
+  defaultConfig: defaultConfig as unknown as Record<string, unknown>,
+  getLayoutDefaults,
+};
+
+export { Dashlet, defaultConfig, getLayoutDefaults } from "./dashlet";
+export { DashletSettings } from "./dashlet.settings";
+export { dashletMeta } from "./dashlet.meta";
+export type { DashletConfig } from "./dashlet";

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/sample.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/sample.ts
@@ -1,0 +1,13 @@
+/**
+ * Generic sample data — used by the "Load sample" button inside the widget.
+ * Not tied to any domain or backend endpoint. Purely for letting a user see
+ * the full flow (parse → preview → import) without having a real file on hand.
+ */
+export const SAMPLE_TSV = [
+  ["name", "email", "role", "active"].join("\t"),
+  ["Alice Johnson", "alice@example.com", "admin", "true"].join("\t"),
+  ["Bob Smith", "bob@example.com", "editor", "true"].join("\t"),
+  ["Carol Davis", "carol@example.com", "viewer", "true"].join("\t"),
+  ["Dan Brown", "dan@example.com", "editor", "false"].join("\t"),
+  ["Eve Wilson", "eve@example.com", "viewer", "true"].join("\t"),
+].join("\n");

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/index.ts
@@ -32,6 +32,7 @@ import { dashletDefinition as statStatusDefinition } from "./stat_status";
 import { dashletDefinition as textCardDefinition } from "./text_card";
 import { dashletDefinition as chartDefinition } from "./chart";
 import { dashletDefinition as fileUploadDefinition } from "./file_upload";
+import { dashletDefinition as batchImportDefinition } from "./batch_import";
 import { dashletDefinition as geographicMapDefinition } from "./geographic_map";
 
 // ============================================================================
@@ -54,6 +55,7 @@ const DASHLET_DEFINITIONS: DashletDefinition[] = [
   textCardDefinition,
   chartDefinition,
   fileUploadDefinition,
+  batchImportDefinition,
   geographicMapDefinition,
 ];
 

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1674,6 +1674,18 @@
         "acceptedFileTypesHint": "Comma-separated extensions or MIME types. Leave empty to accept all.",
         "defaultEnv": "Default (env)"
       },
+      "batchImport": {
+        "buttonLabel": "Button Label",
+        "buttonLabelPlaceholder": "Import data",
+        "endpoint": "Import Endpoint",
+        "defaultEnv": "Default (env)",
+        "defaultStrategy": "Default duplicate strategy",
+        "acceptedFileTypes": "Accepted File Types",
+        "acceptedFileTypesHint": "Comma-separated extensions. Leave empty to accept the defaults (.csv, .tsv, .txt).",
+        "cacheKey": "Cache key",
+        "cacheKeyPlaceholder": "Optional",
+        "cacheKeyHint": "LocalStorage namespace for the row-status cache. Leave empty for an auto-generated one."
+      },
       "filterBarTitle": "Filter Bar",
       "filterBarDescription": "Configure dashboard filter parameters",
       "noFiltersConfigured": "No filters configured. Add filters to enable the dashboard filter bar.",
@@ -1818,6 +1830,39 @@
         "name": "Geographic Map",
         "description": "Interactive map with position markers and filters",
         "load_failed": "Failed to load map data"
+      },
+      "batchImport": {
+        "defaultTitle": "Import data",
+        "title": "Import data",
+        "subtitle": "Paste or upload a CSV / TSV. Headers in the first row become the record keys.",
+        "configureHint": "Configure an endpoint in settings",
+        "loadSample": "Load sample",
+        "loadFile": "Load file…",
+        "pasteHint": "Paste tab-separated or comma-separated content (copy from Excel works):",
+        "headerError": {
+          "empty": "The file is empty.",
+          "no_headers": "The first row has no valid headers."
+        },
+        "statusCol": "Status",
+        "total": "Total",
+        "duplicates": "Duplicates:",
+        "retryFailed": "Retry failed ({count})",
+        "clearCache": "Clear cache",
+        "importing": "Importing…",
+        "importN": "Import {count} rows",
+        "status": {
+          "unprocessed": "Ready",
+          "wait": "Processing…",
+          "processed": "Created",
+          "updated": "Updated",
+          "skipped": "Skipped",
+          "failed": "Failed"
+        },
+        "strategy": {
+          "upsert": "Update (upsert)",
+          "skip": "Skip",
+          "create": "Create only (fail if exists)"
+        }
       }
     },
     "fileUpload": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1700,6 +1700,18 @@
         "acceptedFileTypesHint": "Extensiones o tipos MIME separados por coma. Dejar vacío para aceptar todos.",
         "defaultEnv": "Por defecto (env)"
       },
+      "batchImport": {
+        "buttonLabel": "Etiqueta del botón",
+        "buttonLabelPlaceholder": "Importar datos",
+        "endpoint": "Endpoint de importación",
+        "defaultEnv": "Por defecto (env)",
+        "defaultStrategy": "Estrategia de duplicados por defecto",
+        "acceptedFileTypes": "Tipos de archivo aceptados",
+        "acceptedFileTypesHint": "Extensiones separadas por coma. Dejar vacío para aceptar los valores por defecto (.csv, .tsv, .txt).",
+        "cacheKey": "Clave de caché",
+        "cacheKeyPlaceholder": "Opcional",
+        "cacheKeyHint": "Namespace en localStorage para el caché de estado. Dejar vacío para generar uno automáticamente."
+      },
       "filterBarTitle": "Barra de Filtros",
       "filterBarDescription": "Configurar parámetros de filtro del dashboard",
       "noFiltersConfigured": "No hay filtros configurados. Agregue filtros para habilitar la barra de filtros del dashboard.",
@@ -1843,6 +1855,39 @@
         "name": "Vista Geográfica",
         "description": "Mapa interactivo con marcadores de posición y filtros",
         "load_failed": "Error al cargar datos del mapa"
+      },
+      "batchImport": {
+        "defaultTitle": "Importar datos",
+        "title": "Importar datos",
+        "subtitle": "Pegue o cargue un CSV / TSV. Los encabezados de la primera fila se usan como claves del registro.",
+        "configureHint": "Configura un endpoint en ajustes",
+        "loadSample": "Cargar ejemplo",
+        "loadFile": "Cargar archivo…",
+        "pasteHint": "Pegue contenido tab-separado o separado por comas (copiar desde Excel funciona):",
+        "headerError": {
+          "empty": "El archivo está vacío.",
+          "no_headers": "La primera fila no tiene encabezados válidos."
+        },
+        "statusCol": "Estado",
+        "total": "Total",
+        "duplicates": "Duplicados:",
+        "retryFailed": "Reintentar fallidos ({count})",
+        "clearCache": "Limpiar caché",
+        "importing": "Importando…",
+        "importN": "Importar {count} filas",
+        "status": {
+          "unprocessed": "Listo",
+          "wait": "Procesando…",
+          "processed": "Creado",
+          "updated": "Actualizado",
+          "skipped": "Omitido",
+          "failed": "Fallido"
+        },
+        "strategy": {
+          "upsert": "Actualizar (upsert)",
+          "skip": "Omitir",
+          "create": "Solo crear (falla si existe)"
+        }
       }
     },
     "fileUpload": {


### PR DESCRIPTION
- Add batch-importer engine with CSV/JSON parser and caching
- Add batch importer UI with modal and status icons
- Register dashlet with settings and metadata
- Add EN/ES translations for batch import strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Batch Import dashlet to import CSV/TSV via paste or file, with sample data and per-row status display
  * Configurable duplicate strategies (upsert, skip, create) and retry/clear-cache actions
  * Real-time import progress, per-row error tooltips, and localized UI texts
* **Documentation**
  * Added English and Spanish localization entries for the import UI and settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->