### PR TITLE
feat(calendar): server-side calendarPlanningPriority sort for planner sidebar

### DIFF
--- a/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
@@ -103,7 +103,9 @@ export async function GET(req: NextRequest) {
       // Single call with all definition keys so the backend can apply ORDER BY
       // globally across stages — required for the calendarPlanningPriority
       // preset to be correct on the planner sidebar (ecm-coordinator #238).
-      // toShippingKanban below re-bins the flat response by taskFormKey.
+      // toShippingKanban below re-bins the flat response by taskFormKey, but
+      // the orderedTasks accumulator preserves the global backend order for
+      // consumers that rely on it.
       taskResponses = [
         await getUnbookedTasks(session, columns, options, calendarId),
       ] as FastTasksResponse[];
@@ -115,14 +117,21 @@ export async function GET(req: NextRequest) {
       ])) as FastTasksResponse[];
     }
 
+    // When the proxy issues a single combined backend call (calendarId branch)
+    // the response is already globally sorted; pass an accumulator so callers
+    // that need that order can read it without re-flattening from the
+    // board-binned data.
+    const orderedTasks =
+      calendarId && taskResponses.length === 1 ? [] : undefined;
     taskResponses.forEach((tasks) => {
-      toShippingKanban(tasks, data);
+      toShippingKanban(tasks, data, orderedTasks);
       total += tasks.total;
     });
 
     return NextResponse.json({
       total,
       data,
+      ...(orderedTasks ? { orderedTasks } : {}),
     });
   } catch (e: any) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
@@ -100,11 +100,13 @@ export async function GET(req: NextRequest) {
         }),
       ])) as FinishedWorkflowsResponse[];
     } else if (calendarId) {
-      taskResponses = (await Promise.all([
-        ...columns.map((column) => {
-          return getUnbookedTasks(session, column, options, calendarId);
-        }),
-      ])) as FastTasksResponse[];
+      // Single call with all definition keys so the backend can apply ORDER BY
+      // globally across stages — required for the calendarPlanningPriority
+      // preset to be correct on the planner sidebar (ecm-coordinator #238).
+      // toShippingKanban below re-bins the flat response by taskFormKey.
+      taskResponses = [
+        await getUnbookedTasks(session, columns, options, calendarId),
+      ] as FastTasksResponse[];
     } else {
       taskResponses = (await Promise.all([
         ...columns.map((column) => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -926,7 +926,8 @@ const StoredServiceSchema = z
       .object({
         total_lineasoc_cumplen: z.number(),
         total_lineasoc_incumplen: z.number(),
-        lineasoc_pctn_cumplimiento: z.number(),
+        // null means "not measured yet" — distinct from a measured 0%.
+        lineasoc_pctn_cumplimiento: z.number().nullable(),
       })
       .optional(),
     eta: z.string().optional(),

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -11,7 +11,6 @@ import { tr } from "@/features/i18n/tr.service";
 import {
   usePlanningSelection,
   type SelectedService,
-  getLeadTimeStatus,
   DEBUG_SHOW_TEST_SERVICE,
   TEST_SERVICES,
 } from "./planning-selection-context";
@@ -269,6 +268,11 @@ export function PlanningSidebarClient({
       params.push(`calendarId=${calendarId}`);
     }
 
+    // Server-side sort preset (ecm-coordinator #238): C309 urgency first,
+    // then mintral_deliveryComplianceRate ASC. Resolves the pagination
+    // correctness gap of the previous client-side sort.
+    params.push("orderBy=mintral_calendarPlanningPriority");
+
     return params.join("&");
   }, [searchTags, calendarId]);
 
@@ -385,20 +389,11 @@ export function PlanningSidebarClient({
     []
   );
 
-  // Sort services by urgency/status priority:
-  // 1. Urgent (red-orange)
-  // 2. Error/Delayed (red) - 0% compliance
-  // 3. Warning (yellow) - partial compliance
-  // 4. Success/On time (green) - 100% compliance
+  // Sort order is applied server-side via the calendarPlanningPriority preset
+  // (ecm-coordinator #238). This memo only handles the client-side filters that
+  // don't have API params (lugarCarguio, permanencia, tipoViaje) and the legacy
+  // search-by-match-type fallback; the original order from the API is preserved.
   const sortedServices = useMemo(() => {
-    const getStatusPriority = (service: SelectedService): number => {
-      if (service.incidencias.includes("urgencia")) return 0; // Urgent first
-      const status = getLeadTimeStatus(service.leadTime);
-      if (status === "error") return 1;
-      if (status === "warning") return 2;
-      return 3; // success last
-    };
-
     let services = [...allServices];
 
     // Client-side filtering for attributes that don't have API params (lugarCarguio, permanencia, tipoViaje)
@@ -453,7 +448,7 @@ export function PlanningSidebarClient({
       }
     }
 
-    return services.sort((a, b) => getStatusPriority(a) - getStatusPriority(b));
+    return services;
   }, [
     filteredServiceId,
     filterMatchType,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -110,8 +110,12 @@ function extractMintralIncidents(
     .map((incident) => [incident[0], incident[1]] as [string, string]);
 }
 
-function toPercent(value: number | null | undefined): number {
-  if (value == null) return 0;
+function toPercent(value: number | null | undefined): number | null {
+  // Preserve "no data" semantics — null/undefined upstream means the metric
+  // hasn't been measured, which is distinct from a measured 0%. Rendering
+  // and the backend sort agree on this via the calendarPlanningPriority
+  // preset (ecm-coordinator #238).
+  if (value == null) return null;
   return Math.round(value <= 1 ? value * 100 : value);
 }
 
@@ -307,8 +311,22 @@ export function PlanningSidebarClient({
   // service should resolve it via context's `getLiveTask`, which reads the
   // freshly fetched workflow index by `mintral_serviceCode` and is stable
   // across stage advances.
+  //
+  // Prefer `orderedTasks` when the proxy provides it: the planner relies on
+  // the calendarPlanningPriority preset's GLOBAL sort across stages, which
+  // is lost by `Object.values(data)` (board-binned). The proxy emits
+  // orderedTasks only on the single-call calendarId path; older consumers
+  // and the fanout paths still get the board-binned `data`.
   const apiServices = useMemo(() => {
-    if (!myTasksData?.data) return [];
+    if (!myTasksData) return [];
+
+    if (myTasksData.orderedTasks && myTasksData.orderedTasks.length > 0) {
+      return myTasksData.orderedTasks.map((task) =>
+        transformTaskToService(task)
+      );
+    }
+
+    if (!myTasksData.data) return [];
 
     const services: SelectedService[] = [];
     for (const board of Object.values(myTasksData.data)) {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Badge } from "flowbite-react";
-import { HiExclamation, HiCheck, HiX } from "react-icons/hi";
+import { HiExclamation, HiCheck, HiX, HiMinus } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
 import dayjs from "dayjs";
 import "dayjs/locale/es";
@@ -26,14 +26,15 @@ export interface ServiceEventProps {
 }
 
 /**
- * Get the icon and styles for lead time based on compliance percentage
- * 100% → ✓ CheckMark (success)
- * > 0% and < 100% → ⚠ Warning
- * 0% → ✗ Error
+ * Get the icon and styles for lead time based on compliance percentage.
+ *  unknown (null) → — Minus (no data — distinct from 0%)
+ *  100% → ✓ CheckMark (success)
+ *  > 0% and < 100% → ⚠ Warning
+ *  0% → ✗ Error
  */
 function getLeadTimeStyles(leadTime: LeadTimeData): {
   text: string;
-  icon: typeof HiCheck | typeof HiExclamation | typeof HiX;
+  icon: typeof HiCheck | typeof HiExclamation | typeof HiX | typeof HiMinus;
 } {
   const status = getLeadTimeStatus(leadTime);
   switch (status) {
@@ -51,6 +52,11 @@ function getLeadTimeStyles(leadTime: LeadTimeData): {
       return {
         text: "text-yellow-400 dark:text-yellow-300",
         icon: HiX,
+      };
+    case "unknown":
+      return {
+        text: "text-gray-400 dark:text-gray-500",
+        icon: HiMinus,
       };
   }
 }
@@ -219,7 +225,9 @@ export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
               className={twMerge("w-3.5 h-3.5", leadTimeStyles.text)}
             />
             <span className={twMerge("font-medium", leadTimeStyles.text)}>
-              {service.leadTime.lineasoc_pctn_cumplimiento}%
+              {service.leadTime.lineasoc_pctn_cumplimiento == null
+                ? "—"
+                : `${service.leadTime.lineasoc_pctn_cumplimiento}%`}
             </span>
           </div>
 

--- a/turbo-repo/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/kpi-display/kpi-display.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { HiCheck, HiExclamation, HiClock, HiX } from "react-icons/hi";
+import { HiCheck, HiExclamation, HiClock, HiX, HiMinus } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
 import { type LeadTimeData, getLeadTimeStatus } from "./kpi-display.types";
 import { type I18nRecord } from "@/features/i18n/i18n.service.types";
@@ -117,12 +117,14 @@ const leadTimeStatusColors = {
   success: "text-gray-700 dark:text-gray-300",
   warning: "text-gray-700 dark:text-gray-300",
   error: "text-yellow-500 dark:text-yellow-400",
+  unknown: "text-gray-400 dark:text-gray-500",
 };
 
 const leadTimeBarColors = {
   success: "bg-gray-400",
   warning: "bg-gray-400",
   error: "bg-yellow-400 dark:bg-yellow-300",
+  unknown: "bg-gray-200 dark:bg-gray-600",
 };
 
 /**
@@ -138,7 +140,17 @@ export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProp
     success: HiCheck,
     warning: HiExclamation,
     error: HiX,
+    unknown: HiMinus,
   }[status];
+
+  const pctLabel =
+    leadTime.lineasoc_pctn_cumplimiento == null
+      ? "—"
+      : `${leadTime.lineasoc_pctn_cumplimiento}%`;
+  const barWidth =
+    leadTime.lineasoc_pctn_cumplimiento == null
+      ? "0%"
+      : `${leadTime.lineasoc_pctn_cumplimiento}%`;
 
   const totalLines =
     leadTime.total_lineasoc_cumplen + leadTime.total_lineasoc_incumplen;
@@ -164,7 +176,7 @@ export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProp
                 "h-full rounded-full transition-all",
                 leadTimeBarColors[status]
               )}
-              style={{ width: `${leadTime.lineasoc_pctn_cumplimiento}%` }}
+              style={{ width: barWidth }}
             />
           </div>
           {/* Percentage */}
@@ -174,7 +186,7 @@ export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProp
               leadTimeStatusColors[status]
             )}
           >
-            {leadTime.lineasoc_pctn_cumplimiento}%
+            {pctLabel}
           </span>
           {/* Source breakdown: cumplen/incumplen */}
           <span className="text-xs text-gray-500 dark:text-gray-400 min-w-[100px]">
@@ -213,7 +225,7 @@ export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProp
               leadTimeStatusColors[status]
             )}
           >
-            {leadTime.lineasoc_pctn_cumplimiento}%
+            {pctLabel}
           </span>
         </div>
       </div>
@@ -259,7 +271,7 @@ export function LeadTimeDisplay({ leadTime, compact, dict }: LeadTimeDisplayProp
               "h-full rounded-full transition-all",
               leadTimeBarColors[status]
             )}
-            style={{ width: `${leadTime.lineasoc_pctn_cumplimiento}%` }}
+            style={{ width: barWidth }}
           />
         </div>
         <span className="text-[10px] text-gray-500 dark:text-gray-400 w-8 text-right tabular-nums">

--- a/turbo-repo/apps/app/src/features/common/components/kpi-display/kpi-display.types.ts
+++ b/turbo-repo/apps/app/src/features/common/components/kpi-display/kpi-display.types.ts
@@ -1,20 +1,31 @@
 /**
- * Lead time data for a service - tracks compliance of OC lines
+ * Lead time data for a service - tracks compliance of OC lines.
+ *
+ * `lineasoc_pctn_cumplimiento` is `null` when the upstream service has no
+ * compliance metric calculated yet (e.g. brand-new service, no scheduled
+ * deliveries). This is distinct from `0`, which means measured-and-failing.
+ * The backend's calendarPlanningPriority preset treats null as "lowest
+ * priority" via `COALESCE(rate, 1.0)`, so the FE must render it as a
+ * neutral "no data" state — never as 0%.
  */
 export interface LeadTimeData {
   total_lineasoc_cumplen: number;
   total_lineasoc_incumplen: number;
-  lineasoc_pctn_cumplimiento: number; // 0-100
+  lineasoc_pctn_cumplimiento: number | null; // 0-100 or null when unmeasured
 }
 
 /**
- * Get lead time status based on compliance percentage
- * 100% → success, >0% and <100% → warning, 0% → error
+ * Get lead time status based on compliance percentage.
+ *  null → unknown (no data yet)
+ *  100% → success
+ *  >0% and <100% → warning
+ *  0% → error
  */
 export function getLeadTimeStatus(
   leadTime: LeadTimeData
-): "success" | "warning" | "error" {
+): "success" | "warning" | "error" | "unknown" {
   const pct = leadTime.lineasoc_pctn_cumplimiento;
+  if (pct == null) return "unknown";
   if (pct >= 100) return "success";
   if (pct > 0) return "warning";
   return "error";

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -169,7 +169,7 @@ export async function getUserTasks(
 
 export async function getUnbookedTasks(
   session: Session,
-  definitionKey: string,
+  definitionKey: string | string[],
   options: {
     from?: number;
     size?: number;
@@ -177,22 +177,39 @@ export async function getUnbookedTasks(
   } = {},
   calendarId: string
 ): Promise<FastTasksResponse> {
-  const { from = 0, size = 100, filter = undefined } = options;
+  const { from = 0, size = 100, filter: baseFilter = undefined } = options;
   const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/tasks/unbooked`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+
+  // When called with multiple keys, push them onto filter.definitionKeys so the
+  // backend can issue a single IN-clause query and apply ORDER BY globally —
+  // see ecm-coordinator #238. The singular form is preserved for back-compat.
+  let body: Record<string, unknown>;
+  if (Array.isArray(definitionKey)) {
+    const keys = definitionKey.filter((k) => k.length > 0);
+    body = {
+      from,
+      size,
+      filter: { ...(baseFilter ?? {}), definitionKeys: keys },
+      calendarId,
+    };
+  } else {
+    body = {
+      from,
+      size,
+      definitionKey: definitionKey.length === 0 ? undefined : definitionKey,
+      filter: baseFilter,
+      calendarId,
+    };
+  }
+
   const result = await fetcher(url, {
     method: "POST",
     headers: {
       ...headers,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      from,
-      size,
-      definitionKey: definitionKey.length == 0 ? undefined : definitionKey,
-      filter,
-      calendarId,
-    }),
+    body: JSON.stringify(body),
   });
 
   return result as FastTasksResponse;

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -190,7 +190,7 @@ export async function getUnbookedTasks(
     body = {
       from,
       size,
-      filter: { ...(baseFilter ?? {}), definitionKeys: keys },
+      filter: { ...baseFilter, definitionKeys: keys },
       calendarId,
     };
   } else {

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -125,41 +125,28 @@ export function getStaticPlanningData(): KanbanBoard[] {
 
 export function toShippingKanban(
   tasks: FastTasksResponse | FinishedWorkflowsResponse,
-  index: Record<string, KanbanBoard>
+  index: Record<string, KanbanBoard>,
+  ordered?: KanbanBoardTask[]
 ): Record<string, KanbanBoard> {
+  const collect = (
+    task: { persistentState?: PersistentState } & Record<string, unknown>
+  ) => {
+    const taskFormKey =
+      task.persistentState?.endStateName ?? (task.taskFormKey as string);
+    const boardKey = taskShippingBoardMap[taskFormKey] ?? taskFormKey;
+    index[boardKey] = index[boardKey] || {
+      id: boardKey,
+      title: boardKey,
+      tasks: [],
+    };
+    const kanbanTask = toKanbanBoardTask(task);
+    index[boardKey].tasks.push(kanbanTask);
+    if (ordered) ordered.push(kanbanTask);
+  };
   if ("tasks" in tasks) {
-    tasks.tasks.forEach(
-      (
-        task: { persistentState?: PersistentState } & Record<string, unknown>
-      ) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const taskFormKey =
-          task.persistentState?.endStateName ?? (task.taskFormKey as string);
-        const boardKey = taskShippingBoardMap[taskFormKey] ?? taskFormKey;
-        index[boardKey] = index[boardKey] || {
-          id: boardKey,
-          title: boardKey,
-          tasks: [],
-        };
-        index[boardKey].tasks.push(toKanbanBoardTask(task));
-      }
-    );
+    tasks.tasks.forEach(collect);
   } else {
-    tasks.workflows.forEach(
-      (
-        task: { persistentState?: PersistentState } & Record<string, unknown>
-      ) => {
-        const taskFormKey =
-          task.persistentState?.endStateName ?? (task.taskFormKey as string);
-        const boardKey = taskShippingBoardMap[taskFormKey] ?? taskFormKey;
-        index[boardKey] = index[boardKey] || {
-          id: boardKey,
-          title: boardKey,
-          tasks: [],
-        };
-        index[boardKey].tasks.push(toKanbanBoardTask(task));
-      }
-    );
+    tasks.workflows.forEach(collect);
   }
   return index;
 }

--- a/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
@@ -12,6 +12,15 @@ export type KanbanBoard = {
 export type KanbanBoardTaskResponse = {
   total: number;
   data: Record<string, KanbanBoard>;
+  /**
+   * Flat task list in the order the backend returned them, before being
+   * binned by `taskFormKey` into `data`. Populated when the proxy issues a
+   * single combined backend call (e.g. the calendar planner sidebar). The
+   * board-binned `data` map loses the cross-board order via
+   * `Object.values(...)` iteration, so consumers that rely on the global
+   * sort (calendarPlanningPriority preset) should prefer this list.
+   */
+  orderedTasks?: KanbanBoardTask[];
 };
 
 export type Task = {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/kpis/kpis-card.tsx
@@ -98,6 +98,7 @@ const leadTimeStatusColors = {
   success: "text-gray-700 dark:text-gray-300",
   warning: "text-gray-700 dark:text-gray-300",
   error: "text-yellow-500 dark:text-yellow-400",
+  unknown: "text-gray-400 dark:text-gray-500",
 };
 
 /**
@@ -123,18 +124,20 @@ export default function KpisCard({ task, dict }: KpisCardProps) {
           ({tr("pages.planning.sidebar.form.leadTimeLocCount", dict, { count: String(totalLines) })})
         </span>
       </div>
-      {/* Column 2: Progress bar */}
+      {/* Column 2: Progress bar — null compliance shows an empty bar (see #238). */}
       <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
         <div
-          className={`h-full rounded-full transition-all ${getBarColor(leadTime.lineasoc_pctn_cumplimiento, leadTimeStatus === "error")}`}
-          style={{ width: `${leadTime.lineasoc_pctn_cumplimiento}%` }}
+          className={`h-full rounded-full transition-all ${getBarColor(leadTime.lineasoc_pctn_cumplimiento ?? 0, leadTimeStatus === "error")}`}
+          style={{ width: `${leadTime.lineasoc_pctn_cumplimiento ?? 0}%` }}
         />
       </div>
-      {/* Column 3: Percentage */}
+      {/* Column 3: Percentage — render "—" when there's no measured rate. */}
       <span
         className={`text-xs font-medium text-right ${leadTimeStatusColors[leadTimeStatus]}`}
       >
-        {leadTime.lineasoc_pctn_cumplimiento}%
+        {leadTime.lineasoc_pctn_cumplimiento == null
+          ? "—"
+          : `${leadTime.lineasoc_pctn_cumplimiento}%`}
       </span>
       {/* Column 4: Metadata */}
       <span className="text-xs text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
Frontend half of the work tracked under ecm-coordinator [#238](https://github.com/microboxlabs/ecm-coordinator/issues/238). All three coordinator PRs (#239 + #240 hotfix + #241 multi-key + #242 null-deprioritization) are merged and deployed; this is the FE that consumes them.

## Summary

- Planner sidebar now requests services with the named server-side sort preset `mintral_calendarPlanningPriority`. Replaces the old client-side `getStatusPriority` comparator, which only saw page 1 and so produced wrong top-N when the result set exceeded the page size.
- The proxy's calendarId branch (`/app/api/task/mytasks`) collapses the per-column fanout (5 calls → 1) so the backend can apply `ORDER BY` globally across stages. The other two proxy branches (showFinished, no-calendarId) still fan out per column — they aren't affected by this bug.
- The proxy now exposes a flat `orderedTasks` array alongside the existing `data` (board-binned) when it makes a single combined call. The planner sidebar consumes `orderedTasks`; everything else continues to read `data`.
- Null compliance (`mintral_deliveryComplianceRate == null`) now renders as **"—" with a neutral minus icon** instead of "0% with a red ✗". This matches the backend's "no data" semantics — where the latest coordinator change (#242) deprioritises null rows within their tie-bucket.

## Commits in order

1. `4ec6ba5a5` — switch to the preset, drop client-side comparator
2. `3f70bc223` — collapse the per-column fanout into a single call
3. `0a487ece7` — preserve the global sort end-to-end (`orderedTasks`) and render null compliance as no-data

## Touched files

- `apps/app/src/app/api/task/mytasks/route.ts` — single call on the calendarId branch; emits `orderedTasks` when applicable.
- `apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts` — `getUnbookedTasks` accepts `string | string[]`; array form sends `filter.definitionKeys`.
- `apps/app/src/features/shipping/services/data.service.ts` — `toShippingKanban` accepts an optional ordered accumulator.
- `apps/app/src/features/shipping/types/common.types.ts` — `KanbanBoardTaskResponse.orderedTasks?` added.
- `apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx` — consume `orderedTasks`, drop the local comparator, propagate null compliance through `toPercent`.
- `apps/app/src/features/calendar/components/planning/planning-selection-context.tsx` — Zod schema for `lineasoc_pctn_cumplimiento` becomes `z.number().nullable()`.
- `apps/app/src/features/calendar/components/planning/service-event.tsx` — render "—" + minus icon for null compliance.
- `apps/app/src/features/common/components/kpi-display/kpi-display.tsx` and `.types.ts` — type relaxed to `number | null`, `getLeadTimeStatus` returns a fourth `"unknown"` state, render "—" for nulls.

## Verification

- `tsc --noEmit` clean for all touched files.
- End-to-end smoke against the running dev coordinator (which hits prod): single combined HTTP request fires, `orderedTasks` length equals visible service count, rendered list matches `orderedTasks` order item-for-item.
- After #242 deployed, "—" rows now sit below "100%" rows within each compliance tie-bucket — confirmed visually on the planner.

## Out of scope

- Replacing the secondary key with the `lineasoc_recoverable` / `at_risk` / `lost` dimensions — pending Gabriel's spec response (`db-scripts/plans/lineasoc-recoverable-dimensions.md`). When delivered the FE doesn't need to change again; the preset name stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing compliance data in KPI displays—now shows "unknown" status instead of potentially misleading values.
  * Enhanced lead-time percentage display to gracefully handle null values.

* **Performance Improvements**
  * Optimized task ordering with unified backend calls, reducing redundant requests and improving consistency across task lists.
  * Implemented server-side sorting for more efficient and reliable task prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->