### PR TITLE
feat: add integration connections module

### DIFF
--- a/quarkus-srv/README.md
+++ b/quarkus-srv/README.md
@@ -11,6 +11,7 @@ miot-fleet/           Fleet directory (vehicles, trucks, trailers, carriers)
 miot-driver/          Driver directory (lifecycle, documents, compliance, scoring)
 miot-tracking/        Asset tracking (GPS ingestion via Pulsar)
 miot-gateway/         Routing gateway (body-aware traffic forking, canary splits) → README
+miot-integrations/    External API connections, credential profiles, auth resolution
 miot-cli/             Application entrypoint
 ```
 
@@ -18,7 +19,7 @@ miot-cli/             Application entrypoint
 
 - **Quarkus 3.x** — CDI conditional activation, Kubernetes-native
 - **Java 21**
-- **PostgreSQL** — Schema-per-component via Flyway (`miot_core`, `miot_fleet`, `miot_resource`, `miot_driver`)
+- **PostgreSQL** — Schema-per-component via Flyway (`miot_core`, `miot_resource`, `miot_fleet`, `miot_driver`, `miot_tracking`, `miot_integrations`)
 - **Hibernate Reactive + Panache**
 - **Vert.x EventBus** — In-process inter-component messaging
 - **Micrometer + Prometheus** — Per-client metrics with `client_id` tags
@@ -38,6 +39,7 @@ miot-cli/             Application entrypoint
 ./start.sh driver           # driver only
 ./start.sh fleet driver     # fleet + driver
 ./start.sh gateway          # gateway only (no DB required)
+./start.sh integrations     # integration connections and credential profiles
 
 # Pass extra Maven/Quarkus args after --
 ./start.sh fleet -- -Dquarkus.http.port=9090
@@ -62,6 +64,7 @@ miot.component.fleet.enabled=true
 miot.component.driver.enabled=true
 miot.component.tracking.enabled=true
 miot.component.gateway.enabled=true
+miot.component.integrations.enabled=true
 ```
 
 Override at runtime via env vars:
@@ -73,9 +76,10 @@ MIOT_COMPONENT_ALL_ENABLED=true
 # Single component
 MIOT_COMPONENT_FLEET_ENABLED=true
 MIOT_COMPONENT_GATEWAY_ENABLED=true
+MIOT_COMPONENT_INTEGRATIONS_ENABLED=true
 ```
 
-Only the schemas for enabled components are created by Flyway. Starting with `./start.sh fleet` will create `miot_core`, `miot_resource`, and `miot_fleet` schemas — but not `miot_driver`. The gateway component requires no database.
+Only the schemas for enabled DB-backed components are created by Flyway. Starting with `./start.sh fleet` will create `miot_core`, `miot_resource`, and `miot_fleet` schemas — but not `miot_driver`. Starting with `./start.sh integrations` creates `miot_core`, `miot_resource`, and `miot_integrations`. The gateway component requires no database.
 
 ## Database
 
@@ -86,7 +90,20 @@ miot-core/src/main/resources/db/migration/core/             # tenants, assets (a
 miot-resource-core/src/main/resources/db/migration/resource/ # entity events, scores, sync cursors, links, profiles (always)
 miot-fleet/src/main/resources/db/migration/fleet/            # vehicles, trips, trucks, trailers, carriers
 miot-driver/src/main/resources/db/migration/driver/          # drivers
+miot-tracking/src/main/resources/db/migration/tracking/      # asset data, client maps, metrics, latest snapshot functions
+miot-integrations/src/main/resources/db/migration/integrations/ # credential profiles, connections, operations, test/audit events
 ```
+
+Migration version ranges are reserved per component so subset deployments can include only the active module locations while Flyway still has stable ordering:
+
+| Component | Schema | Migration range |
+|-----------|--------|-----------------|
+| Core | `miot_core` | `V0.1.x` |
+| Fleet | `miot_fleet` | `V0.2.x` |
+| Resource Core | `miot_resource` | `V0.3.x` |
+| Driver | `miot_driver` | `V0.4.x` |
+| Tracking | `miot_tracking` | `V0.5.x` |
+| Integrations | `miot_integrations` | `V0.6.x` |
 
 ## API Documentation
 
@@ -95,7 +112,7 @@ When running in dev mode, Swagger UI is available at:
 - **Swagger UI**: http://localhost:8180/q/swagger-ui/
 - **OpenAPI spec**: http://localhost:8180/q/openapi
 
-Endpoints are grouped by component tag (Fleet, Drivers). Only enabled components appear in the spec.
+Endpoints are grouped by component tag (Fleet, Drivers, Asset Tracking, Integration Connections). Only enabled components appear in the spec.
 
 ## Endpoints
 
@@ -107,6 +124,10 @@ Endpoints are grouped by component tag (Fleet, Drivers). Only enabled components
 | Fleet | `GET /api/v1/fleet/carriers[/{id}]` | List/get carriers |
 | Driver | `GET /api/v1/drivers[/{id}]` | List/get drivers |
 | Tracking | `POST /api/v1/asset/track` | Ingest GPS position |
+| Integrations | `GET /api/v1/orgs/{organizationId}/integrations/connections` | List integration connections |
+| Integrations | `POST /api/v1/orgs/{organizationId}/integrations/connections` | Create an integration connection |
+| Integrations | `GET /api/v1/orgs/{organizationId}/integrations/credential-profiles` | List credential profiles |
+| Integrations | `POST /api/v1/orgs/{organizationId}/integrations/credential-profiles` | Create a credential profile |
 | Gateway | `POST /{path}` | APISIX mirror receiver (any path) |
 | Gateway | `GET /internal/fork/rules` | List fork rules and filter sizes |
 | Gateway | `POST /internal/fork/rules/{id}/filter` | Add routing keys to in-memory filter |

--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-integrations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
             <artifactId>miot-driver</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -32,6 +32,9 @@ public class FlywayMigrator {
     @ConfigProperty(name = "miot.component.tracking.enabled", defaultValue = "false")
     boolean trackingEnabled;
 
+    @ConfigProperty(name = "miot.component.integrations.enabled", defaultValue = "false")
+    boolean integrationsEnabled;
+
     @ConfigProperty(name = "quarkus.datasource.active", defaultValue = "true")
     boolean dataSourceActive;
 
@@ -39,7 +42,7 @@ public class FlywayMigrator {
         // Gateway and other stateless components have no DB schema.
         // Skip migration entirely when no DB-dependent component is active
         // to avoid connecting to (or validating against) a database that isn't needed.
-        if (!fleetEnabled && !driverEnabled && !trackingEnabled) {
+        if (!fleetEnabled && !driverEnabled && !trackingEnabled && !integrationsEnabled) {
             LOG.debug("No DB-dependent components enabled — skipping Flyway");
             return;
         }
@@ -64,6 +67,9 @@ public class FlywayMigrator {
         }
         if (trackingEnabled) {
             locations.add("db/migration/tracking");
+        }
+        if (integrationsEnabled) {
+            locations.add("db/migration/integrations");
         }
 
         LOG.infof("Flyway locations: %s", locations);

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -12,6 +12,7 @@ miot.component.fleet.enabled=${miot.component.all.enabled}
 miot.component.driver.enabled=${miot.component.all.enabled}
 miot.component.tracking.enabled=${miot.component.all.enabled}
 miot.component.gateway.enabled=${miot.component.all.enabled}
+miot.component.integrations.enabled=${miot.component.all.enabled}
 
 # --- HTTP ---
 quarkus.http.port=8180

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -13,6 +13,7 @@ miot.component.driver.enabled=${miot.component.all.enabled}
 miot.component.tracking.enabled=${miot.component.all.enabled}
 miot.component.gateway.enabled=${miot.component.all.enabled}
 miot.component.integrations.enabled=${miot.component.all.enabled}
+miot.integrations.secret-key=${MIOT_INTEGRATIONS_SECRET_KEY:not-configured}
 
 # --- HTTP ---
 quarkus.http.port=8180

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microboxlabs.miot</groupId>
+        <artifactId>miot-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>miot-integrations</artifactId>
+    <name>ModularIoT — Integrations</name>
+    <description>Reusable integration connections, credential profiles, and auth resolution</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-pg-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/IntegrationsComponent.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/IntegrationsComponent.java
@@ -1,0 +1,40 @@
+package com.microboxlabs.miot.integrations;
+
+import com.microboxlabs.miot.core.config.IMiotComponent;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class IntegrationsComponent implements IMiotComponent {
+
+    private static final Logger LOG = Logger.getLogger(IntegrationsComponent.class);
+
+    @Override
+    public String name() {
+        return "integrations";
+    }
+
+    @Override
+    public int priority() {
+        return 150;
+    }
+
+    @Override
+    public void onStart() {
+        LOG.info("Integrations component started");
+    }
+
+    @Override
+    public void onStop() {
+        LOG.info("Integrations component stopped");
+    }
+
+    @Override
+    public HealthCheck healthCheck() {
+        return () -> HealthCheckResponse.named("integrations").up().build();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.integrations.api;
 
+import com.microboxlabs.miot.core.auth.OrganizationContext;
 import com.microboxlabs.miot.core.auth.TenantContext;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
 import com.microboxlabs.miot.integrations.dto.CreateCredentialProfileRequest;
@@ -15,11 +16,14 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.Objects;
 
 @Path("/api/v1/orgs/{organizationId}/integrations")
 @Produces(MediaType.APPLICATION_JSON)
@@ -31,11 +35,16 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 public class OrgIntegrationConnectionsResource {
 
     private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
     private final IntegrationConnectionService service;
 
     @Inject
-    public OrgIntegrationConnectionsResource(TenantContext tenantContext, IntegrationConnectionService service) {
+    public OrgIntegrationConnectionsResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            IntegrationConnectionService service) {
         this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
         this.service = service;
     }
 
@@ -43,7 +52,7 @@ public class OrgIntegrationConnectionsResource {
     @Path("/credential-profiles")
     @Operation(summary = "List credential profiles")
     public Response listCredentialProfiles(@PathParam("organizationId") String organizationId) {
-        return Response.ok(service.listCredentialProfiles(tenantCode())).build();
+        return Response.ok(service.listCredentialProfiles(tenantCode(organizationId))).build();
     }
 
     @POST
@@ -53,7 +62,7 @@ public class OrgIntegrationConnectionsResource {
             @PathParam("organizationId") String organizationId,
             CreateCredentialProfileRequest req) {
         return Response.status(Response.Status.CREATED)
-                .entity(service.createCredentialProfile(tenantCode(), req))
+                .entity(service.createCredentialProfile(tenantCode(organizationId), req))
                 .build();
     }
 
@@ -61,7 +70,7 @@ public class OrgIntegrationConnectionsResource {
     @Path("/connections")
     @Operation(summary = "List integration connections")
     public Response listConnections(@PathParam("organizationId") String organizationId) {
-        return Response.ok(service.listConnections(tenantCode())).build();
+        return Response.ok(service.listConnections(tenantCode(organizationId))).build();
     }
 
     @POST
@@ -71,7 +80,7 @@ public class OrgIntegrationConnectionsResource {
             @PathParam("organizationId") String organizationId,
             CreateIntegrationConnectionRequest req) {
         return Response.status(Response.Status.CREATED)
-                .entity(service.createConnection(tenantCode(), req))
+                .entity(service.createConnection(tenantCode(organizationId), req))
                 .build();
     }
 
@@ -81,7 +90,7 @@ public class OrgIntegrationConnectionsResource {
     public Response getConnection(
             @PathParam("organizationId") String organizationId,
             @PathParam("connectionId") String connectionId) {
-        var connection = service.getConnection(tenantCode(), connectionId);
+        var connection = service.getConnection(tenantCode(organizationId), connectionId);
         return connection == null ? Response.status(Response.Status.NOT_FOUND).build() : Response.ok(connection).build();
     }
 
@@ -92,7 +101,7 @@ public class OrgIntegrationConnectionsResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("connectionId") String connectionId,
             ConnectionTestRequest req) {
-        return Response.ok(service.testConnection(tenantCode(), connectionId, req)).build();
+        return Response.ok(service.testConnection(tenantCode(organizationId), connectionId, req)).build();
     }
 
     @GET
@@ -101,7 +110,7 @@ public class OrgIntegrationConnectionsResource {
     public Response listOperations(
             @PathParam("organizationId") String organizationId,
             @PathParam("connectionId") String connectionId) {
-        return Response.ok(service.listOperations(tenantCode(), connectionId)).build();
+        return Response.ok(service.listOperations(tenantCode(organizationId), connectionId)).build();
     }
 
     @POST
@@ -111,13 +120,19 @@ public class OrgIntegrationConnectionsResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("connectionId") String connectionId,
             CreateIntegrationOperationRequest req) {
-        var operation = service.addOperation(tenantCode(), connectionId, req);
+        var operation = service.addOperation(tenantCode(organizationId), connectionId, req);
         return operation == null
                 ? Response.status(Response.Status.NOT_FOUND).build()
                 : Response.status(Response.Status.CREATED).entity(operation).build();
     }
 
-    private String tenantCode() {
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity("{\"error\":\"Organization context does not match request path\"}")
+                    .build());
+        }
         return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
@@ -1,0 +1,121 @@
+package com.microboxlabs.miot.integrations.api;
+
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.CreateCredentialProfileRequest;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationOperationRequest;
+import com.microboxlabs.miot.integrations.service.IntegrationConnectionService;
+import io.quarkus.arc.properties.IfBuildProperty;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/api/v1/orgs/{organizationId}/integrations")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Integration Connections", description = "External API connections, credential profiles, and endpoint operations")
+@SecurityRequirement(name = "oidc")
+@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class OrgIntegrationConnectionsResource {
+
+    private final TenantContext tenantContext;
+    private final IntegrationConnectionService service;
+
+    @Inject
+    public OrgIntegrationConnectionsResource(TenantContext tenantContext, IntegrationConnectionService service) {
+        this.tenantContext = tenantContext;
+        this.service = service;
+    }
+
+    @GET
+    @Path("/credential-profiles")
+    @Operation(summary = "List credential profiles")
+    public Response listCredentialProfiles(@PathParam("organizationId") String organizationId) {
+        return Response.ok(service.listCredentialProfiles(tenantCode())).build();
+    }
+
+    @POST
+    @Path("/credential-profiles")
+    @Operation(summary = "Create a credential profile")
+    public Response createCredentialProfile(
+            @PathParam("organizationId") String organizationId,
+            CreateCredentialProfileRequest req) {
+        return Response.status(Response.Status.CREATED)
+                .entity(service.createCredentialProfile(tenantCode(), req))
+                .build();
+    }
+
+    @GET
+    @Path("/connections")
+    @Operation(summary = "List integration connections")
+    public Response listConnections(@PathParam("organizationId") String organizationId) {
+        return Response.ok(service.listConnections(tenantCode())).build();
+    }
+
+    @POST
+    @Path("/connections")
+    @Operation(summary = "Create an integration connection")
+    public Response createConnection(
+            @PathParam("organizationId") String organizationId,
+            CreateIntegrationConnectionRequest req) {
+        return Response.status(Response.Status.CREATED)
+                .entity(service.createConnection(tenantCode(), req))
+                .build();
+    }
+
+    @GET
+    @Path("/connections/{connectionId}")
+    @Operation(summary = "Get an integration connection")
+    public Response getConnection(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("connectionId") String connectionId) {
+        var connection = service.getConnection(tenantCode(), connectionId);
+        return connection == null ? Response.status(Response.Status.NOT_FOUND).build() : Response.ok(connection).build();
+    }
+
+    @POST
+    @Path("/connections/{connectionId}/test")
+    @Operation(summary = "Test an integration connection")
+    public Response testConnection(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("connectionId") String connectionId,
+            ConnectionTestRequest req) {
+        return Response.ok(service.testConnection(tenantCode(), connectionId, req)).build();
+    }
+
+    @GET
+    @Path("/connections/{connectionId}/operations")
+    @Operation(summary = "List integration operations")
+    public Response listOperations(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("connectionId") String connectionId) {
+        return Response.ok(service.listOperations(tenantCode(), connectionId)).build();
+    }
+
+    @POST
+    @Path("/connections/{connectionId}/operations")
+    @Operation(summary = "Create an integration operation")
+    public Response createOperation(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("connectionId") String connectionId,
+            CreateIntegrationOperationRequest req) {
+        var operation = service.addOperation(tenantCode(), connectionId, req);
+        return operation == null
+                ? Response.status(Response.Status.NOT_FOUND).build()
+                : Response.status(Response.Status.CREATED).entity(operation).build();
+    }
+
+    private String tenantCode() {
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationConnectionsResource.java
@@ -7,6 +7,7 @@ import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest
 import com.microboxlabs.miot.integrations.dto.CreateIntegrationOperationRequest;
 import com.microboxlabs.miot.integrations.service.IntegrationConnectionService;
 import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -25,6 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Integration Connections", description = "External API connections, credential profiles, and endpoint operations")
 @SecurityRequirement(name = "oidc")
+@Authenticated
 @IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
 public class OrgIntegrationConnectionsResource {
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthResolutionException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthResolutionException.java
@@ -1,0 +1,12 @@
+package com.microboxlabs.miot.integrations.auth;
+
+public class AuthResolutionException extends RuntimeException {
+
+    public AuthResolutionException(String message) {
+        super(message);
+    }
+
+    public AuthResolutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthStrategy.java
@@ -1,0 +1,11 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.util.Set;
+
+public interface AuthStrategy<TConfig> {
+
+    Set<AuthType> supportedTypes();
+
+    ResolvedAuth resolve(TConfig config);
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/AuthStrategy.java
@@ -3,9 +3,9 @@ package com.microboxlabs.miot.integrations.auth;
 import com.microboxlabs.miot.integrations.domain.AuthType;
 import java.util.Set;
 
-public interface AuthStrategy<TConfig> {
+public interface AuthStrategy<C> {
 
     Set<AuthType> supportedTypes();
 
-    ResolvedAuth resolve(TConfig config);
+    ResolvedAuth resolve(C config);
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/ResolvedAuth.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/ResolvedAuth.java
@@ -1,0 +1,14 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ResolvedAuth(
+        Map<String, String> headers,
+        Map<String, String> queryParams,
+        Instant expiresAt) {
+
+    public static ResolvedAuth headers(Map<String, String> headers, Instant expiresAt) {
+        return new ResolvedAuth(Map.copyOf(headers), Map.of(), expiresAt);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyConfig.java
@@ -1,0 +1,9 @@
+package com.microboxlabs.miot.integrations.auth.apikey;
+
+import com.microboxlabs.miot.integrations.domain.ApiKeyPlacement;
+
+public record ApiKeyConfig(
+        String name,
+        String value,
+        ApiKeyPlacement placement) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyConfig.java
@@ -6,4 +6,9 @@ public record ApiKeyConfig(
         String name,
         String value,
         ApiKeyPlacement placement) {
+
+    @Override
+    public String toString() {
+        return "ApiKeyConfig[name=" + name + ", value=<redacted>, placement=" + placement + "]";
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyStrategy.java
@@ -1,0 +1,26 @@
+package com.microboxlabs.miot.integrations.auth.apikey;
+
+import com.microboxlabs.miot.integrations.auth.AuthStrategy;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.ApiKeyPlacement;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class ApiKeyStrategy implements AuthStrategy<ApiKeyConfig> {
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.API_KEY_HEADER, AuthType.API_KEY_QUERY);
+    }
+
+    @Override
+    public ResolvedAuth resolve(ApiKeyConfig config) {
+        if (config.placement() == ApiKeyPlacement.QUERY) {
+            return new ResolvedAuth(Map.of(), Map.of(config.name(), config.value()), null);
+        }
+        return new ResolvedAuth(Map.of(config.name(), config.value()), Map.of(), null);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyStrategy.java
@@ -21,6 +21,10 @@ public class ApiKeyStrategy implements AuthStrategy<ApiKeyConfig> {
         if (config.placement() == ApiKeyPlacement.QUERY) {
             return new ResolvedAuth(Map.of(), Map.of(config.name(), config.value()), null);
         }
-        return new ResolvedAuth(Map.of(config.name(), config.value()), Map.of(), null);
+        if (config.placement() == ApiKeyPlacement.HEADER) {
+            return new ResolvedAuth(Map.of(config.name(), config.value()), Map.of(), null);
+        }
+        throw new IllegalArgumentException(
+                "Unsupported API key placement for credential '" + config.name() + "': " + config.placement());
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
@@ -3,4 +3,9 @@ package com.microboxlabs.miot.integrations.auth.basic;
 public record BasicAuthConfig(
         String username,
         String password) {
+
+    @Override
+    public String toString() {
+        return "BasicAuthConfig[username=" + username + ", password=<redacted>]";
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.integrations.auth.basic;
+
+public record BasicAuthConfig(
+        String username,
+        String password) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthConfig.java
@@ -6,6 +6,6 @@ public record BasicAuthConfig(
 
     @Override
     public String toString() {
-        return "BasicAuthConfig[username=" + username + ", password=<redacted>]";
+        return "BasicAuthConfig[username=" + username + ", secret=<redacted>]";
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicAuthStrategy.java
@@ -1,0 +1,26 @@
+package com.microboxlabs.miot.integrations.auth.basic;
+
+import com.microboxlabs.miot.integrations.auth.AuthStrategy;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class BasicAuthStrategy implements AuthStrategy<BasicAuthConfig> {
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.BASIC);
+    }
+
+    @Override
+    public ResolvedAuth resolve(BasicAuthConfig config) {
+        String raw = config.username() + ":" + config.password();
+        String encoded = Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+        return ResolvedAuth.headers(Map.of("Authorization", "Basic " + encoded), null);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
@@ -1,4 +1,9 @@
 package com.microboxlabs.miot.integrations.auth.bearer;
 
 public record BearerTokenConfig(String token) {
+
+    @Override
+    public String toString() {
+        return "BearerTokenConfig[token=<redacted>]";
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
@@ -1,6 +1,15 @@
 package com.microboxlabs.miot.integrations.auth.bearer;
 
+import java.util.Objects;
+
 public record BearerTokenConfig(String token) {
+
+    public BearerTokenConfig {
+        Objects.requireNonNull(token, "Bearer token must not be null");
+        if (token.isBlank()) {
+            throw new IllegalArgumentException("Bearer token must not be blank");
+        }
+    }
 
     @Override
     public String toString() {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenConfig.java
@@ -1,0 +1,4 @@
+package com.microboxlabs.miot.integrations.auth.bearer;
+
+public record BearerTokenConfig(String token) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerTokenStrategy.java
@@ -1,0 +1,22 @@
+package com.microboxlabs.miot.integrations.auth.bearer;
+
+import com.microboxlabs.miot.integrations.auth.AuthStrategy;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class BearerTokenStrategy implements AuthStrategy<BearerTokenConfig> {
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.BEARER_TOKEN);
+    }
+
+    @Override
+    public ResolvedAuth resolve(BearerTokenConfig config) {
+        return ResolvedAuth.headers(Map.of("Authorization", "Bearer " + config.token()), null);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
@@ -25,4 +25,15 @@ public record OAuth2ClientCredentialsConfig(
                 Optional.empty(),
                 tokenRequestFormat);
     }
+
+    @Override
+    public String toString() {
+        return "OAuth2ClientCredentialsConfig[tokenUrl=" + tokenUrl
+                + ", clientId=" + clientId
+                + ", clientSecret=<redacted>"
+                + ", scope=" + scope
+                + ", audience=" + audience
+                + ", tokenRequestFormat=" + tokenRequestFormat
+                + "]";
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
@@ -12,8 +12,17 @@ public record OAuth2ClientCredentialsConfig(
         Optional<String> audience,
         TokenRequestFormat tokenRequestFormat) {
 
-    public OAuth2ClientCredentialsConfig {
-        scope = scope == null ? Optional.empty() : scope;
-        audience = audience == null ? Optional.empty() : audience;
+    public static OAuth2ClientCredentialsConfig withoutOptionalClaims(
+            URI tokenUrl,
+            String clientId,
+            String clientSecret,
+            TokenRequestFormat tokenRequestFormat) {
+        return new OAuth2ClientCredentialsConfig(
+                tokenUrl,
+                clientId,
+                clientSecret,
+                Optional.empty(),
+                Optional.empty(),
+                tokenRequestFormat);
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsConfig.java
@@ -1,0 +1,19 @@
+package com.microboxlabs.miot.integrations.auth.oauth;
+
+import com.microboxlabs.miot.integrations.domain.TokenRequestFormat;
+import java.net.URI;
+import java.util.Optional;
+
+public record OAuth2ClientCredentialsConfig(
+        URI tokenUrl,
+        String clientId,
+        String clientSecret,
+        Optional<String> scope,
+        Optional<String> audience,
+        TokenRequestFormat tokenRequestFormat) {
+
+    public OAuth2ClientCredentialsConfig {
+        scope = scope == null ? Optional.empty() : scope;
+        audience = audience == null ? Optional.empty() : audience;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategy.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategy.java
@@ -1,0 +1,140 @@
+package com.microboxlabs.miot.integrations.auth.oauth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.integrations.auth.AuthResolutionException;
+import com.microboxlabs.miot.integrations.auth.AuthStrategy;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import com.microboxlabs.miot.integrations.domain.TokenRequestFormat;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class OAuth2ClientCredentialsStrategy implements AuthStrategy<OAuth2ClientCredentialsConfig> {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final long DEFAULT_EXPIRES_IN_SECONDS = 3600;
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OAuth2ClientCredentialsStrategy() {
+        this(HttpClient.newHttpClient(), new ObjectMapper());
+    }
+
+    OAuth2ClientCredentialsStrategy(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.OAUTH2_CLIENT_CREDENTIALS);
+    }
+
+    @Override
+    public ResolvedAuth resolve(OAuth2ClientCredentialsConfig config) {
+        HttpRequest request = buildTokenRequest(config);
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new AuthResolutionException("OAuth token request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AuthResolutionException("OAuth token request interrupted", e);
+        }
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new AuthResolutionException("OAuth token request failed with HTTP " + response.statusCode());
+        }
+
+        OAuthToken token = parseToken(response.body());
+        return ResolvedAuth.headers(
+                Map.of("Authorization", "Bearer " + token.accessToken()),
+                token.expiresAt());
+    }
+
+    HttpRequest buildTokenRequest(OAuth2ClientCredentialsConfig config) {
+        Map<String, String> params = tokenParams(config);
+        if (config.tokenRequestFormat() == TokenRequestFormat.JSON) {
+            return buildJsonRequest(config.tokenUrl(), params);
+        }
+        return buildFormRequest(config.tokenUrl(), params);
+    }
+
+    private Map<String, String> tokenParams(OAuth2ClientCredentialsConfig config) {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("grant_type", "client_credentials");
+        params.put("client_id", config.clientId());
+        params.put("client_secret", config.clientSecret());
+        config.scope().filter(s -> !s.isBlank()).ifPresent(s -> params.put("scope", s));
+        config.audience().filter(s -> !s.isBlank()).ifPresent(s -> params.put("audience", s));
+        return params;
+    }
+
+    private HttpRequest buildFormRequest(URI tokenUrl, Map<String, String> params) {
+        String body = encodeForm(params);
+        return HttpRequest.newBuilder(tokenUrl)
+                .timeout(REQUEST_TIMEOUT)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+    }
+
+    private HttpRequest buildJsonRequest(URI tokenUrl, Map<String, String> params) {
+        try {
+            return HttpRequest.newBuilder(tokenUrl)
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(params)))
+                    .build();
+        } catch (IOException e) {
+            throw new AuthResolutionException("Could not serialize OAuth token request", e);
+        }
+    }
+
+    private String encodeForm(Map<String, String> params) {
+        StringBuilder body = new StringBuilder();
+        params.forEach((key, value) -> {
+            if (!body.isEmpty()) {
+                body.append('&');
+            }
+            body.append(URLEncoder.encode(key, StandardCharsets.UTF_8));
+            body.append('=');
+            body.append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+        });
+        return body.toString();
+    }
+
+    private OAuthToken parseToken(String body) {
+        try {
+            JsonNode json = objectMapper.readTree(body);
+            JsonNode accessToken = json.get("access_token");
+            if (accessToken == null || accessToken.asText().isBlank()) {
+                throw new AuthResolutionException("OAuth response did not include access_token");
+            }
+            long expiresIn = json.has("expires_in")
+                    ? json.get("expires_in").asLong(DEFAULT_EXPIRES_IN_SECONDS)
+                    : DEFAULT_EXPIRES_IN_SECONDS;
+            return new OAuthToken(accessToken.asText(), Instant.now().plusSeconds(expiresIn));
+        } catch (IOException e) {
+            throw new AuthResolutionException("OAuth response was not valid JSON", e);
+        }
+    }
+
+    private record OAuthToken(String accessToken, Instant expiresAt) {
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ApiKeyPlacement.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ApiKeyPlacement.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.integrations.domain;
+
+public enum ApiKeyPlacement {
+    HEADER,
+    QUERY
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/AuthType.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/AuthType.java
@@ -1,0 +1,11 @@
+package com.microboxlabs.miot.integrations.domain;
+
+public enum AuthType {
+    NONE,
+    BEARER_TOKEN,
+    API_KEY_HEADER,
+    API_KEY_QUERY,
+    BASIC,
+    OAUTH2_CLIENT_CREDENTIALS,
+    CUSTOM_HEADERS
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ConnectionStatus.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ConnectionStatus.java
@@ -1,0 +1,8 @@
+package com.microboxlabs.miot.integrations.domain;
+
+public enum ConnectionStatus {
+    DRAFT,
+    ACTIVE,
+    INACTIVE,
+    TEST_FAILED
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/CredentialProfile.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/CredentialProfile.java
@@ -1,0 +1,17 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record CredentialProfile(
+        String id,
+        String tenantCode,
+        String displayName,
+        AuthType authType,
+        Map<String, Object> publicConfig,
+        String encryptedSecretJson,
+        String secretPreview,
+        int secretVersion,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationConnection.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationConnection.java
@@ -1,0 +1,18 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record IntegrationConnection(
+        String id,
+        String tenantCode,
+        String name,
+        ProviderType providerType,
+        URI baseUrl,
+        String credentialProfileId,
+        ConnectionStatus status,
+        OffsetDateTime lastTestedAt,
+        Boolean lastTestResult,
+        Map<String, Object> metadata) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationOperation.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationOperation.java
@@ -1,0 +1,14 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.util.Map;
+
+public record IntegrationOperation(
+        String id,
+        String connectionId,
+        String name,
+        String method,
+        String path,
+        Map<String, Object> requestSchema,
+        Map<String, Object> responseSchema,
+        boolean testOperation) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ProviderType.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ProviderType.java
@@ -1,0 +1,10 @@
+package com.microboxlabs.miot.integrations.domain;
+
+public enum ProviderType {
+    POSTGREST,
+    ALERCE_TMS,
+    N8N,
+    AUTH0,
+    ECM,
+    CUSTOM_HTTP
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/TokenRequestFormat.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/TokenRequestFormat.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.integrations.domain;
+
+public enum TokenRequestFormat {
+    FORM,
+    JSON
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ConnectionTestRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ConnectionTestRequest.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.integrations.dto;
+
+public record ConnectionTestRequest(
+        String method,
+        String path) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ConnectionTestResponse.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ConnectionTestResponse.java
@@ -1,0 +1,9 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.time.OffsetDateTime;
+
+public record ConnectionTestResponse(
+        boolean success,
+        OffsetDateTime testedAt,
+        String message) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateCredentialProfileRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateCredentialProfileRequest.java
@@ -1,0 +1,11 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.util.Map;
+
+public record CreateCredentialProfileRequest(
+        String displayName,
+        AuthType authType,
+        Map<String, Object> publicConfig,
+        Map<String, Object> secretConfig) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationConnectionRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationConnectionRequest.java
@@ -1,0 +1,13 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import java.net.URI;
+import java.util.Map;
+
+public record CreateIntegrationConnectionRequest(
+        String name,
+        ProviderType providerType,
+        URI baseUrl,
+        String credentialProfileId,
+        Map<String, Object> metadata) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationOperationRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationOperationRequest.java
@@ -1,0 +1,12 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.util.Map;
+
+public record CreateIntegrationOperationRequest(
+        String name,
+        String method,
+        String path,
+        Map<String, Object> requestSchema,
+        Map<String, Object> responseSchema,
+        boolean testOperation) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CredentialProfileResponse.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CredentialProfileResponse.java
@@ -1,0 +1,17 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record CredentialProfileResponse(
+        String id,
+        String tenantCode,
+        String displayName,
+        AuthType authType,
+        Map<String, Object> publicConfig,
+        String secretPreview,
+        int secretVersion,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
@@ -1,0 +1,94 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CredentialProfileRepository {
+
+    private static final String SELECT_BY_TENANT = """
+            SELECT id, tenant_code, display_name, auth_type, public_config, encrypted_secret_json,
+                   secret_preview, secret_version, created_at, updated_at
+            FROM miot_integrations.credential_profiles
+            WHERE tenant_code = $1 AND active
+            ORDER BY display_name
+            """;
+
+    private static final String INSERT = """
+            INSERT INTO miot_integrations.credential_profiles (
+                id, tenant_code, display_name, auth_type, public_config, encrypted_secret_json,
+                secret_preview, secret_version, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id, tenant_code, display_name, auth_type, public_config, encrypted_secret_json,
+                      secret_preview, secret_version, created_at, updated_at
+            """;
+
+    private final Instance<Pool> clientInstance;
+
+    CredentialProfileRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public List<CredentialProfile> listByTenant(String tenantCode) {
+        return client().preparedQuery(SELECT_BY_TENANT)
+                .execute(Tuple.of(tenantCode))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public CredentialProfile create(CredentialProfile profile) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(profile.id()))
+                .addString(profile.tenantCode())
+                .addString(profile.displayName())
+                .addString(profile.authType().name())
+                .addJsonObject(toJson(profile.publicConfig()))
+                .addString(profile.encryptedSecretJson())
+                .addString(profile.secretPreview())
+                .addInteger(profile.secretVersion())
+                .addOffsetDateTime(profile.createdAt())
+                .addOffsetDateTime(profile.updatedAt());
+        return mapRow(client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely()
+                .iterator().next());
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private CredentialProfile mapRow(Row row) {
+        return new CredentialProfile(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("display_name"),
+                AuthType.valueOf(row.getString("auth_type")),
+                toMap(row.getJsonObject("public_config")),
+                row.getString("encrypted_secret_json"),
+                row.getString("secret_preview"),
+                row.getInteger("secret_version"),
+                row.getOffsetDateTime("created_at"),
+                row.getOffsetDateTime("updated_at"));
+    }
+
+    private JsonObject toJson(Map<String, Object> value) {
+        return new JsonObject(value == null ? Map.of() : value);
+    }
+
+    private Map<String, Object> toMap(JsonObject value) {
+        return value == null ? Map.of() : Map.copyOf(value.getMap());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
@@ -8,7 +8,6 @@ import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
-import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
@@ -9,6 +9,7 @@ import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -89,6 +90,6 @@ public class CredentialProfileRepository {
     }
 
     private Map<String, Object> toMap(JsonObject value) {
-        return value == null ? Map.of() : Map.copyOf(value.getMap());
+        return value == null ? Map.of() : new LinkedHashMap<>(value.getMap());
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
@@ -1,0 +1,140 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class IntegrationConnectionRepository {
+
+    private static final String SELECT_BY_TENANT = """
+            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
+                   status, last_tested_at, last_test_result, metadata
+            FROM miot_integrations.integration_connections
+            WHERE tenant_code = $1 AND active
+            ORDER BY name
+            """;
+
+    private static final String SELECT_BY_TENANT_AND_ID = """
+            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
+                   status, last_tested_at, last_test_result, metadata
+            FROM miot_integrations.integration_connections
+            WHERE tenant_code = $1 AND id = $2 AND active
+            """;
+
+    private static final String INSERT = """
+            INSERT INTO miot_integrations.integration_connections (
+                id, tenant_code, name, provider_type, base_url, credential_profile_id,
+                status, last_tested_at, last_test_result, metadata
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id, tenant_code, name, provider_type, base_url, credential_profile_id,
+                      status, last_tested_at, last_test_result, metadata
+            """;
+
+    private static final String UPDATE_TEST_RESULT = """
+            UPDATE miot_integrations.integration_connections
+            SET status = $3, last_tested_at = $4, last_test_result = $5, updated_at = $4
+            WHERE tenant_code = $1 AND id = $2 AND active
+            RETURNING id, tenant_code, name, provider_type, base_url, credential_profile_id,
+                      status, last_tested_at, last_test_result, metadata
+            """;
+
+    private final Instance<Pool> clientInstance;
+
+    IntegrationConnectionRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public List<IntegrationConnection> listByTenant(String tenantCode) {
+        return client().preparedQuery(SELECT_BY_TENANT)
+                .execute(Tuple.of(tenantCode))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public IntegrationConnection create(IntegrationConnection connection) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(connection.id()))
+                .addString(connection.tenantCode())
+                .addString(connection.name())
+                .addString(connection.providerType().name())
+                .addString(connection.baseUrl().toString())
+                .addUUID(toUuid(connection.credentialProfileId()))
+                .addString(connection.status().name())
+                .addOffsetDateTime(connection.lastTestedAt())
+                .addBoolean(connection.lastTestResult())
+                .addJsonObject(toJson(connection.metadata()));
+        return mapRow(client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely()
+                .iterator().next());
+    }
+
+    public IntegrationConnection findByTenantAndId(String tenantCode, String connectionId) {
+        var rows = client().preparedQuery(SELECT_BY_TENANT_AND_ID)
+                .execute(Tuple.of(tenantCode, UUID.fromString(connectionId)))
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public IntegrationConnection updateTestResult(
+            String tenantCode,
+            String connectionId,
+            ConnectionStatus status,
+            OffsetDateTime testedAt,
+            Boolean testResult) {
+        var rows = client().preparedQuery(UPDATE_TEST_RESULT)
+                .execute(Tuple.of(
+                        tenantCode,
+                        UUID.fromString(connectionId),
+                        status.name(),
+                        testedAt,
+                        testResult))
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private IntegrationConnection mapRow(Row row) {
+        UUID credentialProfileId = row.getUUID("credential_profile_id");
+        return new IntegrationConnection(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("name"),
+                ProviderType.valueOf(row.getString("provider_type")),
+                URI.create(row.getString("base_url")),
+                credentialProfileId == null ? null : credentialProfileId.toString(),
+                ConnectionStatus.valueOf(row.getString("status")),
+                row.getOffsetDateTime("last_tested_at"),
+                row.getBoolean("last_test_result"),
+                toMap(row.getJsonObject("metadata")));
+    }
+
+    private UUID toUuid(String value) {
+        return value == null || value.isBlank() ? null : UUID.fromString(value);
+    }
+
+    private JsonObject toJson(Map<String, Object> value) {
+        return new JsonObject(value == null ? Map.of() : value);
+    }
+
+    private Map<String, Object> toMap(JsonObject value) {
+        return value == null ? Map.of() : Map.copyOf(value.getMap());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -135,6 +136,6 @@ public class IntegrationConnectionRepository {
     }
 
     private Map<String, Object> toMap(JsonObject value) {
-        return value == null ? Map.of() : Map.copyOf(value.getMap());
+        return value == null ? Map.of() : new LinkedHashMap<>(value.getMap());
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
@@ -7,6 +7,7 @@ import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -80,6 +81,6 @@ public class IntegrationOperationRepository {
     }
 
     private Map<String, Object> toMap(JsonObject value) {
-        return value == null ? Map.of() : Map.copyOf(value.getMap());
+        return value == null ? Map.of() : new LinkedHashMap<>(value.getMap());
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
@@ -1,0 +1,85 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class IntegrationOperationRepository {
+
+    private static final String SELECT_BY_CONNECTION = """
+            SELECT id, connection_id, name, method, path, request_schema, response_schema, test_operation
+            FROM miot_integrations.integration_operations
+            WHERE connection_id = $1 AND active
+            ORDER BY name
+            """;
+
+    private static final String INSERT = """
+            INSERT INTO miot_integrations.integration_operations (
+                id, connection_id, name, method, path, request_schema, response_schema, test_operation
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id, connection_id, name, method, path, request_schema, response_schema, test_operation
+            """;
+
+    private final Instance<Pool> clientInstance;
+
+    IntegrationOperationRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public List<IntegrationOperation> listByConnection(String connectionId) {
+        return client().preparedQuery(SELECT_BY_CONNECTION)
+                .execute(Tuple.of(UUID.fromString(connectionId)))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public IntegrationOperation create(IntegrationOperation operation) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(operation.id()))
+                .addUUID(UUID.fromString(operation.connectionId()))
+                .addString(operation.name())
+                .addString(operation.method())
+                .addString(operation.path())
+                .addJsonObject(toJson(operation.requestSchema()))
+                .addJsonObject(toJson(operation.responseSchema()))
+                .addBoolean(operation.testOperation());
+        return mapRow(client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely()
+                .iterator().next());
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private IntegrationOperation mapRow(Row row) {
+        return new IntegrationOperation(
+                row.getUUID("id").toString(),
+                row.getUUID("connection_id").toString(),
+                row.getString("name"),
+                row.getString("method"),
+                row.getString("path"),
+                toMap(row.getJsonObject("request_schema")),
+                toMap(row.getJsonObject("response_schema")),
+                row.getBoolean("test_operation"));
+    }
+
+    private JsonObject toJson(Map<String, Object> value) {
+        return new JsonObject(value == null ? Map.of() : value);
+    }
+
+    private Map<String, Object> toMap(JsonObject value) {
+        return value == null ? Map.of() : Map.copyOf(value.getMap());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipher.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipher.java
@@ -1,0 +1,106 @@
+package com.microboxlabs.miot.integrations.secret;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class IntegrationSecretCipher {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_BITS = 128;
+    private static final int IV_BYTES = 12;
+    private static final String NOT_CONFIGURED = "not-configured";
+    private static final TypeReference<Map<String, Object>> SECRET_CONFIG_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+    private final SecureRandom secureRandom;
+    private final String encryptionKey;
+
+    public IntegrationSecretCipher(
+            ObjectMapper objectMapper,
+            @ConfigProperty(name = "miot.integrations.secret-key", defaultValue = NOT_CONFIGURED)
+            String encryptionKey) {
+        this(objectMapper, new SecureRandom(), encryptionKey);
+    }
+
+    IntegrationSecretCipher(ObjectMapper objectMapper, SecureRandom secureRandom, String encryptionKey) {
+        this.objectMapper = objectMapper;
+        this.secureRandom = secureRandom;
+        this.encryptionKey = encryptionKey;
+    }
+
+    public String encrypt(Map<String, Object> secretConfig) {
+        if (secretConfig == null || secretConfig.isEmpty()) {
+            return null;
+        }
+        if (encryptionKey == null || encryptionKey.isBlank() || NOT_CONFIGURED.equals(encryptionKey)) {
+            throw new IntegrationSecretEncryptionException(
+                    "Integration secret encryption key is not configured",
+                    null);
+        }
+
+        try {
+            byte[] iv = new byte[IV_BYTES];
+            secureRandom.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(
+                    Cipher.ENCRYPT_MODE,
+                    new SecretKeySpec(deriveAesKey(), "AES"),
+                    new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] ciphertext = cipher.doFinal(objectMapper.writeValueAsBytes(secretConfig));
+
+            return "v1:" + Base64.getEncoder().encodeToString(iv)
+                    + ":" + Base64.getEncoder().encodeToString(ciphertext);
+        } catch (GeneralSecurityException | JsonProcessingException e) {
+            throw new IntegrationSecretEncryptionException("Unable to encrypt integration secret config", e);
+        }
+    }
+
+    public Map<String, Object> decrypt(String encryptedSecretJson) {
+        if (encryptedSecretJson == null || encryptedSecretJson.isBlank()) {
+            return Map.of();
+        }
+        if (encryptionKey == null || encryptionKey.isBlank() || NOT_CONFIGURED.equals(encryptionKey)) {
+            throw new IntegrationSecretEncryptionException(
+                    "Integration secret encryption key is not configured",
+                    null);
+        }
+
+        try {
+            String[] parts = encryptedSecretJson.split(":", 3);
+            if (parts.length != 3 || !"v1".equals(parts[0])) {
+                throw new IntegrationSecretEncryptionException("Unsupported integration secret ciphertext format", null);
+            }
+
+            byte[] iv = Base64.getDecoder().decode(parts[1]);
+            byte[] ciphertext = Base64.getDecoder().decode(parts[2]);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(
+                    Cipher.DECRYPT_MODE,
+                    new SecretKeySpec(deriveAesKey(), "AES"),
+                    new GCMParameterSpec(GCM_TAG_BITS, iv));
+            return objectMapper.readValue(cipher.doFinal(ciphertext), SECRET_CONFIG_TYPE);
+        } catch (GeneralSecurityException | IllegalArgumentException | IOException e) {
+            throw new IntegrationSecretEncryptionException("Unable to decrypt integration secret config", e);
+        }
+    }
+
+    private byte[] deriveAesKey() throws GeneralSecurityException {
+        return MessageDigest.getInstance("SHA-256").digest(encryptionKey.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipher.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipher.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -29,6 +30,7 @@ public class IntegrationSecretCipher {
     private final SecureRandom secureRandom;
     private final String encryptionKey;
 
+    @Inject
     public IntegrationSecretCipher(
             ObjectMapper objectMapper,
             @ConfigProperty(name = "miot.integrations.secret-key", defaultValue = NOT_CONFIGURED)

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretEncryptionException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretEncryptionException.java
@@ -1,0 +1,8 @@
+package com.microboxlabs.miot.integrations.secret;
+
+public class IntegrationSecretEncryptionException extends RuntimeException {
+
+    public IntegrationSecretEncryptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -10,23 +10,35 @@ import com.microboxlabs.miot.integrations.dto.CreateCredentialProfileRequest;
 import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest;
 import com.microboxlabs.miot.integrations.dto.CreateIntegrationOperationRequest;
 import com.microboxlabs.miot.integrations.dto.CredentialProfileResponse;
+import com.microboxlabs.miot.integrations.persistence.CredentialProfileRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class IntegrationConnectionService {
 
-    private final Map<String, CredentialProfile> credentialProfiles = new ConcurrentHashMap<>();
-    private final Map<String, IntegrationConnection> connections = new ConcurrentHashMap<>();
-    private final Map<String, IntegrationOperation> operations = new ConcurrentHashMap<>();
+    private final CredentialProfileRepository credentialProfileRepository;
+    private final IntegrationConnectionRepository connectionRepository;
+    private final IntegrationOperationRepository operationRepository;
+
+    @Inject
+    public IntegrationConnectionService(
+            CredentialProfileRepository credentialProfileRepository,
+            IntegrationConnectionRepository connectionRepository,
+            IntegrationOperationRepository operationRepository) {
+        this.credentialProfileRepository = credentialProfileRepository;
+        this.connectionRepository = connectionRepository;
+        this.operationRepository = operationRepository;
+    }
 
     public List<CredentialProfileResponse> listCredentialProfiles(String tenantCode) {
-        return credentialProfiles.values().stream()
-                .filter(profile -> profile.tenantCode().equals(tenantCode))
+        return credentialProfileRepository.listByTenant(tenantCode).stream()
                 .map(this::toResponse)
                 .toList();
     }
@@ -44,14 +56,11 @@ public class IntegrationConnectionService {
                 1,
                 now,
                 now);
-        credentialProfiles.put(profile.id(), profile);
-        return toResponse(profile);
+        return toResponse(credentialProfileRepository.create(profile));
     }
 
     public List<IntegrationConnection> listConnections(String tenantCode) {
-        return connections.values().stream()
-                .filter(connection -> connection.tenantCode().equals(tenantCode))
-                .toList();
+        return connectionRepository.listByTenant(tenantCode);
     }
 
     public IntegrationConnection createConnection(String tenantCode, CreateIntegrationConnectionRequest req) {
@@ -66,16 +75,11 @@ public class IntegrationConnectionService {
                 null,
                 null,
                 safeMap(req.metadata()));
-        connections.put(connection.id(), connection);
-        return connection;
+        return connectionRepository.create(connection);
     }
 
     public IntegrationConnection getConnection(String tenantCode, String connectionId) {
-        IntegrationConnection connection = connections.get(connectionId);
-        if (connection == null || !connection.tenantCode().equals(tenantCode)) {
-            return null;
-        }
-        return connection;
+        return connectionRepository.findByTenantAndId(tenantCode, connectionId);
     }
 
     public IntegrationOperation addOperation(
@@ -95,17 +99,14 @@ public class IntegrationConnectionService {
                 safeMap(req.requestSchema()),
                 safeMap(req.responseSchema()),
                 req.testOperation());
-        operations.put(operation.id(), operation);
-        return operation;
+        return operationRepository.create(operation);
     }
 
     public List<IntegrationOperation> listOperations(String tenantCode, String connectionId) {
         if (getConnection(tenantCode, connectionId) == null) {
             return List.of();
         }
-        return operations.values().stream()
-                .filter(operation -> operation.connectionId().equals(connectionId))
-                .toList();
+        return operationRepository.listByConnection(connectionId);
     }
 
     public ConnectionTestResponse testConnection(
@@ -118,18 +119,7 @@ public class IntegrationConnectionService {
         }
 
         OffsetDateTime now = OffsetDateTime.now();
-        IntegrationConnection updated = new IntegrationConnection(
-                connection.id(),
-                connection.tenantCode(),
-                connection.name(),
-                connection.providerType(),
-                connection.baseUrl(),
-                connection.credentialProfileId(),
-                ConnectionStatus.ACTIVE,
-                now,
-                true,
-                connection.metadata());
-        connections.put(updated.id(), updated);
+        connectionRepository.updateTestResult(connection.tenantCode(), connection.id(), ConnectionStatus.ACTIVE, now, true);
         return new ConnectionTestResponse(true, now, testMessage(req));
     }
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -18,6 +18,7 @@ import com.microboxlabs.miot.integrations.secret.IntegrationSecretEncryptionExce
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -163,7 +164,7 @@ public class IntegrationConnectionService {
     }
 
     private Map<String, Object> safeMap(Map<String, Object> map) {
-        return map == null ? Map.of() : Map.copyOf(map);
+        return map == null ? Map.of() : new LinkedHashMap<>(map);
     }
 
     private String maskSecret(Map<String, Object> secretConfig) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -130,7 +130,15 @@ public class IntegrationConnectionService {
                 true,
                 connection.metadata());
         connections.put(updated.id(), updated);
-        return new ConnectionTestResponse(true, now, "Connection contract is valid; runtime probe pending");
+        return new ConnectionTestResponse(true, now, testMessage(req));
+    }
+
+    private String testMessage(ConnectionTestRequest req) {
+        if (req == null || req.path() == null || req.path().isBlank()) {
+            return "Connection contract is valid; runtime probe pending";
+        }
+        String method = req.method() == null || req.method().isBlank() ? "GET" : req.method();
+        return "Connection contract is valid for " + method + " " + req.path() + "; runtime probe pending";
     }
 
     private CredentialProfileResponse toResponse(CredentialProfile profile) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -13,28 +13,36 @@ import com.microboxlabs.miot.integrations.dto.CredentialProfileResponse;
 import com.microboxlabs.miot.integrations.persistence.CredentialProfileRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import com.microboxlabs.miot.integrations.secret.IntegrationSecretCipher;
+import com.microboxlabs.miot.integrations.secret.IntegrationSecretEncryptionException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class IntegrationConnectionService {
 
+    private static final Logger LOG = Logger.getLogger(IntegrationConnectionService.class);
+
     private final CredentialProfileRepository credentialProfileRepository;
     private final IntegrationConnectionRepository connectionRepository;
     private final IntegrationOperationRepository operationRepository;
+    private final IntegrationSecretCipher secretCipher;
 
     @Inject
     public IntegrationConnectionService(
             CredentialProfileRepository credentialProfileRepository,
             IntegrationConnectionRepository connectionRepository,
-            IntegrationOperationRepository operationRepository) {
+            IntegrationOperationRepository operationRepository,
+            IntegrationSecretCipher secretCipher) {
         this.credentialProfileRepository = credentialProfileRepository;
         this.connectionRepository = connectionRepository;
         this.operationRepository = operationRepository;
+        this.secretCipher = secretCipher;
     }
 
     public List<CredentialProfileResponse> listCredentialProfiles(String tenantCode) {
@@ -45,18 +53,28 @@ public class IntegrationConnectionService {
 
     public CredentialProfileResponse createCredentialProfile(String tenantCode, CreateCredentialProfileRequest req) {
         OffsetDateTime now = OffsetDateTime.now();
+        String encryptedSecretJson = encryptSecretConfig(req);
         CredentialProfile profile = new CredentialProfile(
                 UUID.randomUUID().toString(),
                 tenantCode,
                 req.displayName(),
                 req.authType(),
                 safeMap(req.publicConfig()),
-                "[pending-encryption]",
+                encryptedSecretJson,
                 maskSecret(req.secretConfig()),
                 1,
                 now,
                 now);
         return toResponse(credentialProfileRepository.create(profile));
+    }
+
+    private String encryptSecretConfig(CreateCredentialProfileRequest req) {
+        try {
+            return secretCipher.encrypt(req.secretConfig());
+        } catch (IntegrationSecretEncryptionException e) {
+            LOG.errorf(e, "Failed to encrypt secret config for credential profile '%s'", req.displayName());
+            throw e;
+        }
     }
 
     public List<IntegrationConnection> listConnections(String tenantCode) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -1,0 +1,159 @@
+package com.microboxlabs.miot.integrations.service;
+
+import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import com.microboxlabs.miot.integrations.dto.CreateCredentialProfileRequest;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationOperationRequest;
+import com.microboxlabs.miot.integrations.dto.CredentialProfileResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApplicationScoped
+public class IntegrationConnectionService {
+
+    private final Map<String, CredentialProfile> credentialProfiles = new ConcurrentHashMap<>();
+    private final Map<String, IntegrationConnection> connections = new ConcurrentHashMap<>();
+    private final Map<String, IntegrationOperation> operations = new ConcurrentHashMap<>();
+
+    public List<CredentialProfileResponse> listCredentialProfiles(String tenantCode) {
+        return credentialProfiles.values().stream()
+                .filter(profile -> profile.tenantCode().equals(tenantCode))
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public CredentialProfileResponse createCredentialProfile(String tenantCode, CreateCredentialProfileRequest req) {
+        OffsetDateTime now = OffsetDateTime.now();
+        CredentialProfile profile = new CredentialProfile(
+                UUID.randomUUID().toString(),
+                tenantCode,
+                req.displayName(),
+                req.authType(),
+                safeMap(req.publicConfig()),
+                "[pending-encryption]",
+                maskSecret(req.secretConfig()),
+                1,
+                now,
+                now);
+        credentialProfiles.put(profile.id(), profile);
+        return toResponse(profile);
+    }
+
+    public List<IntegrationConnection> listConnections(String tenantCode) {
+        return connections.values().stream()
+                .filter(connection -> connection.tenantCode().equals(tenantCode))
+                .toList();
+    }
+
+    public IntegrationConnection createConnection(String tenantCode, CreateIntegrationConnectionRequest req) {
+        IntegrationConnection connection = new IntegrationConnection(
+                UUID.randomUUID().toString(),
+                tenantCode,
+                req.name(),
+                req.providerType(),
+                req.baseUrl(),
+                req.credentialProfileId(),
+                ConnectionStatus.DRAFT,
+                null,
+                null,
+                safeMap(req.metadata()));
+        connections.put(connection.id(), connection);
+        return connection;
+    }
+
+    public IntegrationConnection getConnection(String tenantCode, String connectionId) {
+        IntegrationConnection connection = connections.get(connectionId);
+        if (connection == null || !connection.tenantCode().equals(tenantCode)) {
+            return null;
+        }
+        return connection;
+    }
+
+    public IntegrationOperation addOperation(
+            String tenantCode,
+            String connectionId,
+            CreateIntegrationOperationRequest req) {
+        IntegrationConnection connection = getConnection(tenantCode, connectionId);
+        if (connection == null) {
+            return null;
+        }
+        IntegrationOperation operation = new IntegrationOperation(
+                UUID.randomUUID().toString(),
+                connectionId,
+                req.name(),
+                req.method(),
+                req.path(),
+                safeMap(req.requestSchema()),
+                safeMap(req.responseSchema()),
+                req.testOperation());
+        operations.put(operation.id(), operation);
+        return operation;
+    }
+
+    public List<IntegrationOperation> listOperations(String tenantCode, String connectionId) {
+        if (getConnection(tenantCode, connectionId) == null) {
+            return List.of();
+        }
+        return operations.values().stream()
+                .filter(operation -> operation.connectionId().equals(connectionId))
+                .toList();
+    }
+
+    public ConnectionTestResponse testConnection(
+            String tenantCode,
+            String connectionId,
+            ConnectionTestRequest req) {
+        IntegrationConnection connection = getConnection(tenantCode, connectionId);
+        if (connection == null) {
+            return new ConnectionTestResponse(false, OffsetDateTime.now(), "Connection not found");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        IntegrationConnection updated = new IntegrationConnection(
+                connection.id(),
+                connection.tenantCode(),
+                connection.name(),
+                connection.providerType(),
+                connection.baseUrl(),
+                connection.credentialProfileId(),
+                ConnectionStatus.ACTIVE,
+                now,
+                true,
+                connection.metadata());
+        connections.put(updated.id(), updated);
+        return new ConnectionTestResponse(true, now, "Connection contract is valid; runtime probe pending");
+    }
+
+    private CredentialProfileResponse toResponse(CredentialProfile profile) {
+        return new CredentialProfileResponse(
+                profile.id(),
+                profile.tenantCode(),
+                profile.displayName(),
+                profile.authType(),
+                profile.publicConfig(),
+                profile.secretPreview(),
+                profile.secretVersion(),
+                profile.createdAt(),
+                profile.updatedAt());
+    }
+
+    private Map<String, Object> safeMap(Map<String, Object> map) {
+        return map == null ? Map.of() : Map.copyOf(map);
+    }
+
+    private String maskSecret(Map<String, Object> secretConfig) {
+        if (secretConfig == null || secretConfig.isEmpty()) {
+            return "none";
+        }
+        return "****";
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.0__create_integrations_schema.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.0__create_integrations_schema.sql
@@ -1,0 +1,125 @@
+-- Integration connections: reusable external API connection and credential metadata
+CREATE SCHEMA IF NOT EXISTS miot_integrations;
+
+CREATE TABLE miot_integrations.credential_profiles (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id             BIGINT REFERENCES miot_core.tenants(id),
+    tenant_code           VARCHAR(128) NOT NULL,
+    display_name          VARCHAR(160) NOT NULL,
+    auth_type             VARCHAR(64)  NOT NULL,
+    public_config         JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    encrypted_secret_json TEXT,
+    secret_preview        VARCHAR(32),
+    secret_version        INTEGER      NOT NULL DEFAULT 1,
+    active                BOOLEAN      NOT NULL DEFAULT true,
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_credential_profiles_auth_type CHECK (
+        auth_type IN (
+            'NONE',
+            'BEARER_TOKEN',
+            'API_KEY_HEADER',
+            'API_KEY_QUERY',
+            'BASIC',
+            'OAUTH2_CLIENT_CREDENTIALS',
+            'CUSTOM_HEADERS'
+        )
+    )
+);
+
+CREATE INDEX idx_credential_profiles_tenant_code
+    ON miot_integrations.credential_profiles(tenant_code);
+CREATE INDEX idx_credential_profiles_auth_type
+    ON miot_integrations.credential_profiles(auth_type);
+CREATE UNIQUE INDEX idx_credential_profiles_tenant_name_active
+    ON miot_integrations.credential_profiles(tenant_code, lower(display_name))
+    WHERE active;
+
+CREATE TABLE miot_integrations.integration_connections (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id             BIGINT REFERENCES miot_core.tenants(id),
+    tenant_code           VARCHAR(128) NOT NULL,
+    name                  VARCHAR(160) NOT NULL,
+    provider_type         VARCHAR(64)  NOT NULL,
+    base_url              TEXT         NOT NULL,
+    credential_profile_id UUID REFERENCES miot_integrations.credential_profiles(id),
+    status                VARCHAR(32)  NOT NULL DEFAULT 'DRAFT',
+    last_tested_at        TIMESTAMPTZ,
+    last_test_result      BOOLEAN,
+    metadata              JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    active                BOOLEAN      NOT NULL DEFAULT true,
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_integration_connections_provider_type CHECK (
+        provider_type IN (
+            'POSTGREST',
+            'ALERCE_TMS',
+            'N8N',
+            'AUTH0',
+            'ECM',
+            'CUSTOM_HTTP'
+        )
+    ),
+    CONSTRAINT chk_integration_connections_status CHECK (
+        status IN ('DRAFT', 'ACTIVE', 'INACTIVE', 'TEST_FAILED')
+    )
+);
+
+CREATE INDEX idx_integration_connections_tenant_code
+    ON miot_integrations.integration_connections(tenant_code);
+CREATE INDEX idx_integration_connections_provider_type
+    ON miot_integrations.integration_connections(provider_type);
+CREATE INDEX idx_integration_connections_credential_profile
+    ON miot_integrations.integration_connections(credential_profile_id);
+CREATE UNIQUE INDEX idx_integration_connections_tenant_name_active
+    ON miot_integrations.integration_connections(tenant_code, lower(name))
+    WHERE active;
+
+CREATE TABLE miot_integrations.integration_operations (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    connection_id   UUID NOT NULL REFERENCES miot_integrations.integration_connections(id) ON DELETE CASCADE,
+    name            VARCHAR(160) NOT NULL,
+    method          VARCHAR(16)  NOT NULL,
+    path            TEXT         NOT NULL,
+    request_schema  JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    response_schema JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    test_operation  BOOLEAN      NOT NULL DEFAULT false,
+    active          BOOLEAN      NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_integration_operations_method CHECK (
+        method IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')
+    )
+);
+
+CREATE INDEX idx_integration_operations_connection
+    ON miot_integrations.integration_operations(connection_id);
+CREATE UNIQUE INDEX idx_integration_operations_connection_name_active
+    ON miot_integrations.integration_operations(connection_id, lower(name))
+    WHERE active;
+
+CREATE TABLE miot_integrations.integration_test_results (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    connection_id UUID NOT NULL REFERENCES miot_integrations.integration_connections(id) ON DELETE CASCADE,
+    operation_id  UUID REFERENCES miot_integrations.integration_operations(id) ON DELETE SET NULL,
+    success       BOOLEAN      NOT NULL,
+    status_code   INTEGER,
+    message       TEXT,
+    tested_at     TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_integration_test_results_connection_tested_at
+    ON miot_integrations.integration_test_results(connection_id, tested_at DESC);
+
+CREATE TABLE miot_integrations.integration_audit_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_code   VARCHAR(128) NOT NULL,
+    connection_id UUID REFERENCES miot_integrations.integration_connections(id) ON DELETE SET NULL,
+    event_type    VARCHAR(80)  NOT NULL,
+    actor         VARCHAR(255),
+    details       JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_integration_audit_events_tenant_created_at
+    ON miot_integrations.integration_audit_events(tenant_code, created_at DESC);

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.integrations.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyConfig;
@@ -9,7 +10,10 @@ import com.microboxlabs.miot.integrations.auth.basic.BasicAuthConfig;
 import com.microboxlabs.miot.integrations.auth.basic.BasicAuthStrategy;
 import com.microboxlabs.miot.integrations.auth.bearer.BearerTokenConfig;
 import com.microboxlabs.miot.integrations.auth.bearer.BearerTokenStrategy;
+import com.microboxlabs.miot.integrations.auth.oauth.OAuth2ClientCredentialsConfig;
 import com.microboxlabs.miot.integrations.domain.ApiKeyPlacement;
+import com.microboxlabs.miot.integrations.domain.TokenRequestFormat;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class SimpleAuthStrategyTest {
@@ -42,5 +46,19 @@ class SimpleAuthStrategyTest {
                 new ApiKeyStrategy().resolve(new ApiKeyConfig("api_key", "secret", null)));
 
         assertEquals("Unsupported API key placement for credential 'api_key': null", exception.getMessage());
+    }
+
+    @Test
+    void authConfigToStringRedactsSecrets() {
+        assertFalse(new BasicAuthConfig("user", "raw-basic-secret").toString().contains("raw-basic-secret"));
+        assertFalse(new BearerTokenConfig("token-123").toString().contains("token-123"));
+        assertFalse(new ApiKeyConfig("api_key", "secret", ApiKeyPlacement.HEADER).toString().contains("secret"));
+        assertFalse(OAuth2ClientCredentialsConfig.withoutOptionalClaims(
+                        URI.create("https://auth.example/token"),
+                        "client-id",
+                        "client-secret",
+                        TokenRequestFormat.FORM)
+                .toString()
+                .contains("client-secret"));
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
@@ -26,6 +26,19 @@ class SimpleAuthStrategyTest {
     }
 
     @Test
+    void rejectsInvalidBearerTokens() {
+        NullPointerException nullException = assertThrows(
+                NullPointerException.class,
+                () -> new BearerTokenConfig(null));
+        IllegalArgumentException blankException = assertThrows(
+                IllegalArgumentException.class,
+                () -> new BearerTokenConfig(" "));
+
+        assertEquals("Bearer token must not be null", nullException.getMessage());
+        assertEquals("Bearer token must not be blank", blankException.getMessage());
+    }
+
+    @Test
     void resolvesBasicAuthHeader() {
         ResolvedAuth auth = new BasicAuthStrategy().resolve(new BasicAuthConfig("user", "pass"));
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
@@ -1,0 +1,37 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyConfig;
+import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyStrategy;
+import com.microboxlabs.miot.integrations.auth.basic.BasicAuthConfig;
+import com.microboxlabs.miot.integrations.auth.basic.BasicAuthStrategy;
+import com.microboxlabs.miot.integrations.auth.bearer.BearerTokenConfig;
+import com.microboxlabs.miot.integrations.auth.bearer.BearerTokenStrategy;
+import com.microboxlabs.miot.integrations.domain.ApiKeyPlacement;
+import org.junit.jupiter.api.Test;
+
+class SimpleAuthStrategyTest {
+
+    @Test
+    void resolvesBearerTokenHeader() {
+        ResolvedAuth auth = new BearerTokenStrategy().resolve(new BearerTokenConfig("token-123"));
+
+        assertEquals("Bearer token-123", auth.headers().get("Authorization"));
+    }
+
+    @Test
+    void resolvesBasicAuthHeader() {
+        ResolvedAuth auth = new BasicAuthStrategy().resolve(new BasicAuthConfig("user", "pass"));
+
+        assertEquals("Basic dXNlcjpwYXNz", auth.headers().get("Authorization"));
+    }
+
+    @Test
+    void resolvesApiKeyAsQueryParameter() {
+        ResolvedAuth auth = new ApiKeyStrategy().resolve(
+                new ApiKeyConfig("api_key", "secret", ApiKeyPlacement.QUERY));
+
+        assertEquals("secret", auth.queryParams().get("api_key"));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
@@ -55,8 +55,11 @@ class SimpleAuthStrategyTest {
 
     @Test
     void rejectsApiKeyWithoutPlacement() {
+        ApiKeyStrategy strategy = new ApiKeyStrategy();
+        ApiKeyConfig config = new ApiKeyConfig("api_key", "secret", null);
+
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                new ApiKeyStrategy().resolve(new ApiKeyConfig("api_key", "secret", null)));
+                strategy.resolve(config));
 
         assertEquals("Unsupported API key placement for credential 'api_key': null", exception.getMessage());
     }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/SimpleAuthStrategyTest.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.integrations.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyConfig;
 import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyStrategy;
@@ -33,5 +34,13 @@ class SimpleAuthStrategyTest {
                 new ApiKeyConfig("api_key", "secret", ApiKeyPlacement.QUERY));
 
         assertEquals("secret", auth.queryParams().get("api_key"));
+    }
+
+    @Test
+    void rejectsApiKeyWithoutPlacement() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                new ApiKeyStrategy().resolve(new ApiKeyConfig("api_key", "secret", null)));
+
+        assertEquals("Unsupported API key placement for credential 'api_key': null", exception.getMessage());
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategyTest.java
@@ -1,0 +1,70 @@
+package com.microboxlabs.miot.integrations.auth.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.TokenRequestFormat;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OAuth2ClientCredentialsStrategyTest {
+
+    private HttpServer server;
+    private String capturedContentType;
+    private String capturedBody;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void resolvesClientCredentialsUsingFormUrlEncodedTokenRequest() throws Exception {
+        URI tokenUrl = startTokenServer();
+        OAuth2ClientCredentialsStrategy strategy = new OAuth2ClientCredentialsStrategy(
+                HttpClient.newHttpClient(), new ObjectMapper());
+
+        ResolvedAuth auth = strategy.resolve(new OAuth2ClientCredentialsConfig(
+                tokenUrl,
+                "Sitrans_AlerceCorViaje",
+                "secret-value",
+                Optional.empty(),
+                Optional.empty(),
+                TokenRequestFormat.FORM));
+
+        assertEquals("application/x-www-form-urlencoded", capturedContentType);
+        assertEquals("grant_type=client_credentials&client_id=Sitrans_AlerceCorViaje&client_secret=secret-value",
+                capturedBody);
+        assertEquals("Bearer alerce-token", auth.headers().get("Authorization"));
+        assertTrue(auth.expiresAt().isAfter(java.time.Instant.now()));
+    }
+
+    private URI startTokenServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/oauth", this::handleTokenRequest);
+        server.start();
+        return URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/oauth");
+    }
+
+    private void handleTokenRequest(HttpExchange exchange) throws IOException {
+        capturedContentType = exchange.getRequestHeaders().getFirst("Content-Type");
+        capturedBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        byte[] response = "{\"access_token\":\"alerce-token\",\"expires_in\":120}".getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategyTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2ClientCredentialsStrategyTest.java
@@ -13,7 +13,6 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,12 +35,10 @@ class OAuth2ClientCredentialsStrategyTest {
         OAuth2ClientCredentialsStrategy strategy = new OAuth2ClientCredentialsStrategy(
                 HttpClient.newHttpClient(), new ObjectMapper());
 
-        ResolvedAuth auth = strategy.resolve(new OAuth2ClientCredentialsConfig(
+        ResolvedAuth auth = strategy.resolve(OAuth2ClientCredentialsConfig.withoutOptionalClaims(
                 tokenUrl,
                 "Sitrans_AlerceCorViaje",
                 "secret-value",
-                Optional.empty(),
-                Optional.empty(),
                 TokenRequestFormat.FORM));
 
         assertEquals("application/x-www-form-urlencoded", capturedContentType);

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipherTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipherTest.java
@@ -1,0 +1,42 @@
+package com.microboxlabs.miot.integrations.secret;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.SecureRandom;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class IntegrationSecretCipherTest {
+
+    @Test
+    void encryptsAndDecryptsSecretConfig() {
+        IntegrationSecretCipher cipher = new IntegrationSecretCipher(
+                new ObjectMapper(),
+                new SecureRandom(),
+                "test-encryption-key");
+
+        String encrypted = cipher.encrypt(Map.of("token", "secret-token"));
+
+        assertTrue(encrypted.startsWith("v1:"));
+        assertFalse(encrypted.contains("secret-token"));
+        assertEquals(Map.of("token", "secret-token"), cipher.decrypt(encrypted));
+    }
+
+    @Test
+    void rejectsNonEmptySecretsWhenKeyIsNotConfigured() {
+        IntegrationSecretCipher cipher = new IntegrationSecretCipher(
+                new ObjectMapper(),
+                new SecureRandom(),
+                "not-configured");
+
+        IntegrationSecretEncryptionException exception = assertThrows(
+                IntegrationSecretEncryptionException.class,
+                () -> cipher.encrypt(Map.of("token", "secret-token")));
+
+        assertEquals("Integration secret encryption key is not configured", exception.getMessage());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipherTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/secret/IntegrationSecretCipherTest.java
@@ -32,10 +32,11 @@ class IntegrationSecretCipherTest {
                 new ObjectMapper(),
                 new SecureRandom(),
                 "not-configured");
+        Map<String, Object> secretConfig = Map.of("token", "secret-token");
 
         IntegrationSecretEncryptionException exception = assertThrows(
                 IntegrationSecretEncryptionException.class,
-                () -> cipher.encrypt(Map.of("token", "secret-token")));
+                () -> cipher.encrypt(secretConfig));
 
         assertEquals("Integration secret encryption key is not configured", exception.getMessage());
     }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
@@ -1,0 +1,29 @@
+package com.microboxlabs.miot.integrations.service;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class IntegrationConnectionServiceTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void safeMapPreservesNullValues() throws Exception {
+        Method safeMap = IntegrationConnectionService.class.getDeclaredMethod("safeMap", Map.class);
+        safeMap.setAccessible(true);
+
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("nullable", null);
+
+        Map<String, Object> result = (Map<String, Object>) safeMap.invoke(serviceWithoutDependencies(), source);
+
+        assertNull(result.get("nullable"));
+    }
+
+    private IntegrationConnectionService serviceWithoutDependencies() {
+        return new IntegrationConnectionService(null, null, null, null);
+    }
+}

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -16,6 +16,7 @@
         <module>miot-gps-model</module>
         <module>miot-core</module>
         <module>miot-resource-core</module>
+        <module>miot-integrations</module>
         <module>miot-fleet</module>
         <module>miot-driver</module>
         <module>miot-tracking</module>
@@ -59,6 +60,11 @@
             <dependency>
                 <groupId>com.microboxlabs.miot</groupId>
                 <artifactId>miot-resource-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microboxlabs.miot</groupId>
+                <artifactId>miot-integrations</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/quarkus-srv/start.sh
+++ b/quarkus-srv/start.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # Extra Maven/Quarkus args can be appended after --:
 #   ./start.sh fleet -- -Dquarkus.http.port=9090
 
-KNOWN_COMPONENTS=(fleet driver tracking gateway)
+KNOWN_COMPONENTS=(fleet driver tracking gateway integrations)
 COMPONENTS=()
 EXTRA_ARGS=()
 PROFILE=""

--- a/turbo-repo/apps/docs/content/en/operations/helm-charts/miot-modulith.mdx
+++ b/turbo-repo/apps/docs/content/en/operations/helm-charts/miot-modulith.mdx
@@ -1,6 +1,6 @@
 # Modulith Chart
 
-The `miot-modulith` chart deploys the ModularIoT Quarkus backend — a modulith server that hosts fleet, driver, tracking, and gateway components. Each component can be independently enabled via values, allowing the same chart and image to serve different deployment roles.
+The `miot-modulith` chart deploys the ModularIoT Quarkus backend — a modulith server that hosts fleet, driver, tracking, gateway, and integrations components. Each component can be independently enabled via values, allowing the same chart and image to serve different deployment roles.
 
 ## Install
 
@@ -27,6 +27,8 @@ components:
     enabled: false
   gateway:
     enabled: false
+  integrations:
+    enabled: false
 ```
 
 Each flag maps to `MIOT_COMPONENT_*_ENABLED` environment variables injected by the chart.
@@ -36,8 +38,9 @@ Each flag maps to `MIOT_COMPONENT_*_ENABLED` environment variables injected by t
 | Deployment | Components | Purpose |
 |---|---|---|
 | `prod-miot-modulith` | fleet + driver | REST API for fleet dashboard |
-| `dev-miot-modulith` | fleet + driver + tracking | All-in-one dev server |
+| `dev-miot-modulith` | fleet + driver + tracking + integrations | All-in-one dev server |
 | `prod-miot-gateway` | gateway | Request forking/mirroring |
+| `prod-miot-integrations` | integrations | External API connections and credential profiles |
 
 All use the same image (`ghcr.io/microboxlabs/miot-srv`) and chart (`miot-modulith`).
 
@@ -117,6 +120,17 @@ flyway:
 ```
 
 The `FlywayMigrator` conditionally includes migration locations based on active components and tolerates previously applied migrations from inactive components.
+
+Migration version ranges are reserved by component:
+
+| Component | Schema | Migration range |
+|---|---|---|
+| Core | `miot_core` | `V0.1.x` |
+| Fleet | `miot_fleet` | `V0.2.x` |
+| Resource Core | `miot_resource` | `V0.3.x` |
+| Driver | `miot_driver` | `V0.4.x` |
+| Tracking | `miot_tracking` | `V0.5.x` |
+| Integrations | `miot_integrations` | `V0.6.x` |
 
 ## APISIX Route
 

--- a/turbo-repo/apps/docs/content/en/operations/helm-charts/miot-modulith.mdx
+++ b/turbo-repo/apps/docs/content/en/operations/helm-charts/miot-modulith.mdx
@@ -279,6 +279,7 @@ The fork engine exposes Prometheus metrics at `/q/metrics`:
 | `components.driver.enabled` | `false` | Enable driver management |
 | `components.tracking.enabled` | `false` | Enable asset tracking |
 | `components.gateway.enabled` | `false` | Enable gateway/fork engine |
+| `components.integrations.enabled` | `false` | Enable integrations component |
 | `postgresql.external.host` | `postgresql` | Database host |
 | `postgresql.external.port` | `5432` | Database port |
 | `postgresql.external.database` | `miot` | Database name |


### PR DESCRIPTION
## Summary

- Add the `miot-integrations` Quarkus module for generic external API connections and credential profiles.
- Introduce auth strategy contracts plus initial bearer token, basic auth, API key, and OAuth2 client-credentials implementations.
- Add org-scoped OpenAPI resources for credential profiles, connections, connection tests, and operations.
- Add the `miot_integrations` Flyway schema using the reserved `V0.6.x` migration range.
- Wire the component into Maven, CLI startup flags, component config, Flyway migration selection, and documentation.

## Verification

- `./mvnw -pl miot-cli -am test`

Closes #375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an integrations module with REST endpoints to create, list, test, and manage integration connections and credential profiles
  * Added multi-method authentication support (API keys, bearer tokens, basic auth, OAuth2 client credentials)
  * Config toggle to enable/disable the integrations component

* **Database**
  * New database schema and migrations for integrations, and reserved per-component migration ranges

* **Documentation**
  * Updated start/deployment and Helm docs to include integrations and migration guidance

* **Tests**
  * Added unit tests for authentication strategies and OAuth2 token flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->