### PR TITLE
feat(miot-calendar-client): expose CalendarFilter on calendar request/response

### DIFF
--- a/turbo-repo/packages/miot-calendar-client/README.md
+++ b/turbo-repo/packages/miot-calendar-client/README.md
@@ -529,6 +529,12 @@ interface CalendarRequest {
   active?: boolean;       // Active status (default: true)
   parallelism?: number;   // Parallel resources per slot (default: 1, e.g. loading docks)
   groups?: string[];      // Group codes to assign. null = no change; [] = remove all; ["code"] = replace all
+  filter?: CalendarFilter; // Optional task filter. null = no change; {} = clear; populated = replace
+}
+
+interface CalendarFilter {
+  origin?: string;        // Origin delegate code (e.g., "ANF")
+  destination?: string;   // Destination delegate code
 }
 ```
 
@@ -546,6 +552,7 @@ interface CalendarResponse {
   createdAt: string;                   // ISO 8601
   updatedAt: string;                   // ISO 8601
   groups?: CalendarGroupResponse[];    // Groups this calendar belongs to
+  filter?: CalendarFilter;             // Optional task filter (origin / destination delegate codes)
 }
 ```
 

--- a/turbo-repo/packages/miot-calendar-client/openapi.json
+++ b/turbo-repo/packages/miot-calendar-client/openapi.json
@@ -197,6 +197,14 @@
             },
             "description" : "List of group codes to assign. null = no change; [] = remove all; [\"code1\"] = replace all"
           },
+          "filter" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "examples" : [ "{\"origin\":\"ANF\"}" ],
+            "description" : "Optional task filter map applied to client-side task lists tied to this calendar. null = no change; {} = clear; populated map = replace. Allowed keys: origin, destination."
+          },
           "autoSlotManager" : {
             "type" : "boolean",
             "description" : "Whether to auto-provision a default SlotManager on creation. Defaults to true when null.",
@@ -259,6 +267,14 @@
               "$ref" : "#/components/schemas/CalendarGroupResponse"
             },
             "description" : "Groups this calendar belongs to"
+          },
+          "filter" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "examples" : [ "{\"origin\":\"ANF\"}" ],
+            "description" : "Optional task filter map applied to client-side task lists tied to this calendar. Keys are drawn from the allowed set (origin, destination)."
           },
           "hasSlotManager" : {
             "type" : "boolean",

--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -9,6 +9,7 @@ export type {
   BookingListResponse,
   CalendarGroupRequest,
   CalendarGroupResponse,
+  CalendarFilter,
   CalendarRequest,
   CalendarResponse,
   TimeWindowRequest,

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -60,6 +60,11 @@ export interface CalendarGroupResponse {
 
 // --- Calendars ---
 
+export interface CalendarFilter {
+  origin?: string;
+  destination?: string;
+}
+
 export interface CalendarRequest {
   code: string;
   name: string;
@@ -68,6 +73,7 @@ export interface CalendarRequest {
   active?: boolean;
   parallelism?: number;
   groups?: string[];
+  filter?: CalendarFilter;
   autoSlotManager?: boolean;
 }
 
@@ -82,6 +88,7 @@ export interface CalendarResponse {
   createdAt: string;
   updatedAt: string;
   groups?: CalendarGroupResponse[];
+  filter?: CalendarFilter;
   hasSlotManager?: boolean;
 }
 


### PR DESCRIPTION
Closes #387
Depends on microboxlabs/miot-calendar#16 (deployed).

## Summary
- New `CalendarFilter` interface (`{ origin?: string; destination?: string }`) added to `@microboxlabs/miot-calendar-client`.
- `CalendarRequest` and `CalendarResponse` carry optional `filter?: CalendarFilter`.
- Bumped `0.5.0` → `0.6.0`; README + openapi.json snapshot updated to match.

## Test plan
- [x] `npx turbo run check-types --filter=@microboxlabs/miot-calendar-client` — pass
- [x] `npx turbo run test build --filter=@microboxlabs/miot-calendar-client` — 78/78 tests, ESM + CJS + DTS build clean
- [x] `npx turbo run check-types --filter=@modulariot/app` — only pre-existing unrelated error (`xlsx` module in dashboard parser); calendar consumers compile cleanly
- [ ] Manual: smoke test the package by importing `CalendarFilter` from a downstream app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive calendar filter feature plan outlining implementation roadmap

* **New Features**
  * Calendar now supports filtering by origin and destination codes
  * Updated package version (0.6.0) to reflect new filtering capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->