### PR TITLE
feat: show client RUT in calendar sidebar (#344)

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -551,6 +551,7 @@ export const TEST_SERVICE: SelectedService = TEST_SERVICES[0];
 export interface SelectedService {
   id: string;
   cliente: string;
+  mintral_clientRut?: string;
   origen: string;
   lugarCarguio: string;
   destino: string;
@@ -688,6 +689,7 @@ const MAX_SERVICES_PER_SLOT = 99;
  */
 const StoredServiceSchema = z
   .object({
+    mintral_clientRut: z.string().optional(),
     origen: z.string().optional(),
     lugarCarguio: z.string().optional(),
     destino: z.string().optional(),

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -118,6 +118,7 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
   return {
     id: serviceId,
     cliente: task.client || task.clientCode || "",
+    mintral_clientRut: task.mintral_clientRut,
     origen: task.origin || "",
     lugarCarguio: "", // Not available in KanbanBoardTask
     destino: task.destination || "",

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -601,6 +601,11 @@ export function PlanningSidebarClient({
               displayState.selectedService
                 ? {
                     ...displayState.selectedService,
+                    mintral_clientRut:
+                      displayState.selectedService.mintral_clientRut ??
+                      allServices.find(
+                        (s) => s.id === displayState.selectedService?.id
+                      )?.mintral_clientRut,
                     slot: displayState.formattedSlot?.full,
                   }
                 : undefined

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -678,6 +678,12 @@ export function PlanningSidebarForm({
           label={tr("pages.planning.sidebar.form.client", dict)}
           value={client}
         />
+        {selectedService.mintral_clientRut && (
+          <InfoRow
+            label={tr("pages.planning.sidebar.form.clientRut", dict)}
+            value={selectedService.mintral_clientRut}
+          />
+        )}
         <InfoRow
           label={tr("pages.planning.sidebar.form.route", dict)}
           value={`${origin} → ${destination}`}

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -71,6 +71,7 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
     destination,
     clientCode,
     client,
+    mintral_clientRut: task.mintral_clientRut as string,
     expectedDepartureDate,
     serviceKind: task.mintral_serviceKind as string,
     executionType: task.mintral_executionType as string,

--- a/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
@@ -29,6 +29,7 @@ export type KanbanBoardTask = {
   destination?: string;
   client?: string;
   clientCode?: string;
+  mintral_clientRut?: string;
   expectedDepartureDate?: string;
   serviceKind: string;
   executionType: string;

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -277,6 +277,7 @@
           "occupancy": "Occupancy",
           "information": "Information",
           "client": "Client",
+          "clientRut": "Client RUT",
           "route": "Route",
           "loadingPlace": "Loading Place",
           "tripType": "Trip Type",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -277,6 +277,7 @@
           "occupancy": "Ocupación",
           "information": "Información",
           "client": "Cliente",
+          "clientRut": "RUT Cliente",
           "route": "Ruta",
           "loadingPlace": "Lugar Cargío",
           "tripType": "Tipo Viaje",


### PR DESCRIPTION
## Summary

- Thread `mintral_clientRut` from backend task payload → `KanbanBoardTask` → `SelectedService` → booking storage schema → sidebar form
- Render a new `InfoRow` ("RUT Cliente" / "Client RUT") below "Cliente" in the Information section, shown only when a value is present
- Hydrate the RUT from the fresh task list for bookings that were stored before the schema change, so previously planned chips display it too

Closes #344

## Test plan

- [x] Open Planning calendar, click a service with `mintral_clientRut` in the sidebar list → RUT shown in Information
- [x] Click a previously planned chip (booking pre-dating this change) → RUT still shown (fresh hydration)
- [x] Click a service without a RUT → row hidden (no empty "—")
- [x] Plan / re-plan and reload → RUT persists via the stored booking payload
- [x] Language toggle shows "RUT Cliente" (es) / "Client RUT" (en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Client RUT field in service bookings and planning interface. The field is now displayed in service information details when populated.

* **Localization**
  * Added Client RUT field translations for English and Spanish language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->