### PR TITLE
feat: wire calendar planning dropdowns to ams.fn_rd_accredited_resources (#346)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
@@ -131,8 +131,7 @@ function applyQuery(
     const name = row.resource_name?.toLowerCase();
     const identifier = row.identifier?.toLowerCase();
     return (
-      (name !== undefined && name.includes(needle)) ||
-      (identifier !== undefined && identifier.includes(needle))
+      name?.includes(needle) === true || identifier?.includes(needle) === true
     );
   });
 }

--- a/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import { requireAuth } from "../../utils/alfresco-crud-client";
+import {
+  fetchAccreditedResources,
+  invalidateAccreditedResourcesCache,
+  type AccreditedResourceType,
+  type PgrestAccreditedResourceRow,
+} from "../../utils/pgrest-client";
+import { logger } from "@/lib/logger";
+
+const ALLOWED_RESOURCE_TYPES: ReadonlySet<AccreditedResourceType> = new Set([
+  "DRIVER",
+  "TRUCK",
+  "TRAILER",
+  "CARRIER",
+]);
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * GET /app/api/calendar/accredited-resources
+ *   ?rutMandante=<rut>
+ *   &delegacion=<code>
+ *   [&resourceType=DRIVER|TRUCK|TRAILER|CARRIER]
+ *   [&q=<search>]
+ *   [&offset=<int>]  default 0
+ *   [&limit=<int>]   default 50, max 200
+ *   [&refresh=1]     bypass the in-memory cache
+ *
+ * Proxies `ams.fn_rd_accredited_resources` via pgrest. The upstream function
+ * returns the full (accredited + non-accredited) set for the scope; this
+ * handler caches it in-process (see `fetchAccreditedResources`), then filters
+ * and slices for pagination + client-side search.
+ *
+ * `q` matches `resource_name` and `identifier` (case-insensitive substring).
+ * The response always echoes the unfiltered total so the client can render
+ * "X / Y" counters alongside the filtered page.
+ */
+export async function GET(request: Request) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { searchParams } = new URL(request.url);
+  const rutMandante = searchParams.get("rutMandante")?.trim();
+  const delegacion = searchParams.get("delegacion")?.trim();
+  const resourceTypeRaw = searchParams.get("resourceType")?.trim().toUpperCase();
+  const carrierId = searchParams.get("carrierId")?.trim() || undefined;
+  const q = searchParams.get("q")?.trim() ?? "";
+  const offsetRaw = searchParams.get("offset");
+  const limitRaw = searchParams.get("limit");
+  const refresh = searchParams.get("refresh") === "1";
+
+  if (!rutMandante || !delegacion) {
+    return NextResponse.json(
+      { error: "rutMandante and delegacion are required" },
+      { status: 400 }
+    );
+  }
+
+  let resourceType: AccreditedResourceType | undefined;
+  if (resourceTypeRaw) {
+    if (!ALLOWED_RESOURCE_TYPES.has(resourceTypeRaw as AccreditedResourceType)) {
+      return NextResponse.json(
+        { error: `Invalid resourceType: ${resourceTypeRaw}` },
+        { status: 400 }
+      );
+    }
+    resourceType = resourceTypeRaw as AccreditedResourceType;
+  }
+
+  const offset = Math.max(0, Number.parseInt(offsetRaw ?? "0", 10) || 0);
+  const rawLimit = Number.parseInt(limitRaw ?? `${DEFAULT_LIMIT}`, 10);
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number.isFinite(rawLimit) ? rawLimit : DEFAULT_LIMIT)
+  );
+
+  try {
+    if (refresh) {
+      invalidateAccreditedResourcesCache({
+        rutMandante,
+        delegacion,
+        resourceType,
+        carrierId,
+      });
+    }
+
+    const allRows = await fetchAccreditedResources({
+      rutMandante,
+      delegacion,
+      resourceType,
+      carrierId,
+    });
+
+    const filtered = applyQuery(allRows, q);
+    const page = filtered.slice(offset, offset + limit);
+
+    return NextResponse.json({
+      data: page,
+      total: allRows.length,
+      filteredTotal: filtered.length,
+      offset,
+      limit,
+      hasMore: offset + page.length < filtered.length,
+    });
+  } catch (error) {
+    logger.error(
+      { err: error, rutMandante, delegacion, resourceType, q },
+      "Failed to fetch accredited resources"
+    );
+    return NextResponse.json(
+      { error: "Failed to fetch accredited resources" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Case-insensitive substring filter against `resource_name` and `identifier`.
+ * Runs server-side (post-cache) so the client only pays for the slice it
+ * actually renders.
+ */
+function applyQuery(
+  rows: PgrestAccreditedResourceRow[],
+  q: string
+): PgrestAccreditedResourceRow[] {
+  if (q.length === 0) return rows;
+  const needle = q.toLowerCase();
+  return rows.filter((row) => {
+    const name = row.resource_name?.toLowerCase();
+    const identifier = row.identifier?.toLowerCase();
+    return (
+      (name !== undefined && name.includes(needle)) ||
+      (identifier !== undefined && identifier.includes(needle))
+    );
+  });
+}

--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -455,6 +455,157 @@ export async function fetchTruckCatalogByIdOrPlate(
 }
 
 /**
+ * Row shape returned by `ams.fn_rd_accredited_resources`. One row per
+ * resource (driver / truck / trailer / carrier) known to the tenant for the
+ * given (rut_mandante, delegacion) pair. The `is_acredited` column flags
+ * whether that resource actually holds an ACCREDITED record — the function
+ * also returns NOT ACCREDITED rows so the UI can surface both states.
+ *
+ * `trip_count` / `last_trip` are derived from `public.historical_trip`,
+ * `symptoms` is a JSON rollup of `public.symptoms` over the last 90 days
+ * (key: symptom_name, value: count).
+ */
+export type AccreditedResourceType = "DRIVER" | "TRUCK" | "TRAILER" | "CARRIER";
+
+export interface PgrestAccreditedResourceRow {
+  resource_type: AccreditedResourceType;
+  resource_id: string;
+  resource_name: string | null;
+  identifier: string | null;
+  faena: string | null;
+  rut_mandante: string | null;
+  is_acredited: "ACREDITED" | "NOT ACREDITED";
+  trip_count: number | null;
+  last_trip: string | null;
+  symptoms: Record<string, number> | null;
+  updated_at: string | null;
+}
+
+/**
+ * Resolve the AMS-schema ingress base URL for the pgrest host. Prod exposes
+ * two APISIX routes on `pgrest.streamhub.cl`:
+ *
+ *   - `/api/v1/pgrest/*`      → public schema
+ *   - `/api/v1/pgrest-ams/*`  → ams schema (APISIX injects `Accept-Profile: ams`
+ *                                and `Content-Profile: ams` for us)
+ *
+ * `STREAMHUB_URL` is inconsistent across envs — sometimes the bare host,
+ * sometimes with the public-schema prefix. Swap the prefix if present,
+ * otherwise append `/api/v1/pgrest-ams`.
+ */
+function amsRouteBaseUrl(): string {
+  const base = pgrestBaseUrl();
+  if (base.endsWith("/api/v1/pgrest")) {
+    return `${base.slice(0, -"/api/v1/pgrest".length)}/api/v1/pgrest-ams`;
+  }
+  if (base.endsWith("/api/v1/pgrest-ams")) return base;
+  return `${base}/api/v1/pgrest-ams`;
+}
+
+const ACCREDITED_RESOURCES_TTL_MS = 5 * 60 * 1000;
+const ACCREDITED_RESOURCES_MAX_ENTRIES = 32;
+
+interface AccreditedCacheEntry {
+  rows: PgrestAccreditedResourceRow[];
+  fetchedAt: number;
+}
+
+const accreditedResourcesCache = new Map<string, AccreditedCacheEntry>();
+
+function accreditedCacheKey(opts: {
+  rutMandante: string;
+  delegacion: string;
+  resourceType?: AccreditedResourceType;
+  carrierId?: string;
+}): string {
+  return [
+    opts.rutMandante,
+    opts.delegacion,
+    opts.resourceType ?? "*",
+    opts.carrierId ?? "*",
+  ].join("|");
+}
+
+/**
+ * Fetch the *full* accredited-resources set for the given scope. Bypasses
+ * pagination — the server-side slicing happens in the route handler on top of
+ * this cached array, since the upstream function does not take `limit/offset`
+ * and re-running the heavy JSONB aggregation per scroll tick would be wasteful.
+ *
+ * Results are cached in-process for {@link ACCREDITED_RESOURCES_TTL_MS}. The
+ * cache is a tiny bounded Map (eldest entry evicted once full) — accreditation
+ * changes rarely, so staleness up to 5 min is acceptable.
+ *
+ * `p_client_id` is pinned to `"mintral"` at the source — the tenant split is
+ * not yet modeled on the ams function and hardcoding matches what the rest of
+ * this feature expects.
+ */
+export async function fetchAccreditedResources(opts: {
+  rutMandante: string;
+  delegacion: string;
+  resourceType?: AccreditedResourceType;
+  /**
+   * Optional CARRIER `resource_id` that scopes child rows (e.g. DRIVER) to a
+   * specific transportist. Maps to the upstream function's `p_carrier_id`.
+   */
+  carrierId?: string;
+}): Promise<PgrestAccreditedResourceRow[]> {
+  const key = accreditedCacheKey(opts);
+  const cached = accreditedResourcesCache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < ACCREDITED_RESOURCES_TTL_MS) {
+    return cached.rows;
+  }
+
+  const token = await bearerToken();
+  const url = `${amsRouteBaseUrl()}/rpc/fn_rd_accredited_resources`;
+  const body: Record<string, unknown> = {
+    p_client_id: "mintral",
+    p_rut_mandante: opts.rutMandante,
+    p_delegacion: opts.delegacion,
+  };
+  if (opts.resourceType) body.p_resource_type = opts.resourceType;
+  if (opts.carrierId) body.p_carrier_id = opts.carrierId;
+  const response = await pgrestFetch(url, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `pgrest POST rpc/fn_rd_accredited_resources failed: ${response.status} ${response.statusText}`
+    );
+  }
+  const rows = (await response.json()) as PgrestAccreditedResourceRow[];
+
+  // Bounded LRU-ish eviction: drop eldest insertion when full.
+  if (accreditedResourcesCache.size >= ACCREDITED_RESOURCES_MAX_ENTRIES) {
+    const eldest = accreditedResourcesCache.keys().next().value;
+    if (eldest !== undefined) accreditedResourcesCache.delete(eldest);
+  }
+  accreditedResourcesCache.set(key, { rows, fetchedAt: Date.now() });
+  return rows;
+}
+
+/** Drop the cached entry — used when the route wants to bypass TTL on demand. */
+export function invalidateAccreditedResourcesCache(opts?: {
+  rutMandante: string;
+  delegacion: string;
+  resourceType?: AccreditedResourceType;
+  carrierId?: string;
+}): void {
+  if (!opts) {
+    accreditedResourcesCache.clear();
+    return;
+  }
+  accreditedResourcesCache.delete(accreditedCacheKey(opts));
+}
+
+/**
  * Fetch the active special-view cards for the current tenant from
  * `ams.fleet_special_views`. Tenant filtering is enforced server-side via
  * the table's RLS policy on the JWT `azp` claim, so no client_id is sent.

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -552,6 +552,7 @@ export interface SelectedService {
   id: string;
   cliente: string;
   mintral_clientRut?: string;
+  mintral_delegacionOrigen?: string;
   origen: string;
   lugarCarguio: string;
   destino: string;
@@ -690,6 +691,7 @@ const MAX_SERVICES_PER_SLOT = 99;
 const StoredServiceSchema = z
   .object({
     mintral_clientRut: z.string().optional(),
+    mintral_delegacionOrigen: z.string().optional(),
     origen: z.string().optional(),
     lugarCarguio: z.string().optional(),
     destino: z.string().optional(),

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -119,6 +119,7 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     id: serviceId,
     cliente: task.client || task.clientCode || "",
     mintral_clientRut: task.mintral_clientRut,
+    mintral_delegacionOrigen: task.mintral_delegacionOrigen,
     origen: task.origin || "",
     lugarCarguio: "", // Not available in KanbanBoardTask
     destino: task.destination || "",
@@ -606,6 +607,11 @@ export function PlanningSidebarClient({
                       allServices.find(
                         (s) => s.id === displayState.selectedService?.id
                       )?.mintral_clientRut,
+                    mintral_delegacionOrigen:
+                      displayState.selectedService.mintral_delegacionOrigen ??
+                      allServices.find(
+                        (s) => s.id === displayState.selectedService?.id
+                      )?.mintral_delegacionOrigen,
                     slot: displayState.formattedSlot?.full,
                   }
                 : undefined

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -785,6 +785,11 @@ export function PlanningSidebarForm({
               value={assignmentData}
               onChange={setAssignmentData}
               dict={dict}
+              mintralClientRut={selectedService?.mintral_clientRut}
+              mintralDelegacionOrigen={
+                selectedService?.mintral_delegacionOrigen ??
+                selectedService?.origen
+              }
             />
             <div className="flex gap-2 pt-2">
               <Button

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/assignment-form.tsx
@@ -7,6 +7,10 @@ import type { MapRef } from "react-map-gl";
 import { PinLayer } from "@/features/geographic-view/components/layers/pin_layer";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
+import {
+  useAccreditedResources,
+  type AccreditedResource,
+} from "@/features/calendar/services/accredited-resources.service";
 import { DriverSearchDropdown } from "./driver-search-dropdown";
 import {
   TransportistaSearchDropdown,
@@ -21,28 +25,6 @@ import {
   type RemolqueOption,
 } from "./remolque-search-dropdown";
 
-// Mock data - replace with actual API data
-const TRANSPORTISTA_OPTIONS: TransportistaOption[] = [
-  {
-    id: "tnl",
-    name: "Transportes Nacionales Libertadores Ltda",
-    rut: "76.123.456-7",
-    estado: "habilitado",
-  },
-  {
-    id: "trn",
-    name: "Transporte Rápido del Norte S.A.",
-    rut: "77.234.567-8",
-    estado: "habilitado",
-  },
-  {
-    id: "lis",
-    name: "Logística Integral del Sur Ltda",
-    rut: "78.345.678-9",
-    estado: "no habilitado",
-  },
-];
-
 export interface ConductorOption {
   id: string;
   name: string;
@@ -53,137 +35,6 @@ export interface ConductorOption {
   excesoVelocidad: number;
   faltasDescanso: number;
 }
-
-const CONDUCTOR_OPTIONS: ConductorOption[] = [
-  {
-    id: "c1",
-    name: "Juan Pérez González",
-    rut: "12.345.678-9",
-    estado: "habilitado",
-    viajesPrevios: 142,
-    ultimoViaje: "2026-03-10",
-    excesoVelocidad: 2,
-    faltasDescanso: 1,
-  },
-  {
-    id: "c2",
-    name: "Carlos Rodríguez Silva",
-    rut: "11.222.333-4",
-    estado: "habilitado",
-    viajesPrevios: 89,
-    ultimoViaje: "2026-03-08",
-    excesoVelocidad: 0,
-    faltasDescanso: 0,
-  },
-  {
-    id: "c3",
-    name: "Miguel Ángel Torres",
-    rut: "9.876.543-2",
-    estado: "no habilitado",
-    viajesPrevios: 56,
-    ultimoViaje: "2026-02-15",
-    excesoVelocidad: 5,
-    faltasDescanso: 3,
-  },
-  {
-    id: "c4",
-    name: "Roberto Fernández López",
-    rut: "15.678.901-K",
-    estado: "habilitado",
-    viajesPrevios: 203,
-    ultimoViaje: "2026-03-11",
-    excesoVelocidad: 1,
-    faltasDescanso: 0,
-  },
-  {
-    id: "c5",
-    name: "Andrés Morales Vega",
-    rut: "18.765.432-1",
-    estado: "habilitado",
-    viajesPrevios: 67,
-    ultimoViaje: "2026-03-09",
-    excesoVelocidad: 0,
-    faltasDescanso: 2,
-  },
-];
-
-const CAMION_OPTIONS: CamionOption[] = [
-  {
-    id: "t1",
-    plate: "BBCC12",
-    marca: "Volvo FH16",
-    tipo: "camion",
-    estado: "disponible",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    viajesPrevios: 234,
-    ultimoViaje: "2026-03-11",
-    perdidasSenal: 2,
-    latitude: -33.4489,
-    longitude: -70.6693,
-    heading: 45,
-  },
-  {
-    id: "t2",
-    plate: "DDEE34",
-    marca: "Scania R500",
-    tipo: "camion",
-    estado: "ocupado",
-    gpsIntegrado: true,
-    estadoGps: "offline",
-    viajesPrevios: 156,
-    ultimoViaje: "2026-03-08",
-    perdidasSenal: 8,
-    latitude: -33.4372,
-    longitude: -70.6506,
-    heading: 120,
-  },
-  {
-    id: "t3",
-    plate: "FFGG56",
-    marca: "Mercedes Actros",
-    tipo: "furgon",
-    estado: "disponible",
-    gpsIntegrado: false,
-    estadoGps: "offline",
-    viajesPrevios: 89,
-    ultimoViaje: "2026-03-05",
-    perdidasSenal: 0,
-    latitude: -33.4569,
-    longitude: -70.6483,
-    heading: 200,
-  },
-  {
-    id: "t4",
-    plate: "HHII78",
-    marca: "MAN TGX",
-    tipo: "camion",
-    estado: "disponible",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    viajesPrevios: 312,
-    ultimoViaje: "2026-03-10",
-    perdidasSenal: 1,
-    latitude: -33.4255,
-    longitude: -70.6142,
-    heading: 90,
-  },
-  {
-    id: "t5",
-    plate: "JJKK90",
-    marca: "DAF XF",
-    tipo: "camioneta",
-    estado: "ocupado",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    viajesPrevios: 178,
-    ultimoViaje: "2026-03-09",
-    perdidasSenal: 5,
-    latitude: -33.4103,
-    longitude: -70.5665,
-    heading: 270,
-  },
-];
 
 const REMOLQUE_OPTIONS: RemolqueOption[] = [
   {
@@ -328,16 +179,164 @@ interface AssignmentFormProps {
   readonly value: AssignmentFormData;
   readonly onChange: (data: AssignmentFormData) => void;
   readonly dict: I18nRecord;
+  /** Client RUT of the mandante — drives the `p_rut_mandante` filter. */
+  readonly mintralClientRut?: string;
+  /** Delegation/origin code — drives the `p_delegacion` filter. */
+  readonly mintralDelegacionOrigen?: string;
 }
 
-export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
-  const selectedCamion = CAMION_OPTIONS.find((c) => c.id === value.camion);
+/**
+ * Map an `ams.fn_rd_accredited_resources` CARRIER row to the shape expected by
+ * `TransportistaSearchDropdown`. The upstream function returns both accredited
+ * and non-accredited carriers; `is_acredited` drives the UI badge. Both states
+ * are surfaced and selectable — the planner sees accreditation as context, not
+ * as a hard block.
+ */
+function carrierRowToOption(row: AccreditedResource): TransportistaOption {
+  const rut = row.identifier ?? "";
+  return {
+    id: row.resource_id,
+    name: row.resource_name ?? rut,
+    rut,
+    estado: row.is_acredited === "ACREDITED" ? "habilitado" : "no habilitado",
+  };
+}
+
+/**
+ * Map an `ams.fn_rd_accredited_resources` TRUCK row onto the existing
+ * `CamionOption` shape. The upstream function does not carry GPS/telemetry
+ * fields, so `gpsIntegrado`, `estadoGps`, lat/lng and `heading` default to a
+ * "no signal" baseline. `estado` piggybacks on `is_acredited` (ACREDITED →
+ * `disponible`, NOT ACREDITED → `ocupado`) to reuse the existing UI badge
+ * without introducing a parallel state flag.
+ */
+function truckRowToOption(row: AccreditedResource): CamionOption {
+  const plate = row.identifier ?? "";
+  const symptoms = row.symptoms ?? {};
+  const ultimoViaje = row.last_trip ? row.last_trip.slice(0, 10) : "-";
+  return {
+    id: row.resource_id,
+    plate,
+    marca: row.resource_name ?? "",
+    tipo: "camion",
+    estado: row.is_acredited === "ACREDITED" ? "disponible" : "ocupado",
+    gpsIntegrado: false,
+    estadoGps: "offline",
+    viajesPrevios: row.trip_count ?? 0,
+    ultimoViaje,
+    perdidasSenal: symptoms["Lost Signal"] ?? 0,
+    latitude: null,
+    longitude: null,
+    heading: 0,
+  };
+}
+
+/**
+ * Map an `ams.fn_rd_accredited_resources` DRIVER row onto the existing
+ * `ConductorOption` shape. The upstream row carries `trip_count`, `last_trip`
+ * (ISO timestamp) and a free-form `symptoms` JSON keyed by symptom name;
+ * the two counters the driver card renders today are derived from the
+ * matching symptom buckets — defaulting to 0 when missing.
+ */
+function driverRowToOption(row: AccreditedResource): ConductorOption {
+  const rut = row.identifier ?? "";
+  const symptoms = row.symptoms ?? {};
+  const ultimoViaje = row.last_trip ? row.last_trip.slice(0, 10) : "-";
+  return {
+    id: row.resource_id,
+    name: row.resource_name ?? rut,
+    rut,
+    estado: row.is_acredited === "ACREDITED" ? "habilitado" : "no habilitado",
+    viajesPrevios: row.trip_count ?? 0,
+    ultimoViaje,
+    excesoVelocidad: symptoms["Speed Limit Standard"] ?? 0,
+    faltasDescanso:
+      (symptoms["Continuous Drive Check"] ?? 0) +
+      (symptoms["Continuous Resting Check"] ?? 0),
+  };
+}
+
+export function AssignmentForm({
+  value,
+  onChange,
+  dict,
+  mintralClientRut,
+  mintralDelegacionOrigen,
+}: AssignmentFormProps) {
+  const [carrierQuery, setCarrierQuery] = useState("");
+  const [driverQuery, setDriverQuery] = useState("");
+  const [truckQuery, setTruckQuery] = useState("");
+
+  const {
+    resources: accreditedCarriers,
+    loadMore: loadMoreCarriers,
+    isLoadingMore: isLoadingMoreCarriers,
+  } = useAccreditedResources({
+    rutMandante: mintralClientRut,
+    delegacion: mintralDelegacionOrigen,
+    resourceType: "CARRIER",
+    query: carrierQuery,
+  });
+
+  const {
+    resources: accreditedDrivers,
+    loadMore: loadMoreDrivers,
+    isLoadingMore: isLoadingMoreDrivers,
+  } = useAccreditedResources({
+    rutMandante: mintralClientRut,
+    delegacion: mintralDelegacionOrigen,
+    resourceType: "DRIVER",
+    carrierId: value.transportista,
+    query: driverQuery,
+    enabled: Boolean(value.transportista),
+  });
+
+  const {
+    resources: accreditedTrucks,
+    loadMore: loadMoreTrucks,
+    isLoadingMore: isLoadingMoreTrucks,
+  } = useAccreditedResources({
+    rutMandante: mintralClientRut,
+    delegacion: mintralDelegacionOrigen,
+    resourceType: "TRUCK",
+    carrierId: value.transportista,
+    query: truckQuery,
+    enabled: Boolean(value.transportista),
+  });
+
+  const transportistaOptions = useMemo(
+    () => accreditedCarriers.map(carrierRowToOption),
+    [accreditedCarriers]
+  );
+
+  const driverOptions = useMemo(
+    () => accreditedDrivers.map(driverRowToOption),
+    [accreditedDrivers]
+  );
+
+  const truckOptions = useMemo(
+    () => accreditedTrucks.map(truckRowToOption),
+    [accreditedTrucks]
+  );
+
+  const selectedCamion = truckOptions.find((c) => c.id === value.camion);
 
   const handleChange = (
     field: keyof AssignmentFormData,
     fieldValue: string | boolean
   ) => {
     const updated = { ...value, [field]: fieldValue };
+
+    // Drivers/trucks are scoped to the selected carrier — clear those slots
+    // when the carrier changes so a stale (carrier, child) pair can't silently
+    // survive. `remolque` uses the same rule for symmetry.
+    if (field === "transportista" && fieldValue !== value.transportista) {
+      updated.conductor = "";
+      updated.segundoConductor = "";
+      updated.camion = "";
+      setDriverQuery("");
+      setTruckQuery("");
+    }
 
     // When changing conductor, clear segundoConductor if it matches the new value
     // or if the second driver section is disabled
@@ -368,7 +367,7 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
       {/* Transportista Dropdown */}
       <TransportistaSearchDropdown
         label={tr("pages.planning.sidebar.assignment.transportista", dict)}
-        transportistas={TRANSPORTISTA_OPTIONS}
+        transportistas={transportistaOptions}
         selectedTransportistaId={value.transportista}
         onSelect={(v: string) => handleChange("transportista", v)}
         placeholder={tr(
@@ -376,12 +375,15 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
           dict
         )}
         dict={dict}
+        onQueryChange={setCarrierQuery}
+        onReachEnd={loadMoreCarriers}
+        isLoadingMore={isLoadingMoreCarriers}
       />
 
       {/* Conductor Dropdown */}
       <DriverSearchDropdown
         label={tr("pages.planning.sidebar.assignment.conductor", dict)}
-        drivers={CONDUCTOR_OPTIONS}
+        drivers={driverOptions}
         selectedDriverId={value.conductor}
         onSelect={(v: string) => handleChange("conductor", v)}
         placeholder={tr(
@@ -389,6 +391,10 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
           dict
         )}
         dict={dict}
+        disabled={!value.transportista}
+        onQueryChange={setDriverQuery}
+        onReachEnd={loadMoreDrivers}
+        isLoadingMore={isLoadingMoreDrivers}
         labelRightElement={
           <label className="flex items-center gap-1 cursor-pointer">
             <span className="text-[10px] text-gray-500 dark:text-gray-400">
@@ -413,7 +419,7 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
       {value.hasSegundoConductor && (
         <DriverSearchDropdown
           label={tr("pages.planning.sidebar.assignment.secondConductor", dict)}
-          drivers={CONDUCTOR_OPTIONS}
+          drivers={driverOptions}
           selectedDriverId={value.segundoConductor}
           onSelect={(v: string) => handleChange("segundoConductor", v)}
           placeholder={tr(
@@ -421,6 +427,10 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
             dict
           )}
           dict={dict}
+          disabled={!value.transportista}
+          onQueryChange={setDriverQuery}
+          onReachEnd={loadMoreDrivers}
+          isLoadingMore={isLoadingMoreDrivers}
           excludeDriverId={value.conductor}
         />
       )}
@@ -429,7 +439,7 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
       <div>
         <TruckSearchDropdown
           label={tr("pages.planning.sidebar.assignment.camion", dict)}
-          trucks={CAMION_OPTIONS}
+          trucks={truckOptions}
           selectedTruckId={value.camion}
           onSelect={(v: string) => handleChange("camion", v)}
           placeholder={tr(
@@ -437,6 +447,10 @@ export function AssignmentForm({ value, onChange, dict }: AssignmentFormProps) {
             dict
           )}
           dict={dict}
+          disabled={!value.transportista}
+          onQueryChange={setTruckQuery}
+          onReachEnd={loadMoreTrucks}
+          isLoadingMore={isLoadingMoreTrucks}
           labelRightElement={
             <label className="flex items-center gap-1 cursor-pointer">
               <span className="text-[10px] text-gray-500 dark:text-gray-400">

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/assignment-form.tsx
@@ -186,6 +186,42 @@ interface AssignmentFormProps {
 }
 
 /**
+ * Upstream symptom names emitted by `public.symptoms.symptom_name` and
+ * aggregated into the `symptoms` JSONB by `ams.fn_rd_accredited_resources`.
+ * Kept as typed constants so the handful of literal keys the mappers look
+ * up — rather than being sprinkled as magic strings — live in one place and
+ * fail typecheck the moment the upstream contract is renamed. See
+ * `db-scripts/outputs/erick/modular_recursos/fn_rd_accredited_resources_v2.sql`
+ * for the source enumeration.
+ */
+const SYMPTOM_LOST_SIGNAL = "Lost Signal" as const;
+const SYMPTOM_SPEED_LIMIT = "Speed Limit Standard" as const;
+const SYMPTOM_CONT_DRIVE = "Continuous Drive Check" as const;
+const SYMPTOM_CONT_REST = "Continuous Resting Check" as const;
+
+/**
+ * Format a `last_trip` ISO-8601 timestamp (as returned by PostgREST) for the
+ * "Último viaje" row on carrier/driver/truck cards.
+ *
+ * Uses `es-CL` + the browser's local timezone so a 2026-04-10T01:40Z trip in
+ * Santiago renders as April 9 — which matches the planner's day instead of
+ * the upstream UTC date. Returns `"-"` when the value is missing or not
+ * parseable, so a malformed string from the API can't leak into the UI.
+ */
+const LAST_TRIP_FORMATTER = new Intl.DateTimeFormat("es-CL", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+function formatLastTrip(raw: string | null | undefined): string {
+  if (!raw) return "-";
+  const t = Date.parse(raw);
+  if (Number.isNaN(t)) return "-";
+  return LAST_TRIP_FORMATTER.format(new Date(t));
+}
+
+/**
  * Map an `ams.fn_rd_accredited_resources` CARRIER row to the shape expected by
  * `TransportistaSearchDropdown`. The upstream function returns both accredited
  * and non-accredited carriers; `is_acredited` drives the UI badge. Both states
@@ -213,7 +249,6 @@ function carrierRowToOption(row: AccreditedResource): TransportistaOption {
 function truckRowToOption(row: AccreditedResource): CamionOption {
   const plate = row.identifier ?? "";
   const symptoms = row.symptoms ?? {};
-  const ultimoViaje = row.last_trip ? row.last_trip.slice(0, 10) : "-";
   return {
     id: row.resource_id,
     plate,
@@ -223,8 +258,8 @@ function truckRowToOption(row: AccreditedResource): CamionOption {
     gpsIntegrado: false,
     estadoGps: "offline",
     viajesPrevios: row.trip_count ?? 0,
-    ultimoViaje,
-    perdidasSenal: symptoms["Lost Signal"] ?? 0,
+    ultimoViaje: formatLastTrip(row.last_trip),
+    perdidasSenal: symptoms[SYMPTOM_LOST_SIGNAL] ?? 0,
     latitude: null,
     longitude: null,
     heading: 0,
@@ -241,18 +276,16 @@ function truckRowToOption(row: AccreditedResource): CamionOption {
 function driverRowToOption(row: AccreditedResource): ConductorOption {
   const rut = row.identifier ?? "";
   const symptoms = row.symptoms ?? {};
-  const ultimoViaje = row.last_trip ? row.last_trip.slice(0, 10) : "-";
   return {
     id: row.resource_id,
     name: row.resource_name ?? rut,
     rut,
     estado: row.is_acredited === "ACREDITED" ? "habilitado" : "no habilitado",
     viajesPrevios: row.trip_count ?? 0,
-    ultimoViaje,
-    excesoVelocidad: symptoms["Speed Limit Standard"] ?? 0,
+    ultimoViaje: formatLastTrip(row.last_trip),
+    excesoVelocidad: symptoms[SYMPTOM_SPEED_LIMIT] ?? 0,
     faltasDescanso:
-      (symptoms["Continuous Drive Check"] ?? 0) +
-      (symptoms["Continuous Resting Check"] ?? 0),
+      (symptoms[SYMPTOM_CONT_DRIVE] ?? 0) + (symptoms[SYMPTOM_CONT_REST] ?? 0),
   };
 }
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/base-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/base-search-dropdown.tsx
@@ -80,6 +80,27 @@ export interface BaseSearchDropdownProps<
 
   // Optional: exclude certain items from the list
   readonly excludeId?: string;
+
+  /**
+   * When provided, the dropdown switches to **server-backed** mode:
+   *
+   * - Client-side filtering and grouped-results UI are skipped; `items` is
+   *   rendered as-is.
+   * - The debounced search query is surfaced via {@link onQueryChange} so the
+   *   caller can forward it to the server (typically as `?q=`).
+   * - {@link onReachEnd} fires when the list is scrolled near the bottom so
+   *   the caller can append the next page.
+   * - {@link isLoadingMore} shows a subtle "loading" hint at the end of the
+   *   list while more rows are being fetched.
+   *
+   * All three props are optional and only activate together: pass
+   * `onQueryChange` to opt into server search, `onReachEnd` to opt into
+   * infinite scroll. Omitting them preserves the original client-side
+   * behavior — no consumer breakage.
+   */
+  readonly onQueryChange?: (query: string) => void;
+  readonly onReachEnd?: () => void;
+  readonly isLoadingMore?: boolean;
 }
 
 export interface CardRenderProps<TOption extends BaseOption> {
@@ -478,7 +499,11 @@ export function BaseSearchDropdown<
   renderSelectedButton,
   canSelect,
   excludeId,
+  onQueryChange,
+  onReachEnd,
+  isLoadingMore = false,
 }: Readonly<BaseSearchDropdownProps<TOption, TMatchType>>) {
+  const isServerMode = onQueryChange !== undefined;
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -502,6 +527,11 @@ export function BaseSearchDropdown<
     return () => clearTimeout(timer);
   }, [query]);
 
+  // Forward the debounced query to the server-side caller when in server mode.
+  useEffect(() => {
+    if (onQueryChange) onQueryChange(debouncedQuery);
+  }, [onQueryChange, debouncedQuery]);
+
   // Calculate grouped results when no filter is active
   const groupedResults = useMemo(
     () =>
@@ -511,6 +541,11 @@ export function BaseSearchDropdown<
 
   // Filter items when a field filter is active
   const filteredItems = useMemo(() => {
+    // Server-mode: `items` is already the authoritative list for the current
+    // query, so skip local filtering entirely.
+    if (isServerMode) {
+      return excludeId ? items.filter((item) => item.id !== excludeId) : items;
+    }
     if (!activeFilter) {
       return excludeId ? items.filter((item) => item.id !== excludeId) : items;
     }
@@ -522,11 +557,12 @@ export function BaseSearchDropdown<
       dict,
       excludeId
     );
-  }, [items, activeFilter, fields, dict, excludeId]);
+  }, [isServerMode, items, activeFilter, fields, dict, excludeId]);
 
-  // Determine if we're in "grouped mode" (showing field types) or "list mode"
+  // Determine if we're in "grouped mode" (showing field types) or "list mode".
+  // Server mode never shows grouped results — the backend is the source of truth.
   const isGroupedMode =
-    debouncedQuery.length >= MIN_CHARACTERS && !activeFilter;
+    !isServerMode && debouncedQuery.length >= MIN_CHARACTERS && !activeFilter;
 
   // Reset highlighted index when results change
   useEffect(() => {
@@ -576,6 +612,18 @@ export function BaseSearchDropdown<
       isKeyboardNavigation.current = false;
     }
   }, [highlightedIndex, isOpen]);
+
+  // Infinite-scroll trigger: when the list is scrolled near the bottom and
+  // we're in server-mode with an `onReachEnd` handler, request the next page.
+  // The 80px threshold leaves a little room so the user doesn't have to hit
+  // the very last pixel — matches common combobox UX.
+  const handleListScroll = useCallback(() => {
+    if (!onReachEnd || !listRef.current) return;
+    const el = listRef.current;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+      onReachEnd();
+    }
+  }, [onReachEnd]);
 
   const handleSelect = useCallback(
     (id: string) => {
@@ -745,6 +793,7 @@ export function BaseSearchDropdown<
         role="presentation"
         className="max-h-75 overflow-y-auto"
         onMouseLeave={() => setHighlightedIndex(-1)}
+        onScroll={handleListScroll}
       >
         {isGroupedMode ? (
           <GroupedResultsContent
@@ -758,17 +807,24 @@ export function BaseSearchDropdown<
             onMouseEnter={setHighlightedIndex}
           />
         ) : (
-          <FilteredItemsList
-            filteredItems={filteredItems}
-            selectedId={selectedId}
-            highlightedIndex={highlightedIndex}
-            dict={dict}
-            noResultsText={tr(translations.noResults, dict)}
-            canSelect={canSelect}
-            renderCard={renderCard}
-            onSelect={handleSelect}
-            onHighlight={setHighlightedIndex}
-          />
+          <>
+            <FilteredItemsList
+              filteredItems={filteredItems}
+              selectedId={selectedId}
+              highlightedIndex={highlightedIndex}
+              dict={dict}
+              noResultsText={tr(translations.noResults, dict)}
+              canSelect={canSelect}
+              renderCard={renderCard}
+              onSelect={handleSelect}
+              onHighlight={setHighlightedIndex}
+            />
+            {isServerMode && isLoadingMore && (
+              <div className="px-4 py-3 text-center text-xs text-gray-500 dark:text-gray-400">
+                {tr("pages.planning.sidebar.assignment.loadingMore", dict)}
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/driver-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/driver-search-dropdown.tsx
@@ -38,6 +38,12 @@ interface DriverSearchDropdownProps {
   readonly dict: I18nRecord;
   readonly labelRightElement?: React.ReactNode;
   readonly excludeDriverId?: string;
+  /** Server-mode: forward debounced search query to the data source. */
+  readonly onQueryChange?: (query: string) => void;
+  /** Server-mode: fetch the next page when the list scrolls near the bottom. */
+  readonly onReachEnd?: () => void;
+  /** Server-mode: show a trailing "loading more" hint during pagination. */
+  readonly isLoadingMore?: boolean;
 }
 
 // ============================================================================
@@ -110,31 +116,33 @@ function DriverCard({
       className={twMerge(
         "w-full text-left p-3 transition-colors",
         isHighlighted && "bg-blue-50 dark:bg-blue-900/30",
-        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50",
-        !isEnabled && "opacity-60"
+        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50"
       )}
     >
-      {/* Header: Name + RUT + Status */}
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            {isSelected && (
-              <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
-            )}
-            <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
-              {driver.name}
-            </span>
-          </div>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            {driver.rut}
-          </span>
-        </div>
-        {isEnabled && (
+      {/* Row 1: Name spans the row so long driver names have room. */}
+      <div className="flex items-center gap-1.5 min-w-0">
+        {isSelected && (
+          <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
+        )}
+        <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
+          {driver.name}
+        </span>
+      </div>
+      {/* Row 2: RUT left, accreditation badge right. */}
+      <div className="mt-0.5 mb-2 flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+          {driver.rut}
+        </span>
+        {isEnabled ? (
           <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
             <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
               <HiCheck className="w-2.5 h-2.5" />
             </span>
             {tr("pages.planning.sidebar.assignment.enabled", dict)}
+          </span>
+        ) : (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
           </span>
         )}
       </div>
@@ -190,25 +198,27 @@ function renderSelectedDriverButton(driver: ConductorOption, dict: I18nRecord) {
   const isEnabled = driver.estado === "habilitado";
 
   return (
-    <div className="flex items-start justify-between gap-2">
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
-          <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
-            {driver.name}
-          </span>
-        </div>
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          {driver.rut}
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-1.5 min-w-0">
+        <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
+        <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
+          {driver.name}
         </span>
       </div>
-      <div className="flex items-center gap-1.5 shrink-0">
-        {isEnabled && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+      <div className="mt-0.5 flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+          {driver.rut}
+        </span>
+        {isEnabled ? (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 shrink-0">
             <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
               <HiCheck className="w-2.5 h-2.5" />
             </span>
             {tr("pages.planning.sidebar.assignment.enabled", dict)}
+          </span>
+        ) : (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 shrink-0">
+            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
           </span>
         )}
       </div>
@@ -230,6 +240,9 @@ export function DriverSearchDropdown({
   dict,
   labelRightElement,
   excludeDriverId,
+  onQueryChange,
+  onReachEnd,
+  isLoadingMore,
 }: DriverSearchDropdownProps) {
   return (
     <BaseSearchDropdown<ConductorOption, DriverMatchType>
@@ -249,7 +262,9 @@ export function DriverSearchDropdown({
       }}
       renderCard={(props) => <DriverCard {...props} />}
       renderSelectedButton={renderSelectedDriverButton}
-      canSelect={(driver) => driver.estado === "habilitado"}
+      onQueryChange={onQueryChange}
+      onReachEnd={onReachEnd}
+      isLoadingMore={isLoadingMore}
     />
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/transportista-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/transportista-search-dropdown.tsx
@@ -37,6 +37,12 @@ interface TransportistaSearchDropdownProps {
   readonly placeholder?: string;
   readonly disabled?: boolean;
   readonly dict: I18nRecord;
+  /** Server-mode: forward debounced search query to the data source. */
+  readonly onQueryChange?: (query: string) => void;
+  /** Server-mode: fetch the next page when the list scrolls near the bottom. */
+  readonly onReachEnd?: () => void;
+  /** Server-mode: show a trailing "loading more" hint during pagination. */
+  readonly isLoadingMore?: boolean;
 }
 
 // ============================================================================
@@ -106,31 +112,33 @@ function TransportistaCard({
       className={twMerge(
         "w-full text-left p-3 transition-colors",
         isHighlighted && "bg-blue-50 dark:bg-blue-900/30",
-        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50",
-        !isEnabled && "opacity-60"
+        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50"
       )}
     >
-      {/* Header: Name + RUT + Status */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            {isSelected && (
-              <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
-            )}
-            <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
-              {transportista.name}
-            </span>
-          </div>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            {transportista.rut}
-          </span>
-        </div>
-        {isEnabled && (
+      {/* Row 1: Name spans the full width so long carrier names get room. */}
+      <div className="flex items-center gap-1.5 min-w-0">
+        {isSelected && (
+          <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
+        )}
+        <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
+          {transportista.name}
+        </span>
+      </div>
+      {/* Row 2: RUT on the left, accreditation badge on the right. */}
+      <div className="mt-0.5 flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+          {transportista.rut}
+        </span>
+        {isEnabled ? (
           <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
             <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
               <HiCheck className="w-2.5 h-2.5" />
             </span>
             {tr("pages.planning.sidebar.assignment.enabled", dict)}
+          </span>
+        ) : (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
           </span>
         )}
       </div>
@@ -149,29 +157,35 @@ function renderSelectedTransportistaButton(
   const isEnabled = transportista.estado === "habilitado";
 
   return (
-    <div className="flex items-start justify-between gap-2">
+    <div className="flex items-center gap-2">
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
+        {/* Row 1: Name + chevron on the right so the name spans the row. */}
+        <div className="flex items-center gap-1.5 min-w-0">
           <HiCheck className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400 shrink-0" />
           <span className="font-medium text-sm text-gray-900 dark:text-white truncate">
             {transportista.name}
           </span>
         </div>
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          {transportista.rut}
-        </span>
-      </div>
-      <div className="flex items-center gap-1.5 shrink-0">
-        {isEnabled && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
-            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-              <HiCheck className="w-2.5 h-2.5" />
-            </span>
-            {tr("pages.planning.sidebar.assignment.enabled", dict)}
+        {/* Row 2: RUT on the left, badge on the right. */}
+        <div className="mt-0.5 flex items-center justify-between gap-2">
+          <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {transportista.rut}
           </span>
-        )}
-        <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
+          {isEnabled ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 shrink-0">
+              <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
+                <HiCheck className="w-2.5 h-2.5" />
+              </span>
+              {tr("pages.planning.sidebar.assignment.enabled", dict)}
+            </span>
+          ) : (
+            <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 shrink-0">
+              {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
+            </span>
+          )}
+        </div>
       </div>
+      <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
     </div>
   );
 }
@@ -188,6 +202,9 @@ export function TransportistaSearchDropdown({
   placeholder,
   disabled = false,
   dict,
+  onQueryChange,
+  onReachEnd,
+  isLoadingMore,
 }: TransportistaSearchDropdownProps) {
   return (
     <BaseSearchDropdown<TransportistaOption, TransportistaMatchType>
@@ -205,7 +222,9 @@ export function TransportistaSearchDropdown({
       }}
       renderCard={(props) => <TransportistaCard {...props} />}
       renderSelectedButton={renderSelectedTransportistaButton}
-      canSelect={(transportista) => transportista.estado === "habilitado"}
+      onQueryChange={onQueryChange}
+      onReachEnd={onReachEnd}
+      isLoadingMore={isLoadingMore}
     />
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
@@ -61,6 +61,12 @@ interface TruckSearchDropdownProps {
   readonly disabled?: boolean;
   readonly dict: I18nRecord;
   readonly labelRightElement?: React.ReactNode;
+  /** Server-mode: forward debounced search query to the data source. */
+  readonly onQueryChange?: (query: string) => void;
+  /** Server-mode: fetch the next page when the list scrolls near the bottom. */
+  readonly onReachEnd?: () => void;
+  /** Server-mode: show a trailing "loading more" hint during pagination. */
+  readonly isLoadingMore?: boolean;
 }
 
 // ============================================================================
@@ -248,6 +254,9 @@ export function TruckSearchDropdown({
   disabled = false,
   dict,
   labelRightElement,
+  onQueryChange,
+  onReachEnd,
+  isLoadingMore,
 }: TruckSearchDropdownProps) {
   return (
     <BaseSearchDropdown<CamionOption, TruckMatchType>
@@ -266,7 +275,9 @@ export function TruckSearchDropdown({
       }}
       renderCard={(props) => <TruckCard {...props} />}
       renderSelectedButton={renderSelectedTruckButton}
-      canSelect={(truck) => truck.estado === "disponible"}
+      onQueryChange={onQueryChange}
+      onReachEnd={onReachEnd}
+      isLoadingMore={isLoadingMore}
     />
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
@@ -236,6 +236,54 @@ function SignalLossValue({
   );
 }
 
+/**
+ * Shared 5-row stats block rendered both inside the dropdown list card and
+ * the currently-selected button, per the planning mockup. Keeping it as a
+ * single component keeps the two views in lock-step — adding or reordering
+ * a row happens in one place.
+ */
+interface TruckStatsRowsProps {
+  readonly truck: CamionOption;
+  readonly dict: I18nRecord;
+}
+
+function TruckStatsRows({ truck, dict }: TruckStatsRowsProps) {
+  const isGpsIntegrado = truck.gpsIntegrado;
+  const isOnline = truck.estadoGps === "online";
+  return (
+    <>
+      <RichStatRow
+        label={tr("pages.planning.sidebar.assignment.gpsIntegrated", dict)}
+        value={
+          <GpsIntegrationValue isGpsIntegrado={isGpsIntegrado} dict={dict} />
+        }
+      />
+      <RichStatRow
+        label={tr("pages.planning.sidebar.assignment.gpsStatus", dict)}
+        value={
+          <GpsStateValue
+            isGpsIntegrado={isGpsIntegrado}
+            isOnline={isOnline}
+            dict={dict}
+          />
+        }
+      />
+      <StatRow
+        label={tr("pages.planning.sidebar.assignment.previousTrips", dict)}
+        value={truck.viajesPrevios}
+      />
+      <StatRow
+        label={tr("pages.planning.sidebar.assignment.lastTrip", dict)}
+        value={truck.ultimoViaje}
+      />
+      <RichStatRow
+        label={tr("pages.planning.sidebar.assignment.signalLosses", dict)}
+        value={<SignalLossValue count={truck.perdidasSenal} dict={dict} />}
+      />
+    </>
+  );
+}
+
 function TruckCard({
   item: truck,
   isSelected,
@@ -245,8 +293,6 @@ function TruckCard({
   onMouseEnter,
 }: CardRenderProps<CamionOption>) {
   const isAvailable = truck.estado === "disponible";
-  const isGpsIntegrado = truck.gpsIntegrado;
-  const isOnline = truck.estadoGps === "online";
   const truckTypeLabel = tr(
     `pages.planning.sidebar.assignment.truckType.${truck.tipo}`,
     dict
@@ -284,37 +330,7 @@ function TruckCard({
 
       {/* 5-row stats block, always visible (mockup). */}
       <div className="flex flex-col gap-0.5 text-[11px]">
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.gpsIntegrated", dict)}
-          value={
-            <GpsIntegrationValue
-              isGpsIntegrado={isGpsIntegrado}
-              dict={dict}
-            />
-          }
-        />
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.gpsStatus", dict)}
-          value={
-            <GpsStateValue
-              isGpsIntegrado={isGpsIntegrado}
-              isOnline={isOnline}
-              dict={dict}
-            />
-          }
-        />
-        <StatRow
-          label={tr("pages.planning.sidebar.assignment.previousTrips", dict)}
-          value={truck.viajesPrevios}
-        />
-        <StatRow
-          label={tr("pages.planning.sidebar.assignment.lastTrip", dict)}
-          value={truck.ultimoViaje}
-        />
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.signalLosses", dict)}
-          value={<SignalLossValue count={truck.perdidasSenal} dict={dict} />}
-        />
+        <TruckStatsRows truck={truck} dict={dict} />
       </div>
     </VehicleCardButton>
   );
@@ -325,8 +341,6 @@ function TruckCard({
 // ============================================================================
 
 function renderSelectedTruckButton(truck: CamionOption, dict: I18nRecord) {
-  const isGpsIntegrado = truck.gpsIntegrado;
-  const isOnline = truck.estadoGps === "online";
   const truckTypeLabel = tr(
     `pages.planning.sidebar.assignment.truckType.${truck.tipo}`,
     dict
@@ -340,37 +354,7 @@ function renderSelectedTruckButton(truck: CamionOption, dict: I18nRecord) {
         <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
       </div>
       <div className="flex flex-col gap-0.5 text-[11px] pt-1 border-t border-gray-100 dark:border-gray-700">
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.gpsIntegrated", dict)}
-          value={
-            <GpsIntegrationValue
-              isGpsIntegrado={isGpsIntegrado}
-              dict={dict}
-            />
-          }
-        />
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.gpsStatus", dict)}
-          value={
-            <GpsStateValue
-              isGpsIntegrado={isGpsIntegrado}
-              isOnline={isOnline}
-              dict={dict}
-            />
-          }
-        />
-        <StatRow
-          label={tr("pages.planning.sidebar.assignment.previousTrips", dict)}
-          value={truck.viajesPrevios}
-        />
-        <StatRow
-          label={tr("pages.planning.sidebar.assignment.lastTrip", dict)}
-          value={truck.ultimoViaje}
-        />
-        <RichStatRow
-          label={tr("pages.planning.sidebar.assignment.signalLosses", dict)}
-          value={<SignalLossValue count={truck.perdidasSenal} dict={dict} />}
-        />
+        <TruckStatsRows truck={truck} dict={dict} />
       </div>
     </div>
   );

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/asignacion/truck-search-dropdown.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import type { ReactNode } from "react";
 import {
   HiTruck,
   HiLocationMarker,
   HiStatusOnline,
   HiClock,
   HiChevronDown,
+  HiCheck,
+  HiExclamation,
 } from "react-icons/hi";
+import { twMerge } from "tailwind-merge";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
@@ -17,11 +21,7 @@ import {
 import {
   VehicleCardButton,
   VehicleHeader,
-  GpsStatusColumn,
   StatRow,
-  WarningBadge,
-  GpsBadge,
-  OnlineStatus,
 } from "./vehicle-card-shared";
 
 // ============================================================================
@@ -131,6 +131,111 @@ const TRUCK_FIELDS: readonly FieldConfig<CamionOption, TruckMatchType>[] = [
 // Truck Card Component
 // ============================================================================
 
+/**
+ * Renders a label/value row where the value is a colored chip (icon + text).
+ * Used for GPS Integrado, Estado GPS and Pérdidas de señal so the list layout
+ * stays a single scannable column per the planning mockup.
+ */
+interface RichStatRowProps {
+  readonly label: string;
+  readonly value: ReactNode;
+}
+
+function RichStatRow({ label, value }: RichStatRowProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-gray-500 dark:text-gray-400">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+function GpsIntegrationValue({
+  isGpsIntegrado,
+  dict,
+}: {
+  readonly isGpsIntegrado: boolean;
+  readonly dict: I18nRecord;
+}) {
+  const tone = isGpsIntegrado
+    ? "text-green-600 dark:text-green-400"
+    : "text-gray-500 dark:text-gray-400";
+  const Icon = isGpsIntegrado ? HiCheck : HiExclamation;
+  return (
+    <span className={twMerge("inline-flex items-center gap-1", tone)}>
+      <Icon className="w-3.5 h-3.5" />
+      {tr(
+        isGpsIntegrado
+          ? "pages.planning.sidebar.assignment.integrated"
+          : "pages.planning.sidebar.assignment.notIntegrated",
+        dict
+      )}
+    </span>
+  );
+}
+
+function GpsStateValue({
+  isGpsIntegrado,
+  isOnline,
+  dict,
+}: {
+  readonly isGpsIntegrado: boolean;
+  readonly isOnline: boolean;
+  readonly dict: I18nRecord;
+}) {
+  // Can't be online if the device isn't integrated in the first place — in
+  // that case the row collapses to a neutral dash so the user doesn't see a
+  // contradictory "Offline" next to "No Integrado".
+  if (!isGpsIntegrado) {
+    return <span className="text-gray-500 dark:text-gray-400">—</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className={twMerge(
+          "w-2 h-2 rounded-full",
+          isOnline ? "bg-green-500" : "bg-gray-400"
+        )}
+      />
+      <span
+        className={twMerge(
+          "font-medium",
+          isOnline
+            ? "text-green-600 dark:text-green-400"
+            : "text-gray-500 dark:text-gray-400"
+        )}
+      >
+        {tr(
+          isOnline
+            ? "pages.planning.sidebar.assignment.online"
+            : "pages.planning.sidebar.assignment.offline",
+          dict
+        )}
+      </span>
+    </span>
+  );
+}
+
+function SignalLossValue({
+  count,
+  dict,
+}: {
+  readonly count: number;
+  readonly dict: I18nRecord;
+}) {
+  if (count <= 0) {
+    return <span className="text-gray-900 dark:text-white">0</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400">
+      <HiExclamation className="w-3.5 h-3.5" />
+      {tr("pages.planning.sidebar.assignment.losses", dict, {
+        count: String(count),
+      })}
+    </span>
+  );
+}
+
 function TruckCard({
   item: truck,
   isSelected,
@@ -146,7 +251,7 @@ function TruckCard({
     `pages.planning.sidebar.assignment.truckType.${truck.tipo}`,
     dict
   );
-  const subtitle = `${truck.marca} · ${truckTypeLabel}`;
+  const subtitle = `${truck.marca || "—"} · ${truckTypeLabel}`;
 
   return (
     <VehicleCardButton
@@ -156,22 +261,48 @@ function TruckCard({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
     >
-      {/* Header: Plate + Brand + Type + GPS Status */}
+      {/* Header: plate + subtitle (marca · tipo). */}
       <div className="flex items-start justify-between gap-2 mb-2">
         <VehicleHeader
           plate={truck.plate}
           subtitle={subtitle}
           isSelected={isSelected}
         />
-        <GpsStatusColumn
-          isGpsIntegrado={isGpsIntegrado}
-          isOnline={isOnline}
-          dict={dict}
-        />
+        {isAvailable ? (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
+              <HiCheck className="w-2.5 h-2.5" />
+            </span>
+            {tr("pages.planning.sidebar.assignment.enabled", dict)}
+          </span>
+        ) : (
+          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
+          </span>
+        )}
       </div>
 
-      {/* Stats Column */}
+      {/* 5-row stats block, always visible (mockup). */}
       <div className="flex flex-col gap-0.5 text-[11px]">
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.gpsIntegrated", dict)}
+          value={
+            <GpsIntegrationValue
+              isGpsIntegrado={isGpsIntegrado}
+              dict={dict}
+            />
+          }
+        />
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.gpsStatus", dict)}
+          value={
+            <GpsStateValue
+              isGpsIntegrado={isGpsIntegrado}
+              isOnline={isOnline}
+              dict={dict}
+            />
+          }
+        />
         <StatRow
           label={tr("pages.planning.sidebar.assignment.previousTrips", dict)}
           value={truck.viajesPrevios}
@@ -180,14 +311,11 @@ function TruckCard({
           label={tr("pages.planning.sidebar.assignment.lastTrip", dict)}
           value={truck.ultimoViaje}
         />
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.signalLosses", dict)}
+          value={<SignalLossValue count={truck.perdidasSenal} dict={dict} />}
+        />
       </div>
-
-      {/* Signal losses - only show if there are any */}
-      <WarningBadge
-        count={truck.perdidasSenal}
-        labelKey="pages.planning.sidebar.assignment.signalLosses"
-        dict={dict}
-      />
     </VehicleCardButton>
   );
 }
@@ -203,24 +331,34 @@ function renderSelectedTruckButton(truck: CamionOption, dict: I18nRecord) {
     `pages.planning.sidebar.assignment.truckType.${truck.tipo}`,
     dict
   );
-  const subtitle = `${truck.marca} · ${truckTypeLabel}`;
+  const subtitle = `${truck.marca || "—"} · ${truckTypeLabel}`;
 
   return (
     <div className="flex flex-col">
-      {/* Header with plate, brand, type, GPS status, and chevron */}
       <div className="flex items-start justify-between gap-2 mb-1.5">
         <VehicleHeader plate={truck.plate} subtitle={subtitle} isSelected />
-        <div className="flex flex-col items-end gap-1 shrink-0">
-          <div className="flex items-center gap-1.5">
-            <GpsBadge isGpsIntegrado={isGpsIntegrado} dict={dict} />
-            <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
-          </div>
-          {isGpsIntegrado && <OnlineStatus isOnline={isOnline} dict={dict} />}
-        </div>
+        <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
       </div>
-
-      {/* Stats */}
       <div className="flex flex-col gap-0.5 text-[11px] pt-1 border-t border-gray-100 dark:border-gray-700">
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.gpsIntegrated", dict)}
+          value={
+            <GpsIntegrationValue
+              isGpsIntegrado={isGpsIntegrado}
+              dict={dict}
+            />
+          }
+        />
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.gpsStatus", dict)}
+          value={
+            <GpsStateValue
+              isGpsIntegrado={isGpsIntegrado}
+              isOnline={isOnline}
+              dict={dict}
+            />
+          }
+        />
         <StatRow
           label={tr("pages.planning.sidebar.assignment.previousTrips", dict)}
           value={truck.viajesPrevios}
@@ -229,14 +367,11 @@ function renderSelectedTruckButton(truck: CamionOption, dict: I18nRecord) {
           label={tr("pages.planning.sidebar.assignment.lastTrip", dict)}
           value={truck.ultimoViaje}
         />
+        <RichStatRow
+          label={tr("pages.planning.sidebar.assignment.signalLosses", dict)}
+          value={<SignalLossValue count={truck.perdidasSenal} dict={dict} />}
+        />
       </div>
-
-      {/* Signal losses - only show if there are any */}
-      <WarningBadge
-        count={truck.perdidasSenal}
-        labelKey="pages.planning.sidebar.assignment.signalLosses"
-        dict={dict}
-      />
     </div>
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -1,0 +1,142 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import useSWRInfinite from "swr/infinite";
+import fetcher from "@/features/common/providers/fetcher";
+import type { FetcherError } from "@/features/common/providers/fetcher.types";
+
+/**
+ * Mirror of `PgrestAccreditedResourceRow` in `app/api/utils/pgrest-client.ts`.
+ * Re-declared here (not imported) so the client bundle does not pull the
+ * `server-only` pgrest module.
+ */
+export interface AccreditedResource {
+  resource_type: "DRIVER" | "TRUCK" | "TRAILER" | "CARRIER";
+  resource_id: string;
+  resource_name: string | null;
+  identifier: string | null;
+  faena: string | null;
+  rut_mandante: string | null;
+  is_acredited: "ACREDITED" | "NOT ACREDITED";
+  trip_count: number | null;
+  last_trip: string | null;
+  symptoms: Record<string, number> | null;
+  updated_at: string | null;
+}
+
+export type AccreditedResourceType = AccreditedResource["resource_type"];
+
+interface AccreditedResourcesPage {
+  data: AccreditedResource[];
+  total: number;
+  filteredTotal: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+const DEFAULT_PAGE_SIZE = 50;
+
+interface UseAccreditedResourcesOpts {
+  rutMandante?: string | null;
+  delegacion?: string | null;
+  resourceType?: AccreditedResourceType;
+  /**
+   * When set, forwards `carrierId=` to the endpoint (→ upstream `p_carrier_id`)
+   * so child resources (DRIVER/TRUCK/TRAILER) are scoped to a transportist.
+   * Empty string or null keeps the hook idle for DRIVER queries gated on a
+   * prior carrier selection.
+   */
+  carrierId?: string | null;
+  /** Case-insensitive substring, matched against resource_name and identifier. */
+  query?: string;
+  pageSize?: number;
+  /**
+   * When false, the hook stays idle regardless of the other args. Use this to
+   * gate child queries (e.g. "only fetch drivers once a carrier is selected").
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Paginated accredited-resources feed, backed by
+ * `/app/api/calendar/accredited-resources` (which in turn caches the upstream
+ * pgrest function for 5 min). Stays idle until both `rutMandante` and
+ * `delegacion` are set — matches the calendar UX where the combobox only
+ * activates once a service is selected.
+ *
+ * Each change to `query` resets the feed to page 0 (SWR key is query-scoped).
+ * `loadMore` fetches the next page; `hasMore` tracks whether the server still
+ * has filtered rows past what we've accumulated.
+ */
+export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
+  const {
+    rutMandante,
+    delegacion,
+    resourceType,
+    carrierId,
+    query = "",
+    pageSize = DEFAULT_PAGE_SIZE,
+    enabled = true,
+  } = opts;
+
+  const canFetch = Boolean(enabled && rutMandante && delegacion);
+
+  const getKey = useCallback(
+    (pageIndex: number, previousPage: AccreditedResourcesPage | null) => {
+      if (!canFetch) return null;
+      if (previousPage && !previousPage.hasMore) return null;
+      const params = new URLSearchParams();
+      if (rutMandante) params.set("rutMandante", rutMandante);
+      if (delegacion) params.set("delegacion", delegacion);
+      if (resourceType) params.set("resourceType", resourceType);
+      if (carrierId) params.set("carrierId", carrierId);
+      if (query) params.set("q", query);
+      params.set("offset", String(pageIndex * pageSize));
+      params.set("limit", String(pageSize));
+      return `/app/api/calendar/accredited-resources?${params.toString()}`;
+    },
+    [canFetch, rutMandante, delegacion, resourceType, carrierId, query, pageSize]
+  );
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<AccreditedResourcesPage, FetcherError>(getKey, fetcher, {
+      revalidateFirstPage: false,
+      revalidateOnFocus: false,
+      errorRetryCount: 2,
+    });
+
+  const resources = useMemo<AccreditedResource[]>(
+    () => (data ?? []).flatMap((page) => page.data),
+    [data]
+  );
+
+  const lastPage = data && data.length > 0 ? data[data.length - 1] : null;
+  const hasMore = lastPage ? lastPage.hasMore : false;
+  const filteredTotal = lastPage ? lastPage.filteredTotal : 0;
+  const total = lastPage ? lastPage.total : 0;
+
+  // `isValidating` + extra pages beyond `size` means we're loading the next page
+  const isLoadingMore =
+    canFetch &&
+    (isLoading ||
+      (size > 0 && data !== undefined && typeof data[size - 1] === "undefined"));
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || isLoadingMore) return;
+    setSize((s) => s + 1);
+  }, [hasMore, isLoadingMore, setSize]);
+
+  return {
+    resources,
+    total,
+    filteredTotal,
+    hasMore,
+    loadMore,
+    isLoading: canFetch && isLoading && !data,
+    isLoadingMore,
+    isValidating,
+    error,
+    refresh: mutate,
+  };
+}

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -111,16 +111,14 @@ export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
     [data]
   );
 
-  const lastPage = data && data.length > 0 ? data[data.length - 1] : null;
+  const lastPage = data && data.length > 0 ? data.at(-1) : null;
   const hasMore = lastPage ? lastPage.hasMore : false;
   const filteredTotal = lastPage ? lastPage.filteredTotal : 0;
   const total = lastPage ? lastPage.total : 0;
 
   // `isValidating` + extra pages beyond `size` means we're loading the next page
   const isLoadingMore =
-    canFetch &&
-    (isLoading ||
-      (size > 0 && data !== undefined && typeof data[size - 1] === "undefined"));
+    canFetch && (isLoading || (size > 0 && data?.[size - 1] === undefined));
 
   const loadMore = useCallback(() => {
     if (!hasMore || isLoadingMore) return;

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -72,6 +72,7 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
     clientCode,
     client,
     mintral_clientRut: task.mintral_clientRut as string,
+    mintral_delegacionOrigen: task.mintral_delegacionOrigen as string,
     expectedDepartureDate,
     serviceKind: task.mintral_serviceKind as string,
     executionType: task.mintral_executionType as string,

--- a/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
@@ -30,6 +30,7 @@ export type KanbanBoardTask = {
   client?: string;
   clientCode?: string;
   mintral_clientRut?: string;
+  mintral_delegacionOrigen?: string;
   expectedDepartureDate?: string;
   serviceKind: string;
   executionType: string;

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -472,7 +472,8 @@
             "gps": "GPS",
             "capacity": "Capacity",
             "mileage": "Mileage"
-          }
+          },
+          "loadingMore": "Loading more…"
         }
       }
     },

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -472,7 +472,8 @@
             "gps": "GPS",
             "capacity": "Capacidad",
             "mileage": "Kilometraje"
-          }
+          },
+          "loadingMore": "Cargando más…"
         }
       }
     },


### PR DESCRIPTION
## Summary

Closes #346.

Replace the mocked carrier/driver/truck arrays in the planning **Asignación**
tab with live data from `ams.fn_rd_accredited_resources`. Three scoped feeds
cascade: **CARRIER** loads on service click; **DRIVER** and **TRUCK** load
when a carrier is picked and are scoped to that `carrierId`. The hook paginates
via infinite scroll, debounces the search query through to the server, and is
backed by an in-process 5-min cache keyed by the scope tuple so the heavy
upstream JSONB aggregation only runs once per (mandante, delegación, type,
carrierId).

- New Next.js route `app/api/calendar/accredited-resources` — accepts
  `rutMandante`, `delegacion`, `resourceType`, `carrierId`, `q`, `offset`,
  `limit`, `refresh`; returns `{ data, total, filteredTotal, offset, limit,
  hasMore }`.
- `amsRouteBaseUrl()` targets the `/api/v1/pgrest-ams` APISIX route (prod
  exposes the function only behind the ams prefix — the old root `/rpc/*`
  returned 404).
- `useAccreditedResources` SWR-infinite hook: paginated scroll, debounced
  server search, `enabled` gating.
- `BaseSearchDropdown` gained additive, non-breaking server-mode props
  (`onQueryChange`, `onReachEnd`, `isLoadingMore`); carrier/driver/truck
  dropdowns opt in.
- Carrier + driver cards use a 2-row layout (name, RUT + accreditation
  badge) so long names have room. Non-accredited rows show an amber
  **Not Accredited** badge and remain selectable.
- Truck card rebuilt as a fixed 5-row stats block (GPS Integrado, Estado GPS,
  Viajes previos, Último viaje, Pérdidas de señal) matching the planning
  mockup. Header carries the same accreditation badge as the other cards.
- Added `mintral_delegacionOrigen` on the service model with a fallback to
  `selectedService.origen` when Alfresco doesn't emit the property.
  `p_client_id` is hardcoded to `"mintral"` at the pgrest-client layer.
- i18n: `pages.planning.sidebar.assignment.loadingMore`.

## Out of scope

- `mintral_delegacionOrigen` is not yet emitted by Alfresco; the form falls
  back to `origen`. Alfresco side-work pending.
- Trailer/remolque dropdown still uses the mock `REMOLQUE_OPTIONS`.
- GPS Integrado / Estado GPS rows on the truck card default to "No Integrado"
  / "—" since `fn_rd_accredited_resources` doesn't carry telemetry.
  Follow-up could lazily fetch `public.fn_dx_senal_detalle(plate)` for the
  selected truck only.

## Test plan

- [ ] Open the planning sidebar for a service with `mintral_clientRut` and an
      `origen` code — a `GET /app/api/calendar/accredited-resources?...&resourceType=CARRIER&offset=0&limit=50`
      fires in the network tab.
- [ ] Scroll the carrier combobox near the bottom — subsequent requests at
      `offset=50`, `offset=100`, etc. fire until `hasMore=false`.
- [ ] Type into the carrier search input — after 300 ms, a request with `?q=`
      fires; the list resets to page 0.
- [ ] Accredited and non-accredited carriers both render; green
      **Acreditado** / amber **No Acreditado** badges distinguish them; both
      selectable.
- [ ] Selecting a carrier enables the conductor and camion dropdowns and
      fires `resourceType=DRIVER` + `resourceType=TRUCK` requests with
      `carrierId=<selected>`.
- [ ] Changing the selected carrier clears `conductor`, `segundoConductor`,
      `camion` and resets the per-list search queries.
- [ ] Second call for the same `(rutMandante, delegacion, resourceType,
      carrierId)` within 5 min hits the in-process cache (no upstream
      pgrest round-trip in the server logs).
- [ ] Truck card shows all five stats rows regardless of sparse data:
      `GPS Integrado`, `Estado GPS`, `Viajes previos`, `Último viaje`,
      `Pérdidas de señal`.
- [ ] `npx tsc --noEmit` — no new errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic resource selection dropdowns with real-time search for carriers, drivers, and trucks.
  * Infinite scroll pagination support for resource lists.

* **UI Updates**
  * Enhanced resource card layouts and status badge displays for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->