### PR TITLE
Based/dashboard ingestion tooltip fix

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -145,15 +145,30 @@ function getRowState(
  * Build the initial rowStates map from a freshly parsed document by
  * surfacing per-row validation errors from /validate as `failed` states.
  * Rows without errors are absent from the map and default to `unprocessed`.
+ *
+ * `prev` lets us reuse the existing RowState reference when a row's failed
+ * error string is identical between runs. Without that, every re-validation
+ * (e.g. triggered by a header rename) hands React.memo'd Rows fresh state
+ * objects, forcing a full re-render of every failed row — which unmounts
+ * any open Tooltip/popper underneath the cursor.
  */
 function hydrateStates(
   doc: ParsedDocument,
   validations: Record<number, string>,
+  prev: ReadonlyMap<number, RowState>,
 ): Map<number, RowState> {
   const map = new Map<number, RowState>();
   for (const r of doc.rows) {
     const err = validations[r.index];
-    if (err) {
+    if (!err) continue;
+    const prior = prev.get(r.index);
+    if (
+      prior &&
+      prior.status === "failed" &&
+      prior.errorMessage === err
+    ) {
+      map.set(r.index, prior);
+    } else {
       map.set(r.index, { status: "failed", errorMessage: err });
     }
   }
@@ -340,7 +355,7 @@ export function useBatchImporter({
      *  /bulk progress. See PRESERVE_DURING_IMPORT at module scope. */
     const applyHydrate = (validations: Record<number, string>) => {
       setRowStates((prev) => {
-        const next = hydrateStates(doc, validations);
+        const next = hydrateStates(doc, validations, prev);
         if (importingRef.current) {
           for (const [idx, state] of prev) {
             if (PRESERVE_DURING_IMPORT.has(state.status)) {
@@ -1193,10 +1208,17 @@ function VirtualPreview({
                 if (!row) return null;
                 const s = rowStates.get(row.index) ?? DEFAULT_STATE;
                 return (
+                  // `transform: translateY(...)` on each virtual row creates
+                  // its own stacking context. The StatusIcon's tooltip popper
+                  // is a sibling node (Flowbite renders inline, no portal),
+                  // so without `hover:z-20` later rows in DOM order paint
+                  // over the popper. Lifting the hovered row above its
+                  // siblings is enough — only one row is `:hover` at a time.
                   <div
                     key={v.index}
                     data-index={v.index}
                     ref={virtualizer.measureElement}
+                    className="hover:z-20"
                     style={{
                       position: "absolute",
                       top: 0,

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/batch-importer.tsx
@@ -162,11 +162,7 @@ function hydrateStates(
     const err = validations[r.index];
     if (!err) continue;
     const prior = prev.get(r.index);
-    if (
-      prior &&
-      prior.status === "failed" &&
-      prior.errorMessage === err
-    ) {
+    if (prior?.status === "failed" && prior.errorMessage === err) {
       map.set(r.index, prior);
     } else {
       map.set(r.index, { status: "failed", errorMessage: err });

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/components/status-icon.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/components/status-icon.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Tooltip } from "flowbite-react";
 import type { RowStatus } from "../engine/types";
 
 interface StatusStyle {
@@ -38,10 +39,14 @@ const STYLES: Record<RowStatus, StatusStyle> = {
 };
 
 /**
- * Intentionally uses a plain `title` attribute rather than Flowbite's Tooltip.
- * With 4000+ rows, mounting 4000 Tooltip instances (each with its own popper
- * machinery) was the single largest contributor to the preview table's freeze.
- * Native title shows on hover at zero DOM / JS cost.
+ * Failed rows mount a real Tooltip; everything else stays a bare span. The
+ * native `title` we used before inherits an OS-controlled show delay (often
+ * 1–2s, occasionally much longer) and resets that timer on every cursor move
+ * or DOM update beneath the pointer — which made errors take tens of seconds
+ * to appear during a streaming import. The popper-cost concern that drove the
+ * native-only choice is addressed by virtualization (only ~12 rows rendered)
+ * + this `tooltip ?` gate (only failed rows mount one), so the live count is
+ * a handful, not thousands.
  */
 export function StatusIcon({
   status,
@@ -49,16 +54,30 @@ export function StatusIcon({
   label,
 }: Readonly<{ status: RowStatus; tooltip?: string; label: string }>) {
   const style = STYLES[status];
-  const title = tooltip ? `${label}\n${tooltip}` : label;
-  // cursor-help: signals a hover-tooltip is available without implying a
-  // click action. Matches what users expect on validation-error indicators.
-  return (
+  const icon = (
     <span
-      title={title}
-      className={`inline-flex h-6 w-6 cursor-help items-center justify-center rounded-full text-sm font-bold leading-none ${style.className}`}
+      className={`inline-flex h-6 w-6 ${tooltip ? "cursor-help" : ""} items-center justify-center rounded-full text-sm font-bold leading-none ${style.className}`}
       aria-label={label}
     >
       {style.glyph}
     </span>
+  );
+
+  if (!tooltip) return icon;
+
+  return (
+    <Tooltip
+      content={
+        <div className="max-w-sm whitespace-pre-line text-left">
+          <div className="font-semibold">{label}</div>
+          <div>{tooltip}</div>
+        </div>
+      }
+      placement="right"
+      style="light"
+      arrow={false}
+    >
+      {icon}
+    </Tooltip>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hovered rows in batch import being obscured by tooltips and overlapping rows by ensuring hovered rows stack above siblings.

* **Improvements**
  * Replaced native browser tooltips with conditional structured tooltips (rendered only when content exists) for consistent visuals and behavior.
  * Preserved failed-row objects during re-validation to avoid unnecessary re-renders and keep memoized row/tooltips stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->