### PR TITLE
fix: share map screenshots as decoded PNG blobs instead of data URLs

### DIFF
--- a/turbo-repo/apps/app/src/features/geographic-view/components/side-bar/inner-menu/download.tsx
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/side-bar/inner-menu/download.tsx
@@ -12,7 +12,7 @@ import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { useState } from "react";
 import DownloadCSV from "./components/download_csv";
 import { MapPosition } from "@/features/geographic-view/types/map";
-import { handleScreenshot } from "../../tool-bar/screenshot-utils";
+import { handleScreenshot, shareScreenshot } from "../../tool-bar/screenshot-utils";
 
 export default function Download({
   dict,
@@ -41,30 +41,20 @@ export default function Download({
     }
   };
 
-  // Function to share the screenshot (could be expanded)
-  const handleShare = () => {
-    // Basic share implementation (could be expanded)
-    if (navigator.share && screenshotDataUrl) {
-      navigator
-        .share({
-          title: "Previsualización de la vista geográfica",
-          text: "Compartir la vista geográfica",
-          //url: screenshotDataUrl, // TODO: Add this when we have a URL
-          files: [
-            new File([screenshotDataUrl], "vista-geografica.png", {
-              type: "image/png",
-            }),
-          ],
-        })
-        .then(() => {
-          setStatus("Screenshot shared!");
-        })
-        .catch((error) => {
-          console.error("Share error:", error);
-          setStatus("Error sharing screenshot");
-        });
-    } else {
-      console.error("Sharing is not supported on this device/browser");
+  const handleShare = async () => {
+    if (!screenshotDataUrl) return;
+    try {
+      const result = await shareScreenshot(
+        screenshotDataUrl,
+        `vista-geografica-${new Date().toISOString().slice(0, 10)}.png`,
+        "Previsualización de la vista geográfica",
+        "Compartir la vista geográfica",
+      );
+      if (result === "shared") setStatus("Screenshot shared!");
+      else if (result === "unsupported") setStatus("Sharing is not supported on this device");
+    } catch (error) {
+      console.error("Share error:", error);
+      setStatus("Error sharing screenshot");
     }
   };
 

--- a/turbo-repo/apps/app/src/features/geographic-view/components/tool-bar/screenshot-utils.ts
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/tool-bar/screenshot-utils.ts
@@ -40,6 +40,46 @@ export const handleScreenshot = async (
   }
 };
 
+export type ShareScreenshotResult = "shared" | "cancelled" | "unsupported";
+
+/**
+ * Share a screenshot via the Web Share API.
+ *
+ * The `dataUrl` must be a `data:image/png;base64,…` string (what the capture
+ * helpers produce). We convert it to a real `Blob` via `fetch`, so the shared
+ * file contains decoded PNG bytes — not the raw data-URL text.
+ *
+ * Returns `"cancelled"` when the user dismisses the native sheet (AbortError),
+ * `"unsupported"` when the platform can't share a file of this type, and
+ * `"shared"` on success. Throws on unexpected share errors.
+ */
+export const shareScreenshot = async (
+  dataUrl: string,
+  filename: string,
+  title: string,
+  text: string,
+): Promise<ShareScreenshotResult> => {
+  if (typeof navigator === "undefined" || typeof navigator.share !== "function") {
+    return "unsupported";
+  }
+
+  const response = await fetch(dataUrl);
+  const blob = await response.blob();
+  const file = new File([blob], filename, { type: blob.type || "image/png" });
+
+  if (typeof navigator.canShare === "function" && !navigator.canShare({ files: [file] })) {
+    return "unsupported";
+  }
+
+  try {
+    await navigator.share({ files: [file], title, text });
+    return "shared";
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") return "cancelled";
+    throw err;
+  }
+};
+
 // Capture the entire map container
 export const captureMapContainer = async () => {
   try {

--- a/turbo-repo/apps/app/src/features/geographic-view/components/tool-bar/screenshot.tsx
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/tool-bar/screenshot.tsx
@@ -4,7 +4,7 @@ import { FaCamera, FaDownload, FaShare } from "react-icons/fa";
 import { IoClose } from "react-icons/io5";
 import { Button, Label } from "flowbite-react";
 import Image from "next/image";
-import { handleScreenshot } from "./screenshot-utils";
+import { handleScreenshot, shareScreenshot } from "./screenshot-utils";
 
 export default function Screenshot() {
   const [openScreenshot, setOpenScreenshot] = useState(false);
@@ -15,31 +15,21 @@ export default function Screenshot() {
     null
   );
 
-  // Function to share the screenshot (could be expanded)
-  const handleShare = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Stop event from bubbling up
-    // Basic share implementation (could be expanded)
-    if (navigator.share && screenshotDataUrl) {
-      navigator
-        .share({
-          title: "Previsualización de la vista geográfica",
-          text: "Compartir la vista geográfica",
-          //url: screenshotDataUrl, // TODO: Add this when we have a URL
-          files: [
-            new File([screenshotDataUrl], "vista-geografica.png", {
-              type: "image/png",
-            }),
-          ],
-        })
-        .then(() => {
-          setStatus("Screenshot shared!");
-        })
-        .catch((error) => {
-          console.error("Share error:", error);
-          setStatus("Error sharing screenshot");
-        });
-    } else {
-      console.error("Sharing is not supported on this device/browser");
+  const handleShare = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!screenshotDataUrl) return;
+    try {
+      const result = await shareScreenshot(
+        screenshotDataUrl,
+        `vista-geografica-${new Date().toISOString().slice(0, 10)}.png`,
+        "Previsualización de la vista geográfica",
+        "Compartir la vista geográfica",
+      );
+      if (result === "shared") setStatus("Screenshot shared!");
+      else if (result === "unsupported") setStatus("Sharing is not supported on this device");
+    } catch (error) {
+      console.error("Share error:", error);
+      setStatus("Error sharing screenshot");
     }
   };
 


### PR DESCRIPTION
- Extract shareScreenshot helper that converts data URLs to Blob/File via fetch
- Reuse helper in download menu and toolbar share actions
- Handle AbortError and unsupported platforms with explicit result states