### PR TITLE
feat(miot-calendar-client): expose time window color

### DIFF
--- a/turbo-repo/packages/miot-calendar-client/README.md
+++ b/turbo-repo/packages/miot-calendar-client/README.md
@@ -177,6 +177,7 @@ Create a time window within a calendar.
 | `capacity` | `number` | No | `1` | Total number of services this window can handle across all slots |
 | `daysOfWeek` | `string` | No | — | Comma-separated days (1=Mon … 7=Sun) |
 | `active` | `boolean` | No | `true` | Whether the time window is active |
+| `color` | `string` | No | — | UI color token (e.g., `"emerald"`, `"amber"`) |
 
 **Returns:** `TimeWindowResponse`
 

--- a/turbo-repo/packages/miot-calendar-client/openapi.json
+++ b/turbo-repo/packages/miot-calendar-client/openapi.json
@@ -742,6 +742,12 @@
             "type" : "boolean",
             "description" : "Whether the time window is active",
             "default" : true
+          },
+          "color" : {
+            "type" : "string",
+            "examples" : [ "emerald" ],
+            "maxLength" : 32,
+            "description" : "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")"
           }
         }
       },
@@ -813,6 +819,11 @@
           "active" : {
             "type" : "boolean",
             "description" : "Whether the time window is active"
+          },
+          "color" : {
+            "type" : "string",
+            "examples" : [ "emerald" ],
+            "description" : "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")"
           },
           "createdAt" : {
             "$ref" : "#/components/schemas/ZonedDateTime",

--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -103,6 +103,7 @@ export interface TimeWindowRequest {
   daysOfWeek?: string;
   validTo?: string;
   active?: boolean;
+  color?: string;
 }
 
 export interface TimeWindowResponse {
@@ -117,6 +118,7 @@ export interface TimeWindowResponse {
   validFrom: string;
   validTo?: string;
   active: boolean;
+  color?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Closes #395

## Summary

- Add optional `color?: string` to `TimeWindowRequest` and `TimeWindowResponse`
- Mirror the field in `openapi.json` for both schemas
- Document `color` in the `createTimeWindow` body table in the package README
- Bump `@microboxlabs/miot-calendar-client` to `0.7.0`

Phase 2 of the time window color persistence fix. Phase 1 (backend) is in `microboxlabs/miot-calendar` PR [#19](https://github.com/microboxlabs/miot-calendar/pull/19).

The package is consumed by `apps/app` as a workspace dep (`"*"`), so no publish step is needed before Phase 3 (app router schema + frontend mapper) lands.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` — 78 tests pass
- [x] Backend (#19) is deployed before this is merged so the API actually accepts/returns `color`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional color field to time windows for UI color customization (e.g., "emerald").

* **Documentation**
  * Updated API documentation with the new color field specification and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->