### PR TITLE
feat: read-only view for past services in calendar planning grid

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -54,6 +54,7 @@ interface DayGridSlotCellProps {
   } | null;
   onCellClick: (slot: { hour: number; minutes: number }) => void;
   onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
+  onChipClick: (ps: PlannedService) => void;
   dict: I18nDictionary;
 }
 
@@ -68,6 +69,7 @@ function DayGridSlotCell({
   reassigningService,
   onCellClick,
   onContextMenu,
+  onChipClick,
   dict,
 }: Readonly<DayGridSlotCellProps>) {
   const { slotBlocked, isDisabled } = state;
@@ -85,6 +87,7 @@ function DayGridSlotCell({
       disabled={isDisabled}
       className={getSlotCellClassName(state, isPastDay, selected, {
         isLastSlot,
+        isFirstEditable: !isPastDay,
       })}
     >
       <SlotCellContent
@@ -93,6 +96,7 @@ function DayGridSlotCell({
         services={slotServices}
         reassigningServiceId={reassigningService?.service.service.id}
         onContextMenu={onContextMenu}
+        onChipClick={onChipClick}
         dict={dict}
         servicesLayout="row"
       />
@@ -136,6 +140,7 @@ export default function DayGrid({
     handleDeleteAssignmentRequest,
     handleConfirmDeleteAssignment,
     handleCancelDeleteAssignment,
+    viewPlannedService,
   } = usePlanningGrid({ startHour, endHour });
 
   const dayInfo = useMemo(
@@ -187,15 +192,21 @@ export default function DayGrid({
             className={twMerge(
               "h-20 flex flex-col items-center justify-center",
               "border-l border-t border-r border-gray-200 dark:border-gray-700",
-              "bg-gray-50 dark:bg-gray-900 rounded-tr-lg"
+              "bg-gray-50 dark:bg-gray-900 rounded-tr-lg",
+              !isPastDay &&
+                "border-l-2 border-l-primary-500 dark:border-l-primary-400"
             )}
           >
             <span
               className={twMerge(
                 "text-sm font-medium capitalize",
-                dayInfo.isToday
-                  ? "text-primary-600 dark:text-primary-400"
-                  : "text-gray-500 dark:text-gray-400"
+                dayInfo.isToday && "text-primary-600 dark:text-primary-400",
+                !dayInfo.isToday &&
+                  !isPastDay &&
+                  "text-gray-500 dark:text-gray-400",
+                !dayInfo.isToday &&
+                  isPastDay &&
+                  "text-gray-400 dark:text-gray-500 italic"
               )}
             >
               {dayInfo.dayName}
@@ -203,9 +214,14 @@ export default function DayGrid({
             <span
               className={twMerge(
                 "text-2xl font-bold",
-                dayInfo.isToday
-                  ? "bg-primary-600 text-white rounded-full w-10 h-10 flex items-center justify-center"
-                  : "text-gray-900 dark:text-white"
+                dayInfo.isToday &&
+                  "bg-primary-600 text-white rounded-full w-10 h-10 flex items-center justify-center",
+                !dayInfo.isToday &&
+                  !isPastDay &&
+                  "text-gray-900 dark:text-white",
+                !dayInfo.isToday &&
+                  isPastDay &&
+                  "text-gray-400 dark:text-gray-500 font-normal"
               )}
             >
               {dayInfo.dayNumber}
@@ -242,6 +258,7 @@ export default function DayGrid({
                 reassigningService={reassigningService}
                 onCellClick={handleCellClick}
                 onContextMenu={handleContextMenu}
+                onChipClick={viewPlannedService}
                 dict={dict}
               />
             </Fragment>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -53,6 +53,8 @@ interface PlannedServiceChipProps {
   readonly plannedService: PlannedService;
   readonly isBeingReassigned?: boolean;
   readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
+  /** Optional left-click handler — opens the sidebar in view/read-only mode. */
+  readonly onClick?: (ps: PlannedService) => void;
   /** Additional size/layout classes to apply */
   readonly className?: string;
   readonly dict: I18nRecord;
@@ -66,6 +68,7 @@ export function PlannedServiceChip({
   plannedService,
   isBeingReassigned = false,
   onContextMenu,
+  onClick,
   className,
   dict,
 }: PlannedServiceChipProps) {
@@ -76,6 +79,15 @@ export function PlannedServiceChip({
   return (
     <button
       type="button"
+      onClick={
+        onClick
+          ? (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onClick(plannedService);
+            }
+          : undefined
+      }
       onContextMenu={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -96,7 +108,8 @@ export function PlannedServiceChip({
       }}
       className={twMerge(
         "min-w-0 w-full",
-        "rounded flex items-center cursor-context-menu",
+        "rounded flex items-center",
+        onClick ? "cursor-pointer" : "cursor-context-menu",
         "text-xs font-medium px-1.5 py-1 border-l-4",
         getPlannedServiceChipClassName(hasUrgencia),
         isBeingReassigned &&

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   type ReactNode,
 } from "react";
+import { useSearchParams } from "next/navigation";
 import dayjs from "dayjs";
 import isoWeek from "dayjs/plugin/isoWeek";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
@@ -25,6 +26,7 @@ import {
   listBookings,
   updateServiceCategory,
 } from "@/features/common/providers/client-api.provider";
+import { parseUrlDate } from "@/features/calendar/services/calendar.service";
 import type { SlotResponse } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
@@ -674,6 +676,12 @@ interface PlanningSelectionContextType {
   /** Cancel assignment-only mode */
   cancelAssignment: () => void;
   /**
+   * Open the sidebar in view-only mode for an already-planned service. Sets
+   * the service and slot without entering reassign/assign mode — the form
+   * renders the existing values and suppresses its action buttons.
+   */
+  viewPlannedService: (plannedService: PlannedService) => void;
+  /**
    * Patch the assignment tuple (carrier/drivers/truck/trailer) on a planned
    * service. Any omitted field is left untouched; passing `undefined`
    * explicitly clears that slot. Client-side only — persistence travels on
@@ -860,6 +868,19 @@ export function PlanningSelectionProvider({
     }
   }, [apiTimeWindows, timeSlotsError]);
 
+  // The upstream bookings endpoint returns an empty list when no date range is
+  // passed, so derive a ±30-day window around the URL `date` param (the same
+  // param the week/day views consume). Stays well inside the backend's 90-day
+  // cap and covers any reasonable week navigation without refetching mid-view.
+  const searchParams = useSearchParams();
+  const bookingsRange = useMemo(() => {
+    const anchor = parseUrlDate(searchParams.get("date")) ?? dayjs();
+    return {
+      startDate: anchor.subtract(30, "day").format("YYYY-MM-DD"),
+      endDate: anchor.add(30, "day").format("YYYY-MM-DD"),
+    };
+  }, [searchParams]);
+
   // Load existing bookings from the backend when a calendar is selected.
   // An AbortController cancels the in-flight request when calendarId changes
   // or the component unmounts, preventing stale responses from overwriting state.
@@ -868,7 +889,14 @@ export function PlanningSelectionProvider({
 
     const controller = new AbortController();
 
-    listBookings({ calendarId }, controller.signal)
+    listBookings(
+      {
+        calendarId,
+        startDate: bookingsRange.startDate,
+        endDate: bookingsRange.endDate,
+      },
+      controller.signal
+    )
       .then((result) => {
         // Discard the response if the effect was cleaned up before it resolved.
         if (controller.signal.aborted) return;
@@ -942,7 +970,7 @@ export function PlanningSelectionProvider({
     return () => {
       controller.abort();
     };
-  }, [calendarId]);
+  }, [calendarId, bookingsRange.startDate, bookingsRange.endDate]);
 
   // Derived arrays from unified state (memoized for performance)
   const timeWindows = useMemo(
@@ -1528,6 +1556,17 @@ export function PlanningSelectionProvider({
     setSelectedService(null);
   }, []);
 
+  // Open the sidebar to inspect a planned service without entering an edit
+  // mode. Left-clicking a chip routes here; the form reads `selectedSlot` and
+  // `selectedService`, sees no reassign/assign mode, and (when the slot is
+  // past) renders with mutations disabled.
+  const viewPlannedService = useCallback((plannedService: PlannedService) => {
+    setReassigningService(null);
+    setAssigningService(null);
+    setSelectedService(plannedService.service);
+    setSelectedSlot(plannedService.slot);
+  }, []);
+
   /**
    * Patch a planned service's assignment tuple client-side.
    *
@@ -1602,6 +1641,7 @@ export function PlanningSelectionProvider({
       cancelReassignment,
       startAssignment,
       cancelAssignment,
+      viewPlannedService,
       updateServiceAssignment,
       bookingsLoadError,
       backendSlots,
@@ -1645,6 +1685,7 @@ export function PlanningSelectionProvider({
       cancelReassignment,
       startAssignment,
       cancelAssignment,
+      viewPlannedService,
       updateServiceAssignment,
       bookingsLoadError,
       backendSlots,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -58,6 +58,7 @@ function PlanningTabContent({
   isSlotsLoading,
   canConfirm,
   reassigningService,
+  isReadOnlyView,
 }: {
   dict: I18nRecord;
   selectedService: SelectedService & { slot?: string };
@@ -76,6 +77,7 @@ function PlanningTabContent({
   isSlotsLoading: boolean;
   canConfirm: boolean;
   reassigningService: unknown;
+  isReadOnlyView: boolean;
 }) {
   const [isCategoryOpen, setIsCategoryOpen] = useState(false);
   const categoryRef = useRef<HTMLDivElement>(null);
@@ -165,18 +167,20 @@ function PlanningTabContent({
           isLoadingServiceTypes={isLoadingServiceTypes}
         />
       )}
-      <div className="flex gap-2 pt-2">
-        <Button
-          type="submit"
-          color="blue"
-          className="flex-1"
-          disabled={!canConfirm}
-        >
-          {reassigningService
-            ? tr("pages.planning.sidebar.form.confirmReassignment", dict)
-            : tr("pages.planning.sidebar.form.confirm", dict)}
-        </Button>
-      </div>
+      {!isReadOnlyView && (
+        <div className="flex gap-2 pt-2">
+          <Button
+            type="submit"
+            color="blue"
+            className="flex-1"
+            disabled={!canConfirm}
+          >
+            {reassigningService
+              ? tr("pages.planning.sidebar.form.confirmReassignment", dict)
+              : tr("pages.planning.sidebar.form.confirm", dict)}
+          </Button>
+        </div>
+      )}
     </>
   );
 }
@@ -290,6 +294,16 @@ export function PlanningSidebarForm({
   const canAssign =
     !isLoadingPermissions && hasPermission(["GROUP_ASSIGNMENT"]);
   const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
+
+  // View-only mode: the sidebar was opened by left-clicking a past-day chip
+  // (no reassign/assign active). Form controls stay visible to show the
+  // existing values, but every mutation path — inputs and action buttons — is
+  // suppressed. The context already blocks the right-click menu for past
+  // chips, so this is the only remaining route that reaches the form.
+  const isReadOnlyView = useMemo(() => {
+    if (!selectedSlot || reassigningService || assigningService) return false;
+    return dayjs(selectedSlot.date).isBefore(dayjs().startOf("day"), "day");
+  }, [selectedSlot, reassigningService, assigningService]);
 
   // Tab state management
   type TabType = "planificacion" | "assignment";
@@ -593,7 +607,16 @@ export function PlanningSidebarForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {/* Flags Section */}
+      {isReadOnlyView && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700/50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+          {tr("pages.planning.sidebar.form.readOnlyBanner", dict)}
+        </div>
+      )}
+      <fieldset
+        disabled={isReadOnlyView}
+        className="flex flex-col gap-4 min-w-0 border-0 p-0 m-0"
+      >
+        {/* Flags Section */}
       {hasIncidencias && (
         <FormSection title={tr("pages.planning.sidebar.form.flags", dict)}>
           <div className="flex flex-wrap gap-2 max-h-24 overflow-y-auto">
@@ -825,6 +848,7 @@ export function PlanningSidebarForm({
             isSlotsLoading={isSlotsLoading}
             canConfirm={canConfirm}
             reassigningService={reassigningService}
+            isReadOnlyView={isReadOnlyView}
           />
         )}
         {activeTab === "assignment" && canAssign && (
@@ -839,25 +863,28 @@ export function PlanningSidebarForm({
                 selectedService?.origen
               }
             />
-            <div className="flex gap-2 pt-2">
-              <Button
-                type="button"
-                color="blue"
-                className="flex-1"
-                onClick={handleAssign}
-                disabled={
-                  !assigningService ||
-                  !assignmentData.carrier ||
-                  !assignmentData.driver ||
-                  !assignmentData.truck
-                }
-              >
-                {tr("pages.planning.sidebar.form.assign", dict)}
-              </Button>
-            </div>
+            {!isReadOnlyView && (
+              <div className="flex gap-2 pt-2">
+                <Button
+                  type="button"
+                  color="blue"
+                  className="flex-1"
+                  onClick={handleAssign}
+                  disabled={
+                    !assigningService ||
+                    !assignmentData.carrier ||
+                    !assignmentData.driver ||
+                    !assignmentData.truck
+                  }
+                >
+                  {tr("pages.planning.sidebar.form.assign", dict)}
+                </Button>
+              </div>
+            )}
           </>
         )}
-      </div>
+        </div>
+      </fieldset>
 
       {/* Actions */}
     </form>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -296,10 +296,13 @@ export function PlanningSidebarForm({
   const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
 
   // View-only mode: the sidebar was opened by left-clicking a past-day chip
-  // (no reassign/assign active). Form controls stay visible to show the
-  // existing values, but every mutation path — inputs and action buttons — is
-  // suppressed. The context already blocks the right-click menu for past
-  // chips, so this is the only remaining route that reaches the form.
+  // without entering reassign/assign. Form controls stay visible so the
+  // existing values can be inspected, but every mutation path — inputs and
+  // action buttons — is suppressed. The right-click context menu on past
+  // chips is intentionally still available so users can Replanificar /
+  // Asignar / Eliminar for reconciliation; picking either reassign or assign
+  // sets `reassigningService` / `assigningService`, which drops the flag
+  // below and returns the form to edit mode.
   const isReadOnlyView = useMemo(() => {
     if (!selectedSlot || reassigningService || assigningService) return false;
     return dayjs(selectedSlot.date).isBefore(dayjs().startOf("day"), "day");

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-slot-utils.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-slot-utils.ts
@@ -72,6 +72,8 @@ export function computeSlotState(
 export interface SlotCellClassNameOptions {
   isLastDay?: boolean;
   isLastSlot?: boolean;
+  /** Mark the left edge as the boundary between past (read-only) and today. */
+  isFirstEditable?: boolean;
 }
 
 export function getSlotCellClassName(
@@ -88,23 +90,26 @@ export function getSlotCellClassName(
     windowColor,
     blockedStripeClass,
   } = state;
-  const { isLastDay = false, isLastSlot = false } = options ?? {};
+  const {
+    isLastDay = false,
+    isLastSlot = false,
+    isFirstEditable = false,
+  } = options ?? {};
   return twMerge(
     "h-full w-full relative",
     "border-l border-t border-gray-200 dark:border-gray-700",
+    isFirstEditable && "border-l-2 border-l-primary-500 dark:border-l-primary-400",
     "transition-all duration-200 p-1",
     blockedStripeClass,
-    isPastDay && "bg-gray-100 dark:bg-gray-900/50 opacity-50",
+    isPastDay && !hasTimeWindow && "bg-gray-50/60 dark:bg-gray-900/20",
     isDisabled ? "cursor-not-allowed" : "cursor-pointer",
     !isPastDay && !slotBlocked && isQuotaFull && "opacity-60",
-    !isPastDay &&
-      !slotBlocked &&
+    !slotBlocked &&
       hasTimeWindow &&
       !selected &&
       !isQuotaFull &&
       windowColor.bg,
-    !isPastDay &&
-      !slotBlocked &&
+    !slotBlocked &&
       hasTimeWindow &&
       !selected &&
       isQuotaFull &&

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -57,6 +57,7 @@ interface WeekSlotCellProps {
   } | null;
   onCellClick: (day: WeekDay, slot: { hour: number; minutes: number }) => void;
   onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
+  onChipClick: (ps: PlannedService) => void;
   dict: I18nRecord;
 }
 
@@ -71,6 +72,7 @@ function WeekSlotCell({
   reassigningService,
   onCellClick,
   onContextMenu,
+  onChipClick,
   dict,
 }: Readonly<WeekSlotCellProps>) {
   const { slotBlocked, isDisabled } = slotState;
@@ -93,6 +95,7 @@ function WeekSlotCell({
         getSlotCellClassName(slotState, dayIsPast, selected, {
           isLastDay,
           isLastSlot,
+          isFirstEditable: day.isToday,
         })
       )}
     >
@@ -102,6 +105,7 @@ function WeekSlotCell({
         services={slotServices}
         reassigningServiceId={reassigningService?.service.service.id}
         onContextMenu={onContextMenu}
+        onChipClick={onChipClick}
         dict={dict}
         servicesLayout="column"
       />
@@ -148,6 +152,7 @@ export default function PlanningWeekView({
     handleDeleteAssignmentRequest,
     handleConfirmDeleteAssignment,
     handleCancelDeleteAssignment,
+    viewPlannedService,
   } = usePlanningGrid({ startHour, endHour });
 
   // Read date from URL, fallback to prop or today
@@ -212,42 +217,57 @@ export default function PlanningWeekView({
         </div>
 
         {/* Header row - day columns */}
-        {weekDays.map((day, idx) => (
-          <div
-            key={day.dayNumber}
-            className="sticky top-0 z-10 bg-white dark:bg-gray-800"
-          >
+        {weekDays.map((day, idx) => {
+          const dayIsPast = isPastDay(day);
+          return (
             <div
-              className={twMerge(
-                "h-16 flex flex-col items-center justify-center",
-                "border-l border-t border-gray-200 dark:border-gray-700",
-                "bg-gray-50 dark:bg-gray-900",
-                isLastDay(idx) && "border-r rounded-tr-lg"
-              )}
+              key={day.dayNumber}
+              className="sticky top-0 z-10 bg-white dark:bg-gray-800"
             >
-              <span
+              <div
                 className={twMerge(
-                  "text-xs font-medium",
-                  day.isToday
-                    ? "text-primary-600 dark:text-primary-400"
-                    : "text-gray-500 dark:text-gray-400"
+                  "h-16 flex flex-col items-center justify-center",
+                  "border-l border-t border-gray-200 dark:border-gray-700",
+                  "bg-gray-50 dark:bg-gray-900",
+                  day.isToday &&
+                    "border-l-2 border-l-primary-500 dark:border-l-primary-400",
+                  isLastDay(idx) && "border-r rounded-tr-lg"
                 )}
               >
-                {day.dayName}
-              </span>
-              <span
-                className={twMerge(
-                  "text-lg font-semibold",
-                  day.isToday
-                    ? "bg-primary-600 text-white rounded-full w-8 h-8 flex items-center justify-center"
-                    : "text-gray-900 dark:text-white"
-                )}
-              >
-                {day.dayNumber}
-              </span>
+                <span
+                  className={twMerge(
+                    "text-xs font-medium",
+                    day.isToday &&
+                      "text-primary-600 dark:text-primary-400",
+                    !day.isToday &&
+                      !dayIsPast &&
+                      "text-gray-500 dark:text-gray-400",
+                    !day.isToday &&
+                      dayIsPast &&
+                      "text-gray-400 dark:text-gray-500 italic"
+                  )}
+                >
+                  {day.dayName}
+                </span>
+                <span
+                  className={twMerge(
+                    "text-lg font-semibold",
+                    day.isToday &&
+                      "bg-primary-600 text-white rounded-full w-8 h-8 flex items-center justify-center",
+                    !day.isToday &&
+                      !dayIsPast &&
+                      "text-gray-900 dark:text-white",
+                    !day.isToday &&
+                      dayIsPast &&
+                      "text-gray-400 dark:text-gray-500 font-normal"
+                  )}
+                >
+                  {day.dayNumber}
+                </span>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
 
         {/* Time slots grid */}
         {timeSlots.map((slot, slotIdx) => {
@@ -298,6 +318,7 @@ export default function PlanningWeekView({
                     reassigningService={reassigningService}
                     onCellClick={handleCellClick}
                     onContextMenu={handleContextMenu}
+                    onChipClick={viewPlannedService}
                     dict={dict}
                   />
                 );

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/slot-cell-shared.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/slot-cell-shared.tsx
@@ -124,6 +124,7 @@ interface SlotServicesProps {
   readonly services: PlannedService[];
   readonly reassigningServiceId?: string;
   readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
+  readonly onChipClick?: (ps: PlannedService) => void;
   readonly dict: I18nDictionary | I18nRecord;
   readonly layout?: "row" | "column";
 }
@@ -132,6 +133,7 @@ export function SlotServices({
   services,
   reassigningServiceId,
   onContextMenu,
+  onChipClick,
   dict,
   layout = "row",
 }: SlotServicesProps) {
@@ -151,6 +153,7 @@ export function SlotServices({
           plannedService={ps}
           isBeingReassigned={reassigningServiceId === ps.service.id}
           onContextMenu={onContextMenu}
+          onClick={onChipClick}
           className={layout === "row" ? "flex-1" : "w-full"}
           dict={dict}
         />
@@ -169,6 +172,7 @@ interface SlotCellContentProps {
   readonly services: PlannedService[];
   readonly reassigningServiceId?: string;
   readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
+  readonly onChipClick?: (ps: PlannedService) => void;
   readonly dict: I18nDictionary | I18nRecord;
   readonly servicesLayout?: "row" | "column";
   readonly children?: ReactNode;
@@ -180,6 +184,7 @@ export function SlotCellContent({
   services,
   reassigningServiceId,
   onContextMenu,
+  onChipClick,
   dict,
   servicesLayout = "row",
   children,
@@ -218,6 +223,7 @@ export function SlotCellContent({
         services={services}
         reassigningServiceId={reassigningServiceId}
         onContextMenu={onContextMenu}
+        onChipClick={onChipClick}
         dict={dict}
         layout={servicesLayout}
       />

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -49,6 +49,7 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     startAssignment,
     reassigningService,
     updateServiceAssignment,
+    viewPlannedService,
   } = usePlanningSelection();
 
   // Clear every assignment slot on the planned service — carrier, drivers,
@@ -141,6 +142,9 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
 
     // Reassignment
     reassigningService,
+
+    // View-only inspection of a planned service (left-click on chip)
+    viewPlannedService,
 
     // Service actions (context menu, delete modals)
     ...serviceActions,

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1758,9 +1758,9 @@ const BookingListResponseSchema = z.object({
       calendarId: z.string(),
       resource: z.object({
         id: z.string(),
-        type: z.string().optional(),
-        label: z.string().optional(),
-        data: z.record(z.string(), z.unknown()).optional(),
+        type: z.string().nullable().optional(),
+        label: z.string().nullable().optional(),
+        data: z.record(z.string(), z.unknown()).nullable().optional(),
       }),
       slot: z
         .object({
@@ -1770,7 +1770,7 @@ const BookingListResponseSchema = z.object({
         })
         .nullable(),
       createdAt: z.string(),
-      createdBy: z.string().optional(),
+      createdBy: z.string().nullable().optional(),
     })
   ),
   total: z.number(),

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -289,6 +289,7 @@
           "confirm": "Confirm",
           "cancelReassignment": "Cancel",
           "confirmReassignment": "Reassign",
+          "readOnlyBanner": "Past service — read-only",
           "loadUtilization": "Load Utilization",
           "constraint": "Constraint",
           "maxUtilization": "Total",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -289,6 +289,7 @@
           "confirm": "Confirmar",
           "cancelReassignment": "Cancelar",
           "confirmReassignment": "Reasignar",
+          "readOnlyBanner": "Servicio pasado — solo lectura",
           "loadUtilization": "Utilización de carga",
           "constraint": "Restricción",
           "maxUtilization": "Total",


### PR DESCRIPTION
## Summary

- Past-day planning-grid cells no longer fade chips; past cells keep their time-window color so planners can see which TW contained a historical booking, with today's column separated by a primary-colored vertical rule.
- Left-clicking any chip opens the sidebar; for past-day services it opens in a read-only shape (amber "Servicio pasado — solo lectura" banner, disabled `<fieldset>`, no Confirmar/Asignar buttons). Right-click still offers Replanificar/Asignar/Eliminar for reconciliation.
- Incidental fixes: `listBookings` now defaults to a ±30-day window so past bookings actually load, and the Zod schema tolerates the nulls the calendar backend returns for `createdBy` / `resource.type` / `label` / `data`.

Closes #363.

## Test plan

- [x] Open the planning calendar on a week that contains today; confirm the primary-colored rule sits on today's column and past-day headers are italic/muted.
- [x] Confirm past-day cells inside a time window keep the emerald/TW background; empty past cells outside a TW show the faint gray tint.
- [ ] Left-click a past-day planned chip → read-only sidebar (banner visible, inputs disabled, no Confirmar/Asignar).
- [ ] Left-click a today/future chip → sidebar opens in normal editable mode.
- [ ] Right-click a past-day chip → context menu opens; picking Replanificar or Asignar lets the form transition to edit mode.
- [ ] Watch the browser console while the calendar loads — no Zod `BookingListResponse validation warning` spam from null `createdBy`.
- [ ] Navigate weeks; bookings refetch within the ±30-day window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now click on planned service chips to view and inspect service details
  * Past-date services are displayed in read-only mode with a visual indicator, preventing accidental modifications
  * Enhanced calendar styling to visually distinguish between past, today, and upcoming days

<!-- end of auto-generated comment: release notes by coderabbit.ai -->