### PR TITLE
fix(calendar): always show some flags inline, collapse the rest

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -758,7 +758,7 @@ export function PlanningSidebarClient({
                           "ring-2 ring-amber-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-800"
                       )}
                     >
-                      <ServiceEvent service={service} />
+                      <ServiceEvent service={service} dict={dict} />
                     </div>
                   );
                 })

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -559,8 +559,15 @@ export function PlanningSidebarForm({
   // Categorize incidencias into primary (always visible) and secondary (expandable)
   const { primary, secondary } = categorizeIncidencias(incidentCodes);
   const hasIncidencias = primary.length > 0 || secondary.length > 0;
-  // Show secondary directly if no primary and 2 or fewer secondary
-  const showSecondaryDirectly = primary.length === 0 && secondary.length <= 2;
+  // Always reserve up to INLINE_BUDGET inline slots: primary first, then top up with secondary.
+  const INLINE_BUDGET = 2;
+  const inlineSecondaryCount = Math.max(
+    0,
+    Math.min(secondary.length, INLINE_BUDGET - primary.length)
+  );
+  const inlineSecondary = secondary.slice(0, inlineSecondaryCount);
+  const collapsedSecondary = secondary.slice(inlineSecondaryCount);
+  const hasCollapsed = collapsedSecondary.length > 0;
 
   // Use real data from selectedService
   const id = selectedService.id;
@@ -640,9 +647,27 @@ export function PlanningSidebarForm({
               );
             })}
 
-            {/* Secondary incidencias - shown directly if ≤2 and no primary, otherwise when expanded */}
-            {(showSecondaryDirectly || showAllIncidencias) &&
-              secondary.map(({ key, config }) => {
+            {/* Inline secondary incidencias - always visible */}
+            {inlineSecondary.map(({ key, config }) => {
+              const tooltip =
+                codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
+              return (
+                <Badge
+                  key={key}
+                  size="xs"
+                  color="gray"
+                  className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5"
+                  title={tooltip}
+                >
+                  {config.label}
+                </Badge>
+              );
+            })}
+
+            {/* Collapsed secondary incidencias - revealed when expanded */}
+            {hasCollapsed &&
+              showAllIncidencias &&
+              collapsedSecondary.map(({ key, config }) => {
                 const tooltip =
                   codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
                 return (
@@ -658,33 +683,29 @@ export function PlanningSidebarForm({
                 );
               })}
 
-            {/* "+N more" button to expand secondary incidencias - only if not showing directly */}
-            {!showSecondaryDirectly &&
-              secondary.length > 0 &&
-              !showAllIncidencias && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllIncidencias(true)}
-                  className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 cursor-pointer transition-colors"
-                >
-                  {tr("pages.planning.sidebar.form.showMore", dict, {
-                    count: String(secondary.length),
-                  })}
-                </button>
-              )}
+            {/* "+N more" button to expand collapsed secondary incidencias */}
+            {hasCollapsed && !showAllIncidencias && (
+              <button
+                type="button"
+                onClick={() => setShowAllIncidencias(true)}
+                className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 cursor-pointer transition-colors"
+              >
+                {tr("pages.planning.sidebar.form.showMore", dict, {
+                  count: String(collapsedSecondary.length),
+                })}
+              </button>
+            )}
 
-            {/* "Show less" button when expanded - only if not showing directly */}
-            {!showSecondaryDirectly &&
-              secondary.length > 0 &&
-              showAllIncidencias && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllIncidencias(false)}
-                  className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 cursor-pointer transition-colors"
-                >
-                  {tr("pages.planning.sidebar.form.showLess", dict)}
-                </button>
-              )}
+            {/* "Show less" button when expanded */}
+            {hasCollapsed && showAllIncidencias && (
+              <button
+                type="button"
+                onClick={() => setShowAllIncidencias(false)}
+                className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 cursor-pointer transition-colors"
+              >
+                {tr("pages.planning.sidebar.form.showLess", dict)}
+              </button>
+            )}
           </div>
         </FormSection>
       )}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -13,12 +13,15 @@ import {
 } from "./planning-selection-context";
 import { categorizeIncidencias } from "./incidencias.types";
 import { formatPercent } from "./planning-format";
+import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
 
 // Set Spanish locale for dayjs
 dayjs.locale("es");
 
 export interface ServiceEventProps {
   readonly service: SelectedService;
+  readonly dict: I18nRecord;
   readonly className?: string;
 }
 
@@ -67,7 +70,7 @@ function getOccupancyColor(percentage: number): string {
  * 2. KPIs (Lead Time, Ocupación)
  * 3. Static (Cliente, Origen → Destino)
  */
-export function ServiceEvent({ service, className }: ServiceEventProps) {
+export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
   const { selectedService, selectService } = usePlanningSelection();
 
   const isSelected = selectedService?.id === service.id;
@@ -200,7 +203,9 @@ export function ServiceEvent({ service, className }: ServiceEventProps) {
             {/* Collapsed count for remaining secondary incidencias */}
             {collapsedSecondaryCount > 0 && (
               <span className="text-xs text-gray-500 dark:text-gray-400">
-                (+{collapsedSecondaryCount} más)
+                {tr("pages.planning.sidebar.form.showMore", dict, {
+                  count: String(collapsedSecondaryCount),
+                })}
               </span>
             )}
           </div>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -89,8 +89,14 @@ export function ServiceEvent({ service, className }: ServiceEventProps) {
   // Categorize using the codes - the dictionary will map C307/C309 to their configs
   const { primary, secondary } = categorizeIncidencias(incidentCodes);
   const hasFlags = primary.length > 0 || secondary.length > 0;
-  // Show secondary directly if no primary and 2 or fewer secondary
-  const showSecondaryDirectly = primary.length === 0 && secondary.length <= 2;
+  // Always reserve up to INLINE_BUDGET inline slots: primary first, then top up with secondary.
+  const INLINE_BUDGET = 2;
+  const inlineSecondaryCount = Math.max(
+    0,
+    Math.min(secondary.length, INLINE_BUDGET - primary.length)
+  );
+  const inlineSecondary = secondary.slice(0, inlineSecondaryCount);
+  const collapsedSecondaryCount = secondary.length - inlineSecondaryCount;
 
   const handleClick = () => {
     selectService(service);
@@ -174,28 +180,27 @@ export function ServiceEvent({ service, className }: ServiceEventProps) {
               );
             })}
 
-            {/* Secondary incidencias - shown directly if ≤2 and no primary */}
-            {showSecondaryDirectly &&
-              secondary.map(({ key, config }) => {
-                const tooltip =
-                  codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
-                return (
-                  <Badge
-                    key={key}
-                    className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 cursor-help"
-                    color="gray"
-                    size="xs"
-                    title={tooltip}
-                  >
-                    {config.label}
-                  </Badge>
-                );
-              })}
+            {/* Inline secondary incidencias - always visible */}
+            {inlineSecondary.map(({ key, config }) => {
+              const tooltip =
+                codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
+              return (
+                <Badge
+                  key={key}
+                  className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 cursor-help"
+                  color="gray"
+                  size="xs"
+                  title={tooltip}
+                >
+                  {config.label}
+                </Badge>
+              );
+            })}
 
-            {/* Secondary incidencias count - not clickable, only if not showing directly */}
-            {!showSecondaryDirectly && secondary.length > 0 && (
+            {/* Collapsed count for remaining secondary incidencias */}
+            {collapsedSecondaryCount > 0 && (
               <span className="text-xs text-gray-500 dark:text-gray-400">
-                (+{secondary.length} más)
+                (+{collapsedSecondaryCount} más)
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Replace the `showSecondaryDirectly` boolean (primary===0 && secondary≤2) with an explicit `INLINE_BUDGET = 2`: primary flags fill first, secondary top up the budget, only the remainder is collapsed behind `+N más`.
- Apply the same rule to the calendar service chip (`service-event.tsx`) so its `(+N más)` count reflects only what's truly hidden.

Before: a service with 3 secondary flags and no primary rendered as just `+3 más` with nothing inline (repro: service `1626731-V` in coordinador-prod, flags `C308 / C319 / C320`).

After:
| service | flags | rendered |
|---|---|---|
| 1626731 | 0P, 3S | `[C308] [C319] +1 más` |
| 1626686 | 0P, 2S | `[C308] [C319]` |
| 1627188 | 1P SHUTDOWN, 1S | `[SHUTDOWN] [C308]` |

Closes #391

## Test plan
- [ ] Open the calendar planning sidebar against service `1626731-V` (coordinador-prod) — verify two C308/C319 badges render inline and `+1 más` button reveals C320 when expanded; "show less" collapses again.
- [ ] Verify service `1626686` (0P, 2S) shows both inline with no expand button.
- [ ] Verify service `1627188` (1P SHUTDOWN, 1S) shows `[SHUTDOWN] [C308]` with no `+N más`.
- [ ] Verify the calendar chip (service-event card) shows the same inline + collapsed-count behaviour.
- [ ] Verify a service with no flags still hides the FLAGS section entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated secondary items display in calendar planning to show up to 2 items inline consistently, with remaining items hidden behind expand/collapse controls
  * Refined secondary badge styling with improved visual consistency and hover tooltips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->