### PR TITLE
feat(miot-calendar-client): expose TimeWindow `kind` (WINDOW vs BLOCK)

### DIFF
--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/calendars.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/calendars.test.ts
@@ -33,6 +33,7 @@ const sampleTimeWindow: TimeWindowResponse = {
   daysOfWeek: "MON,TUE,WED,THU,FRI",
   validFrom: "2025-01-01",
   active: true,
+  kind: "WINDOW",
   createdAt: "2025-01-01T00:00:00Z",
   updatedAt: "2025-01-01T00:00:00Z",
 };
@@ -194,6 +195,29 @@ describe("calendars", () => {
         `${BASE_URL}${CALENDARS_PATH}/cal-1/time-windows`,
       );
       expect(call.init.body).toBe(JSON.stringify(twRequest));
+    });
+
+    it("forwards kind=BLOCK and surfaces it on the response", async () => {
+      const blockRequest: TimeWindowRequest = {
+        name: "Maintenance",
+        startHour: 10,
+        endHour: 12,
+        validFrom: "2025-01-01",
+        kind: "BLOCK",
+      };
+      const blockResponse: TimeWindowResponse = {
+        ...sampleTimeWindow,
+        capacity: 0,
+        kind: "BLOCK",
+      };
+      const { fn, call } = createMockFetch(blockResponse);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.calendars.createTimeWindow("cal-1", blockRequest);
+
+      expect(call.init.body).toBe(JSON.stringify(blockRequest));
+      expect(result.kind).toBe("BLOCK");
+      expect(result.capacity).toBe(0);
     });
   });
 

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -12,6 +12,7 @@ export type {
   CalendarFilter,
   CalendarRequest,
   CalendarResponse,
+  TimeWindowKind,
   TimeWindowRequest,
   TimeWindowResponse,
   GenerateSlotsRequest,

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -94,6 +94,16 @@ export interface CalendarResponse {
 
 // --- Time Windows ---
 
+/**
+ * Discriminator for a time window.
+ *
+ * - `WINDOW` — bookable period with a capacity quota (the historical default).
+ * - `BLOCK`  — non-bookable period (holiday, maintenance, manual closure);
+ *   slot generation produces CLOSED slots so the planning UI can paint them
+ *   and the backend rejects bookings against them.
+ */
+export type TimeWindowKind = "WINDOW" | "BLOCK";
+
 export interface TimeWindowRequest {
   name: string;
   startHour: number;
@@ -104,6 +114,8 @@ export interface TimeWindowRequest {
   validTo?: string;
   active?: boolean;
   color?: string;
+  /** Defaults to `WINDOW` server-side when omitted. */
+  kind?: TimeWindowKind;
 }
 
 export interface TimeWindowResponse {
@@ -119,6 +131,7 @@ export interface TimeWindowResponse {
   validTo?: string;
   active: boolean;
   color?: string;
+  kind: TimeWindowKind;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- Adds `TimeWindowKind = "WINDOW" | "BLOCK"` to the `@microboxlabs/miot-calendar-client` types and surfaces it on `TimeWindowRequest` (optional; backend defaults to `WINDOW`) and `TimeWindowResponse` (required).
- Re-exports the new type from the package entry point.
- Bumps to **0.8.0** — additive only, no breaking semantics.

## Why

Phase 2 of the temporal-blockade persistence work. Phase 1 (microboxlabs/miot-calendar#21) added the backend `kind` discriminator so blocks emit `CLOSED` slots. This phase exposes that field on the TS client so Phase 3 (the `apps/app` planning UI) can stop dropping blocks on reload.

## Out of scope

- `apps/app` wiring (`time-window.service.ts`, `planning-selection-context.tsx`) — separate issue.
- npm publish — happens via the existing `publish-npm` workflow on tag push.

## Test plan

- [x] `npm test` → 79/79 pass (added a `BLOCK` round-trip case in `calendars.test.ts`).
- [x] `npm run build` → `dist/index.d.ts` exports `TimeWindowKind` and the updated request/response types.
- [x] Tag + publish 0.8.0 once this lands so Phase 3 can consume it.

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time windows now include a `kind` field to distinguish between bookable windows and non-bookable blocks.

* **Tests**
  * Added test coverage for time window requests and responses with kind validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->