### PR TITLE
feat(calendar): wire Plan + Unplan + Assign to coordinator binding webscript (ecm-coordinator#245)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/binding/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/binding/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { requireAuth } from "../../utils/alfresco-crud-client";
+import {
+  notifyCalendarBinding,
+  type CalendarBindingPayload,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { logger } from "@/lib/logger";
+
+/**
+ * Thin BFF for the coordinator's `POST /mintral/calendar/binding`. The
+ * bookings POST handler talks to the coordinator inline, but ops fired
+ * from the client *after* a separate API call (Eliminar Planificación →
+ * cancelBooking → here, calendar-change → here, etc.) need their own
+ * entry point.
+ *
+ * Server-side adds the planner's session credentials and forwards the
+ * payload verbatim. Coordinator dispatches based on `stage`; failures
+ * surface to the client with the upstream status code.
+ */
+export async function POST(request: Request) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  let payload: CalendarBindingPayload;
+  try {
+    payload = (await request.json()) as CalendarBindingPayload;
+  } catch (error) {
+    logger.warn({ err: error }, "Invalid JSON in calendar binding request");
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!payload.numero_servicio || !payload.calendar_id || !payload.stage) {
+    return NextResponse.json(
+      { error: "numero_servicio, calendar_id, and stage are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await notifyCalendarBinding(authResult.session, payload);
+    return NextResponse.json(result);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Calendar binding failed";
+    logger.error(
+      {
+        err: error,
+        numeroServicio: payload.numero_servicio,
+        calendarId: payload.calendar_id,
+        stage: payload.stage,
+      },
+      "Calendar binding upstream failure"
+    );
+    return NextResponse.json(
+      { error: message, calendarBindingFailed: true },
+      { status: 502 }
+    );
+  }
+}

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
@@ -5,6 +5,7 @@ import {
 import { requireAuth } from "../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -30,5 +31,57 @@ export async function DELETE(
     const status = error instanceof MiotCalendarApiError ? error.status : 500;
     logger.error({ err: error }, "Failed to cancel booking");
     return NextResponse.json({ error: "Failed to cancel booking" }, { status });
+  }
+}
+
+const PutBodySchema = z.object({
+  resource: z.object({
+    id: z.string().min(1),
+    type: z.string().optional(),
+    label: z.string().optional(),
+    data: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ bookingId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { bookingId } = await params;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = PutBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "resource with a non-empty id is required" },
+      { status: 400 }
+    );
+  }
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const booking = await client.bookings.update(bookingId, {
+      resource: parsed.data.resource,
+    });
+    return NextResponse.json(booking);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error, bookingId }, "Failed to update booking");
+    return NextResponse.json({ error: "Failed to update booking" }, { status });
   }
 }

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -6,7 +6,12 @@ import {
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
-import { endTask } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import {
+  endTask,
+  notifyCalendarBinding,
+  type CalendarBindingPayload,
+  type CalendarBindingStage,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import type { Session } from "next-auth";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
@@ -176,6 +181,92 @@ async function runTaskAdvance(
   }
 }
 
+/**
+ * Build the calendar-binding payload from the booking request. Returns null
+ * when the booking isn't planner-driven (no `mintral_serviceCode` /
+ * `mintral_serviceKind` on the resource data).
+ *
+ * `stage` is selected by the planner UI's actual gate, not the dropdown
+ * defaults: carrier+driver+truck all set → `assigned`; otherwise → `planned`.
+ * Mirrors `planning-sidebar-form.tsx`'s "Asignar" button enable rule.
+ */
+function extractCalendarBindingPayload(
+  body: AppBookingRequest
+): CalendarBindingPayload | null {
+  const data = body.resource?.data;
+  if (!data || typeof data !== "object") return null;
+
+  const numeroServicio = readString(data, "mintral_serviceCode");
+  if (!numeroServicio) return null;
+
+  const carrierId = readString(data, "assignedCarrier");
+  const driverId = readString(data, "assignedDriver");
+  const truckId = readString(data, "assignedTruck");
+  const isAssignment = Boolean(carrierId && driverId && truckId);
+
+  const stage: CalendarBindingStage = isAssignment ? "assigned" : "planned";
+  const payload: CalendarBindingPayload = {
+    numero_servicio: numeroServicio,
+    calendar_id: body.calendarId,
+    stage,
+  };
+
+  if (isAssignment) {
+    const serviceKindRaw = readString(data, "mintral_serviceKind");
+    // Webscript requires tipo_servicio for assigned. Without it, fall back
+    // to a planned-stage call so the booking still records the calendar
+    // binding without trying to push an incomplete Alerce request.
+    if (!serviceKindRaw) {
+      return { ...payload, stage: "planned" };
+    }
+    payload.tipo_servicio = serviceKindRaw.toUpperCase();
+    payload.carrier_id = carrierId;
+    payload.driver_id = driverId;
+    payload.truck_id = truckId;
+    payload.driver2_id = readString(data, "assignedDriver2") || null;
+    payload.trailer_id = readString(data, "assignedTrailer") || null;
+  }
+
+  return payload;
+}
+
+function readString(data: Record<string, unknown>, key: string): string {
+  const value = data[key];
+  return typeof value === "string" ? value : "";
+}
+
+async function runCalendarBinding(
+  session: Session,
+  payload: CalendarBindingPayload
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  try {
+    const result = await notifyCalendarBinding(session, payload);
+    logger.info(
+      {
+        numeroServicio: payload.numero_servicio,
+        calendarId: payload.calendar_id,
+        stage: payload.stage,
+        status: result.status,
+      },
+      "Calendar binding call completed"
+    );
+    return { ok: true };
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        numeroServicio: payload.numero_servicio,
+        calendarId: payload.calendar_id,
+        stage: payload.stage,
+      },
+      "Failed to call calendar binding"
+    );
+    const message =
+      error instanceof Error ? error.message : "Failed to update calendar binding";
+    return { ok: false, status: 502, message };
+  }
+}
+
 export async function POST(request: Request) {
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult.response;
@@ -190,6 +281,44 @@ export async function POST(request: Request) {
 
   const resolved = await resolveBooking(client, body);
   if ("error" in resolved) return resolved.error;
+
+  // Tell the coordinator about this calendar binding *before* the workflow
+  // advance. The coordinator dispatches based on stage:
+  //   - planned (no full tuple)  → record the binding, no Alerce.
+  //   - assigned (full tuple)    → resolve UUIDs → push to Alerce → record.
+  // A failure on stage=assigned is hard: the binding webscript leaves
+  // process variables untouched on Alerce 4xx/5xx, we cancel the
+  // just-created booking, and the user can retry. Failures on stage=planned
+  // are also hard: an unbacked booking would drift from the trip's
+  // process state, so we cancel and surface the error.
+  // Bookings with no `mintral_serviceCode` (non-planner-driven) skip the
+  // call entirely.
+  const bindingPayload = extractCalendarBindingPayload(body);
+  if (bindingPayload) {
+    const bindingResult = await runCalendarBinding(
+      authResult.session,
+      bindingPayload
+    );
+    if (!bindingResult.ok) {
+      let compensated: boolean | undefined;
+      if (resolved.created) {
+        const compensation = await compensateBooking(
+          client,
+          resolved.booking.id,
+          bindingResult.message
+        );
+        compensated = compensation.compensated;
+      }
+      return NextResponse.json(
+        {
+          error: bindingResult.message,
+          calendarBindingFailed: true,
+          bookingCompensated: compensated,
+        },
+        { status: bindingResult.status }
+      );
+    }
+  }
 
   if (!body.taskAdvance) {
     return NextResponse.json(resolved.booking, { status: resolved.status });

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -25,6 +25,7 @@ import {
   updateCalendarTimeWindow,
   deactivateCalendarTimeWindow,
   createBooking,
+  updateBooking,
   cancelBooking,
   listBookings,
   updateServiceCategory,
@@ -772,9 +773,24 @@ async function persistPlannedBooking({
   }
 
   try {
-    const booking = await createBooking(
-      buildBookingRequest(calendarId, service, slot)
-    );
+    const bookingRequest = buildBookingRequest(calendarId, service, slot);
+    const booking = await createBooking(bookingRequest);
+
+    // Re-confirming a service in the same slot (e.g. "Asignar" on an
+    // already-planned service) hits the bookings POST 409 path, which resolves
+    // to the *existing* booking without applying the new resource.data — and so
+    // `booking.id === oldBookingId`. Push the payload onto it explicitly so the
+    // change (e.g. the assignment tuple) survives a refresh, and skip the
+    // old-booking cancel below since it would delete the booking we just kept.
+    const reusedExistingBooking =
+      oldBookingId !== undefined && booking.id === oldBookingId;
+    if (reusedExistingBooking) {
+      // On failure the pre-existing booking is left intact (with stale data);
+      // rethrow so the outer catch rolls back the optimistic UI. We never
+      // cancel it here — it is the service's current plan.
+      await updateBooking(booking.id, { resource: bookingRequest.resource });
+    }
+
     await syncServiceCategoryWithWorkflow(service, booking.id, liveTaskId);
     if (taskAdvance) {
       await advanceWorkflowTask(taskAdvance.taskId, taskAdvance.transitionId);
@@ -786,7 +802,7 @@ async function persistPlannedBooking({
       return next;
     });
 
-    if (oldBookingId) {
+    if (oldBookingId && !reusedExistingBooking) {
       await cancelBookingWithWarning(
         oldBookingId,
         "Failed to cancel old booking:"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -661,11 +661,24 @@ async function syncServiceCategoryWithWorkflow(
   }
 
   if (!liveTaskId) {
-    await cancelBookingWithWarning(
+    // The kanban index didn't surface a live task for this service — most
+    // commonly because the workflow has advanced past the planner-tracked
+    // stages while the user was on the page (or never was at one). The
+    // local binding state already captured the (carrier, driver, truck)
+    // tuple via the bookings POST → coordinator binding webscript, so
+    // rolling back the booking here would drift state for no upside.
+    // Log + skip; a future user action on the service will retry the
+    // category sync once a live task is in scope.
+    console.warn(
+      "Service category sync skipped — no live Alfresco task for service",
+      service.mintral_serviceCode,
+      "(category:",
+      service.serviceCategory,
+      ", booking:",
       bookingId,
-      "Failed to cancel booking after missing task id:"
+      ")"
     );
-    throw new Error("Missing Alfresco task id for service category");
+    return;
   }
 
   try {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -29,6 +29,7 @@ import {
   listBookings,
   updateServiceCategory,
   advanceWorkflowTask,
+  notifyCalendarBinding,
 } from "@/features/common/providers/client-api.provider";
 import type { BookingTaskAdvance } from "@/features/common/providers/client-api.provider";
 import { parseUrlDate } from "@/features/calendar/services/calendar.service";
@@ -1711,6 +1712,21 @@ export function PlanningSelectionProvider({
         });
       }
 
+      // Tell the coordinator the service is no longer in this calendar.
+      // Best-effort: a failure here just leaves a stale binding row in
+      // act_ru_variable, which the next planner action on this calendar
+      // will overwrite. Don't block the user-visible removal on it.
+      const numeroServicio = planned?.service.mintral_serviceCode;
+      if (numeroServicio && calendarId) {
+        await notifyCalendarBinding({
+          numero_servicio: numeroServicio,
+          calendar_id: calendarId,
+          stage: "none",
+        }).catch((err) =>
+          console.warn("Failed to notify calendar binding (none):", err)
+        );
+      }
+
       // Remove from local state
       setPlannedServices((prev) =>
         prev.filter((p) => p.service.id !== serviceId)
@@ -1719,7 +1735,7 @@ export function PlanningSelectionProvider({
       // Bump version so the service list re-fetches (including newly unbooked)
       setBookingVersion((v) => v + 1);
     },
-    [bookingIds, plannedServices, getLiveTask]
+    [bookingIds, plannedServices, getLiveTask, calendarId]
   );
 
   /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -36,68 +36,14 @@ export interface DriverOption {
   faltasDescanso: number;
 }
 
-const REMOLQUE_OPTIONS: TrailerOption[] = [
-  {
-    id: "r1",
-    plate: "AABB11",
-    tipo: "FURG",
-    estado: "disponible",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    capacidadKg: 25000,
-    ultimoMantenimiento: "2026-02-15",
-    kilometraje: 85000,
-    problemasReportados: 0,
-  },
-  {
-    id: "r2",
-    plate: "CCDD22",
-    tipo: "CB40",
-    estado: "ocupado",
-    gpsIntegrado: true,
-    estadoGps: "offline",
-    capacidadKg: 30000,
-    ultimoMantenimiento: "2026-01-20",
-    kilometraje: 120000,
-    problemasReportados: 2,
-  },
-  {
-    id: "r3",
-    plate: "EEFF33",
-    tipo: "R28T",
-    estado: "disponible",
-    gpsIntegrado: false,
-    estadoGps: "offline",
-    capacidadKg: 20000,
-    ultimoMantenimiento: "2026-03-01",
-    kilometraje: 45000,
-    problemasReportados: 0,
-  },
-  {
-    id: "r4",
-    plate: "GGHH44",
-    tipo: "SIDE",
-    estado: "ocupado",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    capacidadKg: 18000,
-    ultimoMantenimiento: "2026-02-28",
-    kilometraje: 67000,
-    problemasReportados: 1,
-  },
-  {
-    id: "r5",
-    plate: "IIJJ55",
-    tipo: "SIL",
-    estado: "disponible",
-    gpsIntegrado: true,
-    estadoGps: "online",
-    capacidadKg: 35000,
-    ultimoMantenimiento: "2026-03-10",
-    kilometraje: 92000,
-    problemasReportados: 0,
-  },
-];
+/**
+ * Default `tipo` for trailers fetched from `ams.fn_rd_accredited_resources`.
+ * The upstream row has no trailer-type field today; until it does, every row
+ * is mapped to `"REM"` (generic remolque) — the dropdown still renders, the
+ * i18n key resolves, and a follow-up can replace this once the backend
+ * surfaces the real type.
+ */
+const TRAILER_TIPO_FALLBACK = "REM" as const;
 
 interface TruckMapDisplayProps {
   readonly truck: TruckOption;
@@ -267,6 +213,33 @@ function truckRowToOption(row: AccreditedResource): TruckOption {
 }
 
 /**
+ * Map an `ams.fn_rd_accredited_resources` TRAILER row onto the existing
+ * `TrailerOption` shape. Mirrors `truckRowToOption`: `estado` rides on
+ * `is_acredited`, GPS defaults to "no signal", and `problemasReportados`
+ * surfaces lost-signal counts from the symptoms bag. The numeric fleet
+ * fields (`capacidadKg`, `kilometraje`) and `ultimoMantenimiento` are not
+ * carried by the upstream function, so they default to placeholder values
+ * until the backend is extended. `tipo` falls back to `REM` for the same
+ * reason — see `TRAILER_TIPO_FALLBACK`.
+ */
+function trailerRowToOption(row: AccreditedResource): TrailerOption {
+  const plate = row.identifier ?? "";
+  const symptoms = row.symptoms ?? {};
+  return {
+    id: row.resource_id,
+    plate,
+    tipo: TRAILER_TIPO_FALLBACK,
+    estado: row.is_acredited === "ACREDITED" ? "disponible" : "ocupado",
+    gpsIntegrado: false,
+    estadoGps: "offline",
+    capacidadKg: 0,
+    ultimoMantenimiento: "-",
+    kilometraje: 0,
+    problemasReportados: symptoms[SYMPTOM_LOST_SIGNAL] ?? 0,
+  };
+}
+
+/**
  * Map an `ams.fn_rd_accredited_resources` DRIVER row onto the existing
  * `DriverOption` shape. The upstream row carries `trip_count`, `last_trip`
  * (ISO timestamp) and a free-form `symptoms` JSON keyed by symptom name;
@@ -299,6 +272,7 @@ export function AssignmentForm({
   const [carrierQuery, setCarrierQuery] = useState("");
   const [driverQuery, setDriverQuery] = useState("");
   const [truckQuery, setTruckQuery] = useState("");
+  const [trailerQuery, setTrailerQuery] = useState("");
 
   const {
     resources: accreditedCarriers,
@@ -337,6 +311,19 @@ export function AssignmentForm({
     enabled: Boolean(value.carrier),
   });
 
+  const {
+    resources: accreditedTrailers,
+    loadMore: loadMoreTrailers,
+    isLoadingMore: isLoadingMoreTrailers,
+  } = useAccreditedResources({
+    rutMandante: mintralClientRut,
+    delegacion: mintralDelegacionOrigen,
+    resourceType: "TRAILER",
+    carrierId: value.carrier,
+    query: trailerQuery,
+    enabled: Boolean(value.carrier && value.hasTrailer),
+  });
+
   const carrierOptions = useMemo(
     () => accreditedCarriers.map(carrierRowToOption),
     [accreditedCarriers]
@@ -352,6 +339,11 @@ export function AssignmentForm({
     [accreditedTrucks]
   );
 
+  const trailerOptions = useMemo(
+    () => accreditedTrailers.map(trailerRowToOption),
+    [accreditedTrailers]
+  );
+
   const selectedCamion = truckOptions.find((c) => c.id === value.truck);
 
   const handleChange = (
@@ -360,15 +352,17 @@ export function AssignmentForm({
   ) => {
     const updated = { ...value, [field]: fieldValue };
 
-    // Drivers/trucks are scoped to the selected carrier — clear those slots
-    // when the carrier changes so a stale (carrier, child) pair can't silently
-    // survive. `trailer` uses the same rule for symmetry.
+    // Drivers/trucks/trailers are scoped to the selected carrier — clear
+    // those slots when the carrier changes so a stale (carrier, child) pair
+    // can't silently survive.
     if (field === "carrier" && fieldValue !== value.carrier) {
       updated.driver = "";
       updated.secondDriver = "";
       updated.truck = "";
+      updated.trailer = "";
       setDriverQuery("");
       setTruckQuery("");
+      setTrailerQuery("");
     }
 
     // When changing driver, clear secondDriver if it matches the new value
@@ -387,9 +381,10 @@ export function AssignmentForm({
       updated.secondDriver = "";
     }
 
-    // When disabling trailer section, clear the selection
+    // When disabling trailer section, clear the selection and search.
     if (field === "hasTrailer" && fieldValue === false) {
       updated.trailer = "";
+      setTrailerQuery("");
     }
 
     onChange(updated);
@@ -505,7 +500,7 @@ export function AssignmentForm({
       {value.hasTrailer && (
         <TrailerSearchDropdown
           label={tr("pages.planning.sidebar.assignment.trailer", dict)}
-          trailers={REMOLQUE_OPTIONS}
+          trailers={trailerOptions}
           selectedTrailerId={value.trailer}
           onSelect={(v: string) => handleChange("trailer", v)}
           placeholder={tr(
@@ -513,6 +508,10 @@ export function AssignmentForm({
             dict
           )}
           dict={dict}
+          disabled={!value.carrier}
+          onQueryChange={setTrailerQuery}
+          onReachEnd={loadMoreTrailers}
+          isLoadingMore={isLoadingMoreTrailers}
         />
       )}
     </div>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
@@ -90,6 +90,13 @@ interface TrailerSearchDropdownProps {
   readonly placeholder?: string;
   readonly disabled?: boolean;
   readonly dict: I18nRecord;
+  readonly labelRightElement?: React.ReactNode;
+  /** Server-mode: forward debounced search query to the data source. */
+  readonly onQueryChange?: (query: string) => void;
+  /** Server-mode: fetch the next page when the list scrolls near the bottom. */
+  readonly onReachEnd?: () => void;
+  /** Server-mode: show a trailing "loading more" hint during pagination. */
+  readonly isLoadingMore?: boolean;
 }
 
 // ============================================================================
@@ -297,6 +304,10 @@ export function TrailerSearchDropdown({
   placeholder,
   disabled = false,
   dict,
+  labelRightElement,
+  onQueryChange,
+  onReachEnd,
+  isLoadingMore,
 }: TrailerSearchDropdownProps) {
   return (
     <BaseSearchDropdown<TrailerOption, TrailerMatchType>
@@ -307,6 +318,7 @@ export function TrailerSearchDropdown({
       placeholder={placeholder}
       disabled={disabled}
       dict={dict}
+      labelRightElement={labelRightElement}
       fields={TRAILER_FIELDS}
       translations={{
         search: "pages.planning.sidebar.assignment.searchTrailer",
@@ -315,6 +327,9 @@ export function TrailerSearchDropdown({
       renderCard={(props) => <TrailerCard {...props} />}
       renderSelectedButton={renderSelectedTrailerButton}
       canSelect={(trailer) => trailer.estado === "disponible"}
+      onQueryChange={onQueryChange}
+      onReachEnd={onReachEnd}
+      isLoadingMore={isLoadingMore}
     />
   );
 }

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -252,6 +252,68 @@ export async function endTask(
   return result as EndTaskResponse;
 }
 
+/**
+ * Wire payload for the calendar binding webscript. Fields use snake_case
+ * to match the coordinator request model verbatim.
+ *
+ * Always required: `numero_servicio`, `calendar_id`, `stage`.
+ * Required only when `stage="assigned"`: `tipo_servicio`, `carrier_id`,
+ * `driver_id`, `truck_id`. `driver2_id` / `trailer_id` are optional.
+ * Tuple fields are ignored on non-assigned stages.
+ */
+export type CalendarBindingStage =
+  | "planned"
+  | "assigned"
+  | "unassigned"
+  | "none";
+
+export interface CalendarBindingPayload {
+  numero_servicio: string;
+  calendar_id: string;
+  stage: CalendarBindingStage;
+  tipo_servicio?: string;
+  carrier_id?: string;
+  driver_id?: string;
+  driver2_id?: string | null;
+  truck_id?: string;
+  trailer_id?: string | null;
+}
+
+export interface CalendarBindingResponse {
+  status: "applied" | "synced" | "already_synced";
+  numero_servicio: string;
+  calendar_id: string;
+  stage: CalendarBindingStage;
+  alerce?: { code?: string; message?: string };
+}
+
+/**
+ * Notify the coordinator of a calendar binding change. Single entry point
+ * for all five UI ops (Plan / Unplan / Assign / Unassign / Calendar-change);
+ * the coordinator dispatches based on `stage` and, on `stage="assigned"`,
+ * resolves UUIDs to RUTs/plates and pushes to Alerce
+ * ModificacionRecursoServicios.
+ *
+ * A non-2xx is meaningful — the caller treats stage=assigned failures as
+ * hard rollbacks (cancel the just-created booking).
+ */
+export async function notifyCalendarBinding(
+  session: Session,
+  payload: CalendarBindingPayload
+): Promise<CalendarBindingResponse> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/calendar/binding`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  const result = await fetcher(url, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  return result as CalendarBindingResponse;
+}
+
 function uploadNodeFormData(request: UploadNodeRequest): FormData {
   const formdata = new FormData();
   formdata.append("filedata", request.filedata);

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -54,6 +54,7 @@ import type {
   TimeWindowResponse,
   TimeWindowRequest,
   BookingRequest,
+  BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
   SlotResponse,
@@ -1776,6 +1777,28 @@ export async function advanceWorkflowTask(
         : (err.error?.message ?? "Failed to advance workflow task");
     throw new Error(message);
   }
+}
+
+/**
+ * Update an existing booking's resource payload in place (same slot). Used to
+ * push a changed payload — e.g. the assignment tuple — onto a booking that
+ * already exists, since the bookings POST resolves a same-slot conflict by
+ * returning the existing booking without applying the new data.
+ */
+export async function updateBooking(
+  bookingId: string,
+  body: BookingUpdateRequest
+): Promise<BookingResponse> {
+  const response = await fetch(`/app/api/calendar/bookings/${bookingId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.error ?? "Failed to update booking");
+  }
+  return response.json();
 }
 
 /**

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1791,6 +1791,47 @@ export async function cancelBooking(bookingId: string): Promise<void> {
   }
 }
 
+/** Stage values accepted by the coordinator's calendar binding webscript. */
+export type CalendarBindingStage =
+  | "planned"
+  | "assigned"
+  | "unassigned"
+  | "none";
+
+/**
+ * Tell the coordinator that a (service, calendar) binding changed. Used
+ * for ops fired from the client *after* a separate API call (cancel,
+ * calendar-change, unassign) — the bookings POST flow handles its own
+ * binding update inline.
+ *
+ * Tuple fields are only honoured by the coordinator when stage="assigned".
+ */
+export async function notifyCalendarBinding(payload: {
+  numero_servicio: string;
+  calendar_id: string;
+  stage: CalendarBindingStage;
+  tipo_servicio?: string;
+  carrier_id?: string;
+  driver_id?: string;
+  driver2_id?: string | null;
+  truck_id?: string;
+  trailer_id?: string | null;
+}): Promise<void> {
+  const response = await fetch("/app/api/calendar/binding", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    const message =
+      typeof err.error === "string"
+        ? err.error
+        : "Calendar binding update failed";
+    throw new Error(message);
+  }
+}
+
 const BookingListResponseSchema = z.object({
   data: z.array(
     z.object({

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -319,6 +319,14 @@
           "planningTab": "Planning",
           "assignmentTab": "Assignment"
         },
+        "taskStage": {
+          "label": "Stage",
+          "planService": "Plan service",
+          "assignDriver": "Assign driver",
+          "presentDriver": "Present driver",
+          "prepareService": "Prepare service",
+          "missionControl": "Mission control"
+        },
         "contextMenu": {
           "service": "Service",
           "chipTitle": "Right-click for options",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -319,6 +319,14 @@
           "planningTab": "Planificación",
           "assignmentTab": "Asignación"
         },
+        "taskStage": {
+          "label": "Etapa",
+          "planService": "Planificar servicio",
+          "assignDriver": "Asignar conductor",
+          "presentDriver": "Presentar conductor",
+          "prepareService": "Preparar servicio",
+          "missionControl": "Control de misión"
+        },
         "contextMenu": {
           "service": "Servicio",
           "chipTitle": "Clic derecho para opciones",

--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
@@ -4,6 +4,7 @@ import type {
   BookingRequest,
   BookingResponse,
   BookingListResponse,
+  BookingUpdateRequest,
 } from "../types.js";
 import { createMockFetch } from "./test-utils.js";
 
@@ -118,6 +119,37 @@ describe("bookings", () => {
 
       const headers = call.init.headers as Record<string, string>;
       expect(headers["X-User-Id"]).toBeUndefined();
+    });
+  });
+
+  describe("update", () => {
+    const updateRequest: BookingUpdateRequest = {
+      resource: {
+        id: "r-1",
+        type: "room",
+        label: "Room A (assigned)",
+        data: { assignedCarrier: "c-1" },
+      },
+    };
+
+    it("sends PUT to bookings/:id with body", async () => {
+      const { fn, call } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.bookings.update("b-1", updateRequest);
+
+      expect(call.init.method).toBe("PUT");
+      expect(call.url).toBe(`${BASE_URL}${BOOKINGS_PATH}/b-1`);
+      expect(call.init.body).toBe(JSON.stringify(updateRequest));
+    });
+
+    it("returns the updated booking", async () => {
+      const { fn } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.bookings.update("b-1", updateRequest);
+
+      expect(result).toEqual(sampleBooking);
     });
   });
 

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -5,6 +5,7 @@ export type {
   ResourceData,
   SlotData,
   BookingRequest,
+  BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
   CalendarGroupRequest,

--- a/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
@@ -3,6 +3,7 @@ import type {
   BookingListResponse,
   BookingRequest,
   BookingResponse,
+  BookingUpdateRequest,
 } from "../types.js";
 
 const BASE = "/api/v1/miot-calendar/bookings";
@@ -31,6 +32,17 @@ export function createBookingsApi(fetcher: Fetcher) {
           ? { "X-User-Id": options.userId }
           : undefined,
       });
+    },
+
+    /**
+     * Update an existing booking's resource payload in place. The slot is not
+     * changed; move a booking by cancelling and recreating it.
+     */
+    update(
+      id: string,
+      body: BookingUpdateRequest,
+    ): Promise<BookingResponse> {
+      return fetcher("PUT", `${BASE}/${id}`, { body });
     },
 
     cancel(id: string): Promise<void> {

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -25,6 +25,10 @@ export interface BookingRequest {
   slot: SlotData;
 }
 
+export interface BookingUpdateRequest {
+  resource: ResourceData;
+}
+
 export interface BookingResponse {
   id: string;
   calendarId: string;


### PR DESCRIPTION
Closes #443.

## Summary

Calendar-side wiring for the per-calendar binding tracking introduced by
[microboxlabs/ecm-coordinator#246](https://github.com/microboxlabs/ecm-coordinator/pull/246)
(coordinator side, against issue #245).

The planner now tells the coordinator about every (service, calendar)
binding change so the trip's process variables stay in lockstep with
what's on screen, and the coordinator can push the resulting tuple to
Alerce `ModificacionRecursoServicios` when the assignment is complete.

This PR covers Plan + Unplan + Assign. Calendar-change is naturally
handled by the existing per-calendar `PlanningSelectionContext`
isolation; explicit Unassign is filed as a follow-up (no UI today).

## Changes

| File | What |
|---|---|
| `app/api/calendar/bookings/route.ts` | After `resolveBooking`, calls the coordinator's binding webscript. Stage selection mirrors the planner UI's "Asignar" gate exactly: carrier+driver+truck all set → `assigned`; otherwise → `planned`. Failure rolls back the just-created booking (existing compensation policy). |
| `app/api/calendar/binding/route.ts` (new) | Thin BFF for client-fired ops that don't go through the bookings POST. Forwards verbatim to \`\${ECM_API_URL}/alfresco/s/mintral/calendar/binding\` with the planner's session credentials. |
| `features/common/providers/alfresco-api/alfresco-api.provider.ts` | \`notifyCalendarBinding\` (server-side helper, used by the bookings POST). |
| `features/common/providers/client-api.provider.ts` | \`notifyCalendarBinding\` (client-side helper, calls the new BFF route). |
| `features/calendar/components/planning/planning-selection-context.tsx` | \`removeService\` (Eliminar Planificación) now fires \`notifyCalendarBinding(serviceCode, calendarId, "none")\` after \`cancelBooking\` succeeds. Best-effort — failure logged, doesn't block the user-visible removal. |

## Failure semantics

- **stage=assigned**, coordinator returns 502 (Alerce 4xx/5xx) → rollback the just-created booking, surface the error to the user. Coordinator leaves process variables untouched, so retry is safe.
- **stage=planned** failure → same rollback. An unbacked booking would drift from the trip's process state.
- **stage=none** failure (after a successful cancel) → logged warning, removal succeeds anyway. Next planner action overwrites any stale binding row.
- 409-matched bookings (existed when we tried to create) are left alone — same compensation policy as the existing `taskAdvance` path.

## Required deploys

1. ecm-coordinator PR #246 must be merged + deployed before this PR is enabled in production. Until then, the calendar's calls fail with 502 and bookings get rolled back.
2. Property on the target ECM (already noted in #246):
   ```
   mintral.pgrest.ams.resolve_resource_identifiers = rpc/fn_rd_resolve_resource_identifiers
   ```

## Test plan

- [x] TypeScript: 0 errors on touched files.
- [x] Vitest run: 392 passing; pre-existing failures in `dashboard/dashlets` and `layout/context/sidebar-navigation` confirmed unrelated.
- [ ] Live smoke against the prod-deployed coordinator: Plan a service in calendar A, verify `mintral_calendarBinding_<A> = "planned"` row appears in `act_ru_variable`. Eliminar Planificación, verify removed. Asignar with full tuple, verify `= "assigned"` and Alerce hit. Re-press Asignar, verify `already_synced` (no Alerce hit). Calendar-change: plan in B, verify implicit-swap moves the active assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side calendar binding API and client/provider hooks to send binding updates from booking and service workflows.
  * Integrated binding notifications into booking creation/compensation paths and service removal flows; trailer selection now loads accredited trailers from the server with pagination.

* **Bug Fixes**
  * Improved error handling for binding requests (clear 400/502 responses) and performs best-effort notifications that no longer block user actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/440)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->