### PR TITLE
feat(calendar): surface task filter in create modal, gear menu, and sidebar

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/route.ts
@@ -7,12 +7,20 @@ import {
 } from "../../utils/calendar-route-utils";
 import { NextResponse } from "next/server";
 
+const CalendarFilterSchema = z
+  .object({
+    origin: z.string().optional(),
+    destination: z.string().optional(),
+  })
+  .optional();
+
 const CalendarPatchSchema = z.object({
   parallelism: z.number().int().min(1).optional(),
   name: z.string().optional(),
   description: z.string().optional(),
   timezone: z.string().optional(),
   active: z.boolean().optional(),
+  filter: CalendarFilterSchema,
   autoSlotManager: z.boolean().optional(),
 });
 
@@ -42,6 +50,7 @@ export async function PUT(
       timezone: parsed.data.timezone ?? current.timezone,
       active: parsed.data.active ?? current.active,
       parallelism: parsed.data.parallelism ?? current.parallelism,
+      filter: parsed.data.filter ?? current.filter,
       autoSlotManager: parsed.data.autoSlotManager,
       groups: current.groups?.map((g) => g.code),
     });

--- a/turbo-repo/apps/app/src/app/api/calendar/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/route.ts
@@ -7,6 +7,13 @@ import {
 } from "../utils/calendar-route-utils";
 import { NextResponse } from "next/server";
 
+const CalendarFilterSchema = z
+  .object({
+    origin: z.string().optional(),
+    destination: z.string().optional(),
+  })
+  .optional();
+
 const CalendarRequestSchema = z.object({
   code: z.string(),
   name: z.string(),
@@ -15,6 +22,7 @@ const CalendarRequestSchema = z.object({
   active: z.boolean().optional(),
   parallelism: z.number().int().min(1).optional(),
   groups: z.array(z.string()).optional(),
+  filter: CalendarFilterSchema,
   autoSlotManager: z.boolean().optional(),
 });
 

--- a/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
@@ -61,6 +61,18 @@ export const CREATE_CALENDAR_FORM_CONFIG: DynamicFormConfig = {
       options: TIMEZONE_OPTIONS,
     },
     {
+      name: "filterOrigin",
+      labelKey: "create.filterOriginLabel",
+      type: "text",
+      placeholder: "SCL",
+    },
+    {
+      name: "filterDestination",
+      labelKey: "create.filterDestinationLabel",
+      type: "text",
+      placeholder: "ANF",
+    },
+    {
       name: "active",
       labelKey: "create.activeLabel",
       type: "checkbox",

--- a/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
@@ -9,7 +9,11 @@ import {
   useCalendarGroups,
   createCalendar,
 } from "@/features/common/providers/client-api.provider";
-import type { CalendarGroupResponse, CalendarRequest } from "@microboxlabs/miot-calendar-client";
+import type {
+  CalendarFilter,
+  CalendarGroupResponse,
+  CalendarRequest,
+} from "@microboxlabs/miot-calendar-client";
 
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
@@ -68,6 +72,12 @@ export function CreateCalendarModal({
     setIsProcessing(true);
 
     try {
+      const filter: CalendarFilter = {};
+      const filterOrigin = (formValues.filterOrigin as string)?.trim();
+      const filterDestination = (formValues.filterDestination as string)?.trim();
+      if (filterOrigin) filter.origin = filterOrigin;
+      if (filterDestination) filter.destination = filterDestination;
+
       const body: CalendarRequest = {
         name: formValues.name as string,
         code: formValues.code as string,
@@ -76,6 +86,7 @@ export function CreateCalendarModal({
         parallelism: (formValues.parallelism as number) ?? 1,
         active: (formValues.active as boolean) ?? true,
         groups: selectedGroupCode ? [selectedGroupCode] : [],
+        filter,
         autoSlotManager: true,
       };
 
@@ -114,9 +125,14 @@ export function CreateCalendarModal({
       size="2xl"
     >
       <div className="flex flex-col gap-4">
-        {/* name, code, description, timezone */}
+        {/* name, code, parallelism, description, timezone */}
         {standardFields
-          .filter((f) => f.name !== "active")
+          .filter(
+            (f) =>
+              f.name !== "active" &&
+              f.name !== "filterOrigin" &&
+              f.name !== "filterDestination"
+          )
           .map((field) => (
             <DynamicFormField
               key={field.name}
@@ -136,6 +152,26 @@ export function CreateCalendarModal({
           onGroupCreated={handleGroupCreated}
           dict={dict}
         />
+
+        {/* filter: origin + destination side by side */}
+        <div className="flex gap-3">
+          {standardFields
+            .filter(
+              (f) =>
+                f.name === "filterOrigin" || f.name === "filterDestination"
+            )
+            .map((field) => (
+              <div key={field.name} className="flex-1">
+                <DynamicFormField
+                  field={field}
+                  value={formValues[field.name] ?? field.defaultValue ?? ""}
+                  onChange={(value) => setFormValue(field.name, value)}
+                  isVisible={isFieldVisible(field)}
+                  translate={(key) => tr(key, dict)}
+                />
+              </div>
+            ))}
+        </div>
 
         {/* active checkbox */}
         {standardFields

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/calendar-rules.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/calendar-rules.tsx
@@ -11,6 +11,8 @@ import AndenesManager, {
   type PlatformConfig,
   getAndenesManagerMessages,
 } from "./andenes-manager";
+import FilterManager, { getFilterManagerMessages } from "./filter-manager";
+import type { CalendarFilter } from "@microboxlabs/miot-calendar-client";
 import { ChevronLeft } from "flowbite-react-icons/outline";
 import { twMerge } from "tailwind-merge";
 import { type TimeWindow, type TimeBlock } from "../planning-selection-context";
@@ -18,7 +20,7 @@ import type { ReactNode } from "react";
 import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 
-type SettingOption = "quota" | "timeBlock" | "andenes" | null;
+type SettingOption = "quota" | "timeBlock" | "andenes" | "filter" | null;
 
 function isSectionExpanded(
   selected: SettingOption,
@@ -182,6 +184,10 @@ export interface CalendarRulesMessages {
     title: string;
     description: string;
   };
+  taskFilter: {
+    title: string;
+    description: string;
+  };
 }
 
 const CALENDAR_RULES_BASE = "layout.planning.calendarRules" as const;
@@ -212,6 +218,10 @@ export function getCalendarRulesMessages(
         dict
       ),
     },
+    taskFilter: {
+      title: tr(`${CALENDAR_RULES_BASE}.taskFilter.title`, dict),
+      description: tr(`${CALENDAR_RULES_BASE}.taskFilter.description`, dict),
+    },
   };
 }
 
@@ -219,18 +229,22 @@ interface CalendarRulesProps {
   dict: I18nDictionary;
   messages: CalendarRulesMessages;
   andenesCount?: number;
+  taskFilter?: CalendarFilter;
   onRulesChange?: (windows: TimeWindow[]) => void;
   onBlocksChange?: (blocks: TimeBlock[]) => void;
   onAndenesChange?: (config: PlatformConfig) => void;
+  onTaskFilterChange?: (filter: CalendarFilter) => void;
 }
 
 export default function CalendarRules({
   dict,
   messages,
   andenesCount,
+  taskFilter,
   onRulesChange,
   onBlocksChange,
   onAndenesChange,
+  onTaskFilterChange,
 }: Readonly<CalendarRulesProps>) {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<SettingOption>(null);
@@ -298,6 +312,23 @@ export default function CalendarRules({
               initialCount={andenesCount}
               onConfigChange={(config) => {
                 onAndenesChange?.(config);
+                closePanel();
+              }}
+            />
+          </CalendarRulesSection>
+
+          <CalendarRulesSection
+            option="filter"
+            selected={selected}
+            setSelected={setSelected}
+            title={messages.taskFilter.title}
+            description={messages.taskFilter.description}
+          >
+            <FilterManager
+              messages={getFilterManagerMessages(dict)}
+              initialFilter={taskFilter}
+              onFilterChange={(filter) => {
+                onTaskFilterChange?.(filter);
                 closePanel();
               }}
             />

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/filter-manager.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/filter-manager.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Button, TextInput, Label } from "flowbite-react";
+import { useCallback, useEffect, useState } from "react";
+import { HiCheck } from "react-icons/hi";
+import type { CalendarFilter } from "@microboxlabs/miot-calendar-client";
+import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+
+export interface FilterManagerMessages {
+  originLabel: string;
+  destinationLabel: string;
+  originPlaceholder: string;
+  destinationPlaceholder: string;
+  hint: string;
+  save: string;
+}
+
+const FILTER_MANAGER_BASE = "layout.planning.calendarRules.taskFilter" as const;
+
+export function getFilterManagerMessages(
+  dict: I18nDictionary
+): FilterManagerMessages {
+  return {
+    originLabel: tr(`${FILTER_MANAGER_BASE}.originLabel`, dict),
+    destinationLabel: tr(`${FILTER_MANAGER_BASE}.destinationLabel`, dict),
+    originPlaceholder: tr(`${FILTER_MANAGER_BASE}.originPlaceholder`, dict),
+    destinationPlaceholder: tr(
+      `${FILTER_MANAGER_BASE}.destinationPlaceholder`,
+      dict
+    ),
+    hint: tr(`${FILTER_MANAGER_BASE}.hint`, dict),
+    save: tr(`${FILTER_MANAGER_BASE}.save`, dict),
+  };
+}
+
+interface FilterManagerProps {
+  messages: FilterManagerMessages;
+  initialFilter?: CalendarFilter;
+  onFilterChange?: (filter: CalendarFilter) => void;
+}
+
+/**
+ * Task filter manager — lets the user constrain the planning sidebar's
+ * task list to a specific origin and/or destination delegate code.
+ */
+export default function FilterManager({
+  messages,
+  initialFilter,
+  onFilterChange,
+}: Readonly<FilterManagerProps>) {
+  const [origin, setOrigin] = useState<string>(initialFilter?.origin ?? "");
+  const [destination, setDestination] = useState<string>(
+    initialFilter?.destination ?? ""
+  );
+
+  useEffect(() => {
+    setOrigin(initialFilter?.origin ?? "");
+    setDestination(initialFilter?.destination ?? "");
+  }, [initialFilter?.origin, initialFilter?.destination]);
+
+  const handleSave = useCallback(() => {
+    const next: CalendarFilter = {};
+    const o = origin.trim();
+    const d = destination.trim();
+    if (o) next.origin = o;
+    if (d) next.destination = d;
+    onFilterChange?.(next);
+  }, [origin, destination, onFilterChange]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-3">
+        <div className="flex-1 space-y-2">
+          <Label
+            htmlFor="filter-origin"
+            className="text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            {messages.originLabel}
+          </Label>
+          <TextInput
+            id="filter-origin"
+            type="text"
+            value={origin}
+            placeholder={messages.originPlaceholder}
+            onChange={(e) => setOrigin(e.target.value.toUpperCase())}
+            sizing="sm"
+          />
+        </div>
+
+        <div className="flex-1 space-y-2">
+          <Label
+            htmlFor="filter-destination"
+            className="text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            {messages.destinationLabel}
+          </Label>
+          <TextInput
+            id="filter-destination"
+            type="text"
+            value={destination}
+            placeholder={messages.destinationPlaceholder}
+            onChange={(e) => setDestination(e.target.value.toUpperCase())}
+            sizing="sm"
+          />
+        </div>
+      </div>
+
+      <div className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded-lg p-3">
+        {messages.hint}
+      </div>
+
+      <Button color="blue" size="sm" className="w-full" onClick={handleSave}>
+        <HiCheck className="mr-2 h-4 w-4" />
+        {messages.save}
+      </Button>
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-header.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-header.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/features/common/providers/client-api.provider";
 import { ShowNotification } from "@/features/notifications/notification";
 import { tr } from "@/features/i18n/tr.service";
+import type { CalendarFilter } from "@microboxlabs/miot-calendar-client";
 
 dayjs.extend(weekOfYear);
 
@@ -82,8 +83,12 @@ export default function PlanningHeader({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { andenesCount, setAndenesCount } = usePlanningSelection();
-  const { refresh: refreshCalendars } = useCalendars();
+  const { calendars, refresh: refreshCalendars } = useCalendars();
   const groupCode = searchParams.get("groupCode");
+  const activeCalendar = useMemo(
+    () => calendars.find((c) => c.id === calendarId),
+    [calendars, calendarId]
+  );
 
   // Read state from URL, fallback to props/defaults
   const currentDate = useMemo(() => {
@@ -186,6 +191,7 @@ export default function PlanningHeader({
           dict={dict}
           messages={getCalendarRulesMessages(dict)}
           andenesCount={andenesCount}
+          taskFilter={activeCalendar?.filter}
           onAndenesChange={async (config) => {
             setAndenesCount(config.count);
             if (!calendarId) return;
@@ -200,6 +206,22 @@ export default function PlanningHeader({
               ShowNotification({
                 type: "error",
                 message: tr("layout.planning.calendarRules.platformConfig.saveError", dict),
+              });
+            }
+          }}
+          onTaskFilterChange={async (filter: CalendarFilter) => {
+            if (!calendarId) return;
+            try {
+              await updateCalendar(calendarId, { filter });
+              await refreshCalendars();
+              ShowNotification({
+                type: "success",
+                message: tr("layout.planning.calendarRules.taskFilter.saveSuccess", dict),
+              });
+            } catch {
+              ShowNotification({
+                type: "error",
+                message: tr("layout.planning.calendarRules.taskFilter.saveError", dict),
               });
             }
           }}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -20,7 +20,10 @@ import { PlanningSidebarForm } from "./planning-sidebar-form";
 import { ServiceEvent } from "./service-event";
 import { PlanningSearchAutocomplete } from "./planning-search-autocomplete";
 import { PlanningSearchTags } from "./planning-search-tags";
-import { useMyTasks } from "@/features/common/providers/client-api.provider";
+import {
+  useCalendars,
+  useMyTasks,
+} from "@/features/common/providers/client-api.provider";
 import { formatDateString } from "@/features/common/components/formatted-date/formatted-date";
 import type { KanbanBoardTask } from "@/features/shipping/types/common.types";
 
@@ -207,6 +210,37 @@ export function PlanningSidebarClient({
   const [searchTags, setSearchTags] = useState<
     Array<{ matchType: PlanningSearchMatchType; value: string }>
   >([]);
+
+  // Seed search tags from the active calendar's stored filter (origin /
+  // destination delegate codes). Re-seed only when the filter signature
+  // changes — i.e. when the user navigates to a different calendar or
+  // updates the calendar's filter via the gear menu. Manual chip removals
+  // are session-only and must not get re-seeded.
+  const { calendars } = useCalendars();
+  const activeCalendar = useMemo(
+    () => calendars.find((c) => c.id === calendarId),
+    [calendars, calendarId]
+  );
+  const lastSeededSigRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeCalendar) return;
+    const sig = `${activeCalendar.id}|${activeCalendar.filter?.origin ?? ""}|${activeCalendar.filter?.destination ?? ""}`;
+    if (lastSeededSigRef.current === sig) return;
+    lastSeededSigRef.current = sig;
+
+    const seeded: Array<{ matchType: PlanningSearchMatchType; value: string }> =
+      [];
+    if (activeCalendar.filter?.origin) {
+      seeded.push({ matchType: "origen", value: activeCalendar.filter.origin });
+    }
+    if (activeCalendar.filter?.destination) {
+      seeded.push({
+        matchType: "destino",
+        value: activeCalendar.filter.destination,
+      });
+    }
+    setSearchTags(seeded);
+  }, [activeCalendar]);
 
   // Build API params from search tags
   const apiParams = useMemo(() => {

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1449,6 +1449,18 @@
           "save": "Save",
           "saveSuccess": "Loading docks updated",
           "saveError": "Failed to update loading docks"
+        },
+        "taskFilter": {
+          "title": "Task filter",
+          "description": "Constrain the planning sidebar to trips with a specific origin and/or destination.",
+          "originLabel": "Origin code",
+          "destinationLabel": "Destination code",
+          "originPlaceholder": "SCL",
+          "destinationPlaceholder": "ANF",
+          "hint": "Leave a field empty to skip that constraint. Both fields applied together require trips to match both.",
+          "save": "Save",
+          "saveSuccess": "Task filter updated",
+          "saveError": "Failed to update task filter"
         }
       }
     },
@@ -2930,6 +2942,8 @@
       "descriptionLabel": "Description",
       "timezoneLabel": "Timezone",
       "groupLabel": "Group",
+      "filterOriginLabel": "Origin filter (optional)",
+      "filterDestinationLabel": "Destination filter (optional)",
       "activeLabel": "Active",
       "submit": "Create Calendar",
       "group": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1474,6 +1474,18 @@
           "save": "Guardar",
           "saveSuccess": "Andenes actualizados",
           "saveError": "Error al actualizar andenes"
+        },
+        "taskFilter": {
+          "title": "Filtro de servicios",
+          "description": "Restringe el listado lateral a viajes con un origen y/o destino específicos.",
+          "originLabel": "Código de origen",
+          "destinationLabel": "Código de destino",
+          "originPlaceholder": "SCL",
+          "destinationPlaceholder": "ANF",
+          "hint": "Deja un campo vacío para no aplicar esa restricción. Si usas ambos, los viajes deben coincidir con los dos.",
+          "save": "Guardar",
+          "saveSuccess": "Filtro de servicios actualizado",
+          "saveError": "Error al actualizar el filtro"
         }
       }
     },
@@ -2961,6 +2973,8 @@
       "descriptionLabel": "Descripción",
       "timezoneLabel": "Zona Horaria",
       "groupLabel": "Grupo",
+      "filterOriginLabel": "Filtro de origen (opcional)",
+      "filterDestinationLabel": "Filtro de destino (opcional)",
       "activeLabel": "Activo",
       "submit": "Crear Calendario",
       "group": {

--- a/turbo-repo/packages/miot-calendar-client/README.md
+++ b/turbo-repo/packages/miot-calendar-client/README.md
@@ -122,6 +122,7 @@ Create a new calendar.
 | `active` | `boolean` | No | `true` | Whether the calendar is active |
 | `parallelism` | `number` | No | `1` | Parallel resources per slot (e.g. loading docks) |
 | `groups` | `string[]` | No | — | Group codes to assign. `null` = no change; `[]` = remove all; `["code"]` = replace all |
+| `filter` | [`CalendarFilter`](#calendarfilter) | No | — | Task filter map (`origin?`, `destination?`). `null` = no change; `{}` = clear; populated = replace |
 
 **Returns:** `CalendarResponse`
 
@@ -531,12 +532,18 @@ interface CalendarRequest {
   groups?: string[];      // Group codes to assign. null = no change; [] = remove all; ["code"] = replace all
   filter?: CalendarFilter; // Optional task filter. null = no change; {} = clear; populated = replace
 }
+```
 
+### `CalendarFilter`
+
+```ts
 interface CalendarFilter {
   origin?: string;        // Origin delegate code (e.g., "ANF")
   destination?: string;   // Destination delegate code
 }
 ```
+
+Optional map persisted on a calendar so client UIs can constrain task lists tied to that calendar. Both keys are optional; when both are set, the backend AND-combines them.
 
 ### `CalendarResponse`
 


### PR DESCRIPTION
Closes #389
Builds on microboxlabs/miot-calendar#16 (deployed) and #387 (merged via #388).

## Summary
- **Create modal** — optional Origin / Destination text inputs (side-by-side, auto-uppercase, dropped if blank).
- **Gear menu** — new "Task filter" section in `CalendarRules`; seeds from the active calendar's filter, saves via `updateCalendar`.
- **Planning sidebar** — auto-seeds `searchTags` chips from the calendar's filter on mount and on filter-signature changes (different calendar OR filter updated). Chip removal is session-only.
- **API routes** — `/api/calendar` (POST) and `/api/calendar/[calendarId]` (PUT) Zod schemas now include `filter`; PUT forwards `parsed.data.filter ?? current.filter`. Previously stripped silently.
- **Docs** — README's `calendars.create(body)` table now lists `filter` and links to a new `CalendarFilter` type subsection.
- **i18n** — EN + ES keys added for both surfaces.

## Test plan
- [x] Create a calendar with `Origin: ANF` → GET round-trips `filter: { origin: "ANF" }`.
- [x] Open gear menu → "Filtro de servicios" → values pre-populated; update → toast → re-open shows new values.
- [x] Save with both fields cleared → backend stores NULL; on reopen the form is empty.
- [x] Planning sidebar mounts with chips matching the active calendar's filter; removing a chip clears the constraint for the session and does not re-seed.
- [x] Switching calendars or editing the filter via the gear menu re-seeds the chips.
- [x] `npx turbo run check-types --filter=@modulariot/app` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)