### PR TITLE
fix(calendar): restore replan connector and preserve service category

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/day/day-grid.tsx
@@ -67,8 +67,6 @@ function DayGridSlotCell({
 }: Readonly<DayGridSlotCellProps>) {
   return (
     <div
-      data-slot-date={dayjs(currentDate).format("YYYY-MM-DD")}
-      data-slot-time={`${slot.hour.toString().padStart(2, "0")}:${slot.minutes.toString().padStart(2, "0")}`}
       className={getSlotCellClassName(state, isPastDay, {
         isLastSlot,
         isFirstEditable: !isPastDay,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -280,7 +280,8 @@ export function PlanningSidebarForm({
   // so typing/selecting within the same service doesn't thrash.
   useEffect(() => {
     setAssignmentData(assignmentDataFromService(selectedService));
-  }, [selectedService?.id]);
+    setSelectedServiceCategory(selectedService?.serviceCategory ?? "");
+  }, [selectedService?.id, selectedService?.serviceCategory]);
 
   const { serviceTypes, isLoading: isLoadingServiceTypes } = useServiceTypes();
   const serviceCategoryOptions = serviceTypes.map((t) => ({

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-week-view.tsx
@@ -72,8 +72,6 @@ function WeekSlotCell({
   return (
     <div className="w-full h-full">
       <div
-        data-slot-date={dayjs(day.date).format("YYYY-MM-DD")}
-        data-slot-time={`${slot.hour.toString().padStart(2, "0")}:${slot.minutes.toString().padStart(2, "0")}`}
         className={twMerge(
           "appearance-none border-0 p-0 m-0 text-left",
           getSlotCellClassName(slotState, dayIsPast, {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dayjs from "dayjs";
 import { twMerge } from "tailwind-merge";
 import type {
   PlannedService,
@@ -90,6 +91,8 @@ export function ShiftOverlayLayer({
         return (
           <div
             key={s.id}
+            data-slot-date={dayjs(s.date).format("YYYY-MM-DD")}
+            data-slot-time={labelHM}
             className={className}
             style={positionStyle}
             title={title}


### PR DESCRIPTION
## Summary

- Move the `data-slot-date` / `data-slot-time` anchors from the static 30-min cells onto the TW-driven shift overlays so the reassignment connector finds the rectangles the user actually clicks.
- Re-hydrate `selectedServiceCategory` in the sidebar form when the planned service id (or its persisted category) changes, so reassign starts with the original category preselected.

Closes #416.

## Why

After the planning grid was migrated from static 30-min cells to TW-driven slots, "Volver a planificar" felt broken: no curved preview between origin and target, and the submit button stayed disabled even after picking a time and andén.

- The connector queries `[data-slot-date][data-slot-time="HH:MM"]` to draw the line. Those attrs lived on the half-hour static cells; TW slots can start at any time the duration allows (e.g. `12:24`, `12:36`), so neither origin nor target lookup found anything.
- `selectedServiceCategory` was only seeded from `selectedService` on mount, so reassigning an already-planned service surfaced an empty category — and `canConfirm` (which requires a non-empty category) blocked the submit.

## Test plan

- [x] In a calendar with a TW whose slot duration isn't a divisor of 30 (e.g. 12 min):
  - [x] Plan a service into one of those slots, picking a service category.
  - [x] Right-click the chip → "Volver a planificar" → click another slot. Confirm:
    - [x] Curved connector arcs from origin to target.
    - [x] Service category is preselected from the original planning.
    - [x] Submit button is enabled with a valid time/andén selected.
    - [x] Reassignment completes successfully.
- [x] In a calendar with a TW on a 30-min cadence, repeat — connector still draws and submit still works.
- [x] Day-view replan still works the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)