### PR TITLE
fix(calendar): persist time window color end-to-end in app

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
@@ -9,4 +9,5 @@ export const TimeWindowRequestSchema = z.object({
   daysOfWeek: z.string().optional(),
   validTo: z.string().optional(),
   active: z.boolean().optional(),
+  color: z.string().optional(),
 });

--- a/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
@@ -1,6 +1,9 @@
 import type { TimeWindowRequest } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
-import type { TimeSlot } from "../components/planning/planning-selection-context";
+import type {
+  TimeSlot,
+  TimeWindowColor,
+} from "../components/planning/planning-selection-context";
 import dayjs from "dayjs";
 
 export const TimeWindowResponseSchema = z.object({
@@ -18,6 +21,7 @@ export const TimeWindowResponseSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .nullish(),
   active: z.boolean(),
+  color: z.string().nullish(),
 });
 
 type ValidatedTimeWindowResponse = z.infer<typeof TimeWindowResponseSchema>;
@@ -73,6 +77,8 @@ export function apiToLocalTimeWindow(
   const isDailyOverride =
     Boolean(response.validTo) && response.validFrom === response.validTo;
 
+  const color = (response.color as TimeWindowColor | undefined) ?? "emerald";
+
   if (isDailyOverride) {
     const startTs = `${response.validFrom}T${response.startHour.toString().padStart(2, "0")}:00:00`;
     const endTs = `${response.validTo ?? response.validFrom}T${response.endHour.toString().padStart(2, "0")}:00:00`;
@@ -84,7 +90,7 @@ export function apiToLocalTimeWindow(
       startTimestamp: startTs,
       endTimestamp: endTs,
       quota: response.capacity,
-      color: "emerald",
+      color,
     };
   }
 
@@ -102,7 +108,7 @@ export function apiToLocalTimeWindow(
     type: "weekly",
     weeklyPattern,
     quota: response.capacity,
-    color: "emerald",
+    color,
   };
 }
 
@@ -135,6 +141,7 @@ export function localToApiTimeWindow(
       daysOfWeek: String(formatDay),
       capacity: slot.quota ?? 1,
       active: true,
+      color: slot.color,
     };
   }
 
@@ -151,6 +158,7 @@ export function localToApiTimeWindow(
       daysOfWeek: "1,2,3,4,5",
       capacity: slot.quota ?? 1,
       active: true,
+      color: slot.color,
     };
   }
 
@@ -167,5 +175,6 @@ export function localToApiTimeWindow(
     daysOfWeek: days.join(","),
     capacity: slot.quota ?? 1,
     active: true,
+    color: slot.color,
   };
 }


### PR DESCRIPTION
Closes #399

## Summary

Wires the calendar UI's color picker selection through the app's API boundary so the chosen color survives a refresh. Pairs with the backend persistence change (`microboxlabs/miot-calendar` PR [#19](https://github.com/microboxlabs/miot-calendar/pull/19)) and the SDK types update (already merged in [#396](https://github.com/microboxlabs/modulariot/pull/396)).

## Changes

- **Phase 3** — `time-window.schema.ts`: accept `color: z.string().optional()` so inbound requests aren't stripped.
- **Phase 4** — `localToApiTimeWindow`: send `slot.color` on all three return paths (daily-override, weekly, fallback).
- **Phase 5** — `apiToLocalTimeWindow`: read `response.color` and fall back to `"emerald"` only when missing. `TimeWindowResponseSchema` now declares `color: z.string().nullish()` so Zod preserves the field.

## Why one PR

Phases 3-5 are tightly coupled — splitting would create a window where the schema accepts the field but the mapper drops it (or vice versa). The original migration plan in `docs/time-window-color-persistence-plan.md` explicitly recommends bundling them.

## Deploy ordering

1. Backend (#19) must be deployed first — until then the API rejects the field. ✋
2. SDK (#396) is already merged.
3. This PR can land after the backend is deployed to production.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Create a time window with a non-default color (e.g. `amber`); refresh; color persists
- [x] Edit the window to a different color; refresh; color persists
- [x] Pre-migration row (or a row with `color: null`) renders as `emerald` via the existing fallback in `planning-slot-utils.ts:54`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time windows can now be assigned custom colors for better visual organization and identification in the calendar. Default colors are automatically applied for consistency when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->