### PR TITLE
fix(ci): enable integrations component in Quarkus Build & Test

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -84,7 +84,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Build & Test
-        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true
+        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true -Dmiot.component.integrations.enabled=true
         working-directory: quarkus-srv
 
       - name: SonarCloud Scan


### PR DESCRIPTION
## Summary
- The `Build & Test` step in `.github/workflows/quarkus.yml` only enabled `fleet`/`driver`/`tracking`/`gateway`, omitting `integrations`.
- Flyway in CI therefore didn't see the integrations module migrations, while production has them applied — causing `Detected applied migration not resolved locally: 0.6.0` on startup.
- Adds `-Dmiot.component.integrations.enabled=true` to the `mvnw clean verify` command.

Closes #434

## Test plan
- [x] CI run on this branch is green (Quarkus CI workflow)
- [x] Confirmed local clean compile succeeds with all five component flags
- [x] No other workflow changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build configuration to enable extended component verification during the JVM build and test process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->