### PR TITLE
Document calendar client 0.8 capabilities

### DIFF
--- a/turbo-repo/apps/docs/content/en/reference/changelog.mdx
+++ b/turbo-repo/apps/docs/content/en/reference/changelog.mdx
@@ -21,6 +21,48 @@ Features and improvements in development:
 
 ## Recent Releases
 
+### `miot-calendar-client` v0.8.0 — Time Window Blocks (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Adds typed support for distinguishing normal bookable time windows from non-bookable blocks.
+
+**Updated — `client.calendars`:**
+- `calendars.createTimeWindow()` and `calendars.updateTimeWindow()` accept `TimeWindowRequest.kind?: TimeWindowKind` — use `WINDOW` for bookable capacity or `BLOCK` for closures
+- `TimeWindowResponse.kind: TimeWindowKind` — responses now identify whether each time window is a bookable window or a block
+
+**New types exported:** `TimeWindowKind`
+
+---
+
+### `miot-calendar-client` v0.7.0 — Time Window Colors (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Adds a time-window color field so planning UIs can persist and render calendar color selections through the API.
+
+**Updated — `client.calendars`:**
+- `TimeWindowRequest.color?: string` — optional UI color token when creating or updating a time window
+- `TimeWindowResponse.color?: string` — optional UI color token returned with time-window data
+
+---
+
+### `miot-calendar-client` v0.6.0 — Calendar Task Filters (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Adds calendar-level task filters and exposes SlotManager provisioning metadata for calendar configuration screens.
+
+**Updated — `client.calendars`:**
+- `CalendarRequest.filter?: CalendarFilter` — persist task filters such as `origin` and `destination` on a calendar
+- `CalendarRequest.autoSlotManager?: boolean` — request default SlotManager provisioning when creating a calendar
+- `CalendarResponse.filter?: CalendarFilter` — read the persisted task filter from calendar responses
+- `CalendarResponse.hasSlotManager?: boolean` — check whether a calendar has a SlotManager provisioned
+
+**New types exported:** `CalendarFilter`
+
+---
+
 ### `miot-calendar-client` v0.3.0 — Slot Managers (2026-02-20)
 
 **`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)

--- a/turbo-repo/apps/docs/content/en/reference/sdks/miot-calendar-client.mdx
+++ b/turbo-repo/apps/docs/content/en/reference/sdks/miot-calendar-client.mdx
@@ -61,13 +61,13 @@ const booking = await client.bookings.create({
 ## Features
 
 ### Calendars
-Create and manage calendars with timezone support. Each calendar groups time windows, slots, and bookings. Optionally assign calendars to one or more groups via the `groups` field on create or update.
+Create and manage calendars with timezone support. Each calendar groups time windows, slots, and bookings. Optionally assign calendars to one or more groups via the `groups` field, persist task filters such as `origin` and `destination` with `filter`, and inspect whether a SlotManager has been provisioned with `hasSlotManager`.
 
 ### Calendar Groups
 Organize calendars into named groups with `client.groups`. Filter calendar lists by `groupCode`, and read which groups a calendar belongs to from `CalendarResponse.groups`.
 
 ### Time Windows
-Define recurring availability windows — specify hours, days of week, slot duration, and capacity per slot.
+Define recurring availability windows with hours, days of week, capacity, and UI color tokens. Time windows can also be marked as `WINDOW` for bookable capacity or `BLOCK` for non-bookable closures such as holidays, maintenance, or manual downtime.
 
 ### Slots
 Generate slots automatically from time windows, or manage them individually. Filter by availability, date range, and calendar.

--- a/turbo-repo/apps/docs/content/es/reference/changelog.mdx
+++ b/turbo-repo/apps/docs/content/es/reference/changelog.mdx
@@ -21,6 +21,48 @@ Features and improvements in development:
 
 ## Lanzamientos Recientes
 
+### `miot-calendar-client` v0.8.0 — Bloqueos de ventanas horarias (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Agrega soporte tipado para distinguir ventanas horarias reservables de bloqueos no reservables.
+
+**Actualizado — `client.calendars`:**
+- `calendars.createTimeWindow()` y `calendars.updateTimeWindow()` aceptan `TimeWindowRequest.kind?: TimeWindowKind` — usa `WINDOW` para capacidad reservable o `BLOCK` para cierres
+- `TimeWindowResponse.kind: TimeWindowKind` — las respuestas ahora identifican si cada ventana horaria es reservable o un bloqueo
+
+**Nuevos tipos exportados:** `TimeWindowKind`
+
+---
+
+### `miot-calendar-client` v0.7.0 — Colores de ventanas horarias (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Agrega un campo de color para que las interfaces de planificación puedan persistir y renderizar selecciones de color del calendario a través de la API.
+
+**Actualizado — `client.calendars`:**
+- `TimeWindowRequest.color?: string` — token opcional de color de UI al crear o actualizar una ventana horaria
+- `TimeWindowResponse.color?: string` — token opcional de color de UI retornado con los datos de la ventana horaria
+
+---
+
+### `miot-calendar-client` v0.6.0 — Filtros de tareas por calendario (2026-05-02)
+
+**`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)
+
+Agrega filtros de tareas a nivel de calendario y expone metadatos de provisionamiento de SlotManager para pantallas de configuración.
+
+**Actualizado — `client.calendars`:**
+- `CalendarRequest.filter?: CalendarFilter` — persiste filtros de tareas como `origin` y `destination` en un calendario
+- `CalendarRequest.autoSlotManager?: boolean` — solicita provisionamiento de SlotManager por defecto al crear un calendario
+- `CalendarResponse.filter?: CalendarFilter` — lee el filtro de tareas persistido desde las respuestas de calendario
+- `CalendarResponse.hasSlotManager?: boolean` — consulta si un calendario tiene un SlotManager provisionado
+
+**Nuevos tipos exportados:** `CalendarFilter`
+
+---
+
 ### `miot-calendar-client` v0.3.0 — Gestores de Slots (2026-02-20)
 
 **`@microboxlabs/miot-calendar-client`** — [npm](https://www.npmjs.com/package/@microboxlabs/miot-calendar-client) | [GitHub](https://github.com/microboxlabs/modulariot/tree/trunk/packages/miot-calendar-client)

--- a/turbo-repo/apps/docs/content/es/reference/sdks/miot-calendar-client.mdx
+++ b/turbo-repo/apps/docs/content/es/reference/sdks/miot-calendar-client.mdx
@@ -61,13 +61,13 @@ const booking = await client.bookings.create({
 ## Funcionalidades
 
 ### Calendarios
-Crea y gestiona calendarios con soporte de zona horaria. Cada calendario agrupa ventanas horarias, slots y reservas. Opcionalmente, asigna calendarios a uno o más grupos mediante el campo `groups` al crear o actualizar.
+Crea y gestiona calendarios con soporte de zona horaria. Cada calendario agrupa ventanas horarias, slots y reservas. Opcionalmente, asigna calendarios a uno o más grupos mediante `groups`, persiste filtros de tareas como `origin` y `destination` con `filter`, y consulta si tiene un SlotManager provisionado mediante `hasSlotManager`.
 
 ### Grupos de calendarios
 Organiza calendarios en grupos con nombre mediante `client.groups`. Filtra listas de calendarios por `groupCode`, y consulta a qué grupos pertenece un calendario desde `CalendarResponse.groups`.
 
 ### Ventanas horarias
-Define ventanas de disponibilidad recurrentes — especifica horas, días de la semana, duración del slot y capacidad por slot.
+Define ventanas de disponibilidad recurrentes con horas, días de la semana, capacidad y tokens de color para la UI. Las ventanas también pueden marcarse como `WINDOW` para capacidad reservable o `BLOCK` para cierres no reservables como feriados, mantención o bloqueos manuales.
 
 ### Slots
 Genera slots automáticamente a partir de ventanas horarias, o gestiónales individualmente. Filtra por disponibilidad, rango de fechas y calendario.

--- a/turbo-repo/packages/miot-calendar-client/README.md
+++ b/turbo-repo/packages/miot-calendar-client/README.md
@@ -123,6 +123,7 @@ Create a new calendar.
 | `parallelism` | `number` | No | `1` | Parallel resources per slot (e.g. loading docks) |
 | `groups` | `string[]` | No | — | Group codes to assign. `null` = no change; `[]` = remove all; `["code"]` = replace all |
 | `filter` | [`CalendarFilter`](#calendarfilter) | No | — | Task filter map (`origin?`, `destination?`). `null` = no change; `{}` = clear; populated = replace |
+| `autoSlotManager` | `boolean` | No | `true` | Auto-provision a default SlotManager when the calendar is created |
 
 **Returns:** `CalendarResponse`
 
@@ -153,6 +154,8 @@ Deactivate a calendar (soft delete).
 
 Time windows are managed through the `calendars` namespace.
 
+Time windows can be normal bookable windows or non-bookable blocks. `kind: "WINDOW"` is the historical default and generates bookable capacity. `kind: "BLOCK"` represents closures such as holidays, maintenance, or manual downtime; slot generation creates closed slots and the backend rejects bookings against them.
+
 #### `calendars.listTimeWindows(calendarId)`
 
 List all time windows for a calendar.
@@ -178,6 +181,7 @@ Create a time window within a calendar.
 | `daysOfWeek` | `string` | No | — | Comma-separated days (1=Mon … 7=Sun) |
 | `active` | `boolean` | No | `true` | Whether the time window is active |
 | `color` | `string` | No | — | UI color token (e.g., `"emerald"`, `"amber"`) |
+| `kind` | [`TimeWindowKind`](#timewindowkind) | No | `"WINDOW"` | Whether this is a bookable window or a non-bookable block |
 
 **Returns:** `TimeWindowResponse`
 
@@ -532,6 +536,7 @@ interface CalendarRequest {
   parallelism?: number;   // Parallel resources per slot (default: 1, e.g. loading docks)
   groups?: string[];      // Group codes to assign. null = no change; [] = remove all; ["code"] = replace all
   filter?: CalendarFilter; // Optional task filter. null = no change; {} = clear; populated = replace
+  autoSlotManager?: boolean; // Auto-provision a default SlotManager on create (default: true)
 }
 ```
 
@@ -561,8 +566,18 @@ interface CalendarResponse {
   updatedAt: string;                   // ISO 8601
   groups?: CalendarGroupResponse[];    // Groups this calendar belongs to
   filter?: CalendarFilter;             // Optional task filter (origin / destination delegate codes)
+  hasSlotManager?: boolean;            // Whether this calendar has a SlotManager provisioned
 }
 ```
+
+### `TimeWindowKind`
+
+```ts
+type TimeWindowKind = "WINDOW" | "BLOCK";
+```
+
+- `WINDOW` — bookable period with a capacity quota.
+- `BLOCK` — non-bookable period such as a holiday, maintenance window, or manual closure. Slot generation produces `CLOSED` slots for blocks.
 
 ### `TimeWindowRequest`
 
@@ -576,6 +591,8 @@ interface TimeWindowRequest {
   capacity?: number;            // Default: 1 — total services this window can handle
   daysOfWeek?: string;          // Comma-separated: "1,2,3,4,5" (1=Mon, 7=Sun)
   active?: boolean;             // Default: true
+  color?: string;               // UI color token, e.g. "emerald" or "amber"
+  kind?: TimeWindowKind;        // Default: "WINDOW"; use "BLOCK" for non-bookable periods
 }
 ```
 
@@ -594,6 +611,8 @@ interface TimeWindowResponse {
   validFrom: string;
   validTo?: string;
   active: boolean;              // Always present (default: true)
+  color?: string;               // UI color token
+  kind: TimeWindowKind;         // "WINDOW" or "BLOCK"
   createdAt: string;            // ISO 8601
   updatedAt: string;            // ISO 8601
 }

--- a/turbo-repo/packages/miot-calendar-client/openapi.json
+++ b/turbo-repo/packages/miot-calendar-client/openapi.json
@@ -748,12 +748,22 @@
             "examples" : [ "emerald" ],
             "maxLength" : 32,
             "description" : "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")"
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/TimeWindowKind",
+            "description" : "Whether this time window is bookable capacity (WINDOW) or a non-bookable closure (BLOCK)",
+            "default" : "WINDOW"
           }
         }
       },
+      "TimeWindowKind" : {
+        "type" : "string",
+        "enum" : [ "WINDOW", "BLOCK" ],
+        "description" : "Discriminator for time-window behavior. WINDOW creates bookable capacity; BLOCK creates non-bookable closed slots."
+      },
       "TimeWindowResponse" : {
         "type" : "object",
-        "required" : [ "id", "calendarId", "name", "startHour", "endHour", "slotDurationMinutes", "capacity", "daysOfWeek", "validFrom", "active", "createdAt", "updatedAt" ],
+        "required" : [ "id", "calendarId", "name", "startHour", "endHour", "slotDurationMinutes", "capacity", "daysOfWeek", "validFrom", "active", "kind", "createdAt", "updatedAt" ],
         "description" : "Time window data returned by the API",
         "properties" : {
           "id" : {
@@ -824,6 +834,10 @@
             "type" : "string",
             "examples" : [ "emerald" ],
             "description" : "UI color token for displaying this time window (e.g., \"emerald\", \"amber\")"
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/TimeWindowKind",
+            "description" : "Whether this time window is bookable capacity (WINDOW) or a non-bookable closure (BLOCK)"
           },
           "createdAt" : {
             "$ref" : "#/components/schemas/ZonedDateTime",


### PR DESCRIPTION
## Summary

- updates the miot-calendar-client README for calendar filters, SlotManager provisioning metadata, time-window color, and `TimeWindowKind`
- updates EN/ES docs app SDK summaries with the new calendar planning capabilities
- adds EN/ES changelog entries for `miot-calendar-client` v0.6.0, v0.7.0, and v0.8.0
- syncs the package OpenAPI reference with the `kind` field and `TimeWindowKind` schema

## Validation

- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('turbo-repo/packages/miot-calendar-client/openapi.json', 'utf8'))"`
- `npm run check-types --workspace=apps/docs`
- `npm run lint --workspace=apps/docs` (passes with one existing warning in `apps/docs/app/api/downloads/postman/route.ts`)

Closes #406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for calendar client versions (v0.8.0–v0.6.0) with new features and API updates
  * Enhanced feature documentation covering timezone support, task filtering, and time window capabilities

* **New Features**
  * Time windows can now be classified as bookable slots or non-bookable closures
  * Added optional color customization and task filtering for calendar management
  * Added slot manager auto-provisioning and detection capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->