### PR TITLE
fix: hide assignment removal for planned services

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -27,6 +27,14 @@ interface ServiceContextMenuProps {
   dict: I18nRecord;
 }
 
+function hasRequiredAssignedResources(plannedService: PlannedService): boolean {
+  const { service } = plannedService;
+
+  return Boolean(
+    service.assignedCarrier && service.assignedDriver && service.assignedTruck
+  );
+}
+
 /**
  * Calculate adjusted position to keep menu within viewport
  */
@@ -78,6 +86,10 @@ export function ServiceContextMenu({
     !isLoadingPermissions && hasPermission(["GROUP_ASSIGNMENT"]);
   // Check if user has planning permission to show replan/delete buttons
   const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
+  const canDeleteAssignment =
+    plannedService !== null &&
+    canAssign &&
+    hasRequiredAssignedResources(plannedService);
 
   // Estimated menu dimensions for initial position calculation
   // Height varies based on number of visible buttons
@@ -85,7 +97,8 @@ export function ServiceContextMenu({
   const MENU_HEADER_HEIGHT = 32;
   const MENU_BUTTON_HEIGHT = 38;
   const MENU_PADDING = 8;
-  const buttonCount = (canAssign ? 2 : 0) + (canPlan ? 2 : 0);
+  const buttonCount =
+    (canAssign ? 1 : 0) + (canDeleteAssignment ? 1 : 0) + (canPlan ? 2 : 0);
   const MENU_HEIGHT =
     MENU_HEADER_HEIGHT + MENU_PADDING + buttonCount * MENU_BUTTON_HEIGHT;
 
@@ -191,7 +204,7 @@ export function ServiceContextMenu({
           </Button>
         )}
 
-        {canAssign && (
+        {canDeleteAssignment && (
           <Button
             color={"alternative"}
             type="button"

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1374,12 +1374,12 @@
       "dispatch": "Despacho",
       "reception": "Recepción",
       "deleteModal": {
-        "title": "Confirmar eliminación",
-        "messagePrefix": "¿Eliminar la asignación del servicio ",
+        "title": "Eliminar planificación",
+        "messagePrefix": "¿Eliminar la planificación del servicio ",
         "messageSuffix": "?",
         "close": "Cerrar",
         "cancel": "Cancelar",
-        "delete": "Eliminar"
+        "delete": "Eliminar planificación"
       },
       "deleteAssignmentModal": {
         "title": "Eliminar asignación",


### PR DESCRIPTION
## Summary
- Hide the resource "Eliminar asignación" context-menu action unless a planned service has a completed resource assignment.
- Keep "Asignar" visible for users with assignment permissions.
- Update Spanish planning-delete modal copy so planned-service deletion says "planificación" instead of "asignación".

## Root Cause
The context menu gated the resource-assignment removal action only by `GROUP_ASSIGNMENT`, so planned-only services could display an action that should apply only after carrier, driver, and truck resources were assigned. The Spanish planning-delete modal also reused assignment wording, making the wrong action appear even more confusing.

## Validation
- `npx eslint src/features/calendar/components/planning/service-context-menu.tsx`
- `node -e "JSON.parse(require('fs').readFileSync('src/lang/es.json','utf8')); console.log('es.json ok')"`

Closes #373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delete assignment option now only appears when all required resources are properly assigned.

* **Chores**
  * Updated Spanish translations in the planning deletion confirmation modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->