### PR TITLE
feat(calendar): persist temporal blockades end-to-end

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/time-windows/time-window.schema.ts
@@ -10,4 +10,5 @@ export const TimeWindowRequestSchema = z.object({
   validTo: z.string().optional(),
   active: z.boolean().optional(),
   color: z.string().optional(),
+  kind: z.enum(["WINDOW", "BLOCK"]).optional(),
 });

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -1177,13 +1177,12 @@ export function PlanningSelectionProvider({
     [calendarId]
   );
 
-  /** Create or update local window slots against the API; returns error strings. */
-  const saveLocalWindows = useCallback(
+  /** Create or update local slots (windows AND blocks) against the API; returns error strings. */
+  const saveLocalSlots = useCallback(
     async (slots: TimeSlot[], currentIds: Set<string>): Promise<string[]> => {
       if (!calendarId) return [];
       const errors: string[] = [];
       for (const slot of slots) {
-        if (slot.kind !== "window") continue; // blocks are local-only
         try {
           const body = localToApiTimeWindow(slot);
           if (currentIds.has(slot.id)) {
@@ -1213,13 +1212,13 @@ export function PlanningSelectionProvider({
 
       const currentApiWindows = apiTimeWindows;
       const currentIds = new Set(currentApiWindows.map((w) => w.id));
-      const newWindowIds = new Set(
-        slots.filter((s) => s.kind === "window").map((s) => s.id)
-      );
+      // Both kinds round-trip through the API now; track every local id so
+      // we don't deactivate a block that's still present.
+      const newSlotIds = new Set(slots.map((s) => s.id));
 
       const [deactivateErrors, saveErrors] = await Promise.all([
-        deactivateRemovedWindows(currentApiWindows, newWindowIds),
-        saveLocalWindows(slots, currentIds),
+        deactivateRemovedWindows(currentApiWindows, newSlotIds),
+        saveLocalSlots(slots, currentIds),
       ]);
 
       // Reload from API to replace temp IDs with real server IDs
@@ -1235,7 +1234,7 @@ export function PlanningSelectionProvider({
       apiTimeWindows,
       refreshTimeWindows,
       deactivateRemovedWindows,
-      saveLocalWindows,
+      saveLocalSlots,
     ]
   );
 

--- a/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
@@ -22,6 +22,9 @@ export const TimeWindowResponseSchema = z.object({
     .nullish(),
   active: z.boolean(),
   color: z.string().nullish(),
+  // Defaulted server-side to WINDOW; older deployments that haven't shipped
+  // the discriminator yet are tolerated via the default.
+  kind: z.enum(["WINDOW", "BLOCK"]).default("WINDOW"),
 });
 
 type ValidatedTimeWindowResponse = z.infer<typeof TimeWindowResponseSchema>;
@@ -70,6 +73,9 @@ function hourToHHMM(hour: number): string {
  * Convention:
  *  - If validFrom === validTo → "daily-override" (specific-date window)
  *  - Otherwise              → "weekly" (recurring weekly pattern)
+ *
+ * The API `kind` (WINDOW | BLOCK) maps directly to the local discriminant
+ * (window | block); BLOCK rows carry capacity = 0 from the backend.
  */
 export function apiToLocalTimeWindow(
   response: ValidatedTimeWindowResponse
@@ -78,6 +84,7 @@ export function apiToLocalTimeWindow(
     Boolean(response.validTo) && response.validFrom === response.validTo;
 
   const color = (response.color as TimeWindowColor | undefined) ?? "emerald";
+  const localKind = response.kind === "BLOCK" ? "block" : "window";
 
   if (isDailyOverride) {
     const startTs = `${response.validFrom}T${response.startHour.toString().padStart(2, "0")}:00:00`;
@@ -85,7 +92,7 @@ export function apiToLocalTimeWindow(
     return {
       id: response.id,
       name: response.name,
-      kind: "window",
+      kind: localKind,
       type: "daily-override",
       startTimestamp: startTs,
       endTimestamp: endTs,
@@ -104,7 +111,7 @@ export function apiToLocalTimeWindow(
   return {
     id: response.id,
     name: response.name,
-    kind: "window",
+    kind: localKind,
     type: "weekly",
     weeklyPattern,
     quota: response.capacity,
@@ -123,6 +130,11 @@ export function localToApiTimeWindow(
   slot: TimeSlot,
   validFrom?: string
 ): TimeWindowRequest {
+  const apiKind = slot.kind === "block" ? "BLOCK" : "WINDOW";
+  // Blocks have no quota — the backend ignores capacity for BLOCK rows but
+  // requires a non-negative number; send 0 explicitly.
+  const capacity = slot.kind === "block" ? 0 : slot.quota ?? 1;
+
   if (slot.type === "daily-override") {
     const start = slot.startTimestamp ? dayjs(slot.startTimestamp) : dayjs();
     const end = slot.endTimestamp
@@ -139,9 +151,10 @@ export function localToApiTimeWindow(
       validFrom: dateStr,
       validTo: dateStr,
       daysOfWeek: String(formatDay),
-      capacity: slot.quota ?? 1,
+      capacity,
       active: true,
       color: slot.color,
+      kind: apiKind,
     };
   }
 
@@ -156,9 +169,10 @@ export function localToApiTimeWindow(
       endHour: 17,
       validFrom: validFrom ?? dayjs().format("YYYY-MM-DD"),
       daysOfWeek: "1,2,3,4,5",
-      capacity: slot.quota ?? 1,
+      capacity,
       active: true,
       color: slot.color,
+      kind: apiKind,
     };
   }
 
@@ -173,8 +187,9 @@ export function localToApiTimeWindow(
     endHour,
     validFrom: validFrom ?? dayjs().format("YYYY-MM-DD"),
     daysOfWeek: days.join(","),
-    capacity: slot.quota ?? 1,
+    capacity,
     active: true,
     color: slot.color,
+    kind: apiKind,
   };
 }


### PR DESCRIPTION
## Summary

Phase 3 of the temporal-blockade persistence work. Wires the planning UI so user-created blocks survive a reload.

- Next.js API schema accepts `kind: "WINDOW" | "BLOCK"`.
- `localToApiTimeWindow` writes `kind` (and `capacity=0` for blocks); `apiToLocalTimeWindow` reads it back into the local discriminant.
- `planning-selection-context.tsx` stops dropping blocks in the per-slot save loop, and the deactivation guard tracks both kinds.

## Stack (all merged before this lands)

- Phase 1 (backend): microboxlabs/miot-calendar#21 ✅
- Phase 2 (client types `kind` + 0.8.0): #403 ✅
- Phase 3 (frontend wiring): this PR

## Test plan

- [x] `npx tsc --noEmit -p .` in `apps/app` is clean.
- [x] Manual: create a temporal blockade in the planning UI, click Apply, hard reload — the block stays.
- [x] Manual: try to book a service over the blocked range — backend returns 409 / surface as a slot-closed error.
- [x] Manual: delete a block in the UI, confirm it's removed on the server (deactivated).

Closes #404