### PR TITLE
fix(calendar): omit null validTo when deactivating time window

### DIFF
--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1674,7 +1674,7 @@ export async function deactivateCalendarTimeWindow(
     startHour: window.startHour,
     endHour: window.endHour,
     validFrom: window.validFrom,
-    validTo: window.validTo,
+    ...(window.validTo ? { validTo: window.validTo } : {}),
     daysOfWeek: window.daysOfWeek,
     capacity: window.capacity,
     active: false,

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26545,7 +26545,7 @@
     },
     "packages/miot-calendar-client": {
       "name": "@microboxlabs/miot-calendar-client",
-      "version": "0.6.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",


### PR DESCRIPTION
## Summary

- Conditionally include `validTo` in the deactivate PUT body so `null` (returned by the backend for windows without expiration) is omitted instead of failing the request schema.

Closes #414.

## Root cause

`TimeWindowResponseSchema` allows `validTo: null` (`.nullish()`), but `TimeWindowRequestSchema` only accepts `string | undefined` (`.optional()`). `deactivateCalendarTimeWindow` spread the response's `validTo` directly into the update body — `JSON.stringify` preserved the `null`, and Zod rejected it with `Expected string, received null`.

## Test plan

- [x] Open a calendar with a time window that has no `validTo` (e.g. `0b806ec2-df29-4e05-b654-9c7bbc7509f2` / `v1`)
- [x] Click "deactivate" on that window
- [x] Confirm the request succeeds and the window flips to inactive (no 400 toast)
- [x] Deactivate a window that *does* have a `validTo` and confirm the date is preserved on the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar time window deactivation to correctly handle requests when optional fields are not provided, improving reliability of update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->