### PR TITLE
fix(calendar): revert task to planService on Eliminar Planificación

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -1034,19 +1034,20 @@ export function PlanningSelectionProvider({
     refresh: refreshSlots,
   } = useCalendarSlots(calendarId ?? null, selectedDateStr);
 
-  // Live workflow index for this calendar's services. Fetched calendar-wide
-  // (no search filters — those are sidebar-display concerns) so any consumer
-  // that needs to act on a service's *current* Alfresco task can resolve it
-  // by `mintral_serviceCode`. The booking never persists `taskId` because
-  // Alfresco mints a new task per workflow stage, so a stored id goes stale
-  // the instant the workflow advances; this index is the single source of
-  // truth for "which task represents service X right now".
+  // Live workflow index for the user's active services. Intentionally
+  // *not* scoped by calendarId — the kanban API switches to
+  // `getUnbookedTasks` when calendarId is present, which excludes already-
+  // planned services and would make `getLiveTask` return undefined for any
+  // service the user is reassigning or removing. This index is keyed by
+  // `mintral_serviceCode` (unique across calendars), so the wider fetch is
+  // safe. Booking never persists `taskId` because Alfresco mints a new
+  // task per workflow stage; this is the single source of truth for "which
+  // Alfresco task represents service X right now".
   const { data: liveTasksData, refresh: refreshLiveTasks } = useMyTasks(
     ["planService", "assignDriver", "presentDriver", "prepareService", "missionControl"],
     false,
     1,
-    100,
-    calendarId ? `calendarId=${calendarId}` : undefined
+    500
   );
 
   const serviceCodeToLiveTask = useMemo<

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -34,7 +34,10 @@ import { parseUrlDate } from "@/features/calendar/services/calendar.service";
 import type { SlotResponse } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
-import { getNextTransition } from "@/features/calendar/services/task-stage-transitions";
+import {
+  getNextTransition,
+  UNPLAN_TRANSITION,
+} from "@/features/calendar/services/task-stage-transitions";
 import { ShowNotification } from "@/features/notifications/notification";
 import {
   apiToLocalTimeWindow,
@@ -1583,6 +1586,16 @@ export function PlanningSelectionProvider({
    */
   const removeService = useCallback(
     async (serviceId: string) => {
+      // Move the workflow task back to planService BEFORE cancelling the
+      // booking. If the transition fails (e.g. task in a stage that doesn't
+      // expose this transition), bail out so the calendar still shows the
+      // service and the user can retry — mirrors the consistency guarantee
+      // the bookings POST gives on the forward direction.
+      const planned = plannedServices.find((p) => p.service.id === serviceId);
+      if (planned?.service.taskId) {
+        await advanceWorkflowTask(planned.service.taskId, UNPLAN_TRANSITION);
+      }
+
       // Cancel the booking in the calendar backend
       const bookingId = bookingIds.get(serviceId);
       if (bookingId) {
@@ -1604,7 +1617,7 @@ export function PlanningSelectionProvider({
       // Bump version so the service list re-fetches (including newly unbooked)
       setBookingVersion((v) => v + 1);
     },
-    [bookingIds]
+    [bookingIds, plannedServices]
   );
 
   /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -20,6 +20,7 @@ import {
   useCalendarTimeWindows,
   useCalendarSlots,
   useCalendars,
+  useMyTasks,
   createCalendarTimeWindow,
   updateCalendarTimeWindow,
   deactivateCalendarTimeWindow,
@@ -35,8 +36,9 @@ import type { SlotResponse } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
 import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
 import {
+  asTaskStageFromColumn,
   getNextTransition,
-  UNPLAN_TRANSITION,
+  getUnplanTransition,
 } from "@/features/calendar/services/task-stage-transitions";
 import { ShowNotification } from "@/features/notifications/notification";
 import {
@@ -560,8 +562,13 @@ export const TEST_SERVICE: SelectedService = TEST_SERVICES[0];
  */
 export interface SelectedService {
   id: string;
-  /** Alfresco workflow task id used for task formprocessor updates. */
-  taskId?: string;
+  /**
+   * Stable business id for the service (e.g. "1626876"). Mirrors
+   * `mintral_serviceCode` from Alfresco; the only key that survives every
+   * workflow stage advance, so use it — never `taskId` or `id` — when
+   * resolving the live workflow task for a planned service.
+   */
+  mintral_serviceCode?: string;
   cliente: string;
   mintral_clientRut?: string;
   mintral_delegacionOrigen?: string;
@@ -600,12 +607,6 @@ export interface SelectedService {
   assignedTruck?: string;
   /** Assigned trailer id — placeholder until the trailer feed is wired. */
   assignedTrailer?: string;
-  /**
-   * Kanban column the task came from — used to pick the workflow transition
-   * when the user plans or assigns the service. Ephemeral; re-derived from
-   * the live kanban each fetch and not persisted on the booking.
-   */
-  currentStage?: TaskStage;
 }
 
 export type TaskStage =
@@ -648,13 +649,14 @@ async function cancelBookingWithWarning(
 
 async function syncServiceCategoryWithWorkflow(
   service: SelectedService,
-  bookingId: string
+  bookingId: string,
+  liveTaskId: string | undefined
 ): Promise<void> {
   if (!service.serviceCategory) {
     return;
   }
 
-  if (!service.taskId) {
+  if (!liveTaskId) {
     await cancelBookingWithWarning(
       bookingId,
       "Failed to cancel booking after missing task id:"
@@ -663,7 +665,7 @@ async function syncServiceCategoryWithWorkflow(
   }
 
   try {
-    await updateServiceCategory(service.taskId, service.serviceCategory);
+    await updateServiceCategory(liveTaskId, service.serviceCategory);
   } catch (err) {
     await cancelBookingWithWarning(
       bookingId,
@@ -680,9 +682,16 @@ interface PersistPlannedBookingParams {
   oldBookingId?: string;
   originalPlannedService: PlannedService | null;
   /**
-   * When set, the bookings POST also runs an Alfresco task transition. The
-   * server compensates (cancels the just-created booking) if the transition
-   * fails.
+   * Live Alfresco task id for the service at the moment the user confirmed,
+   * resolved from the kanban — never the booking — so it always points at
+   * the task currently representing this service. Undefined when the
+   * service has no active workflow task (rare; means the workflow finished
+   * before the user clicked Confirm).
+   */
+  liveTaskId: string | undefined;
+  /**
+   * When set, the workflow task is advanced after the booking is written
+   * (and after the service-category sync, when applicable).
    */
   taskAdvance?: BookingTaskAdvance;
   setBookingIds: Dispatch<SetStateAction<Map<string, string>>>;
@@ -734,6 +743,7 @@ async function persistPlannedBooking({
   slot,
   oldBookingId,
   originalPlannedService,
+  liveTaskId,
   taskAdvance,
   setBookingIds,
   setBookingVersion,
@@ -748,7 +758,7 @@ async function persistPlannedBooking({
     const booking = await createBooking(
       buildBookingRequest(calendarId, service, slot)
     );
-    await syncServiceCategoryWithWorkflow(service, booking.id);
+    await syncServiceCategoryWithWorkflow(service, booking.id, liveTaskId);
     if (taskAdvance) {
       await advanceWorkflowTask(taskAdvance.taskId, taskAdvance.transitionId);
     }
@@ -873,6 +883,16 @@ interface PlanningSelectionContextType {
   refreshSlots: () => void;
   /** Counter that increments after each booking change — use to trigger service list refresh */
   bookingVersion: number;
+  /**
+   * Resolve the *live* Alfresco task representing a service. Looks up by
+   * `mintral_serviceCode` against the kanban index — never trust a stored
+   * taskId, which goes stale the instant the workflow advances. Returns
+   * undefined when no active task exists for the service (e.g. the
+   * workflow finished).
+   */
+  getLiveTask: (
+    serviceCode: string | undefined
+  ) => { taskId: string; stage: TaskStage } | undefined;
 }
 
 const MAX_SERVICES_PER_SLOT = 99;
@@ -886,7 +906,13 @@ const StoredServiceSchema = z
   .object({
     mintral_clientRut: z.string().optional(),
     mintral_delegacionOrigen: z.string().optional(),
-    taskId: z.string().optional(),
+    /**
+     * Stable business id for the service. Persisted because `resource.id`
+     * is a derived display label (`${code}-${type}`) whose format is owed
+     * to the kanban transform — keeping the raw code lets the live task
+     * lookup work without parsing strings.
+     */
+    mintral_serviceCode: z.string().optional(),
     origen: z.string().optional(),
     lugarCarguio: z.string().optional(),
     destino: z.string().optional(),
@@ -1008,6 +1034,52 @@ export function PlanningSelectionProvider({
     refresh: refreshSlots,
   } = useCalendarSlots(calendarId ?? null, selectedDateStr);
 
+  // Live workflow index for this calendar's services. Fetched calendar-wide
+  // (no search filters — those are sidebar-display concerns) so any consumer
+  // that needs to act on a service's *current* Alfresco task can resolve it
+  // by `mintral_serviceCode`. The booking never persists `taskId` because
+  // Alfresco mints a new task per workflow stage, so a stored id goes stale
+  // the instant the workflow advances; this index is the single source of
+  // truth for "which task represents service X right now".
+  const { data: liveTasksData, refresh: refreshLiveTasks } = useMyTasks(
+    ["planService", "assignDriver", "presentDriver", "prepareService", "missionControl"],
+    false,
+    1,
+    100,
+    calendarId ? `calendarId=${calendarId}` : undefined
+  );
+
+  const serviceCodeToLiveTask = useMemo<
+    Map<string, { taskId: string; stage: TaskStage }>
+  >(() => {
+    const map = new Map<string, { taskId: string; stage: TaskStage }>();
+    if (!liveTasksData?.data) return map;
+    for (const [columnKey, board] of Object.entries(liveTasksData.data)) {
+      const stage = asTaskStageFromColumn(columnKey);
+      if (!stage) continue;
+      for (const task of board.tasks) {
+        const code = task.mintral_serviceCode;
+        if (code) map.set(code, { taskId: task.id, stage });
+      }
+    }
+    return map;
+  }, [liveTasksData]);
+
+  const getLiveTask = useCallback(
+    (serviceCode: string | undefined) =>
+      serviceCode ? serviceCodeToLiveTask.get(serviceCode) : undefined,
+    [serviceCodeToLiveTask]
+  );
+
+  // Re-fetch the live workflow index whenever a booking is created or
+  // removed — the workflow advance that ran alongside it likely changed
+  // each affected service's stage and task id.
+  useEffect(() => {
+    if (bookingVersion > 0) {
+      refreshLiveTasks();
+    }
+  }, [bookingVersion, refreshLiveTasks]);
+
   // Sync time windows from API to local state (only when there's no error)
   useEffect(() => {
     if (timeSlotsError) return;
@@ -1100,6 +1172,13 @@ export function PlanningSelectionProvider({
             // Canonical booking fields always win over stored data
             id: booking.resource.id,
             cliente: booking.resource.label ?? booking.resource.id,
+            // Bookings written before mintral_serviceCode was persisted only
+            // have the kanban-derived `${code}-${type}` resource id. Recover
+            // the code from the prefix so the live-task lookup still works
+            // on legacy bookings.
+            mintral_serviceCode:
+              storedService.mintral_serviceCode ??
+              booking.resource.id.split("-")[0],
           };
 
           loaded.push({
@@ -1517,15 +1596,21 @@ export function PlanningSelectionProvider({
         return updated;
       });
 
+      // Resolve the *current* Alfresco task for this service. We never trust
+      // a stored taskId — Alfresco mints a new task on every workflow stage
+      // advance, so the only safe lookup is by `mintral_serviceCode` against
+      // the live kanban index.
+      const liveTask = getLiveTask(effectiveService.mintral_serviceCode);
+
       // Reassignment only changes the slot; the workflow task has already been
       // advanced by a prior plan/assign action. Skip the transition in that
       // case so we don't try to advance a task that's no longer in scope.
       const transitionId = wasReassigning
         ? undefined
-        : getNextTransition(effectiveService.currentStage);
+        : getNextTransition(liveTask?.stage);
       const taskAdvance: BookingTaskAdvance | undefined =
-        transitionId && effectiveService.taskId
-          ? { taskId: effectiveService.taskId, transitionId }
+        transitionId && liveTask?.taskId
+          ? { taskId: liveTask.taskId, transitionId }
           : undefined;
 
       await persistPlannedBooking({
@@ -1534,6 +1619,7 @@ export function PlanningSelectionProvider({
         slot: slotToUse,
         oldBookingId: bookingIds.get(effectiveService.id),
         originalPlannedService,
+        liveTaskId: liveTask?.taskId,
         taskAdvance,
         setBookingIds,
         setBookingVersion,
@@ -1558,6 +1644,7 @@ export function PlanningSelectionProvider({
       calendarId,
       bookingIds,
       refreshSlots,
+      getLiveTask,
     ]
   );
 
@@ -1586,14 +1673,20 @@ export function PlanningSelectionProvider({
    */
   const removeService = useCallback(
     async (serviceId: string) => {
-      // Move the workflow task back to planService BEFORE cancelling the
-      // booking. If the transition fails (e.g. task in a stage that doesn't
-      // expose this transition), bail out so the calendar still shows the
-      // service and the user can retry — mirrors the consistency guarantee
-      // the bookings POST gives on the forward direction.
+      // Move the workflow task back toward planService BEFORE cancelling the
+      // booking. Resolve the live task by `mintral_serviceCode` against the
+      // kanban index — never trust a stored taskId, because Alfresco mints a
+      // new task per workflow stage. If the transition fails, bail out so
+      // the calendar still shows the service and the user can retry,
+      // mirroring the consistency guarantee the bookings POST gives on the
+      // forward direction.
       const planned = plannedServices.find((p) => p.service.id === serviceId);
-      if (planned?.service.taskId) {
-        await advanceWorkflowTask(planned.service.taskId, UNPLAN_TRANSITION);
+      const liveTask = getLiveTask(planned?.service.mintral_serviceCode);
+      if (liveTask) {
+        const transition = getUnplanTransition(liveTask.stage);
+        if (transition) {
+          await advanceWorkflowTask(liveTask.taskId, transition);
+        }
       }
 
       // Cancel the booking in the calendar backend
@@ -1617,7 +1710,7 @@ export function PlanningSelectionProvider({
       // Bump version so the service list re-fetches (including newly unbooked)
       setBookingVersion((v) => v + 1);
     },
-    [bookingIds, plannedServices]
+    [bookingIds, plannedServices, getLiveTask]
   );
 
   /**
@@ -1772,6 +1865,7 @@ export function PlanningSelectionProvider({
       isSlotsLoading,
       refreshSlots,
       bookingVersion,
+      getLiveTask,
     }),
     [
       calendarId,
@@ -1816,6 +1910,7 @@ export function PlanningSelectionProvider({
       isSlotsLoading,
       refreshSlots,
       bookingVersion,
+      getLiveTask,
     ]
   );
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -11,7 +11,6 @@ import { tr } from "@/features/i18n/tr.service";
 import {
   usePlanningSelection,
   type SelectedService,
-  type TaskStage,
   getLeadTimeStatus,
   DEBUG_SHOW_TEST_SERVICE,
   TEST_SERVICES,
@@ -26,20 +25,6 @@ import {
 } from "@/features/common/providers/client-api.provider";
 import { formatDateString } from "@/features/common/components/formatted-date/formatted-date";
 import type { KanbanBoardTask } from "@/features/shipping/types/common.types";
-
-const KNOWN_TASK_STAGES = new Set<TaskStage>([
-  "planService",
-  "assignDriver",
-  "presentDriver",
-  "prepareService",
-  "missionControl",
-]);
-
-function asTaskStage(columnKey: string): TaskStage | undefined {
-  return KNOWN_TASK_STAGES.has(columnKey as TaskStage)
-    ? (columnKey as TaskStage)
-    : undefined;
-}
 
 interface PlanningSidebarClientProps {
   dict: I18nDictionary;
@@ -132,18 +117,14 @@ function toPercent(value: number | null | undefined): number {
 }
 
 // Transform KanbanBoardTask to SelectedService
-function transformTaskToService(
-  task: KanbanBoardTask,
-  currentStage: TaskStage | undefined
-): SelectedService {
+function transformTaskToService(task: KanbanBoardTask): SelectedService {
   const serviceId = task.name || task.id;
   const tipoViaje = determineTripType(task);
   const permanencia = calculatePermanencia(task);
 
   return {
     id: serviceId,
-    taskId: task.id,
-    currentStage,
+    mintral_serviceCode: task.mintral_serviceCode,
     cliente: task.client || task.clientCode || "",
     mintral_clientRut: task.mintral_clientRut,
     mintral_delegacionOrigen: task.mintral_delegacionOrigen,
@@ -211,6 +192,7 @@ export function PlanningSidebarClient({
     isSlotsLoading,
     bookingVersion,
     isSidebarOpen,
+    getLiveTask,
   } = usePlanningSelection();
   const [filteredServiceId, setFilteredServiceId] = useState<string | null>(
     null
@@ -316,18 +298,19 @@ export function PlanningSidebarClient({
     }
   }, [bookingVersion, refreshTasks]);
 
-  // Transform API data to SelectedService array. Iterate column-by-column so
-  // we can tag each service with the kanban stage it came from — needed to
-  // pick the correct workflow transition when the user plans or assigns it.
+  // Transform API data to SelectedService array. The kanban stage isn't
+  // attached here — every consumer that needs the current stage for a
+  // service should resolve it via context's `getLiveTask`, which reads the
+  // freshly fetched workflow index by `mintral_serviceCode` and is stable
+  // across stage advances.
   const apiServices = useMemo(() => {
     if (!myTasksData?.data) return [];
 
     const services: SelectedService[] = [];
-    for (const [columnKey, board] of Object.entries(myTasksData.data)) {
-      const stage = asTaskStage(columnKey);
+    for (const board of Object.values(myTasksData.data)) {
       for (const task of board.tasks) {
         services.push(
-          transformTaskToService({ ...task, title: board.title }, stage)
+          transformTaskToService({ ...task, title: board.title })
         );
       }
     }
@@ -704,6 +687,10 @@ export function PlanningSidebarClient({
             slotEndTime={displayState.formattedSlot?.endTime}
             backendSlots={backendSlots}
             isSlotsLoading={isSlotsLoading}
+            liveTaskStage={
+              getLiveTask(displayState.selectedService?.mintral_serviceCode)
+                ?.stage
+            }
           />
         ) : (
           <div className="flex flex-col gap-3">

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -16,6 +16,7 @@ import {
   usePlanningSelection,
   type SelectedService,
   type SelectedSlot,
+  type TaskStage,
 } from "./planning-selection-context";
 import { useServiceTypes } from "@/features/common/providers/client-api.provider";
 import {
@@ -244,6 +245,12 @@ interface PlanningSidebarFormProps {
   readonly backendSlots?: SlotResponse[];
   /** Whether backend slots are currently loading */
   readonly isSlotsLoading?: boolean;
+  /**
+   * Live kanban stage of the selected task, derived by the parent from the
+   * freshly fetched myTasks payload. Never persisted on the booking — pass
+   * `undefined` when the task isn't in any active column.
+   */
+  readonly liveTaskStage?: TaskStage;
 }
 
 export function PlanningSidebarForm({
@@ -256,6 +263,7 @@ export function PlanningSidebarForm({
   slotEndTime,
   backendSlots,
   isSlotsLoading = false,
+  liveTaskStage,
 }: PlanningSidebarFormProps) {
   const [showAllIncidencias, setShowAllIncidencias] = useState(false);
   const [selectedTime, setSelectedTime] = useState<string>("");
@@ -708,6 +716,13 @@ export function PlanningSidebarForm({
             )}
           </div>
         </FormSection>
+      )}
+      {/* Live workflow stage — sits above the KPIs as the form's first data row */}
+      {liveTaskStage && (
+        <InfoRow
+          label={tr("pages.planning.sidebar.taskStage.label", dict)}
+          value={tr(`pages.planning.sidebar.taskStage.${liveTaskStage}`, dict)}
+        />
       )}
       {/* KPIs Section */}
       <FormSection title={tr("pages.planning.sidebar.form.kpis", dict)}>

--- a/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
@@ -20,3 +20,11 @@ export function getNextTransition(
 ): string | undefined {
   return stage ? NEXT_TRANSITION[stage] : undefined;
 }
+
+/**
+ * Workflow transition fired when "Eliminar Planificación" cancels a booking.
+ * Mirrors the forward `planService → assignDriver` transition so the task
+ * returns to the planService column. Only valid from the assignDriver stage —
+ * a planned service in a later stage would need to be unassigned first.
+ */
+export const UNPLAN_TRANSITION = "Planificar Servicio";

--- a/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
@@ -23,13 +23,17 @@ export function getNextTransition(
 
 /**
  * Workflow transitions fired when "Eliminar Planificación" cancels a booking,
- * keyed by the task's *live* kanban stage. Each entry steps the workflow one
- * stage back toward `planService`. Stages omitted produce no transition
- * (either already at planService, or removing the planning from there is
- * not a single backward step and requires unassigning first).
+ * keyed by the task's *live* kanban stage. The shipping_coordination BPMN
+ * exposes a direct `"Planificar Servicio"` outcome from every gateway in the
+ * planning arm (assignDriver / presentDriver / prepareService /
+ * missionControl), so a single transition name returns the task all the way
+ * to planService no matter how far it had been advanced.
  */
 const UNPLAN_TRANSITIONS: Partial<Record<TaskStage, string>> = {
   assignDriver: "Planificar Servicio",
+  presentDriver: "Planificar Servicio",
+  prepareService: "Planificar Servicio",
+  missionControl: "Planificar Servicio",
 };
 
 export function getUnplanTransition(

--- a/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
@@ -22,9 +22,43 @@ export function getNextTransition(
 }
 
 /**
- * Workflow transition fired when "Eliminar Planificación" cancels a booking.
- * Mirrors the forward `planService → assignDriver` transition so the task
- * returns to the planService column. Only valid from the assignDriver stage —
- * a planned service in a later stage would need to be unassigned first.
+ * Workflow transitions fired when "Eliminar Planificación" cancels a booking,
+ * keyed by the task's *live* kanban stage. Each entry steps the workflow one
+ * stage back toward `planService`. Stages omitted produce no transition
+ * (either already at planService, or removing the planning from there is
+ * not a single backward step and requires unassigning first).
  */
-export const UNPLAN_TRANSITION = "Planificar Servicio";
+const UNPLAN_TRANSITIONS: Partial<Record<TaskStage, string>> = {
+  assignDriver: "Planificar Servicio",
+};
+
+export function getUnplanTransition(
+  stage: TaskStage | undefined
+): string | undefined {
+  return stage ? UNPLAN_TRANSITIONS[stage] : undefined;
+}
+
+/**
+ * Kanban column keys that the planning calendar cares about. The kanban
+ * board API returns tasks grouped by these keys, which double as our
+ * `TaskStage` identifiers everywhere in the planning UI.
+ */
+const KNOWN_TASK_STAGES = new Set<TaskStage>([
+  "planService",
+  "assignDriver",
+  "presentDriver",
+  "prepareService",
+  "missionControl",
+]);
+
+/**
+ * Narrow a kanban column key (the string the board API uses) to a
+ * `TaskStage`, or undefined for columns the calendar doesn't track.
+ */
+export function asTaskStageFromColumn(
+  columnKey: string
+): TaskStage | undefined {
+  return KNOWN_TASK_STAGES.has(columnKey as TaskStage)
+    ? (columnKey as TaskStage)
+    : undefined;
+}

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -64,6 +64,8 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
   return {
     id: task.id as string,
     name,
+    mintral_serviceCode:
+      task.mintral_serviceCode == null ? undefined : String(serviceCode),
     description: task.bpm_description as string,
     completed: task.state === "COMPLETED",
     daysLeft: 2,

--- a/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
@@ -21,6 +21,14 @@ export type Task = {
 export type KanbanBoardTask = {
   id: string;
   name: string;
+  /**
+   * Stable business identifier for the service. Unlike `id` (which is the
+   * Alfresco task instance id and changes on every workflow stage advance)
+   * and `name` (a derived display label), this value is the same across the
+   * service's whole lifecycle and is the only safe key to correlate kanban
+   * tasks with calendar bookings or other persisted state.
+   */
+  mintral_serviceCode?: string;
   description: string;
   completed: boolean;
   daysLeft: number;

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -232,6 +232,14 @@
         "title": "Plan Trip",
         "assignmentTitle": "Assign Trip",
         "servicesList": "Today's Services",
+        "taskStage": {
+          "label": "Status",
+          "planService": "Plan Service",
+          "assignDriver": "Assign Driver",
+          "presentDriver": "Present Driver",
+          "prepareService": "Control Service",
+          "missionControl": "Start Trip"
+        },
         "noServiceSelected": "Select a service from the calendar to assign driver and vehicle",
         "selectServiceHint": "Select a service to assign driver and vehicle",
         "searchPlaceholder": "Search by client, id, origin, destination, loading place, permanence, trip type...",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -232,6 +232,14 @@
         "title": "Planificar viaje",
         "assignmentTitle": "Asignar viaje",
         "servicesList": "Servicios del día",
+        "taskStage": {
+          "label": "Estado",
+          "planService": "Planificar Servicio",
+          "assignDriver": "Asignar Conductor",
+          "presentDriver": "Presentar Conductor",
+          "prepareService": "Controlar Servicio",
+          "missionControl": "Iniciar viaje"
+        },
         "noServiceSelected": "Seleccione un servicio del calendario para asignar conductor y vehículo",
         "selectServiceHint": "Seleccione un servicio para asignar conductor y vehículo",
         "searchPlaceholder": "Buscar por cliente, id, origen, destino, lugarCarguio, permanencia, tipoViaje...",

--- a/turbo-repo/apps/app/src/releases/v1.31.0.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.0.mdx
@@ -1,102 +1,124 @@
 # 🔔 Release Notes v1.31.0 — ModularIoT
 
-### Fecha: 23/04/2026
+### Fecha: 30/04/2026
 
-**Objetivo**: Esta versión madura el flujo de planificación del calendario con datos acreditados en vivo y hidratación de formularios, incorpora nuevas capacidades en dashboards — Batch Import con validación contra el schema del RPC, compartir dashboards por link/imagen/PDF, control de acceso por roles basado en ACL de Alfresco, columnas sticky y reordenamiento drag-and-drop — y endurece el pipeline de ingesta de métricas extendidas, la seguridad de ACL y el stack de infraestructura (Node.js 24 en CI, migración a `httfetcher`).
+**Objetivo**: Esta versión consolida la planificación operacional del calendario con recursos acreditados, filtros por terminal, bloqueos temporales persistentes, reasignación hidratada y mejor trazabilidad hacia Alfresco. Además, amplía dashboards, integraciones, multitenancy y SDKs para que la plataforma pueda operar con más control, menos fricción y una base técnica más extensible.
 
 ## 🚀 Evolutivos
 
-- **📅 Asignación de Servicios con Recursos Acreditados en Vivo**
-  - **Fuente de datos en vivo**: El formulario de Asignación del calendario reemplaza sus arrays mock por la RPC `ams.fn_rd_accredited_resources`, con feeds en cascada CARRIER → DRIVER → TRUCK/TRAILER que se cargan al seleccionar servicio y carrier. *(Integración OSS — MIOT-0.5.2)*
-  - **Proxy y caché**: Nueva ruta `app/api/calendar/accredited-resources` sobre PostgREST con caché LRU acotado (32 entradas, TTL 5 min) y filtro server-side por subcadena sobre `resource_name` / `identifier`.
-  - **Hidratación desde servicios planificados**: Al reasignar un servicio ya planificado, el sidebar precarga carrier, conductor, camión y acoplado desde la tupla almacenada, en vez de partir en blanco; los toggles de segundo conductor / acoplado se abren automáticamente cuando el slot correspondiente existe.
-  - **Modelo ampliado**: `SelectedService` y `StoredServiceSchema` suman `assignedTransportista`, `assignedCamion` y `assignedRemolque` para que los valores sobrevivan recargas y booking payloads; nuevo helper `assignmentDataFromService` centraliza la derivación.
-  - **Re-hidratación sin fugas**: El `useEffect` keyeado por `selectedService.id` evita que permanezcan pares obsoletos al cambiar entre servicios.
-  - **RUT Cliente en sidebar**: Nueva fila "RUT Cliente" / "Client RUT" en la sección Información del calendario, tomada de `mintral_clientRut` y ocultada cuando el valor no existe.
+- **📅 Planificación de Calendario con Recursos Acreditados**
+  - **Datos en vivo**: El formulario de Asignación reemplaza los mocks por la RPC `ams.fn_rd_accredited_resources`, con feeds en cascada para transportista, conductor, camión y acoplado. *(Integración OSS — MIOT-0.5.2)*
+  - **Proxy y caché**: Nueva ruta `app/api/calendar/accredited-resources` con paginación, búsqueda server-side y caché LRU de 5 minutos para evitar llamadas repetidas a la agregación pesada.
+  - **Hidratación de reasignaciones**: Al reabrir un servicio planificado, el sidebar precarga transportista, conductor, segundo conductor, camión y remolque desde la tupla almacenada, evitando partir desde un formulario vacío. *(Integración OSS — MIOT-0.5.2)*
+  - **Persistencia completa**: `SelectedService` y `StoredServiceSchema` preservan la asignación completa en el payload de booking para sobrevivir recargas y cambios de sesión.
 
-- **📥 Dashlet Batch Import con Validación contra Schema RPC**
-  - **Importación masiva**: Nuevo dashlet bajo la categoría `actions` — sibling de `file_upload` — que permite pegar o cargar CSV/TSV, previsualizar cada fila y enviar a un endpoint PostgREST configurable; genérico, sin cambios de código al onboardear un nuevo target. *(Integración OSS — MIOT-0.5.2)*
-  - **Pre-validación contra OpenAPI**: Introspección de los parámetros del RPC (`name`, `type`, `format`, `required`, `enum`, `minimum`, `maximum`, `pattern`) para construir un validador local, de modo que las filas que violan el schema aparecen como `failed` antes de enviar y el contador del botón Import refleja sólo filas realmente importables.
-  - **Re-validación reactiva**: Si el schema llega asíncronamente después de que el usuario ya pegó datos, las filas existentes se re-validan automáticamente.
-  - **UX de errores mejorada**: Los errores por fila dejan de depender del `title` tooltip del browser (difícil de leer, volátil) y pasan a una superficie explícita en la preview.
+- **🧾 Categoría de Servicio y Datos de Cliente en Workflow**
+  - **Modelo ECM**: Se agregan `mintral:serviceCategory` y `mintral:clientRut` al aspecto de servicio del coordinador, con mapeos para QName, variables de ejecución y payload Alfresco.
+  - **Actualización de tarea**: La planificación usa el ID real de tarea Alfresco, normaliza IDs `activiti$`, envía `prop_mintral_serviceCategory` al formprocessor y trata la escritura de metadata como parte de la confirmación. *(Integración OSS — MIOT-0.5.2)*
+  - **Consistencia operacional**: Si falla la actualización del workflow, la reserva recién creada se revierte para que el calendario no quede adelantado respecto del estado de Alfresco.
+  - **RUT visible**: El calendario muestra `mintral_clientRut` como “RUT Cliente” / “Client RUT” y lo conserva en el payload almacenado para recargas y replanning. *(Integración OSS — MIOT-0.5.2)*
 
-- **🔗 Compartir Dashboards (Link, Imagen, PDF, Share Sheet)**
-  - **Acción dedicada en header**: Share se eleva del dropdown de Settings a una acción propia en el header del dashboard, con un panel que concentra todas las opciones de exportación. *(Integración OSS — MIOT-0.5.2)*
-  - **Opciones completas**: Copy link (kiosk autenticado preservando query params), Download as image (PNG), Download as PDF (single-page con título y timestamp, orientación según aspect ratio) y Share image… (hand-off al share sheet nativo del OS en dispositivos compatibles).
-  - **Degradación controlada**: Cuando la plataforma no soporta compartir archivos, se muestra un mensaje claro en vez de fallar silenciosamente; dismissing del share sheet no emite error.
+- **🧭 Filtros de Tareas por Calendario**
+  - **Backend y SDK**: `miot-calendar` agrega `Calendar.filter` como JSONB con claves permitidas `origin` y `destination`, y `@microboxlabs/miot-calendar-client` expone `CalendarFilter` en request/response. *(Integración OSS — MIOT-0.5.2)*
+  - **Configuración en UI**: El filtro aparece en el modal de creación, en el panel de reglas del calendario y en el sidebar de planificación.
+  - **Lista contextual**: La planificación inicializa chips de origen/destino desde el calendario activo para que “Servicios del día” muestre tareas coherentes con el terminal o delegación correspondiente.
 
-- **📊 Columnas Sticky y Drag-and-Drop en Tablas de Dashboard**
-  - **Columnas fijas**: Pin de columnas a izquierda/derecha para mantenerlas visibles durante el scroll horizontal, con divisores y sombras pulidas. *(Integración OSS — MIOT-0.5.2)*
-  - **Reordenamiento**: Drag-and-drop de columnas en la configuración de tabla y de categorías en el stacked-stat.
-  - **Diálogo de settings pulido**: Mejor scroll, layout y zona fija de acciones (save/refresh) en el modal de configuración.
-  - **i18n**: Nuevas cadenas EN/ES para las opciones de sticky columns.
+- **⛔ Bloqueos Temporales Persistentes**
+  - **Modelo de ventana**: `TimeWindow.kind` distingue `WINDOW` y `BLOCK` para representar periodos reservables y bloqueos reales de calendario. *(Integración OSS — MIOT-0.5.2)*
+  - **Persistencia end-to-end**: Backend, SDK y frontend aceptan `kind`, generan slots cerrados para bloqueos y rechazan reservas sobre periodos no disponibles.
+  - **Color persistente**: Las ventanas de tiempo conservan el color elegido desde backend, cliente TypeScript y app, con fallback compatible para filas antiguas. *(Integración OSS — MIOT-0.5.2)*
+  - **Documentación sincronizada**: README, páginas SDK EN/ES, changelogs y OpenAPI reflejan filtros, provisión automática, color y `kind`.
 
-- **🔐 Control de Acceso por Roles en Dashboards (Alfresco ACL)**
-  - **De filtro app-level a ACL nativo**: Reemplazo del filtro binario `allowedGroups` por roles Alfresco (Consumer, Contributor, Editor, Coordinator) aplicados directamente al nodo del dashboard (`Sites/{site}/documentLibrary/dashboard/{slug}-config.json`). *(Integración OSS — MIOT-0.5.2)*
-  - **Permisos granulares**: Dashboards ahora soportan view vs. edit vs. admin, permitiendo otorgar acceso a usuarios individuales y delegar "puede gestionar permisos".
-  - **Reutilización de infraestructura Alfresco**: Herencia desde site/folder y ACLs por nodo dejan de estar ociosas al quedar expuestas en el producto.
+- **📆 Vista de Solo Lectura para Servicios Pasados**
+  - **Histórico inspeccionable**: Los servicios de días pasados pueden abrirse desde la grilla para revisión sin habilitar edición accidental. *(Integración OSS — MIOT-0.5.2)*
+  - **Señales visuales**: Celdas pasadas, encabezados y borde de “hoy” se ajustan para separar con claridad el histórico del área editable.
+  - **Flujos de reconciliación**: Replanificar, eliminar o completar asignaciones históricas sigue disponible desde el menú contextual cuando el usuario lo necesita.
+  - **Carga de reservas corregida**: La consulta de bookings ahora envía rango de fechas alrededor del `date` de la URL, evitando respuestas vacías por falta de ventana temporal.
 
-- **🧭 Refactor de Sidebar (Desktop + Mobile)**
-  - **Route matching por segmento**: Nuevo helper `isSegmentPrefix()` reemplaza `startsWith`, corrigiendo coincidencias erróneas entre rutas hermanas (p. ej. `/users/settings-archive` ya no resalta `/users/settings`). *(Integración OSS — MIOT-0.5.2)*
-  - **Panel L2 coherente**: El link de Settings cierra el panel L2 al click, alineándose con el resto de ítems de navegación directa.
-  - **Búsqueda por sección**: La query de búsqueda se resetea al cambiar de sección activa, tanto en `SecondaryPanel` como en `MobileSecondaryPanel`.
-  - **Fix mobile**: `findActiveSectionLabel` ahora considera `dynamicItemsSource` además de `items.length > 0`, igualando el predicado del resto de la UI.
-  - **Deduplicación y accesibilidad**: Contenido de panel compartido entre desktop y mobile, con mejoras de accesibilidad.
+- **📥 Batch Import más Escalable y Validado**
+  - **Importación masiva**: Nuevo dashlet de acciones para pegar o cargar CSV/TSV, previsualizar filas y enviarlas a un endpoint PostgREST configurable. *(Integración OSS — MIOT-0.5.2)*
+  - **Validación previa**: El dashlet introspecta parámetros del RPC desde OpenAPI y valida campos requeridos, enums, mínimos/máximos, patrones y formatos antes de enviar.
+  - **Trabajo pesado al backend**: Parsing de CSV/TSV/XLSX/XLS/XLSM/ODS, validación por lote y fan-out a PostgREST pasan al API layer, manteniendo la UX conocida.
+  - **Errores legibles**: Las filas inválidas se marcan como `failed` en la preview y muestran un popover multilinea por campo, reemplazando el tooltip nativo del navegador.
 
-- **📐 Variante Horizontal del Componente Métrica con `children` Bajo el Valor**
-  - **Jerarquía visual corregida**: En el layout horizontal, `children` deja de renderizarse como tercera columna flex y pasa a apilarse bajo el valor y la unidad, alineándose con la documentación del componente. *(Integración OSS — MIOT-0.5.2)*
+- **🔗 Compartir Dashboards por Link, Imagen, PDF y Share Sheet**
+  - **Acción dedicada**: El dashboard incorpora un botón de compartir en el header, separado de Settings. *(Integración OSS — MIOT-0.5.2)*
+  - **Opciones completas**: Permite copiar link kiosk autenticado, descargar PNG, descargar PDF de una página y entregar imagen/PDF al share sheet del sistema operativo cuando el navegador lo soporta.
+  - **Experiencia robusta**: Los botones se deshabilitan durante exportación, los nombres de archivo se sanitizan y los `AbortError` por cancelar el share sheet no generan toast de error.
+
+- **🔐 Control de Acceso por Roles en Dashboards**
+  - **ACL nativo de Alfresco**: Los dashboards pasan del filtro binario `allowedGroups` a permisos por nodo con roles Consumer, Contributor, Editor y Coordinator. *(Integración OSS — MIOT-0.5.2)*
+  - **Permisos granulares**: Usuarios y grupos pueden recibir acceso de solo lectura, edición o administración de permisos desde una única fuente de verdad.
+  - **UI por rol**: Viewers no ven controles de edición; Editors pueden modificar dashboards; Coordinators gestionan permisos e herencia.
+
+- **📊 Dashboards y Navegación más Potentes**
+  - **Columnas sticky**: Las columnas pueden fijarse a izquierda o derecha para mantener contexto durante scroll horizontal. *(Integración OSS — MIOT-0.5.2)*
+  - **Reordenamiento**: Drag-and-drop de columnas en settings de tabla y de categorías en stacked-stat.
+  - **Reglas de color extendidas**: Las reglas dejan de aplicar solo a badges y pasan a funcionar en todos los tipos de columna, con control por columna y mejoras de consistencia. *(Integración OSS — MIOT-0.5.2)*
+  - **Navegación desde KPIs**: El dashlet `stat_icon` puede definir un destino “Go To” estático o con plantillas Handlebars y abrirlo en la misma pestaña o una nueva.
+  - **Pulido diario**: Tooltips con Markdown, dirty-state tracking, confirmación antes de descartar cambios y sidebar segment-aware reducen fricción en configuración y uso.
+
+- **🏢 Settings Multitenant**
+  - **Organizaciones hijas**: El módulo de settings agrega flujos administrativos para organizaciones hijas, nombres visibles y tax IDs normalizados. *(Integración OSS — MIOT-0.5.2)*
+  - **Membresías y módulos**: Permite buscar, listar, agregar y remover miembros, además de ver y reemplazar módulos por organización.
+  - **Contexto activo**: Se incorporan tenant scoping, cambio de organización activa y endpoints Me/People para datos acotados por organización.
 
 ## 🔧 Integraciones
 
-- **🧾 Campo `service_client_rut` Propagado hasta Alfresco**
-  - **Nuevo atributo en el modelo**: `mintral:clientRut` se agrega al `mintral:serviceAspect` junto a `mintral:clientAbbreviation`, con tipo `d:text` indexado; la constante `PARAM_SERVICE_CLIENT_RUT` se incorpora a `ExtTripServiceParamsV2`.
-  - **Flujo completo**: `services` (pg-rest JSON) → `ExtTripServiceParamsV2` → `MintralModel.jsonKeyMapperV2` → propiedad en `mintral:serviceAspect`, espejando el patrón existente de `service_client_code` / `service_client_abbreviation`.
-  - **Consumidor visible**: Este campo alimenta la nueva fila "RUT Cliente" del sidebar de calendario (ver Evolutivos).
+- **🔌 Conexiones de Integración y Perfiles de Credenciales**
+  - **Módulo genérico**: Se introduce una base para `IntegrationConnection`, `CredentialProfile`, `IntegrationOperation` y estrategias de autenticación reutilizables. *(Integración OSS — MIOT-0.5.2)*
+  - **Autenticación flexible**: Soporte inicial para NONE, bearer token, API key por header/query, basic auth, OAuth2 client credentials y headers custom.
+  - **Secretos protegidos**: Los perfiles almacenan material sensible cifrado y exponen solo previews enmascarados.
+  - **OAuth productivo**: El flujo soporta request de token en formato `form` o `json`, caché por perfil y fingerprint de configuración.
 
-- **🟢 Actualización de GitHub Actions a Node.js 24**
-  - **Compliance con deprecación**: GitHub forzará Node.js 24 en los runners de Actions a partir de 2026-06-02 y removerá Node.js 20 el 2026-09-16. *(Integración OSS — MIOT-0.5.2)*
-  - **Acciones actualizadas**: `actions/checkout`, `actions/setup-node`, `actions/cache` (incl. `cache/restore`) y `dorny/paths-filter` en los workflows CI, Quarkus, SonarCloud, ECM, Publish miot-cli y Publish npm.
+- **📦 Clientes TypeScript y Documentación SDK**
+  - **Connections API**: Se agrega `@microboxlabs/miot-connection-client` con métodos para perfiles de credenciales, conexiones, tests y operaciones asociadas. *(Integración OSS — MIOT-0.5.2)*
+  - **Errores tipados**: Las respuestas no-2xx lanzan errores con `status` y `body`, facilitando manejo consistente en consumidores.
+  - **Calendar Client 0.6–0.8**: La documentación del cliente de calendario queda alineada con filtros, color, `kind`, provisión automática de slot-manager y changelogs EN/ES.
 
-- **🔁 Migración de `pgrest-client.ts` a `httfetcher`**
-  - **11 call sites migrados**: Reemplazo de `fetch()` crudos con headers manuales por `httfetcher`, ganando logging estructurado con request IDs, manejo de errores vía `FetcherError` y propagación consistente de user-agent. *(Integración OSS — MIOT-0.5.2)*
-  - **Limpieza**: Tras la migración, el wrapper `pgrestFetch` y la constante `PGREST_FETCH_TIMEOUT_MS` son eliminados.
+- **🛠️ Workflows de Publicación**
+  - **Node actualizado**: Los workflows de publicación migran a Node 24 para usar un npm suficientemente reciente desde el runner. *(Integración OSS — MIOT-0.5.2)*
+  - **Trusted publishing estable**: Se elimina el self-upgrade `npm install -g npm@latest`, que fallaba antes de instalar dependencias o publicar paquetes.
+  - **Cobertura doble**: El ajuste aplica tanto al publish de paquetes como al publish de `miot-cli`.
 
 ## 🐛 Correcciones
 
-- **🐛 Métricas de Extensión (`x.*`) descartadas silenciosamente cuando falta `ts` por ítem**
-  - **Impacto**: `MetricsRepository.addOffsetDateTime` en `quarkus-subscriber-db-writer` dereferenciaba `extensionMetric.getTs().toOffsetDateTime()` sin null-check. Como `MetricItem.ts` es opcional (sin `@NotNull`), todos los payloads con `x.*` keys y sólo `device_ts`/`timestamp` de envelope producían NPE, tragado por el try/catch por ítem y reportado como "Failed to serialize extension metric … null". Resultado: 0 filas en `asset_metric_ext` pese a que `asset_metric_core` escribía correctamente (p. ej. `x.adblue.level`, `x.adblue.rate`, `x.dpf.*` de `src=j1939`). *(Integración OSS — MIOT-0.5.2)*
-  - **Solución**: Fallback a `device_ts` / timestamp de envelope cuando el ítem no trae `ts`, y mensaje de log diferenciado para casos de serialización reales.
+- **🐛 Métricas de Extensión `x.*` Descartadas sin `ts` por Ítem**
+  - **Impacto**: `quarkus-subscriber-db-writer` no persistía métricas extendidas en `asset_metric_ext` cuando el payload traía `device_ts` o `timestamp` de envelope, pero omitía `metrics.items[*].ts`. *(Integración OSS — MIOT-0.5.2)*
+  - **Causa**: La ruta de extensión dereferenciaba `extensionMetric.getTs()` sin null-check y el error se tragaba como fallo de serialización.
+  - **Solución**: La ruta de extensión usa el mismo fallback temporal que las métricas core y mejora el log para distinguir errores reales de serialización.
 
-- **🐛 Screenshot del Mapa Compartido Resulta en Archivo Corrupto**
-  - **Impacto**: En la Geographic View, compartir un screenshot vía Web Share API entregaba un archivo PNG corrupto / ilegible en el destino (WhatsApp, Mail, Drive) — afectaba tanto el preview de la toolbar como el share del side-bar. *(Integración OSS — MIOT-0.5.2)*
-  - **Solución**: El payload del share se construye a partir de los bytes PNG decodificados, no del string data-URL base64, produciendo archivos válidos. Plataformas sin soporte de file sharing muestran un mensaje claro; dismissing del share sheet deja de emitir error.
+- **🐛 Categoría de Servicio y KPIs de Planificación**
+  - **Service Category**: La UI ya no usa el ID visual del servicio para actualizar workflow y el payload usa el prefijo requerido por Alfresco. *(Integración OSS — MIOT-0.5.2)*
+  - **Lead Time**: La proyección kanban preserva `mintral_deliveryComplianceRate`, `mintral_compliantOrderLines` y `mintral_nonCompliantOrderLines`, corrigiendo KPIs que aparecían como `0 líneas LOC` / `0%`. *(Integración OSS — MIOT-0.5.2)*
+  - **Normalización**: La tasa de cumplimiento se renderiza correctamente cuando backend entrega fracciones como `0.238...` o porcentajes ya normalizados.
 
-- **🐛 Fleet Management: Localización Incompleta e Historial de Síntomas Sesgado a ICU 2**
-  - **Impacto**: Textos de la UI de Fleet Management no pasaban por `tr()`, y la consulta de historial de síntomas filtraba silenciosamente sólo ICU code 2, ocultando el resto de eventos históricos del vehículo. *(Integración OSS — MIOT-0.5.2)*
-  - **Solución**: Nuevas claves de traducción EN/ES en `src/lang/en.json` / `es.json` y componentes migrados a `tr()`; corrección del filtro de severidad en la query de historial para retornar todos los síntomas del vehículo seleccionado.
+- **🐛 Acciones Incorrectas en Servicios Solo Planificados**
+  - **Impacto**: Servicios con planificación pero sin asignación completa podían mostrar “Eliminar asignación”. *(Integración OSS — MIOT-0.5.2)*
+  - **Solución**: La acción se muestra solo cuando existe la tupla mínima transportista, conductor y camión; el copy en español distingue eliminar planificación de eliminar asignación.
 
-- **🐛 `allowedGroups` no Normalizado en el Boundary de Storage**
-  - **Impacto**: `importDashboard` y el hook de lectura exponían `allowedGroups` tal cual venía de Alfresco o de un import. Si el valor era algo distinto de `string[]`, los nuevos checks server-side (`src/app/api/dashboard/configs/route.ts`, `src/app/[lang]/(secured)/home/[slug]/page.tsx`) lo trataban como "sin restricciones", de modo que un import malformado podía silenciosamente tumbar las restricciones del dashboard. *(Integración OSS — MIOT-0.5.2)*
-  - **Solución**: Helper `normalizeAllowedGroups(value)` que clamp-ea a un `string[]` validado antes de persistir y antes de retornar desde el hook, filtrando no-arrays y entradas que no sean strings.
+- **🐛 Screenshot de Mapa Compartido Corrupto**
+  - **Impacto**: Compartir un screenshot de Geographic View por Web Share API enviaba un PNG corrupto o vacío a apps como WhatsApp, Mail o Drive. *(Integración OSS — MIOT-0.5.2)*
+  - **Solución**: El share payload se construye desde bytes PNG decodificados, no desde el string data-URL base64, y las plataformas sin file sharing muestran un mensaje claro.
 
-- **🐛 ACL Malformado: Fail-Open Filtra Dashboards Restringidos**
-  - **Impacto**: En el listado de dashboards, cualquier `allowedGroups` no-array se trataba igual que "sin restricción", leakeando dashboards restringidos cuyo `config` había sido corrompido o editado manualmente fuera de la app. *(Integración OSS — MIOT-0.5.2)*
-  - **Solución**: Fail-closed explícito — sólo `undefined` o `[]` se consideran "sin restricción"; shapes inválidos o entradas no-string excluyen el dashboard del listado.
+- **🐛 Fleet Management: Localización e Historial de Síntomas**
+  - **Localización**: Componentes del módulo Fleet Management pasan a usar claves EN/ES mediante `tr()`. *(Integración OSS — MIOT-0.5.2)*
+  - **Historial completo**: La consulta de síntomas deja de limitarse silenciosamente a ICU code 2 y retorna el historial del vehículo seleccionado.
 
 ## 📊 Beneficios
 
-- 📅 **Planificación de calendario lista para producción**: La conexión en vivo con `ams.fn_rd_accredited_resources`, la hidratación de reasignaciones y el RUT Cliente en sidebar eliminan los mocks y convierten el flujo de Asignación en un circuito operativo completo sobre datos acreditados.
-- 📥 **Importación masiva sin fricción**: Batch Import con validación contra el schema del RPC antes de enviar permite a usuarios no-técnicos poblar tablas de forma segura, eliminando el ida-y-vuelta de scripts ad-hoc o correcciones post-submit.
-- 🔗 **Distribución nativa de dashboards**: Compartir por link kiosk, imagen, PDF o share sheet del OS reemplaza el flujo manual de screenshot y mejora la adopción en reportería y reuniones.
-- 🔐 **Seguridad de dashboards endurecida**: La migración a ACL nativo de Alfresco sumada al fail-closed en ACL malformado y la normalización de `allowedGroups` eliminan una superficie de leak silencioso y habilitan delegación fina de permisos.
-- 🛰️ **Ingesta de métricas extendidas confiable**: El fix de `x.*` sin `ts` por ítem cierra un agujero de pérdida silenciosa de datos telemétricos (p. ej. AdBlue, DPF) que afectaba la observabilidad del cliente.
-- 🧭 **Navegación más predecible**: El refactor del sidebar elimina bugs de matching entre rutas hermanas, resetea búsqueda por sección y unifica comportamiento desktop/mobile.
-- 🧰 **Infraestructura en compliance y consistente**: CI en Node.js 24 antes de la deprecación de GitHub, y la migración a `httfetcher` aporta logging estructurado con request IDs en todos los accesos a PostgREST.
+- 📅 **Planificación lista para operación real**: Recursos acreditados, filtros por terminal, bloqueos persistentes, categoría de servicio y vista histórica completan el circuito calendario ↔ workflow ↔ Alfresco.
+- ⛔ **Disponibilidad más confiable**: Los bloqueos dejan de ser estado local del navegador y pasan a existir en backend, SDK y UI, impidiendo reservas sobre periodos cerrados.
+- 📥 **Carga masiva segura y escalable**: Batch Import valida contra schema y mueve parsing/fan-out al backend, reduciendo errores de post-submit y carga del navegador.
+- 🔗 **Distribución nativa de dashboards**: Link kiosk, imagen, PDF y share sheet reemplazan capturas manuales y simplifican reportes operativos.
+- 🔐 **Gobernanza más fina**: ACL de Alfresco, roles de dashboard y settings multitenant habilitan administración por organización, usuario y grupo.
+- 🔌 **Base extensible de integraciones**: Connections, Credential Profiles y SDK TypeScript preparan el terreno para conectar nuevos proveedores con autenticación reutilizable.
+- 🛰️ **Confiabilidad técnica reforzada**: Fixes de métricas `x.*`, publicación npm, screenshots, lead time y Fleet Management reducen pérdidas silenciosas y fallos operativos.
 
 ## 📌 Conclusión
 
-La versión 1.31.0 consolida el flujo de planificación del calendario como un circuito end-to-end: el formulario de Asignación deja atrás los mocks y consume recursos acreditados en vivo con caché y filtros server-side, las reasignaciones hidratan desde la tupla almacenada sin fugas entre servicios, y el nuevo campo `mintral:clientRut` se propaga desde el `services` table hasta el `mintral:serviceAspect` de Alfresco para visibilizarse en el sidebar. Este conjunto de cambios baja la fricción operativa al mínimo y cierra una deuda de integración que venía arrastrándose desde iteraciones previas.
+La versión 1.31.0 convierte el calendario en una herramienta más cercana a la operación real: los recursos provienen de fuentes acreditadas, los servicios se filtran por contexto, las reasignaciones conservan datos previos, las categorías vuelven al workflow de Alfresco y los bloqueos temporales pasan a persistir como datos de primera clase. La incorporación del RUT de cliente y la vista histórica fortalecen la trazabilidad sin abrir puertas a ediciones accidentales.
 
-En paralelo, los dashboards ganan músculo analítico y de distribución: Batch Import con validación contra el schema del RPC habilita carga masiva segura y genérica, la acción de Compartir se eleva a ciudadano de primera clase del header con link kiosk, imagen, PDF y share sheet nativo, y el control de acceso migra al ACL nativo de Alfresco con roles Consumer/Contributor/Editor/Coordinator — complementado por endurecimientos de fail-closed en ACL malformado y normalización de `allowedGroups` que cierran una clase de leaks silenciosos. Las columnas sticky y el drag-and-drop en tablas completan el paquete de mejoras de productividad diaria en el dashboard.
+En dashboards, la release amplía productividad, control y distribución. Batch Import se vuelve más robusto al validar contra schema y mover trabajo pesado al backend; compartir por link, imagen, PDF o share sheet hace más natural entregar información operativa; y el control de acceso basado en ACL reemplaza reglas binarias por permisos por rol, usuario y grupo. Las mejoras de tablas, navegación desde KPIs, tooltips y dirty-state pulen el trabajo diario de configuración.
 
-Finalmente, la release refuerza la base de infraestructura y calidad: el pipeline de ingesta de `quarkus-subscriber-db-writer` deja de descartar silenciosamente métricas de extensión cuando falta el `ts` por ítem, Fleet Management recupera localización completa y el historial íntegro de síntomas, el sidebar se refactoriza para navegación predecible y accesible, el CI queda en compliance con la deprecación de Node.js 20 de GitHub Actions, y los accesos a PostgREST migran a `httfetcher` con logging estructurado. El foco de la próxima iteración quedará en capitalizar estas bases para analítica avanzada, personalización de dashboards y profundización de la integración del calendario con los sistemas operativos del cliente.
+Finalmente, la plataforma gana una base más madura para crecer: settings multitenant, conexiones genéricas, perfiles de credenciales, clientes TypeScript documentados y workflows de publicación más estables reducen acoplamientos y preparan nuevas integraciones sin multiplicar soluciones especiales por caso. Junto con las correcciones de telemetría, planificación, sharing y Fleet Management, esta entrega deja una base más limpia para la siguiente iteración de analítica, operación y conectividad externa.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -1423,7 +1423,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1433,7 +1433,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1467,7 +1467,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1571,7 +1571,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -4897,6 +4897,10 @@
       "resolved": "packages/miot-cli",
       "link": true
     },
+    "node_modules/@microboxlabs/miot-connection-client": {
+      "resolved": "packages/miot-connection-client",
+      "link": true
+    },
     "node_modules/@microboxlabs/miot-resource-client": {
       "resolved": "packages/miot-resource-client",
       "link": true
@@ -6621,7 +6625,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6635,7 +6638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6649,7 +6651,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6663,7 +6664,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6677,7 +6677,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6691,7 +6690,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6705,7 +6703,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6719,7 +6716,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6733,7 +6729,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6747,7 +6742,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6761,7 +6755,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6775,7 +6768,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6789,7 +6781,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6803,7 +6794,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6817,7 +6807,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6831,7 +6820,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6845,7 +6833,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6859,7 +6846,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6873,7 +6859,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6887,7 +6872,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6901,7 +6885,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6915,7 +6898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6929,7 +6911,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6943,7 +6924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6957,7 +6937,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17600,7 +17579,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -24867,7 +24846,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -26567,7 +26545,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",
@@ -27054,10 +27032,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@microboxlabs/miot-connection-client": {
-      "resolved": "packages/miot-connection-client",
-      "link": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- `removeService` now fires the Alfresco `"Planificar Servicio"` transition before cancelling the booking, restoring symmetry with the forward `planService → assignDriver` advance fired on plan confirmation.
- New `UNPLAN_TRANSITION` constant in `task-stage-transitions.ts` lives next to `getNextTransition` so both directions are documented in one place.
- Workflow-first ordering: a failed transition leaves the calendar untouched and surfaces an error via the existing notification handler in `use-service-actions.ts`.

Closes #408

## Test plan

- [x] Plan service 1626876 from the calendar — verify task moves `planService → assignDriver`.
- [x] Right-click the planned chip → **Eliminar Planificación**.
- [x] Confirm booking disappears from the calendar.
- [x] Confirm the task reappears in the `planService` kanban column.
- [x] Negative path: simulate a workflow API failure (e.g. revoke task or block the endpoint) and verify the calendar chip stays put with an error toast.

## Out of scope

- Atomicity (workflow advance + booking cancel are still two calls; can be folded into a server-side bundled DELETE if needed).
- Removal from `presentDriver` or later stages — current implementation only handles the `assignDriver → planService` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services now resolve a live workflow task by a stable service code; the planning sidebar shows the live task stage.
  * Kanban tasks and persisted bookings include a stable service identifier for reliable lookup; stored service data no longer relies on transient task IDs/stages.

* **Bug Fixes**
  * Cancelling/removing a booking properly reverses workflow state so tasks return to the planning stage.

* **Documentation**
  * Added task stage labels/translations in English and Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->