### PR TITLE
fix: preserve planning lead time kpis

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -109,6 +109,11 @@ function extractMintralIncidents(
     .map((incident) => [incident[0], incident[1]] as [string, string]);
 }
 
+function toPercent(value: number | null | undefined): number {
+  if (value == null) return 0;
+  return Math.round(value <= 1 ? value * 100 : value);
+}
+
 // Transform KanbanBoardTask to SelectedService
 function transformTaskToService(task: KanbanBoardTask): SelectedService {
   const serviceId = task.name || task.id;
@@ -124,12 +129,14 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     lugarCarguio: "", // Not available in KanbanBoardTask
     destino: task.destination || "",
     tipoViaje,
-    ocupacion: task.mintral_loadMaxUtilization ?? 0,
+    ocupacion: 100 * (task.mintral_loadMaxUtilization ?? 0),
     permanencia,
     leadTime: {
       total_lineasoc_cumplen: task.mintral_compliantOrderLines ?? 0,
       total_lineasoc_incumplen: task.mintral_nonCompliantOrderLines ?? 0,
-      lineasoc_pctn_cumplimiento: task.mintral_deliveryComplianceRate ?? 0,
+      lineasoc_pctn_cumplimiento: toPercent(
+        task.mintral_deliveryComplianceRate
+      ),
     },
     eta: task.estimatedArrivalDate || task.arrivalDate || "",
     incidencias: extractIncidencias(task),

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -95,6 +95,11 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
     mintral_loadWeightUtilization: task.mintral_loadWeightUtilization as number,
     mintral_loadPalletUtilization: task.mintral_loadPalletUtilization as number,
     mintral_loadMaxUtilization: task.mintral_loadMaxUtilization as number,
+    mintral_deliveryComplianceRate:
+      task.mintral_deliveryComplianceRate as number,
+    mintral_compliantOrderLines: task.mintral_compliantOrderLines as number,
+    mintral_nonCompliantOrderLines:
+      task.mintral_nonCompliantOrderLines as number,
     mintral_serviceCategory: task.mintral_serviceCategory as string,
     mintral_creationDate: task.mintral_creationDate as string,
   };


### PR DESCRIPTION
## Summary
- Preserve lead-time KPI fields when converting task API responses into kanban tasks.
- Normalize planning sidebar lead-time rates so fractional backend values render as percentages.
- Keeps the existing occupancy percentage normalization in the planning mapper.

## Root Cause
The planning right sidebar reads services through `toShippingKanban()` and `toKanbanBoardTask()`. That projection copied load utilization fields, but dropped the lead-time fields before `transformTaskToService()` could build the `leadTime` object. As a result, planning always fell back to zero counts and `0%`, even when `acs.act_ru_variable` had populated values.

Bento showed the correct values because it reads directly from the task payload and multiplies `mintral_deliveryComplianceRate` by 100.

Closes #368


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric display formatting to show utilization and compliance values as rounded percentages instead of raw decimals.

* **Improvements**
  * Shipping task details now include additional metrics for delivery compliance and order line compliance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->