### PR TITLE
feat(calendar): render shift overlays on planning grid

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -15,8 +15,7 @@ import {
 } from "../planning-slot-utils";
 import { SlotCellContent, TimeLabelCell } from "../slot-cell-shared";
 import { usePlanningGrid } from "../use-planning-grid";
-import { PlanningGridOverlays } from "../planning-grid-overlays";
-import { ShiftOverlayLayer } from "../shift-overlay-layer";
+import { PlanningGridShell } from "../planning-grid-shell";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
@@ -217,8 +216,37 @@ export default function DayGrid({
   const TIME_AXIS_WIDTH_PX = 64;
 
   return (
-    <div className="w-full h-full overflow-auto">
-     <div className="relative">
+    <PlanningGridShell
+      shiftOverlayTopPx={HEADER_HEIGHT_PX}
+      shiftOverlayLeftPx={TIME_AXIS_WIDTH_PX}
+      shiftOverlay={{
+        shifts: positionedShifts,
+        onShiftClick: handleShiftClick,
+        isShiftSelected,
+        getServicesForShift,
+        onChipClick: viewPlannedService,
+        onChipContextMenu: handleContextMenu,
+        reassigningServiceId: reassigningService?.service.service.id,
+        dict,
+      }}
+      gridOverlays={{
+        dict,
+        contextMenu,
+        onReassign: handleReassign,
+        onAssign: handleAssign,
+        onDeleteRequest: handleDeleteRequest,
+        onDeleteAssignmentRequest: handleDeleteAssignmentRequest,
+        onCloseContextMenu: handleCloseContextMenu,
+        deleteModal,
+        onConfirmDelete: handleConfirmDelete,
+        onCancelDelete: handleCancelDelete,
+        deleteAssignmentModal,
+        onConfirmDeleteAssignment: handleConfirmDeleteAssignment,
+        onCancelDeleteAssignment: handleCancelDeleteAssignment,
+        reassigningService,
+        selectedSlot,
+      }}
+    >
       <div className="grid" style={{ gridTemplateColumns: "64px 1fr" }}>
         {/* Header row - empty corner cell */}
         <div className="sticky top-0 z-10 bg-white dark:bg-gray-800">
@@ -294,49 +322,6 @@ export default function DayGrid({
           );
         })}
       </div>
-
-      {/* Shift overlay: each rectangle owns its own chips and "add booking"
-          affordance. Sits over the day column only. */}
-      <div
-        className="pointer-events-none absolute"
-        style={{
-          top: HEADER_HEIGHT_PX,
-          left: TIME_AXIS_WIDTH_PX,
-          right: 0,
-          bottom: 0,
-        }}
-      >
-        <ShiftOverlayLayer
-          shifts={positionedShifts}
-          onShiftClick={handleShiftClick}
-          isShiftSelected={isShiftSelected}
-          getServicesForShift={getServicesForShift}
-          onChipClick={viewPlannedService}
-          onChipContextMenu={handleContextMenu}
-          reassigningServiceId={reassigningService?.service.service.id}
-          dict={dict}
-        />
-      </div>
-     </div>
-
-      {/* Context Menu */}
-      <PlanningGridOverlays
-        dict={dict}
-        contextMenu={contextMenu}
-        onReassign={handleReassign}
-        onAssign={handleAssign}
-        onDeleteRequest={handleDeleteRequest}
-        onDeleteAssignmentRequest={handleDeleteAssignmentRequest}
-        onCloseContextMenu={handleCloseContextMenu}
-        deleteModal={deleteModal}
-        onConfirmDelete={handleConfirmDelete}
-        onCancelDelete={handleCancelDelete}
-        deleteAssignmentModal={deleteAssignmentModal}
-        onConfirmDeleteAssignment={handleConfirmDeleteAssignment}
-        onCancelDeleteAssignment={handleCancelDeleteAssignment}
-        reassigningService={reassigningService}
-        selectedSlot={selectedSlot}
-      />
-    </div>
+    </PlanningGridShell>
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -20,8 +20,8 @@ import { ShiftOverlayLayer } from "../shift-overlay-layer";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
+  computeStretchedRowLayout,
   rowOffsetsFromHeights,
-  shiftContentHeightPx,
   type PositionedShift,
 } from "../shift-layout";
 
@@ -188,30 +188,16 @@ export default function DayGrid({
       }),
     [configuredTimeSlots, currentDate, startHour, baselineRowOffsets]
   );
-  const { rowHeights, rowOffsets } = useMemo(() => {
-    const requiredPxPerMin = new Array<number>(timeSlots.length).fill(
-      BASE_ROW_HEIGHT_PX / 30
-    );
-    for (const shift of baseShifts) {
-      const contentPx = shiftContentHeightPx(
-        getServicesForShift(shift).length
-      );
-      if (contentPx <= 0) continue;
-      const required = contentPx / shift.durationMinutes;
-      const startRow = Math.floor((shift.startsAtMin - dayStartMin) / 30);
-      const endRow = Math.min(
-        timeSlots.length - 1,
-        Math.floor((shift.endsAtMin - 1 - dayStartMin) / 30)
-      );
-      for (let r = Math.max(0, startRow); r <= endRow; r++) {
-        if (required > requiredPxPerMin[r]) requiredPxPerMin[r] = required;
-      }
-    }
-    const heights = requiredPxPerMin.map((p) =>
-      Math.max(BASE_ROW_HEIGHT_PX, Math.ceil(p * 30))
-    );
-    return { rowHeights: heights, rowOffsets: rowOffsetsFromHeights(heights) };
-  }, [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]);
+  const { rowHeights, rowOffsets } = useMemo(
+    () =>
+      computeStretchedRowLayout({
+        baseShifts,
+        getServicesCount: (shift) => getServicesForShift(shift).length,
+        rowCount: timeSlots.length,
+        dayStartMin,
+      }),
+    [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]
+  );
 
   const positionedShifts = useMemo(
     () =>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -15,7 +15,10 @@ import {
 } from "../planning-slot-utils";
 import { SlotCellContent, TimeLabelCell } from "../slot-cell-shared";
 import { usePlanningGrid } from "../use-planning-grid";
-import { PlanningGridShell } from "../planning-grid-shell";
+import {
+  PlanningGridShell,
+  buildPlanningGridShellProps,
+} from "../planning-grid-shell";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
@@ -83,8 +86,8 @@ export default function DayGrid({
   startHour = 8,
   endHour = 22,
 }: Readonly<DayGridProps>) {
+  const planningGrid = usePlanningGrid({ startHour, endHour });
   const {
-    selectedSlot,
     handleSelectSlot,
     isSlotSelected: checkSlotSelected,
     timeSlots,
@@ -92,24 +95,9 @@ export default function DayGrid({
     getTimeWindowForSlot,
     getRemainingQuota,
     isSlotBlocked,
-    reassigningService,
-    contextMenu,
-    deleteModal,
-    deleteAssignmentModal,
-    handleContextMenu,
-    handleCloseContextMenu,
-    handleReassign,
-    handleAssign,
-    handleDeleteRequest,
-    handleConfirmDelete,
-    handleCancelDelete,
-    handleDeleteAssignmentRequest,
-    handleConfirmDeleteAssignment,
-    handleCancelDeleteAssignment,
-    viewPlannedService,
     configuredTimeSlots,
     plannedServices,
-  } = usePlanningGrid({ startHour, endHour });
+  } = planningGrid;
 
   const dayInfo = useMemo(
     () => getDayInfo(currentDate, lang),
@@ -215,37 +203,20 @@ export default function DayGrid({
   // Time-axis column width — the overlay covers the day column only.
   const TIME_AXIS_WIDTH_PX = 64;
 
+  const shellProps = buildPlanningGridShellProps({
+    planningGrid,
+    positionedShifts,
+    onShiftClick: handleShiftClick,
+    isShiftSelected,
+    getServicesForShift,
+    dict,
+  });
+
   return (
     <PlanningGridShell
       shiftOverlayTopPx={HEADER_HEIGHT_PX}
       shiftOverlayLeftPx={TIME_AXIS_WIDTH_PX}
-      shiftOverlay={{
-        shifts: positionedShifts,
-        onShiftClick: handleShiftClick,
-        isShiftSelected,
-        getServicesForShift,
-        onChipClick: viewPlannedService,
-        onChipContextMenu: handleContextMenu,
-        reassigningServiceId: reassigningService?.service.service.id,
-        dict,
-      }}
-      gridOverlays={{
-        dict,
-        contextMenu,
-        onReassign: handleReassign,
-        onAssign: handleAssign,
-        onDeleteRequest: handleDeleteRequest,
-        onDeleteAssignmentRequest: handleDeleteAssignmentRequest,
-        onCloseContextMenu: handleCloseContextMenu,
-        deleteModal,
-        onConfirmDelete: handleConfirmDelete,
-        onCancelDelete: handleCancelDelete,
-        deleteAssignmentModal,
-        onConfirmDeleteAssignment: handleConfirmDeleteAssignment,
-        onCancelDeleteAssignment: handleCancelDeleteAssignment,
-        reassigningService,
-        selectedSlot,
-      }}
+      {...shellProps}
     >
       <div className="grid" style={{ gridTemplateColumns: "64px 1fr" }}>
         {/* Header row - empty corner cell */}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -17,7 +17,13 @@ import { SlotCellContent, TimeLabelCell } from "../slot-cell-shared";
 import { usePlanningGrid } from "../use-planning-grid";
 import { PlanningGridOverlays } from "../planning-grid-overlays";
 import { ShiftOverlayLayer } from "../shift-overlay-layer";
-import { buildShiftLayout, type PositionedShift } from "../shift-layout";
+import {
+  BASE_ROW_HEIGHT_PX,
+  buildShiftLayout,
+  rowOffsetsFromHeights,
+  shiftContentHeightPx,
+  type PositionedShift,
+} from "../shift-layout";
 
 interface DayGridProps {
   lang: string;
@@ -133,19 +139,6 @@ export default function DayGrid({
     [checkSlotSelected]
   );
 
-  // Cells no longer expand for chip stacking (chips render inside the shift
-  // overlay rectangles, not in cells), so each row has the same fixed
-  // height. The constant matches the previous base value so the overall
-  // grid density is unchanged.
-  const ROW_HEIGHT_PX = 48;
-  const rowOffsets = useMemo(() => {
-    const offsets = [0];
-    for (let i = 0; i < timeSlots.length; i++) {
-      offsets.push(offsets[i] + ROW_HEIGHT_PX);
-    }
-    return offsets;
-  }, [timeSlots.length]);
-
   // Index planned services by exact start "HH:MM" on the current date so
   // the overlay layer can fetch the chips that belong inside each shift
   // rectangle in O(1).
@@ -169,6 +162,56 @@ export default function DayGrid({
       servicesByStartOnDate.get(`${shift.slotHour}:${shift.slotMinutes}`) ?? [],
     [servicesByStartOnDate]
   );
+
+  // Two-pass shift layout so rows containing chip-heavy shifts can stretch.
+  // Pass 1: build shifts on a baseline 48px-per-row grid to learn each
+  // shift's (start, end, duration) — geometry doesn't depend on heights yet.
+  // Pass 2: walk those shifts, derive a required px/min for each row from
+  // the densest shift inside, rebuild rowOffsets, then re-layout shifts.
+  // This mirrors the old chip-driven cell expansion so the time axis stays
+  // aligned with shift rectangles even when one slot holds multiple chips.
+  const dayStartMin = startHour * 60;
+  const baselineRowOffsets = useMemo(
+    () =>
+      rowOffsetsFromHeights(
+        new Array(timeSlots.length).fill(BASE_ROW_HEIGHT_PX)
+      ),
+    [timeSlots.length]
+  );
+  const baseShifts = useMemo(
+    () =>
+      buildShiftLayout({
+        timeSlots: configuredTimeSlots,
+        date: currentDate,
+        startHour,
+        rowOffsets: baselineRowOffsets,
+      }),
+    [configuredTimeSlots, currentDate, startHour, baselineRowOffsets]
+  );
+  const { rowHeights, rowOffsets } = useMemo(() => {
+    const requiredPxPerMin = new Array<number>(timeSlots.length).fill(
+      BASE_ROW_HEIGHT_PX / 30
+    );
+    for (const shift of baseShifts) {
+      const contentPx = shiftContentHeightPx(
+        getServicesForShift(shift).length
+      );
+      if (contentPx <= 0) continue;
+      const required = contentPx / shift.durationMinutes;
+      const startRow = Math.floor((shift.startsAtMin - dayStartMin) / 30);
+      const endRow = Math.min(
+        timeSlots.length - 1,
+        Math.floor((shift.endsAtMin - 1 - dayStartMin) / 30)
+      );
+      for (let r = Math.max(0, startRow); r <= endRow; r++) {
+        if (required > requiredPxPerMin[r]) requiredPxPerMin[r] = required;
+      }
+    }
+    const heights = requiredPxPerMin.map((p) =>
+      Math.max(BASE_ROW_HEIGHT_PX, Math.ceil(p * 30))
+    );
+    return { rowHeights: heights, rowOffsets: rowOffsetsFromHeights(heights) };
+  }, [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]);
 
   const positionedShifts = useMemo(
     () =>
@@ -251,7 +294,7 @@ export default function DayGrid({
             <Fragment key={slot.label}>
               <TimeLabelCell
                 label={slot.label}
-                minHeight={ROW_HEIGHT_PX}
+                minHeight={rowHeights[slotIdx]}
                 isLastSlot={isLastSlot(slotIdx)}
               />
               <DayGridSlotCell

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -16,6 +16,8 @@ import {
 import { SlotCellContent, TimeLabelCell } from "../slot-cell-shared";
 import { usePlanningGrid } from "../use-planning-grid";
 import { PlanningGridOverlays } from "../planning-grid-overlays";
+import { ShiftOverlayLayer } from "../shift-overlay-layer";
+import { buildShiftLayout, type PositionedShift } from "../shift-layout";
 
 interface DayGridProps {
   lang: string;
@@ -45,17 +47,7 @@ interface DayGridSlotCellProps {
   currentDate: Date;
   isPastDay: boolean;
   state: SlotState;
-  selected: boolean;
-  slotServices: PlannedService[];
   isLastSlot: boolean;
-  reassigningService: {
-    service: PlannedService;
-    originalSlot: { date: Date; hour: number; minutes: number };
-  } | null;
-  onCellClick: (slot: { hour: number; minutes: number }) => void;
-  onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
-  onChipClick: (ps: PlannedService) => void;
-  dict: I18nDictionary;
 }
 
 function DayGridSlotCell({
@@ -63,50 +55,20 @@ function DayGridSlotCell({
   currentDate,
   isPastDay,
   state,
-  selected,
-  slotServices,
   isLastSlot,
-  reassigningService,
-  onCellClick,
-  onContextMenu,
-  onChipClick,
-  dict,
 }: Readonly<DayGridSlotCellProps>) {
-  const { slotBlocked, isDisabled } = state;
-
-  const handleClick = () => {
-    if (!isDisabled) onCellClick(slot);
-  };
-
-  const cellContent = (
-    <button
-      type="button"
+  return (
+    <div
       data-slot-date={dayjs(currentDate).format("YYYY-MM-DD")}
       data-slot-time={`${slot.hour.toString().padStart(2, "0")}:${slot.minutes.toString().padStart(2, "0")}`}
-      onClick={handleClick}
-      disabled={isDisabled}
-      className={getSlotCellClassName(state, isPastDay, selected, {
+      className={getSlotCellClassName(state, isPastDay, {
         isLastSlot,
         isFirstEditable: !isPastDay,
       })}
     >
-      <SlotCellContent
-        state={state}
-        isPastDay={isPastDay}
-        services={slotServices}
-        reassigningServiceId={reassigningService?.service.service.id}
-        onContextMenu={onContextMenu}
-        onChipClick={onChipClick}
-        dict={dict}
-        servicesLayout="row"
-      />
-    </button>
+      <SlotCellContent state={state} isPastDay={isPastDay} />
+    </div>
   );
-
-  if (slotBlocked && !isPastDay) {
-    return <div className="w-full h-full">{cellContent}</div>;
-  }
-  return cellContent;
 }
 
 export default function DayGrid({
@@ -122,7 +84,6 @@ export default function DayGrid({
     isSlotSelected: checkSlotSelected,
     timeSlots,
     isLastSlot,
-    getPlannedServicesForSlot: getServicesForSlot,
     getTimeWindowForSlot,
     getRemainingQuota,
     isSlotBlocked,
@@ -141,6 +102,8 @@ export default function DayGrid({
     handleConfirmDeleteAssignment,
     handleCancelDeleteAssignment,
     viewPlannedService,
+    configuredTimeSlots,
+    plannedServices,
   } = usePlanningGrid({ startHour, endHour });
 
   const dayInfo = useMemo(
@@ -153,33 +116,80 @@ export default function DayGrid({
     return dayjs(currentDate).isBefore(dayjs().startOf("day"), "day");
   }, [currentDate]);
 
-  const handleCellClick = useCallback(
-    (slot: { hour: number; minutes: number }) => {
+  const handleShiftClick = useCallback(
+    (shift: PositionedShift) => {
       handleSelectSlot({
-        date: currentDate,
-        hour: slot.hour,
-        minutes: slot.minutes,
+        date: shift.date,
+        hour: shift.slotHour,
+        minutes: shift.slotMinutes,
       });
     },
-    [handleSelectSlot, currentDate]
+    [handleSelectSlot]
   );
 
-  const isSlotSelected = useCallback(
-    (slot: { hour: number; minutes: number }) => {
-      return checkSlotSelected(currentDate, slot.hour, slot.minutes);
-    },
-    [checkSlotSelected, currentDate]
+  const isShiftSelected = useCallback(
+    (shift: PositionedShift) =>
+      checkSlotSelected(shift.date, shift.slotHour, shift.slotMinutes),
+    [checkSlotSelected]
   );
 
-  const getPlannedServicesForSlot = useCallback(
-    (slot: { hour: number; minutes: number }) => {
-      return getServicesForSlot(currentDate, slot.hour, slot.minutes);
-    },
-    [getServicesForSlot, currentDate]
+  // Cells no longer expand for chip stacking (chips render inside the shift
+  // overlay rectangles, not in cells), so each row has the same fixed
+  // height. The constant matches the previous base value so the overall
+  // grid density is unchanged.
+  const ROW_HEIGHT_PX = 48;
+  const rowOffsets = useMemo(() => {
+    const offsets = [0];
+    for (let i = 0; i < timeSlots.length; i++) {
+      offsets.push(offsets[i] + ROW_HEIGHT_PX);
+    }
+    return offsets;
+  }, [timeSlots.length]);
+
+  // Index planned services by exact start "HH:MM" on the current date so
+  // the overlay layer can fetch the chips that belong inside each shift
+  // rectangle in O(1).
+  const servicesByStartOnDate = useMemo(() => {
+    const map = new Map<string, PlannedService[]>();
+    for (const ps of plannedServices) {
+      if (!dayjs(ps.slot.date).isSame(currentDate, "day")) continue;
+      const key = `${ps.slot.hour}:${ps.slot.minutes}`;
+      const arr = map.get(key);
+      if (arr) {
+        arr.push(ps);
+      } else {
+        map.set(key, [ps]);
+      }
+    }
+    return map;
+  }, [plannedServices, currentDate]);
+
+  const getServicesForShift = useCallback(
+    (shift: PositionedShift) =>
+      servicesByStartOnDate.get(`${shift.slotHour}:${shift.slotMinutes}`) ?? [],
+    [servicesByStartOnDate]
   );
+
+  const positionedShifts = useMemo(
+    () =>
+      buildShiftLayout({
+        timeSlots: configuredTimeSlots,
+        date: currentDate,
+        startHour,
+        rowOffsets,
+      }),
+    [configuredTimeSlots, currentDate, startHour, rowOffsets]
+  );
+
+  // Header band (sticky day/time-axis row) height in px — the time-slot grid
+  // starts immediately below this. Matches `h-20` (5rem) on the header cells.
+  const HEADER_HEIGHT_PX = 80;
+  // Time-axis column width — the overlay covers the day column only.
+  const TIME_AXIS_WIDTH_PX = 64;
 
   return (
     <div className="w-full h-full overflow-auto">
+     <div className="relative">
       <div className="grid" style={{ gridTemplateColumns: "64px 1fr" }}>
         {/* Header row - empty corner cell */}
         <div className="sticky top-0 z-10 bg-white dark:bg-gray-800">
@@ -236,15 +246,12 @@ export default function DayGrid({
             getRemainingQuota,
             isSlotBlocked,
           });
-          const selected = isSlotSelected(slot);
-          const slotServices = getPlannedServicesForSlot(slot);
-          const rowMinHeight = 48 + Math.max(0, slotServices.length - 1) * 20;
 
           return (
             <Fragment key={slot.label}>
               <TimeLabelCell
                 label={slot.label}
-                minHeight={rowMinHeight}
+                minHeight={ROW_HEIGHT_PX}
                 isLastSlot={isLastSlot(slotIdx)}
               />
               <DayGridSlotCell
@@ -252,19 +259,36 @@ export default function DayGrid({
                 currentDate={currentDate}
                 isPastDay={isPastDay}
                 state={slotState}
-                selected={selected}
-                slotServices={slotServices}
                 isLastSlot={isLastSlot(slotIdx)}
-                reassigningService={reassigningService}
-                onCellClick={handleCellClick}
-                onContextMenu={handleContextMenu}
-                onChipClick={viewPlannedService}
-                dict={dict}
               />
             </Fragment>
           );
         })}
       </div>
+
+      {/* Shift overlay: each rectangle owns its own chips and "add booking"
+          affordance. Sits over the day column only. */}
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          top: HEADER_HEIGHT_PX,
+          left: TIME_AXIS_WIDTH_PX,
+          right: 0,
+          bottom: 0,
+        }}
+      >
+        <ShiftOverlayLayer
+          shifts={positionedShifts}
+          onShiftClick={handleShiftClick}
+          isShiftSelected={isShiftSelected}
+          getServicesForShift={getServicesForShift}
+          onChipClick={viewPlannedService}
+          onChipContextMenu={handleContextMenu}
+          reassigningServiceId={reassigningService?.service.service.id}
+          dict={dict}
+        />
+      </div>
+     </div>
 
       {/* Context Menu */}
       <PlanningGridOverlays

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -107,7 +107,7 @@ export function PlannedServiceChip({
         }
       }}
       className={twMerge(
-        "min-w-0 w-full",
+        "min-w-0 w-full pointer-events-auto",
         "rounded flex items-center",
         onClick ? "cursor-pointer" : "cursor-context-menu",
         "text-xs font-medium px-1.5 py-1 border-l-4",

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+import { ShiftOverlayLayer } from "./shift-overlay-layer";
+import { PlanningGridOverlays } from "./planning-grid-overlays";
+
+interface PlanningGridShellProps {
+  /**
+   * The grid itself (time-axis column + day columns + cells). Receives no
+   * props from the shell — the shell only handles outer positioning, the
+   * overlay layer mounted on top, and the context-menu / delete-modal
+   * overlays at the root.
+   */
+  readonly children: ReactNode;
+  /**
+   * Pixel offset from the top of the grid where the shift overlay area
+   * starts (i.e. the height of the sticky header band).
+   */
+  readonly shiftOverlayTopPx: number;
+  /**
+   * Pixel offset from the left where the shift overlay area starts (i.e.
+   * the width of the time-axis column).
+   */
+  readonly shiftOverlayLeftPx: number;
+  /**
+   * Props forwarded verbatim to the `<ShiftOverlayLayer>` mounted over the
+   * day-columns area.
+   */
+  readonly shiftOverlay: ComponentProps<typeof ShiftOverlayLayer>;
+  /**
+   * Props forwarded verbatim to the `<PlanningGridOverlays>` rendered at
+   * the root of the grid (context menu + delete-confirmation modals).
+   */
+  readonly gridOverlays: ComponentProps<typeof PlanningGridOverlays>;
+}
+
+/**
+ * Common scaffolding shared by `DayGrid` and `PlanningWeekView`: the
+ * scroll container, the relative wrapper that anchors the shift-overlay
+ * layer, and the root-level planning context-menu/modal overlays. Each
+ * view supplies its own grid markup as `children`.
+ *
+ * Lifted out of the two views to remove the previous ~50-line copy of
+ * identical wrapping JSX.
+ */
+export function PlanningGridShell({
+  children,
+  shiftOverlayTopPx,
+  shiftOverlayLeftPx,
+  shiftOverlay,
+  gridOverlays,
+}: PlanningGridShellProps) {
+  return (
+    <div className="w-full h-full overflow-auto">
+      <div className="relative">
+        {children}
+
+        {/* Shift overlay: each rectangle owns its own chips and "add
+            booking" affordance. Positioned over the day-columns area
+            (right of the time axis, below the sticky header). */}
+        <div
+          className="pointer-events-none absolute"
+          style={{
+            top: shiftOverlayTopPx,
+            left: shiftOverlayLeftPx,
+            right: 0,
+            bottom: 0,
+          }}
+        >
+          <ShiftOverlayLayer {...shiftOverlay} />
+        </div>
+      </div>
+
+      {/* Context menu + delete modals (rendered at the scroll-container
+          root, outside the relative wrapper, so they're not clipped). */}
+      <PlanningGridOverlays {...gridOverlays} />
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
@@ -3,6 +3,10 @@
 import type { ComponentProps, ReactNode } from "react";
 import { ShiftOverlayLayer } from "./shift-overlay-layer";
 import { PlanningGridOverlays } from "./planning-grid-overlays";
+import type { PlannedService } from "./planning-selection-context";
+import type { PositionedShift } from "./shift-layout";
+import type { UsePlanningGridReturn } from "./use-planning-grid";
+import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
 
 interface PlanningGridShellProps {
   /**
@@ -43,6 +47,62 @@ interface PlanningGridShellProps {
  * Lifted out of the two views to remove the previous ~50-line copy of
  * identical wrapping JSX.
  */
+/**
+ * Build the `shiftOverlay` + `gridOverlays` prop bundles for
+ * `<PlanningGridShell>` from the planning-grid hook plus the view-specific
+ * overlay computeds. Lifts the per-view boilerplate (15+ identical fields
+ * per bundle wired to the same hook) out of `DayGrid` and `PlanningWeekView`.
+ */
+export function buildPlanningGridShellProps(params: {
+  planningGrid: UsePlanningGridReturn;
+  positionedShifts: readonly PositionedShift[];
+  onShiftClick: (shift: PositionedShift) => void;
+  isShiftSelected: (shift: PositionedShift) => boolean;
+  getServicesForShift: (shift: PositionedShift) => readonly PlannedService[];
+  dict: I18nDictionary;
+}): {
+  shiftOverlay: ComponentProps<typeof ShiftOverlayLayer>;
+  gridOverlays: ComponentProps<typeof PlanningGridOverlays>;
+} {
+  const {
+    planningGrid: pg,
+    positionedShifts,
+    onShiftClick,
+    isShiftSelected,
+    getServicesForShift,
+    dict,
+  } = params;
+  return {
+    shiftOverlay: {
+      shifts: positionedShifts,
+      onShiftClick,
+      isShiftSelected,
+      getServicesForShift,
+      onChipClick: pg.viewPlannedService,
+      onChipContextMenu: pg.handleContextMenu,
+      reassigningServiceId: pg.reassigningService?.service.service.id,
+      dict,
+    },
+    gridOverlays: {
+      dict,
+      contextMenu: pg.contextMenu,
+      onReassign: pg.handleReassign,
+      onAssign: pg.handleAssign,
+      onDeleteRequest: pg.handleDeleteRequest,
+      onDeleteAssignmentRequest: pg.handleDeleteAssignmentRequest,
+      onCloseContextMenu: pg.handleCloseContextMenu,
+      deleteModal: pg.deleteModal,
+      onConfirmDelete: pg.handleConfirmDelete,
+      onCancelDelete: pg.handleCancelDelete,
+      deleteAssignmentModal: pg.deleteAssignmentModal,
+      onConfirmDeleteAssignment: pg.handleConfirmDeleteAssignment,
+      onCancelDeleteAssignment: pg.handleCancelDeleteAssignment,
+      reassigningService: pg.reassigningService,
+      selectedSlot: pg.selectedSlot,
+    },
+  };
+}
+
 export function PlanningGridShell({
   children,
   shiftOverlayTopPx,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -962,9 +962,13 @@ interface PlanningSelectionProviderProps {
 }
 
 /**
- * Gets the week number of the month (1-5) for a given date
+ * Gets the week number of the month (1-5) for a given date.
+ * Exported so other modules (e.g. the shift-overlay layout helper) use the
+ * exact same definition the weekly-pattern matcher does — otherwise the
+ * planner and the overlay would disagree on which dates a `W1`/`W2…` TW
+ * covers.
  */
-function getWeekOfMonth(date: dayjs.Dayjs): number {
+export function getWeekOfMonth(date: dayjs.Dayjs): number {
   const firstDayOfMonth = date.startOf("month");
   const firstMonday =
     firstDayOfMonth.isoWeekday() <= 1

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -162,6 +162,9 @@ export interface TimeSlot {
   quota?: number;
   // Visual color (optional, mainly for windows)
   color?: TimeWindowColor;
+  // Server-managed shift cadence in minutes; only present on TWs loaded from
+  // the API. Falls back to the row granularity (30 min) when missing.
+  slotDurationMinutes?: number;
 }
 
 /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-slot-utils.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-slot-utils.ts
@@ -79,14 +79,12 @@ export interface SlotCellClassNameOptions {
 export function getSlotCellClassName(
   state: SlotState,
   isPastDay: boolean,
-  selected: boolean,
   options?: SlotCellClassNameOptions
 ): string {
   const {
     slotBlocked,
     hasTimeWindow,
     isQuotaFull,
-    isDisabled,
     windowColor,
     blockedStripeClass,
   } = state;
@@ -96,36 +94,23 @@ export function getSlotCellClassName(
     isFirstEditable = false,
   } = options ?? {};
   return twMerge(
-    "h-full w-full relative",
+    // The cell is now a passive ruler — overlay rectangles (rendered by
+    // ShiftOverlayLayer) are the actual click target and the only place a
+    // selection ring is drawn. `pointer-events-none` keeps clicks falling
+    // through to whichever element is on top at that point (overlay
+    // rectangle or chip).
+    "h-full w-full relative pointer-events-none",
     "border-l border-t border-gray-200 dark:border-gray-700",
     isFirstEditable && "border-l-2 border-l-primary-500 dark:border-l-primary-400",
-    "transition-all duration-200 p-1",
+    "transition-all duration-200 p-1 cursor-default",
     blockedStripeClass,
     isPastDay && !hasTimeWindow && "bg-gray-50/60 dark:bg-gray-900/20",
-    isDisabled ? "cursor-not-allowed" : "cursor-pointer",
     !isPastDay && !slotBlocked && isQuotaFull && "opacity-60",
+    !slotBlocked && hasTimeWindow && !isQuotaFull && windowColor.bg,
     !slotBlocked &&
       hasTimeWindow &&
-      !selected &&
-      !isQuotaFull &&
-      windowColor.bg,
-    !slotBlocked &&
-      hasTimeWindow &&
-      !selected &&
       isQuotaFull &&
       "bg-red-50 dark:bg-red-900/20",
-    selected
-      ? "bg-primary-100 dark:bg-primary-900/40 ring-2 ring-inset ring-primary-500"
-      : !isPastDay &&
-          !slotBlocked &&
-          !hasTimeWindow &&
-          "hover:bg-gray-50 dark:hover:bg-gray-700/50",
-    !isPastDay &&
-      !slotBlocked &&
-      hasTimeWindow &&
-      !selected &&
-      !isQuotaFull &&
-      windowColor.hover,
     isLastDay && "border-r",
     isLastSlot && "border-b",
     isLastDay && isLastSlot && "rounded-br-lg"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -22,8 +22,7 @@ import {
 } from "./planning-slot-utils";
 import { SlotCellContent, TimeLabelCell } from "./slot-cell-shared";
 import { usePlanningGrid } from "./use-planning-grid";
-import { PlanningGridOverlays } from "./planning-grid-overlays";
-import { ShiftOverlayLayer } from "./shift-overlay-layer";
+import { PlanningGridShell } from "./planning-grid-shell";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
@@ -265,8 +264,37 @@ export default function PlanningWeekView({
   const TIME_AXIS_WIDTH_PX = 64;
 
   return (
-    <div className="w-full h-full overflow-auto">
-     <div className="relative">
+    <PlanningGridShell
+      shiftOverlayTopPx={HEADER_HEIGHT_PX}
+      shiftOverlayLeftPx={TIME_AXIS_WIDTH_PX}
+      shiftOverlay={{
+        shifts: positionedShifts,
+        onShiftClick: handleShiftClick,
+        isShiftSelected,
+        getServicesForShift,
+        onChipClick: viewPlannedService,
+        onChipContextMenu: handleContextMenu,
+        reassigningServiceId: reassigningService?.service.service.id,
+        dict,
+      }}
+      gridOverlays={{
+        dict,
+        contextMenu,
+        onReassign: handleReassign,
+        onAssign: handleAssign,
+        onDeleteRequest: handleDeleteRequest,
+        onDeleteAssignmentRequest: handleDeleteAssignmentRequest,
+        onCloseContextMenu: handleCloseContextMenu,
+        deleteModal,
+        onConfirmDelete: handleConfirmDelete,
+        onCancelDelete: handleCancelDelete,
+        deleteAssignmentModal,
+        onConfirmDeleteAssignment: handleConfirmDeleteAssignment,
+        onCancelDeleteAssignment: handleCancelDeleteAssignment,
+        reassigningService,
+        selectedSlot,
+      }}
+    >
       <div
         className="grid min-w-150"
         style={{
@@ -370,49 +398,6 @@ export default function PlanningWeekView({
           );
         })}
       </div>
-
-      {/* Shift overlay: each rectangle owns its own chips and "add booking"
-          affordance. */}
-      <div
-        className="pointer-events-none absolute"
-        style={{
-          top: HEADER_HEIGHT_PX,
-          left: TIME_AXIS_WIDTH_PX,
-          right: 0,
-          bottom: 0,
-        }}
-      >
-        <ShiftOverlayLayer
-          shifts={positionedShifts}
-          onShiftClick={handleShiftClick}
-          isShiftSelected={isShiftSelected}
-          getServicesForShift={getServicesForShift}
-          onChipClick={viewPlannedService}
-          onChipContextMenu={handleContextMenu}
-          reassigningServiceId={reassigningService?.service.service.id}
-          dict={dict}
-        />
-      </div>
-     </div>
-
-      {/* Overlays */}
-      <PlanningGridOverlays
-        dict={dict}
-        contextMenu={contextMenu}
-        onReassign={handleReassign}
-        onAssign={handleAssign}
-        onDeleteRequest={handleDeleteRequest}
-        onDeleteAssignmentRequest={handleDeleteAssignmentRequest}
-        onCloseContextMenu={handleCloseContextMenu}
-        deleteModal={deleteModal}
-        onConfirmDelete={handleConfirmDelete}
-        onCancelDelete={handleCancelDelete}
-        deleteAssignmentModal={deleteAssignmentModal}
-        onConfirmDeleteAssignment={handleConfirmDeleteAssignment}
-        onCancelDeleteAssignment={handleCancelDeleteAssignment}
-        reassigningService={reassigningService}
-        selectedSlot={selectedSlot}
-      />
-    </div>
+    </PlanningGridShell>
   );
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -22,7 +22,10 @@ import {
 } from "./planning-slot-utils";
 import { SlotCellContent, TimeLabelCell } from "./slot-cell-shared";
 import { usePlanningGrid } from "./use-planning-grid";
-import { PlanningGridShell } from "./planning-grid-shell";
+import {
+  PlanningGridShell,
+  buildPlanningGridShellProps,
+} from "./planning-grid-shell";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
@@ -95,8 +98,8 @@ export default function PlanningWeekView({
 }: Readonly<PlanningWeekViewProps>) {
   const searchParams = useSearchParams();
 
+  const planningGrid = usePlanningGrid({ startHour, endHour });
   const {
-    selectedSlot,
     handleSelectSlot,
     isSlotSelected: checkSlotSelected,
     timeSlots,
@@ -104,24 +107,9 @@ export default function PlanningWeekView({
     getTimeWindowForSlot,
     getRemainingQuota,
     isSlotBlocked,
-    reassigningService,
-    contextMenu,
-    deleteModal,
-    deleteAssignmentModal,
-    handleContextMenu,
-    handleCloseContextMenu,
-    handleReassign,
-    handleAssign,
-    handleDeleteRequest,
-    handleConfirmDelete,
-    handleCancelDelete,
-    handleDeleteAssignmentRequest,
-    handleConfirmDeleteAssignment,
-    handleCancelDeleteAssignment,
-    viewPlannedService,
     configuredTimeSlots,
     plannedServices,
-  } = usePlanningGrid({ startHour, endHour });
+  } = planningGrid;
 
   // Read date from URL, fallback to prop or today
   const currentDate = useMemo(() => {
@@ -263,37 +251,20 @@ export default function PlanningWeekView({
   const HEADER_HEIGHT_PX = 64;
   const TIME_AXIS_WIDTH_PX = 64;
 
+  const shellProps = buildPlanningGridShellProps({
+    planningGrid,
+    positionedShifts,
+    onShiftClick: handleShiftClick,
+    isShiftSelected,
+    getServicesForShift,
+    dict,
+  });
+
   return (
     <PlanningGridShell
       shiftOverlayTopPx={HEADER_HEIGHT_PX}
       shiftOverlayLeftPx={TIME_AXIS_WIDTH_PX}
-      shiftOverlay={{
-        shifts: positionedShifts,
-        onShiftClick: handleShiftClick,
-        isShiftSelected,
-        getServicesForShift,
-        onChipClick: viewPlannedService,
-        onChipContextMenu: handleContextMenu,
-        reassigningServiceId: reassigningService?.service.service.id,
-        dict,
-      }}
-      gridOverlays={{
-        dict,
-        contextMenu,
-        onReassign: handleReassign,
-        onAssign: handleAssign,
-        onDeleteRequest: handleDeleteRequest,
-        onDeleteAssignmentRequest: handleDeleteAssignmentRequest,
-        onCloseContextMenu: handleCloseContextMenu,
-        deleteModal,
-        onConfirmDelete: handleConfirmDelete,
-        onCancelDelete: handleCancelDelete,
-        deleteAssignmentModal,
-        onConfirmDeleteAssignment: handleConfirmDeleteAssignment,
-        onCancelDeleteAssignment: handleCancelDeleteAssignment,
-        reassigningService,
-        selectedSlot,
-      }}
+      {...shellProps}
     >
       <div
         className="grid min-w-150"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -20,10 +20,11 @@ import {
   getSlotCellClassName,
   type SlotState,
 } from "./planning-slot-utils";
-import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { SlotCellContent, TimeLabelCell } from "./slot-cell-shared";
 import { usePlanningGrid } from "./use-planning-grid";
 import { PlanningGridOverlays } from "./planning-grid-overlays";
+import { ShiftOverlayLayer } from "./shift-overlay-layer";
+import { buildShiftLayout, type PositionedShift } from "./shift-layout";
 
 const DAYS_IN_WORK_WEEK = 7; // Mon-Sat
 
@@ -47,76 +48,37 @@ interface WeekSlotCellProps {
   day: WeekDay;
   slot: { hour: number; minutes: number; label: string };
   slotState: SlotState;
-  selected: boolean;
-  slotServices: PlannedService[];
   isLastDay: boolean;
   isLastSlot: boolean;
-  reassigningService: {
-    service: PlannedService;
-    originalSlot: { date: Date; hour: number; minutes: number };
-  } | null;
-  onCellClick: (day: WeekDay, slot: { hour: number; minutes: number }) => void;
-  onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
-  onChipClick: (ps: PlannedService) => void;
-  dict: I18nRecord;
 }
 
 function WeekSlotCell({
   day,
   slot,
   slotState,
-  selected,
-  slotServices,
   isLastDay,
   isLastSlot,
-  reassigningService,
-  onCellClick,
-  onContextMenu,
-  onChipClick,
-  dict,
 }: Readonly<WeekSlotCellProps>) {
-  const { slotBlocked, isDisabled } = slotState;
   const dayIsPast = dayjs(day.date).isBefore(dayjs().startOf("day"), "day");
 
-  const handleClick = () => {
-    if (!isDisabled) onCellClick(day, slot);
-  };
-
-  const cellContent = (
-    <button
-      type="button"
-      tabIndex={isDisabled ? -1 : 0}
-      onClick={handleClick}
-      disabled={isDisabled}
-      data-slot-date={dayjs(day.date).format("YYYY-MM-DD")}
-      data-slot-time={`${slot.hour.toString().padStart(2, "0")}:${slot.minutes.toString().padStart(2, "0")}`}
-      className={twMerge(
-        "appearance-none border-0 p-0 m-0 text-left",
-        getSlotCellClassName(slotState, dayIsPast, selected, {
-          isLastDay,
-          isLastSlot,
-          isFirstEditable: day.isToday,
-        })
-      )}
-    >
-      <SlotCellContent
-        state={slotState}
-        isPastDay={dayIsPast}
-        services={slotServices}
-        reassigningServiceId={reassigningService?.service.service.id}
-        onContextMenu={onContextMenu}
-        onChipClick={onChipClick}
-        dict={dict}
-        servicesLayout="column"
-      />
-    </button>
+  return (
+    <div className="w-full h-full">
+      <div
+        data-slot-date={dayjs(day.date).format("YYYY-MM-DD")}
+        data-slot-time={`${slot.hour.toString().padStart(2, "0")}:${slot.minutes.toString().padStart(2, "0")}`}
+        className={twMerge(
+          "appearance-none border-0 p-0 m-0 text-left",
+          getSlotCellClassName(slotState, dayIsPast, {
+            isLastDay,
+            isLastSlot,
+            isFirstEditable: day.isToday,
+          })
+        )}
+      >
+        <SlotCellContent state={slotState} isPastDay={dayIsPast} />
+      </div>
+    </div>
   );
-
-  if (slotBlocked && !dayIsPast) {
-    return <div className="w-full h-full">{cellContent}</div>;
-  }
-
-  return <div className="w-full h-full">{cellContent}</div>;
 }
 
 export default function PlanningWeekView({
@@ -134,7 +96,6 @@ export default function PlanningWeekView({
     isSlotSelected: checkSlotSelected,
     timeSlots,
     isLastSlot,
-    getPlannedServicesForSlot: getServicesForSlot,
     getTimeWindowForSlot,
     getRemainingQuota,
     isSlotBlocked,
@@ -153,6 +114,8 @@ export default function PlanningWeekView({
     handleConfirmDeleteAssignment,
     handleCancelDeleteAssignment,
     viewPlannedService,
+    configuredTimeSlots,
+    plannedServices,
   } = usePlanningGrid({ startHour, endHour });
 
   // Read date from URL, fallback to prop or today
@@ -177,34 +140,99 @@ export default function PlanningWeekView({
     [today]
   );
 
-  const handleCellClick = useCallback(
-    (day: WeekDay, slot: { hour: number; minutes: number }) => {
+  const handleShiftClick = useCallback(
+    (shift: PositionedShift) => {
       handleSelectSlot({
-        date: day.date,
-        hour: slot.hour,
-        minutes: slot.minutes,
-        dayIndex: weekDays.findIndex((d) => d.date === day.date),
+        date: shift.date,
+        hour: shift.slotHour,
+        minutes: shift.slotMinutes,
+        dayIndex: shift.columnIndex,
       });
     },
-    [handleSelectSlot, weekDays]
+    [handleSelectSlot]
   );
 
-  const isSlotSelected = useCallback(
-    (day: WeekDay, slot: { hour: number; minutes: number }) => {
-      return checkSlotSelected(day.date, slot.hour, slot.minutes);
-    },
+  const isShiftSelected = useCallback(
+    (shift: PositionedShift) =>
+      checkSlotSelected(shift.date, shift.slotHour, shift.slotMinutes),
     [checkSlotSelected]
   );
 
-  const getPlannedServicesForSlot = useCallback(
-    (day: WeekDay, slot: { hour: number; minutes: number }) => {
-      return getServicesForSlot(day.date, slot.hour, slot.minutes);
+  // Cells no longer expand for chip stacking (chips render inside the shift
+  // overlay rectangles, not in cells), so each row has the same fixed
+  // height. Matches the previous base value so the overall grid density is
+  // unchanged.
+  const ROW_HEIGHT_PX = 48;
+  const rowOffsets = useMemo(() => {
+    const offsets = [0];
+    for (let i = 0; i < timeSlots.length; i++) {
+      offsets.push(offsets[i] + ROW_HEIGHT_PX);
+    }
+    return offsets;
+  }, [timeSlots.length]);
+
+  // Index planned services by date and exact "HH:MM" start so the overlay
+  // layer can fetch the chips that belong inside each shift in O(1).
+  const servicesByDateAndStart = useMemo(() => {
+    const map = new Map<string, Map<string, PlannedService[]>>();
+    for (const ps of plannedServices) {
+      const dayKey = dayjs(ps.slot.date).format("YYYY-MM-DD");
+      let inner = map.get(dayKey);
+      if (!inner) {
+        inner = new Map<string, PlannedService[]>();
+        map.set(dayKey, inner);
+      }
+      const slotKey = `${ps.slot.hour}:${ps.slot.minutes}`;
+      const arr = inner.get(slotKey);
+      if (arr) {
+        arr.push(ps);
+      } else {
+        inner.set(slotKey, [ps]);
+      }
+    }
+    return map;
+  }, [plannedServices]);
+
+  const getServicesForShift = useCallback(
+    (shift: PositionedShift) => {
+      const dayKey = dayjs(shift.date).format("YYYY-MM-DD");
+      return (
+        servicesByDateAndStart
+          .get(dayKey)
+          ?.get(`${shift.slotHour}:${shift.slotMinutes}`) ?? []
+      );
     },
-    [getServicesForSlot]
+    [servicesByDateAndStart]
   );
+
+  // One concatenated array of overlay rectangles, with per-shift column
+  // geometry so the overlay layer can place them inside the matching day
+  // column.
+  const positionedShifts = useMemo(() => {
+    const out: PositionedShift[] = [];
+    for (let i = 0; i < weekDays.length; i++) {
+      const day = weekDays[i];
+      out.push(
+        ...buildShiftLayout({
+          timeSlots: configuredTimeSlots,
+          date: day.date,
+          startHour,
+          rowOffsets,
+          columnIndex: i,
+          columnCount: weekDays.length,
+        })
+      );
+    }
+    return out;
+  }, [configuredTimeSlots, weekDays, startHour, rowOffsets]);
+
+  // Header band height in px (h-16 = 4rem = 64px) and time-axis column width.
+  const HEADER_HEIGHT_PX = 64;
+  const TIME_AXIS_WIDTH_PX = 64;
 
   return (
     <div className="w-full h-full overflow-auto">
+     <div className="relative">
       <div
         className="grid min-w-150"
         style={{
@@ -271,22 +299,12 @@ export default function PlanningWeekView({
 
         {/* Time slots grid */}
         {timeSlots.map((slot, slotIdx) => {
-          // Calculate max services across all days for this time slot to determine row height
-          const maxServicesInRow = Math.max(
-            1,
-            ...weekDays.map(
-              (day) => getPlannedServicesForSlot(day, slot).length
-            )
-          );
-          // Base height is 48px (h-12), add 20px per additional service
-          const rowMinHeight = 48 + Math.max(0, maxServicesInRow - 1) * 20;
-
           return (
             <Fragment key={slot.label}>
               {/* Time label column */}
               <TimeLabelCell
                 label={slot.label}
-                minHeight={rowMinHeight}
+                minHeight={ROW_HEIGHT_PX}
                 isLastSlot={isLastSlot(slotIdx)}
               />
 
@@ -302,8 +320,6 @@ export default function PlanningWeekView({
                     isSlotBlocked,
                   }
                 );
-                const selected = isSlotSelected(day, slot);
-                const slotServices = getPlannedServicesForSlot(day, slot);
 
                 return (
                   <WeekSlotCell
@@ -311,15 +327,8 @@ export default function PlanningWeekView({
                     day={day}
                     slot={slot}
                     slotState={slotState}
-                    selected={selected}
-                    slotServices={slotServices}
                     isLastDay={isLastDay(dayIdx)}
                     isLastSlot={isLastSlot(slotIdx)}
-                    reassigningService={reassigningService}
-                    onCellClick={handleCellClick}
-                    onContextMenu={handleContextMenu}
-                    onChipClick={viewPlannedService}
-                    dict={dict}
                   />
                 );
               })}
@@ -327,6 +336,30 @@ export default function PlanningWeekView({
           );
         })}
       </div>
+
+      {/* Shift overlay: each rectangle owns its own chips and "add booking"
+          affordance. */}
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          top: HEADER_HEIGHT_PX,
+          left: TIME_AXIS_WIDTH_PX,
+          right: 0,
+          bottom: 0,
+        }}
+      >
+        <ShiftOverlayLayer
+          shifts={positionedShifts}
+          onShiftClick={handleShiftClick}
+          isShiftSelected={isShiftSelected}
+          getServicesForShift={getServicesForShift}
+          onChipClick={viewPlannedService}
+          onChipContextMenu={handleContextMenu}
+          reassigningServiceId={reassigningService?.service.service.id}
+          dict={dict}
+        />
+      </div>
+     </div>
 
       {/* Overlays */}
       <PlanningGridOverlays

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -24,7 +24,13 @@ import { SlotCellContent, TimeLabelCell } from "./slot-cell-shared";
 import { usePlanningGrid } from "./use-planning-grid";
 import { PlanningGridOverlays } from "./planning-grid-overlays";
 import { ShiftOverlayLayer } from "./shift-overlay-layer";
-import { buildShiftLayout, type PositionedShift } from "./shift-layout";
+import {
+  BASE_ROW_HEIGHT_PX,
+  buildShiftLayout,
+  rowOffsetsFromHeights,
+  shiftContentHeightPx,
+  type PositionedShift,
+} from "./shift-layout";
 
 const DAYS_IN_WORK_WEEK = 7; // Mon-Sat
 
@@ -158,19 +164,6 @@ export default function PlanningWeekView({
     [checkSlotSelected]
   );
 
-  // Cells no longer expand for chip stacking (chips render inside the shift
-  // overlay rectangles, not in cells), so each row has the same fixed
-  // height. Matches the previous base value so the overall grid density is
-  // unchanged.
-  const ROW_HEIGHT_PX = 48;
-  const rowOffsets = useMemo(() => {
-    const offsets = [0];
-    for (let i = 0; i < timeSlots.length; i++) {
-      offsets.push(offsets[i] + ROW_HEIGHT_PX);
-    }
-    return offsets;
-  }, [timeSlots.length]);
-
   // Index planned services by date and exact "HH:MM" start so the overlay
   // layer can fetch the chips that belong inside each shift in O(1).
   const servicesByDateAndStart = useMemo(() => {
@@ -204,6 +197,61 @@ export default function PlanningWeekView({
     },
     [servicesByDateAndStart]
   );
+
+  // Two-pass shift layout (see DayGrid for the rationale). Week-view rows
+  // are shared across all 7 day columns, so the per-row required px/min is
+  // the MAX of any column's densest shift in that row — once any day
+  // column needs the row taller, every column inherits the new height.
+  const dayStartMin = startHour * 60;
+  const baselineRowOffsets = useMemo(
+    () =>
+      rowOffsetsFromHeights(
+        new Array(timeSlots.length).fill(BASE_ROW_HEIGHT_PX)
+      ),
+    [timeSlots.length]
+  );
+  const baseShifts = useMemo(() => {
+    const out: PositionedShift[] = [];
+    for (let i = 0; i < weekDays.length; i++) {
+      const day = weekDays[i];
+      out.push(
+        ...buildShiftLayout({
+          timeSlots: configuredTimeSlots,
+          date: day.date,
+          startHour,
+          rowOffsets: baselineRowOffsets,
+          columnIndex: i,
+          columnCount: weekDays.length,
+        })
+      );
+    }
+    return out;
+  }, [configuredTimeSlots, weekDays, startHour, baselineRowOffsets]);
+
+  const { rowHeights, rowOffsets } = useMemo(() => {
+    const requiredPxPerMin = new Array<number>(timeSlots.length).fill(
+      BASE_ROW_HEIGHT_PX / 30
+    );
+    for (const shift of baseShifts) {
+      const contentPx = shiftContentHeightPx(
+        getServicesForShift(shift).length
+      );
+      if (contentPx <= 0) continue;
+      const required = contentPx / shift.durationMinutes;
+      const startRow = Math.floor((shift.startsAtMin - dayStartMin) / 30);
+      const endRow = Math.min(
+        timeSlots.length - 1,
+        Math.floor((shift.endsAtMin - 1 - dayStartMin) / 30)
+      );
+      for (let r = Math.max(0, startRow); r <= endRow; r++) {
+        if (required > requiredPxPerMin[r]) requiredPxPerMin[r] = required;
+      }
+    }
+    const heights = requiredPxPerMin.map((p) =>
+      Math.max(BASE_ROW_HEIGHT_PX, Math.ceil(p * 30))
+    );
+    return { rowHeights: heights, rowOffsets: rowOffsetsFromHeights(heights) };
+  }, [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]);
 
   // One concatenated array of overlay rectangles, with per-shift column
   // geometry so the overlay layer can place them inside the matching day
@@ -304,7 +352,7 @@ export default function PlanningWeekView({
               {/* Time label column */}
               <TimeLabelCell
                 label={slot.label}
-                minHeight={ROW_HEIGHT_PX}
+                minHeight={rowHeights[slotIdx]}
                 isLastSlot={isLastSlot(slotIdx)}
               />
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -27,8 +27,8 @@ import { ShiftOverlayLayer } from "./shift-overlay-layer";
 import {
   BASE_ROW_HEIGHT_PX,
   buildShiftLayout,
+  computeStretchedRowLayout,
   rowOffsetsFromHeights,
-  shiftContentHeightPx,
   type PositionedShift,
 } from "./shift-layout";
 
@@ -228,30 +228,16 @@ export default function PlanningWeekView({
     return out;
   }, [configuredTimeSlots, weekDays, startHour, baselineRowOffsets]);
 
-  const { rowHeights, rowOffsets } = useMemo(() => {
-    const requiredPxPerMin = new Array<number>(timeSlots.length).fill(
-      BASE_ROW_HEIGHT_PX / 30
-    );
-    for (const shift of baseShifts) {
-      const contentPx = shiftContentHeightPx(
-        getServicesForShift(shift).length
-      );
-      if (contentPx <= 0) continue;
-      const required = contentPx / shift.durationMinutes;
-      const startRow = Math.floor((shift.startsAtMin - dayStartMin) / 30);
-      const endRow = Math.min(
-        timeSlots.length - 1,
-        Math.floor((shift.endsAtMin - 1 - dayStartMin) / 30)
-      );
-      for (let r = Math.max(0, startRow); r <= endRow; r++) {
-        if (required > requiredPxPerMin[r]) requiredPxPerMin[r] = required;
-      }
-    }
-    const heights = requiredPxPerMin.map((p) =>
-      Math.max(BASE_ROW_HEIGHT_PX, Math.ceil(p * 30))
-    );
-    return { rowHeights: heights, rowOffsets: rowOffsetsFromHeights(heights) };
-  }, [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]);
+  const { rowHeights, rowOffsets } = useMemo(
+    () =>
+      computeStretchedRowLayout({
+        baseShifts,
+        getServicesCount: (shift) => getServicesForShift(shift).length,
+        rowCount: timeSlots.length,
+        dayStartMin,
+      }),
+    [baseShifts, getServicesForShift, timeSlots.length, dayStartMin]
+  );
 
   // One concatenated array of overlay rectangles, with per-shift column
   // geometry so the overlay layer can place them inside the matching day

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
@@ -44,6 +44,43 @@ export function rowOffsetsFromHeights(heights: readonly number[]): number[] {
   return offsets;
 }
 
+/**
+ * Walk every base-laid shift, derive its required px/min from the chip
+ * stack height, propagate the maximum to each row the shift spans, and
+ * return the resulting per-row heights + cumulative offsets. Shared by
+ * day and week views — week-view callers pass shifts from all 7 day
+ * columns so the row stretches as soon as any single column's shift
+ * needs more height (rows are shared across columns in the grid).
+ */
+export function computeStretchedRowLayout(params: {
+  baseShifts: readonly PositionedShift[];
+  getServicesCount: (shift: PositionedShift) => number;
+  rowCount: number;
+  dayStartMin: number;
+}): { rowHeights: number[]; rowOffsets: number[] } {
+  const { baseShifts, getServicesCount, rowCount, dayStartMin } = params;
+  const requiredPxPerMin = new Array<number>(rowCount).fill(
+    BASE_ROW_HEIGHT_PX / 30
+  );
+  for (const shift of baseShifts) {
+    const contentPx = shiftContentHeightPx(getServicesCount(shift));
+    if (contentPx <= 0) continue;
+    const required = contentPx / shift.durationMinutes;
+    const startRow = Math.floor((shift.startsAtMin - dayStartMin) / 30);
+    const endRow = Math.min(
+      rowCount - 1,
+      Math.floor((shift.endsAtMin - 1 - dayStartMin) / 30)
+    );
+    for (let r = Math.max(0, startRow); r <= endRow; r++) {
+      if (required > requiredPxPerMin[r]) requiredPxPerMin[r] = required;
+    }
+  }
+  const heights = requiredPxPerMin.map((p) =>
+    Math.max(BASE_ROW_HEIGHT_PX, Math.ceil(p * 30))
+  );
+  return { rowHeights: heights, rowOffsets: rowOffsetsFromHeights(heights) };
+}
+
 export interface PositionedShift {
   id: string;
   twId: string;

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import {
   TimeWindowUtils,
+  getWeekOfMonth,
   isTimeWindow,
   type TimeSlot,
   type TimeWindowColor,
@@ -221,8 +222,7 @@ function getTwRangeOnDate(
   if (!parsed.days.includes(formatDay)) return null;
 
   if (parsed.weeks.length > 0) {
-    const weekOfMonth = Math.ceil(date.date() / 7);
-    if (!parsed.weeks.includes(weekOfMonth)) return null;
+    if (!parsed.weeks.includes(getWeekOfMonth(date))) return null;
   }
 
   return {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
@@ -6,6 +6,44 @@ import {
   type TimeWindowColor,
 } from "./planning-selection-context";
 
+/** Baseline pixel height of one 30-min row when no shift inside needs more. */
+export const BASE_ROW_HEIGHT_PX = 48;
+
+/**
+ * Approximate rendered height of a single chip inside a shift overlay.
+ * Matches the chip's `text-xs px-1.5 py-1` styling with two stacked text
+ * lines (service ID + route).
+ */
+const CHIP_HEIGHT_PX = 40;
+/** Vertical gap between stacked chips (Tailwind `gap-0.5`). */
+const CHIP_GAP_PX = 2;
+/** Total vertical padding inside the overlay (Tailwind `inset-1` × 2). */
+const OVERLAY_PADDING_PX = 8;
+
+/**
+ * Pixel height a shift's chip stack needs. Returns 0 when the shift has no
+ * services (the baseline rectangle suffices). Used by callers to decide
+ * whether the row containing the shift must be stretched.
+ */
+export function shiftContentHeightPx(serviceCount: number): number {
+  if (serviceCount <= 0) return 0;
+  return (
+    OVERLAY_PADDING_PX +
+    serviceCount * CHIP_HEIGHT_PX +
+    Math.max(0, serviceCount - 1) * CHIP_GAP_PX
+  );
+}
+
+/**
+ * Build cumulative pixel offsets from per-row heights. `offsets[i]` is the
+ * top of row `i`; the last entry is the bottom of the grid.
+ */
+export function rowOffsetsFromHeights(heights: readonly number[]): number[] {
+  const offsets = [0];
+  for (const h of heights) offsets.push(offsets[offsets.length - 1] + h);
+  return offsets;
+}
+
 export interface PositionedShift {
   id: string;
   twId: string;

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
@@ -39,8 +39,12 @@ export function shiftContentHeightPx(serviceCount: number): number {
  * top of row `i`; the last entry is the bottom of the grid.
  */
 export function rowOffsetsFromHeights(heights: readonly number[]): number[] {
-  const offsets = [0];
-  for (const h of heights) offsets.push(offsets[offsets.length - 1] + h);
+  let cumulative = 0;
+  const offsets = [cumulative];
+  for (const h of heights) {
+    cumulative += h;
+    offsets.push(cumulative);
+  }
   return offsets;
 }
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-layout.ts
@@ -1,0 +1,168 @@
+import dayjs from "dayjs";
+import {
+  TimeWindowUtils,
+  isTimeWindow,
+  type TimeSlot,
+  type TimeWindowColor,
+} from "./planning-selection-context";
+
+export interface PositionedShift {
+  id: string;
+  twId: string;
+  twName: string;
+  twColor: TimeWindowColor;
+  /** Slot capacity = parent TW's quota (max bookings the slot can hold). */
+  capacity: number;
+  /** The day this shift belongs to. */
+  date: Date;
+  /**
+   * True when the shift's day is strictly before today. Used by the overlay
+   * layer to skip the "add booking" affordance and render the rectangle in
+   * a muted/read-only style — past days cannot be planned or assigned.
+   */
+  isPastDay: boolean;
+  slotHour: number;
+  slotMinutes: number;
+  durationMinutes: number;
+  /** Pixel offset from the top of the overlay container. */
+  top: number;
+  /** Pixel height of the rectangle. */
+  height: number;
+  /** Column geometry: which day-column (0-based) and how many in total. */
+  columnIndex: number;
+  columnCount: number;
+  /** Minutes-of-day where the shift starts. */
+  startsAtMin: number;
+  /** Minutes-of-day where the shift ends (exclusive). */
+  endsAtMin: number;
+}
+
+interface BuildShiftLayoutParams {
+  timeSlots: TimeSlot[];
+  date: Date;
+  startHour: number;
+  /**
+   * Cumulative pixel offsets per 30-min row. Index `i` is the top of row `i`,
+   * length must be `(endHour - startHour) * 2 + 1` so the final entry is the
+   * bottom of the last row. Variable per-row heights (chip stacking) are
+   * preserved by interpolating within each row.
+   */
+  rowOffsets: number[];
+  /**
+   * 0-based index of the day column the overlays belong to. Defaults to 0
+   * (single-day grids). Combined with `columnCount` to compute horizontal
+   * placement in multi-day views.
+   */
+  columnIndex?: number;
+  /** Total number of day columns in the parent grid. Defaults to 1. */
+  columnCount?: number;
+}
+
+/**
+ * Compute absolute-positioned shift rectangles from TW config for a given day.
+ * Pure function — no DOM, no React. Synthesizes shifts at every
+ * `slotDurationMinutes` step within each TW's active range on `date`.
+ *
+ * BLOCK windows are ignored — those are rendered by the existing block
+ * styling on the underlying cells.
+ */
+export function buildShiftLayout({
+  timeSlots,
+  date,
+  startHour,
+  rowOffsets,
+  columnIndex = 0,
+  columnCount = 1,
+}: BuildShiftLayoutParams): PositionedShift[] {
+  const day = dayjs(date);
+  const isPastDay = day.isBefore(dayjs().startOf("day"), "day");
+  const dayStartMin = startHour * 60;
+  const out: PositionedShift[] = [];
+
+  for (const tw of timeSlots) {
+    if (!isTimeWindow(tw)) continue;
+    const duration = tw.slotDurationMinutes ?? 30;
+    if (duration <= 0) continue;
+
+    const range = getTwRangeOnDate(tw, day);
+    if (!range) continue;
+
+    for (let m = range.startMin; m + duration <= range.endMin; m += duration) {
+      const slotHour = Math.floor(m / 60);
+      const slotMinutes = m % 60;
+
+      const top = minutesToPx(m - dayStartMin, rowOffsets);
+      const bottom = minutesToPx(m + duration - dayStartMin, rowOffsets);
+      out.push({
+        id: `${day.format("YYYY-MM-DD")}-${tw.id}-${m}`,
+        twId: tw.id,
+        twName: tw.name,
+        twColor: tw.color ?? "emerald",
+        capacity: tw.quota,
+        date,
+        isPastDay,
+        slotHour,
+        slotMinutes,
+        durationMinutes: duration,
+        top,
+        height: Math.max(2, bottom - top),
+        columnIndex,
+        columnCount,
+        startsAtMin: m,
+        endsAtMin: m + duration,
+      });
+    }
+  }
+
+  return out;
+}
+
+function getTwRangeOnDate(
+  tw: TimeSlot,
+  date: dayjs.Dayjs
+): { startMin: number; endMin: number } | null {
+  if (tw.type === "daily-override") {
+    if (!tw.startTimestamp || !tw.endTimestamp) return null;
+    const start = dayjs(tw.startTimestamp);
+    const end = dayjs(tw.endTimestamp);
+    if (!start.isSame(date, "day")) return null;
+    return {
+      startMin: start.hour() * 60 + start.minute(),
+      endMin: end.hour() * 60 + end.minute(),
+    };
+  }
+
+  if (!tw.weeklyPattern) return null;
+  const parsed = TimeWindowUtils.parseWeeklyPattern(tw.weeklyPattern);
+  if (!parsed) return null;
+
+  // JS day (0=Sun) → format day (1=Mon … 7=Sun); mirrors matchesWeeklyPattern.
+  const jsDay = date.day();
+  const formatDay = jsDay === 0 ? 7 : jsDay;
+  if (!parsed.days.includes(formatDay)) return null;
+
+  if (parsed.weeks.length > 0) {
+    const weekOfMonth = Math.ceil(date.date() / 7);
+    if (!parsed.weeks.includes(weekOfMonth)) return null;
+  }
+
+  return {
+    startMin: parsed.startHour * 60 + parsed.startMinutes,
+    endMin: parsed.endHour * 60 + parsed.endMinutes,
+  };
+}
+
+/**
+ * Map a minute offset (from grid top) to a pixel offset, interpolating inside
+ * the 30-min row that contains it so variable-height rows stay aligned.
+ */
+function minutesToPx(minutesFromTop: number, rowOffsets: number[]): number {
+  if (minutesFromTop <= 0) return rowOffsets[0] ?? 0;
+  const lastIdx = rowOffsets.length - 1;
+  const rowIdx = Math.min(Math.floor(minutesFromTop / 30), lastIdx - 1);
+  const within = minutesFromTop - rowIdx * 30;
+  const top = rowOffsets[rowIdx];
+  const next = rowOffsets[rowIdx + 1];
+  const rowH = next - top;
+  return top + (within / 30) * rowH;
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { twMerge } from "tailwind-merge";
+import type {
+  PlannedService,
+  TimeWindowColor,
+} from "./planning-selection-context";
+import type { PositionedShift } from "./shift-layout";
+import { PlannedServiceChip } from "./planned-service-chip";
+import type {
+  I18nDictionary,
+  I18nRecord,
+} from "@/features/i18n/i18n.service.types";
+
+interface Props {
+  readonly shifts: readonly PositionedShift[];
+  readonly onShiftClick?: (shift: PositionedShift) => void;
+  readonly isShiftSelected?: (shift: PositionedShift) => boolean;
+  readonly getServicesForShift?: (
+    shift: PositionedShift
+  ) => readonly PlannedService[];
+  readonly onChipClick?: (ps: PlannedService) => void;
+  readonly onChipContextMenu?: (
+    e: React.MouseEvent,
+    ps: PlannedService
+  ) => void;
+  readonly reassigningServiceId?: string;
+  readonly dict: I18nDictionary | I18nRecord;
+}
+
+/**
+ * Overlay layer that paints one rectangle per synthesized shift on top of the
+ * underlying day grid. Each rectangle owns:
+ *  - the existing planned-service chips for that exact shift start, rendered
+ *    above the rectangle so chip click + right-click work natively, and
+ *  - an "add booking" affordance (an absolutely-positioned button covering
+ *    the empty area) when the shift has remaining capacity.
+ *
+ * Cells beneath are bare scaffolding (TW colored bg + badges only). All
+ * interactive content for a shift lives here, in one stacking context, so
+ * there is no z-index fight between cells, chips, and overlays.
+ */
+export function ShiftOverlayLayer({
+  shifts,
+  onShiftClick,
+  isShiftSelected,
+  getServicesForShift,
+  onChipClick,
+  onChipContextMenu,
+  reassigningServiceId,
+  dict,
+}: Props) {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0">
+      {shifts.map((s) => {
+        const c = SHIFT_COLOR_CLASSES[s.twColor] ?? SHIFT_COLOR_CLASSES.emerald;
+        const services = getServicesForShift?.(s) ?? [];
+        const isFull = services.length >= s.capacity;
+        // Past-day shifts are read-only: cannot be planned or assigned.
+        // Chips inside them stay clickable for view/inspection only.
+        const canAdd = !s.isPastDay && !isFull && Boolean(onShiftClick);
+        const selected = isShiftSelected?.(s) ?? false;
+        const colWidth = 100 / s.columnCount;
+        const colLeft = colWidth * s.columnIndex;
+        const positionStyle = {
+          top: s.top,
+          height: s.height,
+          left: `calc(${colLeft}% + 4px)`,
+          width: `calc(${colWidth}% - 8px)`,
+        } satisfies React.CSSProperties;
+        const className = twMerge(
+          "absolute rounded-md border border-dashed",
+          c.border,
+          c.tint,
+          canAdd && "transition-colors",
+          canAdd && c.hover,
+          isFull && "border-solid",
+          // Past-day overlays are visually muted and use a non-dashed
+          // grey border so they don't read as "click me to plan".
+          s.isPastDay &&
+            "opacity-50 border-solid border-gray-300 dark:border-gray-700 bg-transparent",
+          selected && `border-solid ring-2 ${c.selectedRing}`
+        );
+        const labelHM = formatHM(s.slotHour, s.slotMinutes);
+        const title = `${labelHM} – ${formatHM(
+          Math.floor(s.endsAtMin / 60),
+          s.endsAtMin % 60
+        )} (${s.durationMinutes}m) — ${services.length}/${s.capacity}`;
+
+        return (
+          <div
+            key={s.id}
+            className={className}
+            style={positionStyle}
+            title={title}
+          >
+            {/* "Add booking" affordance: absolutely covers the rectangle.
+                Rendered first so chips paint on top and win clicks in chip
+                areas; the button only catches clicks in empty space. */}
+            {canAdd && (
+              <button
+                type="button"
+                onClick={() => onShiftClick?.(s)}
+                className="absolute inset-0 cursor-pointer pointer-events-auto"
+                aria-label={`Add booking at ${labelHM}`}
+              />
+            )}
+
+            {/* Time label in the corner — hidden when chips occupy the
+                rectangle since they already make the slot identifiable. */}
+            {services.length === 0 && s.height >= 24 && (
+              <span
+                className={twMerge(
+                  "absolute top-0.5 left-1.5 text-[10px] font-medium leading-none pointer-events-none",
+                  c.label
+                )}
+              >
+                {labelHM}
+              </span>
+            )}
+
+            {/* Chips for this shift's bookings. The container stays
+                pointer-events-none so empty gaps fall through to the
+                "add" button below; chips re-enable pointer-events-auto so
+                their own click + onContextMenu fire natively. Stacked
+                vertically so each chip uses the full overlay width to
+                show the service info; chips beyond the rectangle's
+                height overflow visibly. */}
+            {services.length > 0 && (
+              <div className="absolute inset-1 flex flex-col gap-0.5 pointer-events-none">
+                {services.map((ps) => (
+                  <PlannedServiceChip
+                    key={ps.service.id}
+                    plannedService={ps}
+                    isBeingReassigned={reassigningServiceId === ps.service.id}
+                    onContextMenu={onChipContextMenu ?? noop}
+                    onClick={onChipClick}
+                    className="w-full"
+                    dict={dict}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function noop() {
+  /* noop — used when no context-menu handler is wired. */
+}
+
+function formatHM(h: number, m: number): string {
+  return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+}
+
+// Static class map so Tailwind's JIT can detect every variant. Keep keys in
+// sync with TIME_WINDOW_COLORS; new colors there must be added here.
+const SHIFT_COLOR_CLASSES: Record<
+  TimeWindowColor,
+  {
+    border: string;
+    tint: string;
+    hover: string;
+    label: string;
+    /** Darker tone of the TW color used for the selected-shift ring. */
+    selectedRing: string;
+  }
+> = {
+  emerald: {
+    border: "border-emerald-400/70 dark:border-emerald-500/60",
+    tint: "bg-white/30 dark:bg-emerald-950/20",
+    hover: "hover:bg-emerald-100/50 dark:hover:bg-emerald-900/30",
+    label: "text-emerald-700 dark:text-emerald-300",
+    selectedRing: "ring-emerald-600 dark:ring-emerald-400",
+  },
+  blue: {
+    border: "border-blue-400/70 dark:border-blue-500/60",
+    tint: "bg-white/30 dark:bg-blue-950/20",
+    hover: "hover:bg-blue-100/50 dark:hover:bg-blue-900/30",
+    label: "text-blue-700 dark:text-blue-300",
+    selectedRing: "ring-blue-600 dark:ring-blue-400",
+  },
+  violet: {
+    border: "border-violet-400/70 dark:border-violet-500/60",
+    tint: "bg-white/30 dark:bg-violet-950/20",
+    hover: "hover:bg-violet-100/50 dark:hover:bg-violet-900/30",
+    label: "text-violet-700 dark:text-violet-300",
+    selectedRing: "ring-violet-600 dark:ring-violet-400",
+  },
+  rose: {
+    border: "border-rose-400/70 dark:border-rose-500/60",
+    tint: "bg-white/30 dark:bg-rose-950/20",
+    hover: "hover:bg-rose-100/50 dark:hover:bg-rose-900/30",
+    label: "text-rose-700 dark:text-rose-300",
+    selectedRing: "ring-rose-600 dark:ring-rose-400",
+  },
+  amber: {
+    border: "border-amber-400/70 dark:border-amber-500/60",
+    tint: "bg-white/30 dark:bg-amber-950/20",
+    hover: "hover:bg-amber-100/50 dark:hover:bg-amber-900/30",
+    label: "text-amber-700 dark:text-amber-300",
+    selectedRing: "ring-amber-600 dark:ring-amber-400",
+  },
+  cyan: {
+    border: "border-cyan-400/70 dark:border-cyan-500/60",
+    tint: "bg-white/30 dark:bg-cyan-950/20",
+    hover: "hover:bg-cyan-100/50 dark:hover:bg-cyan-900/30",
+    label: "text-cyan-700 dark:text-cyan-300",
+    selectedRing: "ring-cyan-600 dark:ring-cyan-400",
+  },
+  lime: {
+    border: "border-lime-400/70 dark:border-lime-500/60",
+    tint: "bg-white/30 dark:bg-lime-950/20",
+    hover: "hover:bg-lime-100/50 dark:hover:bg-lime-900/30",
+    label: "text-lime-700 dark:text-lime-300",
+    selectedRing: "ring-lime-600 dark:ring-lime-400",
+  },
+  orange: {
+    border: "border-orange-400/70 dark:border-orange-500/60",
+    tint: "bg-white/30 dark:bg-orange-950/20",
+    hover: "hover:bg-orange-100/50 dark:hover:bg-orange-900/30",
+    label: "text-orange-700 dark:text-orange-300",
+    selectedRing: "ring-orange-600 dark:ring-orange-400",
+  },
+};

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/slot-cell-shared.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/slot-cell-shared.tsx
@@ -3,12 +3,6 @@
 import { twMerge } from "tailwind-merge";
 import type { ReactNode } from "react";
 import type { SlotState } from "./planning-slot-utils";
-import type { PlannedService } from "./planning-selection-context";
-import { PlannedServiceChip } from "./planned-service-chip";
-import type {
-  I18nRecord,
-  I18nDictionary,
-} from "@/features/i18n/i18n.service.types";
 
 // ============================================================================
 // Time Label Cell
@@ -117,76 +111,18 @@ export function QuotaDisplay({
 }
 
 // ============================================================================
-// Slot Services List
-// ============================================================================
-
-interface SlotServicesProps {
-  readonly services: PlannedService[];
-  readonly reassigningServiceId?: string;
-  readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
-  readonly onChipClick?: (ps: PlannedService) => void;
-  readonly dict: I18nDictionary | I18nRecord;
-  readonly layout?: "row" | "column";
-}
-
-export function SlotServices({
-  services,
-  reassigningServiceId,
-  onContextMenu,
-  onChipClick,
-  dict,
-  layout = "row",
-}: SlotServicesProps) {
-  if (services.length === 0) return null;
-
-  return (
-    <div
-      className={twMerge(
-        layout === "row"
-          ? "absolute inset-1 flex flex-row gap-0.5"
-          : "flex flex-col gap-0.5"
-      )}
-    >
-      {services.map((ps) => (
-        <PlannedServiceChip
-          key={ps.service.id}
-          plannedService={ps}
-          isBeingReassigned={reassigningServiceId === ps.service.id}
-          onContextMenu={onContextMenu}
-          onClick={onChipClick}
-          className={layout === "row" ? "flex-1" : "w-full"}
-          dict={dict}
-        />
-      ))}
-    </div>
-  );
-}
-
-// ============================================================================
 // Slot Cell Content (combines all indicators)
 // ============================================================================
 
 interface SlotCellContentProps {
   readonly state: SlotState;
   readonly isPastDay: boolean;
-  readonly services: PlannedService[];
-  readonly reassigningServiceId?: string;
-  readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
-  readonly onChipClick?: (ps: PlannedService) => void;
-  readonly dict: I18nDictionary | I18nRecord;
-  readonly servicesLayout?: "row" | "column";
   readonly children?: ReactNode;
 }
 
 export function SlotCellContent({
   state,
   isPastDay,
-  services,
-  reassigningServiceId,
-  onContextMenu,
-  onChipClick,
-  dict,
-  servicesLayout = "row",
   children,
 }: SlotCellContentProps) {
   const {
@@ -219,14 +155,9 @@ export function SlotCellContent({
         />
       )}
 
-      <SlotServices
-        services={services}
-        reassigningServiceId={reassigningServiceId}
-        onContextMenu={onContextMenu}
-        onChipClick={onChipClick}
-        dict={dict}
-        layout={servicesLayout}
-      />
+      {/* Chips intentionally NOT rendered here — they live inside the
+          ShiftOverlayLayer rectangles so chip click + context-menu work
+          without z-index fights with the overlay. */}
 
       {children}
     </>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -41,6 +41,7 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     selectedSlot,
     selectSlot,
     plannedServices,
+    timeSlots: configuredTimeSlots,
     getTimeWindowForSlot,
     getRemainingQuota,
     isSlotBlocked,
@@ -130,6 +131,10 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     // Time slots
     timeSlots,
     isLastSlot,
+
+    // Configured TWs/blocks for the current calendar (used by overlays
+    // that need to know the real shift cadence per time window).
+    configuredTimeSlots,
 
     // Planned services
     plannedServices,

--- a/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/time-window.service.ts
@@ -98,6 +98,7 @@ export function apiToLocalTimeWindow(
       endTimestamp: endTs,
       quota: response.capacity,
       color,
+      slotDurationMinutes: response.slotDurationMinutes,
     };
   }
 
@@ -116,6 +117,7 @@ export function apiToLocalTimeWindow(
     weeklyPattern,
     quota: response.capacity,
     color,
+    slotDurationMinutes: response.slotDurationMinutes,
   };
 }
 


### PR DESCRIPTION
## Summary

- Replace the cell-as-button planning grid with a `ShiftOverlayLayer` whose rectangles are sized by each TW's `slotDurationMinutes`, making mixed cadences (12-min, 30-min, 60-min) visible and ending the "clicked 08:30 but no shift starts there" dead-end.
- Each overlay owns its planned-service chips and the "add another booking" affordance, so left-click chip / right-click context menu / "add" all coexist in one stacking context — no more z-index fights between cells, chips, and overlays.
- Past-day shifts render in a muted, read-only style so they cannot be planned or assigned; chips inside remain clickable for inspection. Day view and week view share the same primitives via `columnIndex`/`columnCount` geometry.

Closes #412

## Test plan

- [x] Open a calendar in **day view**: shift outlines align with the time axis, clicking an empty overlay opens the sidebar pre-filled with that shift's exact `(hour, minutes)`, clicking outside any overlay does nothing.
- [x] Open the same calendar in **week view**: overlays render per day column, click + selection ring behave the same as day view.
- [x] On a calendar with **mixed shift durations** (e.g. a TW with `slotDurationMinutes = 12`): 12-min rectangles visibly bridge 30-min cell boundaries.
- [x] Plan a service in a slot with **capacity > 1**: chip appears inside the overlay, clicking the empty area of the same overlay still opens the add-booking flow until capacity is reached.
- [x] **Left-click a chip** opens the planned-service sidebar; **right-click a chip** opens the context menu (reassign / delete / etc.).
- [x] **Past-day** shifts have no "add" affordance, are visually muted (opacity-50, grey solid border), and cannot start a planning flow. Chips inside past shifts remain clickable.
- [x] Selected shift gets a ring in the **TW color's darker tone**, not the generic primary blue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Grid now computes stretched per-row heights from shift content rather than using fixed 48px rows
  * Shift/booking interactivity moved into an overlay layer and a new PlanningGridShell for cleaner rendering
  * Individual slot cells simplified to passive, non-interactive rulers; pointer events and per-cell selection removed

* **New Features**
  * Time slot duration can be configured from server (slotDurationMinutes)
  * Exposed utilities for building shift layout and positioned shifts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->