### PR TITLE
Fix publish npm setup

### DIFF
--- a/.github/workflows/publish-miot-cli.yaml
+++ b/.github/workflows/publish-miot-cli.yaml
@@ -11,7 +11,7 @@ on:
         required: true
 
 env:
-  NODE_VERSION: "22"
+  NODE_VERSION: "24"
 
 jobs:
   publish:
@@ -33,9 +33,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: turbo-repo/package-lock.json
-
-      - name: Upgrade npm for trusted publishing (requires >= 11.5.1)
-        run: npm install -g npm@latest
 
       - name: Cache node_modules
         id: cache-modules

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -11,7 +11,7 @@ on:
         required: true
 
 env:
-  NODE_VERSION: "22"
+  NODE_VERSION: "24"
 
 jobs:
   publish:
@@ -33,9 +33,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: turbo-repo/package-lock.json
-
-      - name: Upgrade npm for trusted publishing (requires >= 11.5.1)
-        run: npm install -g npm@latest
 
       - name: Cache node_modules
         id: cache-modules


### PR DESCRIPTION
## Summary

- removes the global `npm install -g npm@latest` step from package publish workflows
- runs publish workflows on Node 24 so trusted publishing uses the bundled npm version instead of self-upgrading
- applies the same fix to `publish-npm` and `publish-miot-cli`

## Root cause

The release job failed before install/publish because the hosted Node 22 npm installation could not load `promise-retry` from npm Arborist while trying to upgrade npm globally.

## Validation

- `git diff --check`
- confirmed both workflows no longer contain `npm install -g npm@latest`

Closes #397
