### PR TITLE
feat: extract share into standalone dropdown with web share support

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx
@@ -18,7 +18,6 @@ import { useDashboard } from "../../context/dashboard-context";
 import { PlannerManagerForm } from "../planner-manager/planner-manager";
 import { ConfirmModal } from "../confirm-modal";
 import { deleteDashboardConfigClient } from "@/features/common/providers/client-api.provider";
-import { ShareForm } from "./share-form";
 import { DashboardPermissionsModal } from "../dashboard-permissions-modal";
 import { ShowNotification } from "@/features/notifications/notification";
 import { tr } from "@/features/i18n/tr.service";
@@ -40,7 +39,6 @@ type SettingOption =
   | "filters"
   | "refresh"
   | "access"
-  | "share"
   | "delete"
   | null;
 
@@ -844,19 +842,6 @@ export default function DashboardSettingsDropdown({
 
       {open && (
         <div className="absolute z-50 right-0 top-full mt-2 h-fit bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg min-w-[360px] w-[440px]">
-          <SettingsSection
-            option="share"
-            selected={selected}
-            setSelected={setSelected}
-            title={tr("dashboard.settings.shareDashboardTitle", dictionary)}
-            description={tr(
-              "dashboard.settings.shareDashboardDescription",
-              dictionary
-            )}
-          >
-            <ShareForm dashboardName={dashboardName} onClose={closePanel} />
-          </SettingsSection>
-
           <SettingsSection
             option="order"
             selected={selected}

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.test.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.test.tsx
@@ -20,8 +20,12 @@ vi.mock("@/features/notifications/notification", () => ({
 
 // Mock html2canvas-pro — dynamically imported
 const mockToDataURL = vi.fn(() => "data:image/png;base64,fakedata");
+const mockToBlob = vi.fn((cb: (b: Blob | null) => void) => {
+  cb(new Blob(["fake-png-bytes"], { type: "image/png" }));
+});
 const mockCanvas = {
   toDataURL: mockToDataURL,
+  toBlob: mockToBlob,
   width: 1200,
   height: 600,
 };
@@ -38,6 +42,7 @@ const mockPdfText = vi.fn();
 const mockPdfSetFontSize = vi.fn();
 const mockPdfSetTextColor = vi.fn();
 const mockPdfAddImage = vi.fn();
+const mockPdfOutput = vi.fn(() => new Blob(["fake-pdf-bytes"], { type: "application/pdf" }));
 
 vi.mock("jspdf", () => {
   class MockJsPDF {
@@ -47,9 +52,14 @@ vi.mock("jspdf", () => {
     setTextColor = mockPdfSetTextColor;
     addImage = mockPdfAddImage;
     save = mockPdfSave;
+    output = mockPdfOutput;
   }
   return { jsPDF: MockJsPDF };
 });
+
+// Web Share API mocks — installed fresh in each beforeEach so share buttons can render.
+const mockShare = vi.fn((_data: ShareData) => Promise.resolve());
+const mockCanShare = vi.fn((_data: ShareData) => true);
 
 // Import after mocks
 const { ShareForm, sanitizeBaseName } = await import("./share-form");
@@ -60,9 +70,23 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockSearchParams = new URLSearchParams();
   mockPathname = "/en/home/myDashboard";
+  mockShare.mockImplementation(() => Promise.resolve());
+  mockCanShare.mockImplementation(() => true);
 
   Object.defineProperty(globalThis.navigator, "clipboard", {
     value: { writeText: vi.fn(() => Promise.resolve()) },
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(globalThis.navigator, "share", {
+    value: mockShare,
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(globalThis.navigator, "canShare", {
+    value: mockCanShare,
     writable: true,
     configurable: true,
   });
@@ -286,6 +310,183 @@ describe("ShareForm", () => {
           message: "PDF downloaded",
         });
         expect(mockOnClose).toHaveBeenCalled();
+      });
+
+      document.body.removeChild(gridEl);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Share via OS (Web Share API)
+  // --------------------------------------------------------------------------
+
+  describe("Share via OS", () => {
+    it("hides share buttons when navigator.canShare is undefined", async () => {
+      Object.defineProperty(globalThis.navigator, "canShare", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+
+      // Wait a tick for the feature-detect effect to run; then assert absence.
+      await waitFor(() => {
+        expect(screen.getByText("Copy link")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Share image...")).not.toBeInTheDocument();
+      expect(screen.queryByText("Share PDF...")).not.toBeInTheDocument();
+    });
+
+    it("hides the PDF share button when canShare rejects a PDF file", async () => {
+      mockCanShare.mockImplementation((data: ShareData) => {
+        const file = data.files?.[0];
+        return file?.type !== "application/pdf";
+      });
+
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Share image...")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Share PDF...")).not.toBeInTheDocument();
+    });
+
+    it("renders both share buttons when canShare returns true for both types", async () => {
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Share image...")).toBeInTheDocument();
+        expect(screen.getByText("Share PDF...")).toBeInTheDocument();
+      });
+    });
+
+    it("shares a PNG file via navigator.share with the sanitized filename", async () => {
+      const gridEl = document.createElement("div");
+      gridEl.className = "dashboard-root-grid";
+      document.body.appendChild(gridEl);
+
+      render(<ShareForm dashboardName="Fleet Status / Q2 2025" onClose={mockOnClose} />);
+      await waitFor(() => screen.getByText("Share image..."));
+      fireEvent.click(screen.getByText("Share image..."));
+
+      await waitFor(() => {
+        expect(mockShare).toHaveBeenCalledTimes(1);
+      });
+
+      const shareArg = mockShare.mock.calls[0][0] as ShareData & { files: File[] };
+      expect(shareArg.files).toHaveLength(1);
+      const file = shareArg.files[0];
+      expect(file).toBeInstanceOf(File);
+      expect(file.type).toBe("image/png");
+      expect(file.name).toMatch(/^Fleet_Status_Q2_2025_\d{4}-\d{2}-\d{2}\.png$/);
+      expect(shareArg.title).toBe("Fleet Status / Q2 2025");
+
+      expect(mockShowNotification).toHaveBeenCalledWith({
+        type: "success",
+        message: "Shared",
+      });
+      expect(mockOnClose).toHaveBeenCalled();
+
+      document.body.removeChild(gridEl);
+    });
+
+    it("shares a PDF file via navigator.share with the sanitized filename", async () => {
+      const gridEl = document.createElement("div");
+      gridEl.className = "dashboard-root-grid";
+      document.body.appendChild(gridEl);
+
+      render(<ShareForm dashboardName="Fleet Status / Q2 2025" onClose={mockOnClose} />);
+      await waitFor(() => screen.getByText("Share PDF..."));
+      fireEvent.click(screen.getByText("Share PDF..."));
+
+      await waitFor(() => {
+        expect(mockShare).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockPdfOutput).toHaveBeenCalledWith("blob");
+      const shareArg = mockShare.mock.calls[0][0] as ShareData & { files: File[] };
+      expect(shareArg.files).toHaveLength(1);
+      const file = shareArg.files[0];
+      expect(file).toBeInstanceOf(File);
+      expect(file.type).toBe("application/pdf");
+      expect(file.name).toMatch(/^Fleet_Status_Q2_2025_\d{4}-\d{2}-\d{2}\.pdf$/);
+
+      document.body.removeChild(gridEl);
+    });
+
+    it("does not show an error toast when the user cancels the share sheet (AbortError)", async () => {
+      const gridEl = document.createElement("div");
+      gridEl.className = "dashboard-root-grid";
+      document.body.appendChild(gridEl);
+
+      const abortErr = new Error("User cancelled");
+      abortErr.name = "AbortError";
+      mockShare.mockRejectedValueOnce(abortErr);
+
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+      await waitFor(() => screen.getByText("Share image..."));
+      fireEvent.click(screen.getByText("Share image..."));
+
+      await waitFor(() => {
+        expect(mockShare).toHaveBeenCalled();
+      });
+
+      expect(mockShowNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      );
+      expect(mockOnClose).not.toHaveBeenCalled();
+
+      document.body.removeChild(gridEl);
+    });
+
+    it("shows an error toast when navigator.share rejects with a non-abort error", async () => {
+      const gridEl = document.createElement("div");
+      gridEl.className = "dashboard-root-grid";
+      document.body.appendChild(gridEl);
+
+      mockShare.mockRejectedValueOnce(new Error("network borked"));
+
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+      await waitFor(() => screen.getByText("Share image..."));
+      fireEvent.click(screen.getByText("Share image..."));
+
+      await waitFor(() => {
+        expect(mockShowNotification).toHaveBeenCalledWith({
+          type: "error",
+          message: "Failed to share dashboard",
+        });
+      });
+
+      document.body.removeChild(gridEl);
+    });
+
+    it("disables all action buttons while a share is in flight", async () => {
+      const gridEl = document.createElement("div");
+      gridEl.className = "dashboard-root-grid";
+      document.body.appendChild(gridEl);
+
+      let resolveShare: (() => void) | undefined;
+      mockShare.mockImplementationOnce(
+        () => new Promise<void>((r) => { resolveShare = r; }),
+      );
+
+      render(<ShareForm dashboardName="Test Dashboard" onClose={mockOnClose} />);
+      await waitFor(() => screen.getByText("Share image..."));
+      fireEvent.click(screen.getByText("Share image..."));
+
+      await waitFor(() => {
+        expect(screen.getByText("Preparing...")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Copy link").closest("button")!).toBeDisabled();
+      expect(screen.getByText("Share PDF...").closest("button")!).toBeDisabled();
+      expect(screen.getByText("Download as image").closest("button")!).toBeDisabled();
+      expect(screen.getByText("Download as PDF").closest("button")!).toBeDisabled();
+
+      resolveShare!();
+      await waitFor(() => {
+        expect(screen.getByText("Share image...")).toBeInTheDocument();
       });
 
       document.body.removeChild(gridEl);

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
@@ -219,7 +219,7 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
       if (!canvas) return;
 
       const pdf = await buildDashboardPdf(canvas);
-      const blob = pdf.output("blob") as Blob;
+      const blob = pdf.output("blob");
       const filename = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.pdf`;
       const file = new File([blob], filename, { type: "application/pdf" });
 

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
@@ -146,6 +146,9 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     return pdf;
   };
 
+  const buildExportFilename = (ext: string) =>
+    `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.${ext}`;
+
   const handleDownloadImage = async () => {
     setExporting("image");
     try {

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
@@ -59,15 +59,16 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     ]);
     const PDF_PROBE = new TextEncoder().encode("%PDF-1.4\n%%EOF\n");
 
-    try {
-      const pngFile = new File([PNG_PROBE], "probe.png", { type: "image/png" });
-      if (navigator.canShare({ files: [pngFile] })) setCanShareImage(true);
-    } catch { /* unsupported */ }
+    const probeCanShare = (bytes: Uint8Array<ArrayBuffer>, name: string, type: string) => {
+      try {
+        return navigator.canShare({ files: [new File([bytes], name, { type })] });
+      } catch {
+        return false;
+      }
+    };
 
-    try {
-      const pdfFile = new File([PDF_PROBE], "probe.pdf", { type: "application/pdf" });
-      if (navigator.canShare({ files: [pdfFile] })) setCanSharePdf(true);
-    } catch { /* unsupported */ }
+    if (probeCanShare(PNG_PROBE, "probe.png", "image/png")) setCanShareImage(true);
+    if (probeCanShare(PDF_PROBE, "probe.pdf", "application/pdf")) setCanSharePdf(true);
   }, []);
 
   const handleCopyKioskLink = () => {
@@ -152,7 +153,7 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
       if (!canvas) return;
 
       const link = document.createElement("a");
-      link.download = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.png`;
+      link.download = buildExportFilename("png");
       link.href = canvas.toDataURL("image/png");
       link.click();
 
@@ -172,7 +173,7 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
       if (!canvas) return;
 
       const pdf = await buildDashboardPdf(canvas);
-      pdf.save(`${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.pdf`);
+      pdf.save(buildExportFilename("pdf"));
       ShowNotification({ type: "success", message: "PDF downloaded" });
       onClose();
     } catch {
@@ -182,18 +183,24 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     }
   };
 
-  const handleShareImage = async () => {
-    setExporting("share-image");
-    try {
-      const canvas = await captureElement();
-      if (!canvas) return;
+  const buildExportFilename = (ext: string) =>
+    `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.${ext}`;
 
-      const blob = await canvasToBlob(canvas);
-      const filename = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.png`;
-      const file = new File([blob], filename, { type: "image/png" });
+  const shareBlob = async (
+    state: Exclude<ExportState, null>,
+    produceBlob: () => Promise<Blob | null>,
+    ext: string,
+    mimeType: string,
+    unsupportedMessage: string,
+  ) => {
+    setExporting(state);
+    try {
+      const blob = await produceBlob();
+      if (!blob) return;
+      const file = new File([blob], buildExportFilename(ext), { type: mimeType });
 
       if (typeof navigator.canShare === "function" && !navigator.canShare({ files: [file] })) {
-        ShowNotification({ type: "error", message: "Sharing this file is not supported" });
+        ShowNotification({ type: "error", message: unsupportedMessage });
         return;
       }
 
@@ -212,36 +219,31 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     }
   };
 
-  const handleSharePdf = async () => {
-    setExporting("share-pdf");
-    try {
-      const canvas = await captureElement();
-      if (!canvas) return;
+  const handleShareImage = () =>
+    shareBlob(
+      "share-image",
+      async () => {
+        const canvas = await captureElement();
+        return canvas ? canvasToBlob(canvas) : null;
+      },
+      "png",
+      "image/png",
+      "Sharing this file is not supported",
+    );
 
-      const pdf = await buildDashboardPdf(canvas);
-      const blob = pdf.output("blob");
-      const filename = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.pdf`;
-      const file = new File([blob], filename, { type: "application/pdf" });
-
-      if (typeof navigator.canShare === "function" && !navigator.canShare({ files: [file] })) {
-        ShowNotification({ type: "error", message: "Sharing PDFs is not supported on this device" });
-        return;
-      }
-
-      await navigator.share({
-        files: [file],
-        title: dashboardName,
-        text: `Dashboard snapshot: ${dashboardName}`,
-      });
-      ShowNotification({ type: "success", message: "Shared" });
-      onClose();
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      ShowNotification({ type: "error", message: "Failed to share dashboard" });
-    } finally {
-      setExporting(null);
-    }
-  };
+  const handleSharePdf = () =>
+    shareBlob(
+      "share-pdf",
+      async () => {
+        const canvas = await captureElement();
+        if (!canvas) return null;
+        const pdf = await buildDashboardPdf(canvas);
+        return pdf.output("blob");
+      },
+      "pdf",
+      "application/pdf",
+      "Sharing PDFs is not supported on this device",
+    );
 
   return (
     <div className="p-4 space-y-4">

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
@@ -59,7 +59,7 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     ]);
     const PDF_PROBE = new TextEncoder().encode("%PDF-1.4\n%%EOF\n");
 
-    const probeCanShare = (bytes: Uint8Array<ArrayBuffer>, name: string, type: string) => {
+    const probeCanShare = (bytes: BlobPart, name: string, type: string) => {
       try {
         return navigator.canShare({ files: [new File([bytes], name, { type })] });
       } catch {
@@ -185,9 +185,6 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
       setExporting(null);
     }
   };
-
-  const buildExportFilename = (ext: string) =>
-    `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.${ext}`;
 
   const shareBlob = async (
     state: Exclude<ExportState, null>,

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/share-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams, usePathname } from "next/navigation";
 import { Button } from "flowbite-react";
 import { HiArrowDownTray, HiLink } from "react-icons/hi2";
+import { FaShare } from "react-icons/fa";
 import { ShowNotification } from "@/features/notifications/notification";
 
 /** CSS selector for the dashboard content area to capture */
@@ -34,10 +35,40 @@ export interface ShareFormProps {
   onClose: () => void;
 }
 
+type ExportState = "image" | "pdf" | "share-image" | "share-pdf" | null;
+
 export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const [exporting, setExporting] = useState<"image" | "pdf" | null>(null);
+  const [exporting, setExporting] = useState<ExportState>(null);
+  const [canShareImage, setCanShareImage] = useState(false);
+  const [canSharePdf, setCanSharePdf] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    if (typeof navigator.canShare !== "function") return;
+
+    // Minimal 1x1 transparent PNG; some platforms validate magic bytes in canShare.
+    const PNG_PROBE = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const PDF_PROBE = new TextEncoder().encode("%PDF-1.4\n%%EOF\n");
+
+    try {
+      const pngFile = new File([PNG_PROBE], "probe.png", { type: "image/png" });
+      if (navigator.canShare({ files: [pngFile] })) setCanShareImage(true);
+    } catch { /* unsupported */ }
+
+    try {
+      const pdfFile = new File([PDF_PROBE], "probe.pdf", { type: "application/pdf" });
+      if (navigator.canShare({ files: [pdfFile] })) setCanSharePdf(true);
+    } catch { /* unsupported */ }
+  }, []);
 
   const handleCopyKioskLink = () => {
     const params = new URLSearchParams(searchParams.toString());
@@ -66,6 +97,54 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
     });
   };
 
+  const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob> =>
+    new Promise((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error("Canvas is empty"))),
+        "image/png",
+      );
+    });
+
+  const buildDashboardPdf = async (canvas: HTMLCanvasElement) => {
+    const { jsPDF } = await import("jspdf");
+
+    const imgWidth = canvas.width;
+    const imgHeight = canvas.height;
+    const ratio = imgWidth / imgHeight;
+
+    const orientation = ratio > 1 ? "landscape" : "portrait";
+    const pdf = new jsPDF({ orientation, unit: "px", format: "a4" });
+
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+    const margin = 20;
+    const contentWidth = pageWidth - margin * 2;
+    const contentHeight = contentWidth / ratio;
+
+    pdf.setFontSize(14);
+    pdf.text(dashboardName, margin, margin + 10);
+
+    pdf.setFontSize(9);
+    pdf.setTextColor(128);
+    pdf.text(new Date().toLocaleString(), margin, margin + 22);
+    pdf.setTextColor(0);
+
+    const imgY = margin + 30;
+    const imgData = canvas.toDataURL("image/png");
+
+    if (imgY + contentHeight <= pageHeight - margin) {
+      pdf.addImage(imgData, "PNG", margin, imgY, contentWidth, contentHeight);
+    } else {
+      const availableHeight = pageHeight - imgY - margin;
+      const scaledWidth = availableHeight * ratio;
+      const finalWidth = Math.min(contentWidth, scaledWidth);
+      const finalHeight = finalWidth / ratio;
+      pdf.addImage(imgData, "PNG", margin, imgY, finalWidth, finalHeight);
+    }
+
+    return pdf;
+  };
+
   const handleDownloadImage = async () => {
     setExporting("image");
     try {
@@ -92,52 +171,73 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
       const canvas = await captureElement();
       if (!canvas) return;
 
-      const { jsPDF } = await import("jspdf");
-
-      const imgWidth = canvas.width;
-      const imgHeight = canvas.height;
-      const ratio = imgWidth / imgHeight;
-
-      // Use landscape if wider than tall, portrait otherwise
-      const orientation = ratio > 1 ? "landscape" : "portrait";
-      const pdf = new jsPDF({ orientation, unit: "px", format: "a4" });
-
-      const pageWidth = pdf.internal.pageSize.getWidth();
-      const pageHeight = pdf.internal.pageSize.getHeight();
-      const margin = 20;
-      const contentWidth = pageWidth - margin * 2;
-      const contentHeight = contentWidth / ratio;
-
-      // Add title
-      pdf.setFontSize(14);
-      pdf.text(dashboardName, margin, margin + 10);
-
-      // Add date
-      pdf.setFontSize(9);
-      pdf.setTextColor(128);
-      pdf.text(new Date().toLocaleString(), margin, margin + 22);
-      pdf.setTextColor(0);
-
-      const imgY = margin + 30;
-      const imgData = canvas.toDataURL("image/png");
-
-      if (imgY + contentHeight <= pageHeight - margin) {
-        // Fits on one page
-        pdf.addImage(imgData, "PNG", margin, imgY, contentWidth, contentHeight);
-      } else {
-        // Scale down to fit
-        const availableHeight = pageHeight - imgY - margin;
-        const scaledWidth = availableHeight * ratio;
-        const finalWidth = Math.min(contentWidth, scaledWidth);
-        const finalHeight = finalWidth / ratio;
-        pdf.addImage(imgData, "PNG", margin, imgY, finalWidth, finalHeight);
-      }
-
+      const pdf = await buildDashboardPdf(canvas);
       pdf.save(`${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.pdf`);
       ShowNotification({ type: "success", message: "PDF downloaded" });
       onClose();
     } catch {
       ShowNotification({ type: "error", message: "Failed to export dashboard as PDF" });
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const handleShareImage = async () => {
+    setExporting("share-image");
+    try {
+      const canvas = await captureElement();
+      if (!canvas) return;
+
+      const blob = await canvasToBlob(canvas);
+      const filename = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.png`;
+      const file = new File([blob], filename, { type: "image/png" });
+
+      if (typeof navigator.canShare === "function" && !navigator.canShare({ files: [file] })) {
+        ShowNotification({ type: "error", message: "Sharing this file is not supported" });
+        return;
+      }
+
+      await navigator.share({
+        files: [file],
+        title: dashboardName,
+        text: `Dashboard snapshot: ${dashboardName}`,
+      });
+      ShowNotification({ type: "success", message: "Shared" });
+      onClose();
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      ShowNotification({ type: "error", message: "Failed to share dashboard" });
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const handleSharePdf = async () => {
+    setExporting("share-pdf");
+    try {
+      const canvas = await captureElement();
+      if (!canvas) return;
+
+      const pdf = await buildDashboardPdf(canvas);
+      const blob = pdf.output("blob") as Blob;
+      const filename = `${sanitizeBaseName(dashboardName)}_${new Date().toISOString().slice(0, 10)}.pdf`;
+      const file = new File([blob], filename, { type: "application/pdf" });
+
+      if (typeof navigator.canShare === "function" && !navigator.canShare({ files: [file] })) {
+        ShowNotification({ type: "error", message: "Sharing PDFs is not supported on this device" });
+        return;
+      }
+
+      await navigator.share({
+        files: [file],
+        title: dashboardName,
+        text: `Dashboard snapshot: ${dashboardName}`,
+      });
+      ShowNotification({ type: "success", message: "Shared" });
+      onClose();
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      ShowNotification({ type: "error", message: "Failed to share dashboard" });
     } finally {
       setExporting(null);
     }
@@ -155,6 +255,32 @@ export function ShareForm({ dashboardName, onClose }: Readonly<ShareFormProps>) 
           <HiLink className="mr-2 h-4 w-4" />
           Copy link
         </Button>
+
+        {/* Share image via OS share sheet */}
+        {canShareImage && (
+          <Button
+            color="light"
+            size="sm"
+            onClick={handleShareImage}
+            disabled={exporting !== null}
+          >
+            <FaShare className="mr-2 h-4 w-4" />
+            {exporting === "share-image" ? "Preparing..." : "Share image..."}
+          </Button>
+        )}
+
+        {/* Share PDF via OS share sheet */}
+        {canSharePdf && (
+          <Button
+            color="light"
+            size="sm"
+            onClick={handleSharePdf}
+            disabled={exporting !== null}
+          >
+            <FaShare className="mr-2 h-4 w-4" />
+            {exporting === "share-pdf" ? "Preparing..." : "Share PDF..."}
+          </Button>
+        )}
 
         {/* Download as image */}
         <Button

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/dashboard-share-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/dashboard-share-dropdown.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "flowbite-react";
+import { FaShare } from "react-icons/fa";
+import { useDashboard } from "../../context/dashboard-context";
+import { tr } from "@/features/i18n/tr.service";
+import { ShareForm } from "../dashboard-settings-dropdown/share-form";
+
+export default function DashboardShareDropdown() {
+  const { dashboardName, dictionary } = useDashboard();
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const closePanel = useCallback(() => setOpen(false), []);
+  const togglePanel = () => setOpen((prev) => !prev);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (event.defaultPrevented) return;
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        closePanel();
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closePanel();
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open, closePanel]);
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <Button
+        color="alternative"
+        size="sm"
+        onClick={togglePanel}
+        title={tr("dashboard.settings.shareDashboardTitle", dictionary)}
+      >
+        <FaShare />
+      </Button>
+
+      {open && (
+        <div className="absolute z-50 right-0 top-full mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg min-w-[320px] w-[360px]">
+          <ShareForm dashboardName={dashboardName} onClose={closePanel} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/index.ts
@@ -1,1 +1,0 @@
-export { default as DashboardShareDropdown } from "./dashboard-share-dropdown";

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/index.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-share-dropdown/index.ts
@@ -1,0 +1,1 @@
+export { default as DashboardShareDropdown } from "./dashboard-share-dropdown";

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -26,6 +26,7 @@ import { AddWidgetModal } from "../add-widget-modal/add-widget-modal";
 import { getDashlet } from "../../dashlets";
 import { GRID_COLS, type GridLayoutItem } from "../../types/dashboard.types";
 import { DashboardSettingsDropdown } from "../dashboard-settings-dropdown";
+import { DashboardShareDropdown } from "../dashboard-share-dropdown";
 import { DashboardNavbarPortal } from "../dashboard-navbar-portal";
 
 /**
@@ -315,6 +316,7 @@ export function DashboardView() {
                   canManagePermissions={canManagePermissions}
                 />
               )}
+              <DashboardShareDropdown />
               <Link
                 href={kioskUrl}
                 target="_blank"

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -26,7 +26,7 @@ import { AddWidgetModal } from "../add-widget-modal/add-widget-modal";
 import { getDashlet } from "../../dashlets";
 import { GRID_COLS, type GridLayoutItem } from "../../types/dashboard.types";
 import { DashboardSettingsDropdown } from "../dashboard-settings-dropdown";
-import { DashboardShareDropdown } from "../dashboard-share-dropdown";
+import DashboardShareDropdown from "../dashboard-share-dropdown/dashboard-share-dropdown";
 import { DashboardNavbarPortal } from "../dashboard-navbar-portal";
 
 /**


### PR DESCRIPTION
- Move ShareForm out of settings dropdown into new dashboard-share-dropdown
- Add Web Share API support for sharing PNG/PDF exports
- Add tests covering share button rendering and blob output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native OS sharing for dashboard snapshots as image and PDF.
  * Added a dedicated share dropdown button in the dashboard toolbar.

* **Changes**
  * Moved share capability out of the settings dropdown into the new share control.
  * UI now shows contextual “Share image…” / “Share PDF…” actions when supported.

* **Tests**
  * Added end-to-end tests covering PNG/PDF share flows, UI states, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->