### PR TITLE
harness(cleanup): unblock T00 pre-flight (format + py.typed + strict mypy + tests)

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -56,3 +56,7 @@ pythonpath = ["src"]
 python_version = "3.11"
 strict = true
 packages = ["miot_harness"]
+
+[[tool.mypy.overrides]]
+module = ["asyncpg", "asyncpg.*", "yaml"]
+ignore_missing_imports = true

--- a/miot-harness/src/miot_harness/__init__.py
+++ b/miot-harness/src/miot_harness/__init__.py
@@ -3,4 +3,3 @@
 __all__ = ["__version__"]
 
 __version__ = "0.1.0"
-

--- a/miot-harness/src/miot_harness/agents/__init__.py
+++ b/miot-harness/src/miot_harness/agents/__init__.py
@@ -1,2 +1,1 @@
 """Agent adapters and subagent definitions."""
-

--- a/miot-harness/src/miot_harness/agents/chat_models.py
+++ b/miot-harness/src/miot_harness/agents/chat_models.py
@@ -11,6 +11,7 @@ plain ANTHROPIC_API_KEY / OPENAI_API_KEY env vars).
 from __future__ import annotations
 
 from langchain_core.language_models import BaseChatModel
+from pydantic import SecretStr
 
 from miot_harness.config import get_settings
 
@@ -22,21 +23,21 @@ def get_chat_model(name: str) -> BaseChatModel:
         from langchain_anthropic import ChatAnthropic
 
         if not settings.anthropic_api_key:
-            raise RuntimeError(
-                "ANTHROPIC_API_KEY is not set; cannot construct Claude chat model"
-            )
-        return ChatAnthropic(model_name=name, api_key=settings.anthropic_api_key, timeout=60, stop=None)
+            raise RuntimeError("ANTHROPIC_API_KEY is not set; cannot construct Claude chat model")
+        return ChatAnthropic(
+            model_name=name,
+            api_key=SecretStr(settings.anthropic_api_key),
+            timeout=60,
+            stop=None,
+        )
 
     if name.startswith("gpt-") or name.startswith("o1-") or name.startswith("o3-"):
         from langchain_openai import ChatOpenAI
 
         if not settings.openai_api_key:
-            raise RuntimeError(
-                "OPENAI_API_KEY is not set; cannot construct OpenAI chat model"
-            )
-        return ChatOpenAI(model=name, api_key=settings.openai_api_key)
+            raise RuntimeError("OPENAI_API_KEY is not set; cannot construct OpenAI chat model")
+        return ChatOpenAI(model=name, api_key=SecretStr(settings.openai_api_key))
 
     raise ValueError(
-        f"Unsupported chat model name: {name!r}. "
-        "Expected a claude-* / gpt-* / o1-* / o3-* prefix."
+        f"Unsupported chat model name: {name!r}. Expected a claude-* / gpt-* / o1-* / o3-* prefix."
     )

--- a/miot-harness/src/miot_harness/agents/critic.py
+++ b/miot-harness/src/miot_harness/agents/critic.py
@@ -49,17 +49,17 @@ async def critic_node(
 
     user_message = state.get("user_message", "")
     evidence = state.get("evidence", [])
-    rendered = json.dumps([e.model_dump() if hasattr(e, "model_dump") else e for e in evidence], default=str)[:2000]
-    human = (
-        f"User question: {user_message}\n\n"
-        f"Proposed answer:\n{answer}\n\n"
-        f"Evidence:\n{rendered}"
-    )
+    rendered = json.dumps(
+        [e.model_dump() if hasattr(e, "model_dump") else e for e in evidence], default=str
+    )[:2000]
+    human = f"User question: {user_message}\n\nProposed answer:\n{answer}\n\nEvidence:\n{rendered}"
 
-    response = await model.ainvoke([
-        SystemMessage(content=_CRITIC_SYSTEM),
-        HumanMessage(content=human),
-    ])
+    response = await model.ainvoke(
+        [
+            SystemMessage(content=_CRITIC_SYSTEM),
+            HumanMessage(content=human),
+        ]
+    )
     text = response.content if hasattr(response, "content") else str(response)
     if not isinstance(text, str):
         text = str(text)

--- a/miot-harness/src/miot_harness/agents/deepagents_adapter.py
+++ b/miot-harness/src/miot_harness/agents/deepagents_adapter.py
@@ -29,9 +29,7 @@ DEFAULT_SUBAGENTS = [
     SubAgentSpec(
         name="dashboard_visualizer",
         description="Proposes dashboard widget drafts from story findings.",
-        system_prompt=(
-            "You propose dashboard widgets as drafts only. Mutations require approval."
-        ),
+        system_prompt=("You propose dashboard widgets as drafts only. Mutations require approval."),
     ),
 ]
 
@@ -46,4 +44,3 @@ def create_deep_agent_kwargs() -> dict[str, Any]:
         ),
         "subagents": [agent.__dict__ for agent in DEFAULT_SUBAGENTS],
     }
-

--- a/miot-harness/src/miot_harness/agents/domain_analyst.py
+++ b/miot-harness/src/miot_harness/agents/domain_analyst.py
@@ -65,14 +65,10 @@ def _render_evidence(evidence: list[NexoEvidence]) -> str:
     for i, ev in enumerate(evidence, start=1):
         stale = " [STALE]" if ev.is_stale else ""
         refreshed = ev.refreshed_at.isoformat() if ev.refreshed_at else "unknown"
-        sample = (
-            f" sample_size={ev.sample_size}" if ev.sample_size is not None else ""
-        )
+        sample = f" sample_size={ev.sample_size}" if ev.sample_size is not None else ""
         # Cap to avoid bloating prompt
         snippet = json.dumps(ev.output, default=str)[:1000]
-        lines.append(
-            f"[{i}] tool={ev.tool} refreshed_at={refreshed}{stale}{sample}\n    {snippet}"
-        )
+        lines.append(f"[{i}] tool={ev.tool} refreshed_at={refreshed}{stale}{sample}\n    {snippet}")
     return "\n".join(lines)
 
 
@@ -89,14 +85,14 @@ async def domain_analyst_node(
     user_message = state.get("user_message", "")
     system = _ANALYST_SYSTEM_TEMPLATE.format(primer=COORDINADOR_PRIMER)
     rendered = _render_evidence(evidence)
-    human = (
-        f"User question:\n{user_message}\n\nEvidence collected so far:\n{rendered}"
-    )
+    human = f"User question:\n{user_message}\n\nEvidence collected so far:\n{rendered}"
 
-    response = await model.ainvoke([
-        SystemMessage(content=system),
-        HumanMessage(content=human),
-    ])
+    response = await model.ainvoke(
+        [
+            SystemMessage(content=system),
+            HumanMessage(content=human),
+        ]
+    )
     text = response.content if hasattr(response, "content") else str(response)
     if not isinstance(text, str):
         text = str(text)

--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -48,6 +48,7 @@ def _strip_fences(text: str) -> str:
         return match.group(1).strip()
     return text
 
+
 _FILTER_EXPERT_SYSTEM_TEMPLATE = """\
 You are the Filter Expert for Coordinador (Mintral fleet operations).
 You pick the SINGLE next coordinador_* tool call to advance the user's
@@ -111,10 +112,12 @@ async def filter_expert_node(
     system = _FILTER_EXPERT_SYSTEM_TEMPLATE.format(catalog=catalog)
 
     user_message = state.get("user_message", "")
-    response = await model.ainvoke([
-        SystemMessage(content=system),
-        HumanMessage(content=user_message),
-    ])
+    response = await model.ainvoke(
+        [
+            SystemMessage(content=system),
+            HumanMessage(content=user_message),
+        ]
+    )
 
     text = response.content if hasattr(response, "content") else str(response)
     if not isinstance(text, str):
@@ -136,9 +139,7 @@ async def filter_expert_node(
         }
 
     if step.tool not in registry.names():
-        logger.error(
-            "filter_expert: model hallucinated tool %r (not in registry)", step.tool
-        )
+        logger.error("filter_expert: model hallucinated tool %r (not in registry)", step.tool)
         return {
             "failure": f"filter_expert proposed unknown tool: {step.tool}",
             "next_action": None,
@@ -155,9 +156,7 @@ async def filter_expert_node(
             )
     except ValidationError as exc:
         # NexoPlan caps steps at max_length=4 (review item N13).
-        logger.warning(
-            "filter_expert: plan capped at max steps; routing to synth (%s)", exc
-        )
+        logger.warning("filter_expert: plan capped at max steps; routing to synth (%s)", exc)
         return {
             "failure": "plan reached max step cap; synthesizing with current evidence",
             "next_action": "ready_to_synthesize",

--- a/miot-harness/src/miot_harness/agents/freshness_judge.py
+++ b/miot-harness/src/miot_harness/agents/freshness_judge.py
@@ -59,7 +59,10 @@ def freshness_judge_node(
             HarnessEvent(
                 run_id=ctx.run_id,
                 type="freshness.warning",
-                message=f"Snapshot age {age_minutes if age_minutes is not None else 'unknown'} min ({verdict})",
+                message=(
+                    f"Snapshot age {age_minutes if age_minutes is not None else 'unknown'} "
+                    f"min ({verdict})"
+                ),
                 data={
                     "tool": last.tool,
                     "verdict": verdict,

--- a/miot-harness/src/miot_harness/agents/summarizer.py
+++ b/miot-harness/src/miot_harness/agents/summarizer.py
@@ -41,10 +41,12 @@ async def summarizer_node(
         return {}
 
     rendered = "\n".join(f"- [{m.get('role')}] {m.get('content', '')}" for m in messages[:-1])
-    response = await model.ainvoke([
-        SystemMessage(content=_SUMMARIZER_SYSTEM),
-        HumanMessage(content=rendered),
-    ])
+    response = await model.ainvoke(
+        [
+            SystemMessage(content=_SUMMARIZER_SYSTEM),
+            HumanMessage(content=rendered),
+        ]
+    )
     text = response.content if hasattr(response, "content") else str(response)
     if not isinstance(text, str):
         text = str(text)

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -110,14 +110,14 @@ async def synthesizer_node(
     user_message = state.get("user_message", "")
     system = _SYNTH_SYSTEM_TEMPLATE.format(primer=COORDINADOR_PRIMER)
     rendered = _render_evidence_for_synth(evidence)
-    human = (
-        f"User question:\n{user_message}\n\nEvidence:\n{rendered}\n\nWrite the answer."
-    )
+    human = f"User question:\n{user_message}\n\nEvidence:\n{rendered}\n\nWrite the answer."
 
-    response = await model.ainvoke([
-        SystemMessage(content=system),
-        HumanMessage(content=human),
-    ])
+    response = await model.ainvoke(
+        [
+            SystemMessage(content=system),
+            HumanMessage(content=human),
+        ]
+    )
     text = response.content if hasattr(response, "content") else str(response)
     if not isinstance(text, str):
         text = str(text)

--- a/miot-harness/src/miot_harness/api/__init__.py
+++ b/miot-harness/src/miot_harness/api/__init__.py
@@ -1,2 +1,1 @@
 """HTTP API entrypoints."""
-

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -20,9 +21,11 @@ from miot_harness.runtime.supervisor import HarnessSupervisor
 logger = logging.getLogger(__name__)
 
 
-def _make_lifespan(harness: HarnessSupervisor, settings: HarnessSettings):
+def _make_lifespan(
+    harness: HarnessSupervisor, settings: HarnessSettings
+) -> Callable[[FastAPI], AbstractAsyncContextManager[None]]:
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.nexo_enabled = False
         app.state.nexo_pool = None
         app.state.nexo_registered = []
@@ -68,7 +71,8 @@ def _make_lifespan(harness: HarnessSupervisor, settings: HarnessSettings):
                     logger.info("Nexo: conversational graph wired")
                 except Exception as exc:  # noqa: BLE001
                     logger.critical(
-                        "Nexo: failed to build chat models / graph (%s); falling back to Nexo disabled",
+                        "Nexo: failed to build chat models / graph (%s); "
+                        "falling back to Nexo disabled",
                         exc,
                     )
                     app.state.nexo_enabled = False

--- a/miot-harness/src/miot_harness/cli.py
+++ b/miot-harness/src/miot_harness/cli.py
@@ -37,4 +37,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -26,10 +26,10 @@ import argparse
 import asyncio
 import json
 import logging
-import os
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -104,14 +104,16 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
         refreshed_at: datetime | None = None
         source: str = "Coordinador · nexo (Citus DB)"
 
-    async def _check(ctx, inp):
+    async def _check(ctx: HarnessContext, inp: BaseModel) -> PermissionResult:
         if ctx.tenant_id != "mintral":
             return PermissionResult.deny("Mintral-only")
         return PermissionResult.allow()
 
     refreshed = datetime.now(UTC)
 
-    async def _call(ctx, inp, progress):
+    async def _call(
+        ctx: HarnessContext, inp: BaseModel, progress: Callable[..., None]
+    ) -> _Out:
         return _Out(
             rows=[{"n_criticos": 2, "n_eta_riesgo": 3, "refreshed_at_servicios": refreshed}],
             refreshed_at=refreshed,
@@ -132,7 +134,8 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
                 call=_call,
             )
         )
-    # Always register a centro_control fallback so empty expected_tools (refusal cases) still resolve
+    # Always register a centro_control fallback so empty expected_tools (refusal cases)
+    # still resolve.
     if "coordinador_centro_control" not in registry.names() and not expected:
         registry.register(
             HarnessTool(
@@ -151,20 +154,31 @@ def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
     expected = entry.get("expected_tools") or ["coordinador_centro_control"]
     chosen = expected[0]
     return {
-        "filter_expert": FakeListChatModel(responses=[
-            json.dumps({
-                "intent": "fetch eval",
-                "tool": chosen,
-                "args": {},
-                "rationale": "scripted",
-            }),
-        ]),
-        "domain_analyst": FakeListChatModel(responses=[
-            json.dumps({"verdict": "ready", "reasoning": "evidence ok"}),
-        ]),
-        "synthesizer": FakeListChatModel(responses=[
-            f"Resultado al snapshot {datetime.now(UTC).isoformat()}: 2 servicios críticos, 3 ETA en riesgo.",
-        ]),
+        "filter_expert": FakeListChatModel(
+            responses=[
+                json.dumps(
+                    {
+                        "intent": "fetch eval",
+                        "tool": chosen,
+                        "args": {},
+                        "rationale": "scripted",
+                    }
+                ),
+            ]
+        ),
+        "domain_analyst": FakeListChatModel(
+            responses=[
+                json.dumps({"verdict": "ready", "reasoning": "evidence ok"}),
+            ]
+        ),
+        "synthesizer": FakeListChatModel(
+            responses=[
+                (
+                    f"Resultado al snapshot {datetime.now(UTC).isoformat()}: "
+                    "2 servicios críticos, 3 ETA en riesgo."
+                ),
+            ]
+        ),
         "critic": FakeListChatModel(responses=[]),
         "summarizer": FakeListChatModel(responses=[]),
     }
@@ -201,24 +215,22 @@ async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
         category=entry.get("category", ""),
         tool_selection=(any(t in expected_tools for t in plan_tools) if expected_tools else None),
         filter_sanity=(not any(t in forbidden for t in plan_tools)),
-        freshness_citation=(
-            "refreshed" in answer
-            or "snapshot" in answer
-            or "hace" in answer
-        ) if not refusal_expected else None,
+        freshness_citation=("refreshed" in answer or "snapshot" in answer or "hace" in answer)
+        if not refusal_expected
+        else None,
         refusal=(answer_is_refusal == refusal_expected) if refusal_expected else None,
         no_hallucination=all(
             sub.lower() in answer for sub in (entry.get("expected_kpis_mentioned") or [])
-        ) if not refusal_expected else None,
+        )
+        if not refusal_expected
+        else None,
         latency_ms=latency_ms,
     )
 
 
 def _commit_sha() -> str:
     try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], text=True
-        ).strip()
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
     except Exception:
         return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
@@ -300,7 +312,11 @@ def main(argv: list[str] | None = None) -> int:
         "--mode",
         default="fake",
         choices=("static", "fake", "real"),
-        help="static = YAML validation only; fake = scripted FakeListChatModel run; real = live LLM (TODO).",
+        help=(
+            "static = YAML validation only; "
+            "fake = scripted FakeListChatModel run; "
+            "real = live LLM (TODO)."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -318,7 +334,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode != "static":
         ok = sum(1 for s in payload["scored"] if not s.get("notes"))
         total = len(payload["scored"])
-        print(f"Wrote {Path(args.out_dir) / (payload.get('commit', 'baseline') + '.json')}: {ok}/{total} ran cleanly")
+        out_path = Path(args.out_dir) / (payload.get("commit", "baseline") + ".json")
+        print(f"Wrote {out_path}: {ok}/{total} ran cleanly")
     else:
         print(f"Validated {len(yaml.safe_load(yaml_path.read_text()))} entries")
     return 0

--- a/miot-harness/src/miot_harness/integrations/nexo/boot.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/boot.py
@@ -90,7 +90,8 @@ async def load_nexo_tools(
         leak = row["fn_refresh_direct_leak"] if row else None
         if leak is None or leak > 0:
             logger.critical(
-                "Nexo: ACL check failed (fn_refresh_direct_leak=%s); disabling integration", leak,
+                "Nexo: ACL check failed (fn_refresh_direct_leak=%s); disabling integration",
+                leak,
             )
             return NexoBootResult(
                 enabled=False,
@@ -121,7 +122,8 @@ async def load_nexo_tools(
             age_minutes = (datetime.now(UTC) - refreshed_at).total_seconds() / 60
             if age_minutes > settings.nexo_freshness_refuse_minutes:
                 logger.critical(
-                    "Nexo: centro_control snapshot is %.0f min old (refuse threshold %d). Disabling.",
+                    "Nexo: centro_control snapshot is %.0f min old "
+                    "(refuse threshold %d). Disabling.",
                     age_minutes,
                     settings.nexo_freshness_refuse_minutes,
                 )
@@ -173,7 +175,9 @@ async def load_nexo_tools(
                 exc,
             )
 
-    logger.info("Nexo: enabled — %d tools registered (alias=%s)", len(registered), settings.nexo_db_alias)
+    logger.info(
+        "Nexo: enabled — %d tools registered (alias=%s)", len(registered), settings.nexo_db_alias
+    )
     return NexoBootResult(enabled=True, registered=registered)
 
 

--- a/miot-harness/src/miot_harness/integrations/nexo/introspect.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/introspect.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
 
 import asyncpg
-
 
 _LAYER_PREFIX_RE = re.compile(r"^(L1|L2|L3|VT)\s*:\s*", re.IGNORECASE)
 _META_BLOCK_RE = re.compile(r"@meta\s*\n(.*?)\n@end", re.DOTALL)
@@ -75,7 +73,7 @@ def parse_pg_description(raw: str | None) -> ParsedDescription:
             meta[key.strip()] = value.strip()
         layer = "meta"
         before = text[: meta_match.start()].strip()
-        after = text[meta_match.end():].strip()
+        after = text[meta_match.end() :].strip()
         title = before.splitlines()[0].strip() if before else ""
         rest_before = "\n".join(before.splitlines()[1:]).strip()
         body = "\n\n".join(part for part in (rest_before, after) if part)
@@ -84,7 +82,7 @@ def parse_pg_description(raw: str | None) -> ParsedDescription:
     prefix = _LAYER_PREFIX_RE.match(text)
     if prefix:
         layer = prefix.group(1).upper()
-        body = text[prefix.end():].strip()
+        body = text[prefix.end() :].strip()
         return ParsedDescription(title="", body=body, layer=layer, meta={})
 
     return ParsedDescription(title="", body=text, layer="", meta={})
@@ -164,7 +162,7 @@ def _split_args(signature: str) -> list[FunctionArg]:
             has_default = False
         else:
             head = raw[:default_idx].strip()
-            default_expr = raw[default_idx + len(" DEFAULT "):].strip()
+            default_expr = raw[default_idx + len(" DEFAULT ") :].strip()
             has_default = True
         head_parts = head.split(maxsplit=1)
         if len(head_parts) == 2:

--- a/miot-harness/src/miot_harness/integrations/nexo/tool_factory.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/tool_factory.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Callable
+from typing import Any
 
 import asyncpg
 from pydantic import BaseModel, ConfigDict, Field, create_model
@@ -31,7 +31,6 @@ from miot_harness.integrations.nexo.introspect import (
     FunctionDescriptor,
 )
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.permissions import PermissionResult
 from miot_harness.runtime.tool import HarnessTool, Progress
 
@@ -78,7 +77,7 @@ def _python_type_for(pg_type: str) -> type:
         # Arrays — strip and wrap in list[]
         inner = _python_type_for(base[:-2].strip())
         return list[inner]  # type: ignore[valid-type]
-    return _PG_TYPE_MAP.get(base, Any)  # type: ignore[return-value]
+    return _PG_TYPE_MAP.get(base, Any)
 
 
 def _input_model_from_args(name: str, args: list[FunctionArg]) -> type[BaseModel]:
@@ -90,7 +89,7 @@ def _input_model_from_args(name: str, args: list[FunctionArg]) -> type[BaseModel
             fields[arg.name] = (py_type | None, Field(default=None))
         else:
             fields[arg.name] = (py_type, Field(...))
-    model = create_model(
+    model: type[BaseModel] = create_model(
         f"_Input_{name}",
         __config__=ConfigDict(arbitrary_types_allowed=True, extra="forbid"),
         **fields,
@@ -99,7 +98,7 @@ def _input_model_from_args(name: str, args: list[FunctionArg]) -> type[BaseModel
 
 
 def _output_model_for(name: str, returns_kind: str) -> type[BaseModel]:
-    common = {
+    common: dict[str, Any] = {
         "refreshed_at": (datetime | None, Field(default=None)),
         "source": (str, Field(default="Coordinador · nexo (Citus DB)")),
         "layer": (str, Field(default="")),
@@ -113,11 +112,12 @@ def _output_model_for(name: str, returns_kind: str) -> type[BaseModel]:
         common["data"] = (dict[str, Any], Field(default_factory=dict))
     else:
         common["value"] = (Any, Field(default=None))
-    return create_model(
+    output_model: type[BaseModel] = create_model(
         f"_Output_{name}",
         __config__=ConfigDict(arbitrary_types_allowed=True),
         **common,
     )
+    return output_model
 
 
 def _render_description(descriptor: FunctionDescriptor) -> str:
@@ -133,18 +133,24 @@ def _render_description(descriptor: FunctionDescriptor) -> str:
             meta_lines.append(f"Domain: {parsed.meta['domain']}")
         if "returns" in parsed.meta:
             meta_lines.append(f"Returns: {parsed.meta['returns']}")
-        body = "\n\n".join(part for part in [
-            "\n\n".join(body_parts),
-            "\n".join(meta_lines),
-            SHARED_FILTER_PRIMER,
-        ] if part)
+        body = "\n\n".join(
+            part
+            for part in [
+                "\n\n".join(body_parts),
+                "\n".join(meta_lines),
+                SHARED_FILTER_PRIMER,
+            ]
+            if part
+        )
         return body
     if parsed.layer in {"L1", "L2", "L3", "VT"}:
         return f"[Layer {parsed.layer}] {parsed.body}\n\n{SHARED_FILTER_PRIMER}"
     return f"{parsed.body or descriptor.name}\n\n{SHARED_FILTER_PRIMER}"
 
 
-def _truncate_rows(rows: list[dict[str, Any]], cap: int = 5) -> tuple[list[dict[str, Any]], int, bool]:
+def _truncate_rows(
+    rows: list[dict[str, Any]], cap: int = 5
+) -> tuple[list[dict[str, Any]], int, bool]:
     total = len(rows)
     if total <= cap:
         return rows, total, False
@@ -185,7 +191,7 @@ def build_nexo_tool(
     pool: asyncpg.Pool,
     tenant_lock: str,
     schema: str = "nexo",
-) -> HarnessTool:
+) -> HarnessTool[BaseModel, BaseModel]:
     name = "coordinador_" + descriptor.name.removeprefix("fn_dx_")
     description = _render_description(descriptor)
     input_model = _input_model_from_args(name, descriptor.args)

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -28,4 +28,3 @@ class UserRequest(BaseModel):
             user_id=self.user_id,
             route_context=self.route_context,
         )
-

--- a/miot-harness/src/miot_harness/runtime/nexo_graph.py
+++ b/miot-harness/src/miot_harness/runtime/nexo_graph.py
@@ -25,7 +25,8 @@ critic seat is wired even when disabled.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Hashable
+from typing import Any, cast
 
 from langchain_core.language_models import BaseChatModel
 from langgraph.graph import END, StateGraph
@@ -86,7 +87,7 @@ def build_nexo_graph(
     registry: ToolRegistry,
     settings: HarnessSettings,
     models: dict[str, BaseChatModel],
-):
+) -> Any:
     graph = StateGraph(NexoState)
 
     def _merge_events(delta: dict[str, Any], events: list[HarnessEvent]) -> dict[str, Any]:
@@ -95,39 +96,53 @@ def build_nexo_graph(
             delta["_events"] = [*existing, *events]
         return delta
 
-    async def _filter_expert(state):
-        return await filter_expert_node(state, registry=registry, model=models["filter_expert"])
+    async def _filter_expert(state: NexoState) -> dict[str, Any]:
+        return await filter_expert_node(
+            cast(dict[str, Any], state), registry=registry, model=models["filter_expert"]
+        )
 
-    async def _data_fetcher(state):
+    async def _data_fetcher(state: NexoState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
         delta = await data_fetcher_node(
-            state, registry=registry, settings=settings, progress=progress
+            cast(dict[str, Any], state),
+            registry=registry,
+            settings=settings,
+            progress=progress,
         )
         return _merge_events(delta, buf)
 
-    def _freshness_judge(state):
+    def _freshness_judge(state: NexoState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
-        delta = freshness_judge_node(state, settings=settings, progress=progress)
+        delta = freshness_judge_node(
+            cast(dict[str, Any], state), settings=settings, progress=progress
+        )
         return _merge_events(delta, buf)
 
-    async def _domain_analyst(state):
-        return await domain_analyst_node(state, model=models["domain_analyst"])
+    async def _domain_analyst(state: NexoState) -> dict[str, Any]:
+        return await domain_analyst_node(
+            cast(dict[str, Any], state), model=models["domain_analyst"]
+        )
 
-    async def _synthesizer(state):
+    async def _synthesizer(state: NexoState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
         delta = await synthesizer_node(
-            state, model=models["synthesizer"], progress=progress, settings=settings
+            cast(dict[str, Any], state),
+            model=models["synthesizer"],
+            progress=progress,
+            settings=settings,
         )
         return _merge_events(delta, buf)
 
-    async def _critic(state):
-        return await critic_node(state, settings=settings, model=models["critic"])
+    async def _critic(state: NexoState) -> dict[str, Any]:
+        return await critic_node(
+            cast(dict[str, Any], state), settings=settings, model=models["critic"]
+        )
 
-    async def _summarizer(state):
-        return await summarizer_node(state, model=models["summarizer"])
+    async def _summarizer(state: NexoState) -> dict[str, Any]:
+        return await summarizer_node(cast(dict[str, Any], state), model=models["summarizer"])
 
-    async def _tenant_gate(state):
-        return await _tenant_gate_node(state, settings=settings)
+    async def _tenant_gate(state: NexoState) -> dict[str, Any]:
+        return await _tenant_gate_node(cast(dict[str, Any], state), settings=settings)
 
     graph.add_node("tenant_gate", _tenant_gate)
     graph.add_node("filter_expert", _filter_expert)
@@ -140,11 +155,12 @@ def build_nexo_graph(
 
     graph.set_entry_point("tenant_gate")
 
-    def route(state):
-        return _route(state, settings)
+    def route(state: NexoState) -> str:
+        return _route(cast(dict[str, Any], state), settings)
 
     # Most nodes route via the supervisor; synthesizer always flows
     # through critic to END so the seat stays wired.
+    _route_map: dict[Hashable, str] = {k: v for k, v in _ROUTE_MAP.items()}
     for source in (
         "tenant_gate",
         "filter_expert",
@@ -153,7 +169,7 @@ def build_nexo_graph(
         "domain_analyst",
         "summarizer",
     ):
-        graph.add_conditional_edges(source, route, _ROUTE_MAP)
+        graph.add_conditional_edges(source, route, _route_map)
 
     graph.add_edge("synthesizer", "critic")
     graph.add_edge("critic", END)

--- a/miot-harness/src/miot_harness/runtime/permissions.py
+++ b/miot-harness/src/miot_harness/runtime/permissions.py
@@ -24,4 +24,3 @@ class PermissionResult(BaseModel):
     @classmethod
     def deny(cls, reason: str) -> "PermissionResult":
         return cls(decision=PermissionDecision.DENY, reason=reason)
-

--- a/miot-harness/src/miot_harness/runtime/run_store.py
+++ b/miot-harness/src/miot_harness/runtime/run_store.py
@@ -28,4 +28,3 @@ class JsonRunStore:
     def load(self, run_id: str) -> HarnessRunRecord:
         path = self.runs_dir / f"{run_id}.json"
         return HarnessRunRecord.model_validate(json.loads(path.read_text(encoding="utf-8")))
-

--- a/miot-harness/src/miot_harness/storytelling/contracts.py
+++ b/miot-harness/src/miot_harness/storytelling/contracts.py
@@ -50,4 +50,3 @@ class StoryArtifact(BaseModel):
     widget_drafts: list[WidgetDraft] = Field(default_factory=list)
     approval_proposals: list[ApprovalProposal] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-

--- a/miot-harness/src/miot_harness/storytelling/module.py
+++ b/miot-harness/src/miot_harness/storytelling/module.py
@@ -145,4 +145,3 @@ class StorytellingModule:
             )
         )
         return story
-

--- a/miot-harness/src/miot_harness/tools/dashboard.py
+++ b/miot-harness/src/miot_harness/tools/dashboard.py
@@ -85,9 +85,7 @@ async def _apply_patch_call(
     __: Progress,
 ) -> DashboardPatchOutput:
     message = (
-        "Dashboard patch accepted for application."
-        if value.approval_id
-        else "Approval required."
+        "Dashboard patch accepted for application." if value.approval_id else "Approval required."
     )
     return DashboardPatchOutput(
         applied=bool(value.approval_id),

--- a/miot-harness/src/miot_harness/utils/truncation.py
+++ b/miot-harness/src/miot_harness/utils/truncation.py
@@ -19,17 +19,19 @@ from typing import Any
 DEFAULT_ROW_CAP = 5
 DEFAULT_DICT_KEY_CAP = 20
 
-_ALWAYS_KEEP_KEYS = frozenset({
-    # KPIs the analyst commonly cites
-    "n_eta_riesgo",
-    "n_pod_pendiente",
-    "n_servicios",
-    "n_criticos",
-    "es_critico",
-    "eta_clasificacion",
-    "fecha_tipo",
-    "delta_eta_horas",
-})
+_ALWAYS_KEEP_KEYS = frozenset(
+    {
+        # KPIs the analyst commonly cites
+        "n_eta_riesgo",
+        "n_pod_pendiente",
+        "n_servicios",
+        "n_criticos",
+        "es_critico",
+        "eta_clasificacion",
+        "fecha_tipo",
+        "delta_eta_horas",
+    }
+)
 
 
 def _is_refreshed_at(key: object) -> bool:
@@ -57,7 +59,11 @@ def _truncate_dict(payload: dict[str, Any], cap: int) -> tuple[dict[str, Any], d
                 if info["truncated"]:
                     any_truncated = True
                     total_count = max(total_count, info["total_count"])
-        return out, {"truncated": any_truncated, "total_count": total_count, "truncated_keys": truncated_keys}
+        return out, {
+            "truncated": any_truncated,
+            "total_count": total_count,
+            "truncated_keys": truncated_keys,
+        }
 
     # Pick keys to keep: refreshed_at_* + always-keep set + first
     # remaining keys to fill the cap.

--- a/miot-harness/tests/integrations/nexo/test_boot.py
+++ b/miot-harness/tests/integrations/nexo/test_boot.py
@@ -23,7 +23,9 @@ def _descriptor(name: str = "fn_dx_centro_control") -> FunctionDescriptor:
         name=name,
         proc_oid=10,
         description=ParsedDescription(layer="L1", body="kpi"),
-        args=[FunctionArg(name="p_tenant", pg_type="text", has_default=True, default_expr="'mintral'")],
+        args=[
+            FunctionArg(name="p_tenant", pg_type="text", has_default=True, default_expr="'mintral'")
+        ],
         returns_kind="table",
         returns_columns=[("refreshed_at_servicios", "timestamptz")],
     )
@@ -128,7 +130,11 @@ async def test_no_pool_disables_nexo_without_raising():
     result = await load_nexo_tools(registry, settings=_settings(), pool=None)
     assert result.enabled is False
     assert registry.names() == []
-    assert "tunnel" in (result.reason or "").lower() or "pool" in (result.reason or "").lower() or "disabled" in (result.reason or "").lower()
+    assert (
+        "tunnel" in (result.reason or "").lower()
+        or "pool" in (result.reason or "").lower()
+        or "disabled" in (result.reason or "").lower()
+    )
 
 
 @pytest.mark.asyncio

--- a/miot-harness/tests/integrations/nexo/test_introspect.py
+++ b/miot-harness/tests/integrations/nexo/test_introspect.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import pytest
-
 from miot_harness.integrations.nexo.introspect import (
     ParsedDescription,
     is_denied,
     parse_pg_description,
 )
-
 
 # ---------- parse_pg_description ----------
 
@@ -98,7 +95,9 @@ def test_denied_by_explicit_name():
 
 
 def test_denied_by_meta_side_effects():
-    assert is_denied(name="fn_dx_anything", meta={"side_effects": "writes_to_all_dx_tables"}) is True
+    assert (
+        is_denied(name="fn_dx_anything", meta={"side_effects": "writes_to_all_dx_tables"}) is True
+    )
     assert is_denied(name="fn_dx_anything", meta={"side_effects": "writes_partial"}) is True
 
 

--- a/miot-harness/tests/integrations/nexo/test_introspect_pg.py
+++ b/miot-harness/tests/integrations/nexo/test_introspect_pg.py
@@ -58,9 +58,9 @@ try:
 except ImportError:  # pragma: no cover
     pytest.skip("pytest-postgresql not installed", allow_module_level=True)
 
-import asyncpg
+import asyncpg  # noqa: E402
 
-from miot_harness.integrations.nexo.introspect import introspect_nexo_functions
+from miot_harness.integrations.nexo.introspect import introspect_nexo_functions  # noqa: E402
 
 _SEED_SQL = """
 CREATE SCHEMA IF NOT EXISTS nexo;
@@ -119,9 +119,7 @@ async def test_introspect_real_pg_filters_denylist(postgresql):
     """postgresql fixture is a psycopg connection; we read the proc info,
     then connect via asyncpg to the same DB to exercise the real query."""
     info = postgresql.info
-    dsn = (
-        f"postgresql://{info.user}@{info.host}:{info.port}/{info.dbname}"
-    )
+    dsn = f"postgresql://{info.user}@{info.host}:{info.port}/{info.dbname}"
 
     # Seed via the psycopg connection (sync)
     with postgresql.cursor() as cur:

--- a/miot-harness/tests/integrations/nexo/test_pool.py
+++ b/miot-harness/tests/integrations/nexo/test_pool.py
@@ -23,9 +23,7 @@ async def test_create_nexo_pool_does_not_pass_server_settings(monkeypatch):
     coordinador-prod. The pool factory must NOT forward
     server_settings to asyncpg.create_pool.
     """
-    creds = NexoCredentials(
-        host="h", port=5432, database="d", user="u", password="p"
-    )
+    creds = NexoCredentials(host="h", port=5432, database="d", user="u", password="p")
     captured: dict = {}
 
     async def fake_create_pool(dsn=None, **kwargs):  # noqa: D401

--- a/miot-harness/tests/integrations/nexo/test_primer.py
+++ b/miot-harness/tests/integrations/nexo/test_primer.py
@@ -18,13 +18,13 @@ def test_primer_covers_required_topics():
     text = COORDINADOR_PRIMER.lower()
     # Per doc 10 lines 165-185, the primer must teach:
     for needle in (
-        "service",          # service / proc_inst
-        "pod",              # POD
-        "eta",              # ETA buckets
-        "fecha_tipo",       # date-type enum
-        "es_critico",       # critical flag
-        "refreshed_at",     # freshness rule
-        "mintral",          # single-tenant lock
+        "service",  # service / proc_inst
+        "pod",  # POD
+        "eta",  # ETA buckets
+        "fecha_tipo",  # date-type enum
+        "es_critico",  # critical flag
+        "refreshed_at",  # freshness rule
+        "mintral",  # single-tenant lock
     ):
         assert needle in text, f"primer missing required topic: {needle}"
 

--- a/miot-harness/tests/integrations/nexo/test_tool_factory.py
+++ b/miot-harness/tests/integrations/nexo/test_tool_factory.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from miot_harness.integrations.nexo.introspect import (
     FunctionArg,
@@ -34,8 +35,12 @@ def _table_descriptor() -> FunctionDescriptor:
             meta={"domain": "[services, fleet]", "returns": "kpi_summary", "side_effects": "none"},
         ),
         args=[
-            FunctionArg(name="p_tenant", pg_type="text", has_default=True, default_expr="'mintral'"),
-            FunctionArg(name="p_window_hours", pg_type="integer", has_default=True, default_expr="24"),
+            FunctionArg(
+                name="p_tenant", pg_type="text", has_default=True, default_expr="'mintral'"
+            ),
+            FunctionArg(
+                name="p_window_hours", pg_type="integer", has_default=True, default_expr="24"
+            ),
         ],
         returns_kind="table",
         returns_columns=[
@@ -51,7 +56,11 @@ def _json_descriptor() -> FunctionDescriptor:
         name="fn_dx_kpi_servicio",
         proc_oid=12346,
         description=ParsedDescription(layer="L3", body="per-service KPI"),
-        args=[FunctionArg(name="p_servicio_id", pg_type="bigint", has_default=False, default_expr=None)],
+        args=[
+            FunctionArg(
+                name="p_servicio_id", pg_type="bigint", has_default=False, default_expr=None
+            )
+        ],
         returns_kind="json",
         returns_columns=[],
     )
@@ -92,7 +101,7 @@ def test_input_model_fields_optional_when_default_present():
 def test_input_model_field_required_when_no_default():
     tool = build_nexo_tool(_json_descriptor(), pool=MagicMock(), tenant_lock="mintral")
     # p_servicio_id is required (no default)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         tool.input_model()
     instance = tool.input_model(p_servicio_id=42)
     assert instance.p_servicio_id == 42
@@ -198,9 +207,7 @@ async def test_invoke_runs_sql_and_lifts_metadata_into_event():
 async def test_invoke_truncates_long_row_lists():
     """S9: row lists capped at 5; truncated=True; total_count preserved."""
     refreshed = datetime(2026, 5, 8, 10, 0, tzinfo=UTC)
-    rows = [
-        {"servicio_id": i, "refreshed_at_servicios": refreshed} for i in range(12)
-    ]
+    rows = [{"servicio_id": i, "refreshed_at_servicios": refreshed} for i in range(12)]
     pool = _make_pool_with_rows(rows)
     tool = build_nexo_tool(_table_descriptor(), pool=pool, tenant_lock="mintral")
     events: list[Any] = []

--- a/miot-harness/tests/test_chat_models.py
+++ b/miot-harness/tests/test_chat_models.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import pytest
 
 from miot_harness.agents.chat_models import get_chat_model
+from miot_harness.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 def test_get_chat_model_returns_anthropic_for_claude(monkeypatch):
@@ -38,10 +46,5 @@ def test_get_chat_model_unknown_provider_raises():
 
 def test_get_chat_model_missing_anthropic_key_raises(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    # Settings cache should not preserve a key
-    from miot_harness.config import get_settings
-
-    get_settings.cache_clear()
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         get_chat_model("claude-haiku-4-5")
-    get_settings.cache_clear()

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from miot_harness.config import HarnessSettings, get_settings
 
@@ -69,5 +70,5 @@ def test_provider_api_keys_read_from_env(monkeypatch):
 
 def test_supervisor_mode_validates_literal(monkeypatch):
     monkeypatch.setenv("MIOT_HARNESS_NEXO_SUPERVISOR_MODE", "bogus")
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         HarnessSettings()

--- a/miot-harness/tests/test_critic.py
+++ b/miot-harness/tests/test_critic.py
@@ -28,7 +28,9 @@ async def test_critic_disabled_passes_through_without_llm():
     # Empty FakeListChatModel — would raise IndexError if invoked
     model = FakeListChatModel(responses=[])
 
-    update = await critic_node(state, settings=HarnessSettings(nexo_critic_enabled=False), model=model)
+    update = await critic_node(
+        state, settings=HarnessSettings(nexo_critic_enabled=False), model=model
+    )
 
     # Pass-through: no changes
     assert update == {} or update.get("answer") == state["answer"]
@@ -47,7 +49,9 @@ async def test_critic_enabled_runs_check_and_can_pass_answer():
         "turn_count": 2,
     }
 
-    update = await critic_node(state, settings=HarnessSettings(nexo_critic_enabled=True), model=model)
+    update = await critic_node(
+        state, settings=HarnessSettings(nexo_critic_enabled=True), model=model
+    )
     # No state change on pass
     assert update == {} or "answer" not in update or update["answer"] == state["answer"]
 
@@ -56,7 +60,9 @@ async def test_critic_enabled_runs_check_and_can_pass_answer():
 async def test_critic_enabled_flags_concerns_in_state():
     """A 'fail' verdict surfaces concerns into state so the synthesizer
     or the run record can show them, but does not block the answer in v1."""
-    model = FakeListChatModel(responses=['{"verdict": "fail", "concerns": "did not cite refreshed_at"}'])
+    model = FakeListChatModel(
+        responses=['{"verdict": "fail", "concerns": "did not cite refreshed_at"}']
+    )
     state = {
         "user_message": "?",
         "ctx": _ctx(),
@@ -65,6 +71,8 @@ async def test_critic_enabled_flags_concerns_in_state():
         "turn_count": 2,
     }
 
-    update = await critic_node(state, settings=HarnessSettings(nexo_critic_enabled=True), model=model)
+    update = await critic_node(
+        state, settings=HarnessSettings(nexo_critic_enabled=True), model=model
+    )
     assert "critic_concerns" in update
     assert "refreshed_at" in update["critic_concerns"]

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -54,7 +54,10 @@ async def test_fetcher_invokes_pending_step_and_appends_evidence():
     registry.register(
         _stub_tool(
             "coordinador_centro_control",
-            {"rows": [{"n_eta_riesgo": 3, "refreshed_at_servicios": refreshed}], "refreshed_at": refreshed},
+            {
+                "rows": [{"n_eta_riesgo": 3, "refreshed_at_servicios": refreshed}],
+                "refreshed_at": refreshed,
+            },
         )
     )
     plan = NexoPlan(

--- a/miot-harness/tests/test_domain_analyst.py
+++ b/miot-harness/tests/test_domain_analyst.py
@@ -30,10 +30,16 @@ def _ev(output: dict[str, Any] | None = None, is_stale: bool = False) -> NexoEvi
 
 @pytest.mark.asyncio
 async def test_analyst_signals_ready_to_synthesize():
-    model = FakeListChatModel(responses=[json.dumps({
-        "verdict": "ready",
-        "reasoning": "evidence covers the user's question",
-    })])
+    model = FakeListChatModel(
+        responses=[
+            json.dumps(
+                {
+                    "verdict": "ready",
+                    "reasoning": "evidence covers the user's question",
+                }
+            )
+        ]
+    )
     state: dict[str, Any] = {
         "user_message": "what's operational status?",
         "ctx": _ctx(),
@@ -48,10 +54,16 @@ async def test_analyst_signals_ready_to_synthesize():
 
 @pytest.mark.asyncio
 async def test_analyst_requests_more_tools():
-    model = FakeListChatModel(responses=[json.dumps({
-        "verdict": "need_more",
-        "reasoning": "need POD compliance to answer the followup",
-    })])
+    model = FakeListChatModel(
+        responses=[
+            json.dumps(
+                {
+                    "verdict": "need_more",
+                    "reasoning": "need POD compliance to answer the followup",
+                }
+            )
+        ]
+    )
     state = {
         "user_message": "and what about POD coverage?",
         "ctx": _ctx(),

--- a/miot-harness/tests/test_events.py
+++ b/miot-harness/tests/test_events.py
@@ -44,6 +44,7 @@ def test_event_seq_settable():
 
 def test_event_seq_must_be_int():
     import pytest
+    from pydantic import ValidationError
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         HarnessEvent(run_id="run_x", type="run.started", message="hi", seq="not-int")

--- a/miot-harness/tests/test_filter_expert.py
+++ b/miot-harness/tests/test_filter_expert.py
@@ -77,12 +77,14 @@ async def test_filter_expert_produces_single_step():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI summary"))
 
-    fake_response = json.dumps({
-        "intent": "fetch operational summary",
-        "tool": "coordinador_centro_control",
-        "args": {},
-        "rationale": "broad question; L1 first",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "fetch operational summary",
+            "tool": "coordinador_centro_control",
+            "args": {},
+            "rationale": "broad question; L1 first",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
 
     state: dict[str, Any] = {
@@ -112,16 +114,20 @@ async def test_filter_expert_appends_to_existing_plan():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_kpi_servicio", "[Layer L3] per-service"))
 
-    fake_response = json.dumps({
-        "intent": "drill into service 42",
-        "tool": "coordinador_kpi_servicio",
-        "args": {"p_servicio_id": 42},
-        "rationale": "follow-up for failing service",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "drill into service 42",
+            "tool": "coordinador_kpi_servicio",
+            "args": {"p_servicio_id": 42},
+            "rationale": "follow-up for failing service",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
 
     existing_plan = NexoPlan(
-        steps=[NexoStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r")]
+        steps=[
+            NexoStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r")
+        ]
     )
     state = {
         "user_message": "and service 42?",
@@ -147,9 +153,14 @@ async def test_filter_expert_clears_next_action():
     so the supervisor doesn't loop right back into this node."""
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
-    fake_response = json.dumps({
-        "intent": "x", "tool": "coordinador_centro_control", "args": {}, "rationale": "r",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "x",
+            "tool": "coordinador_centro_control",
+            "args": {},
+            "rationale": "r",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
     state = {
         "user_message": "?",
@@ -167,7 +178,12 @@ async def test_filter_expert_handles_json_fenced_response():
     """Real Claude often wraps JSON in ```json ... ``` fences."""
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
-    fenced = '```json\n{"intent": "x", "tool": "coordinador_centro_control", "args": {}, "rationale": "r"}\n```'
+    fenced = (
+        '```json\n'
+        '{"intent": "x", "tool": "coordinador_centro_control", '
+        '"args": {}, "rationale": "r"}\n'
+        '```'
+    )
     model = FakeListChatModel(responses=[fenced])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
     update = await filter_expert_node(state, registry=registry, model=model)
@@ -180,9 +196,14 @@ async def test_filter_expert_handles_plan_max_steps():
     """When NexoPlan's max_length=4 cap is hit, fail soft → route to synth."""
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
-    fake_response = json.dumps({
-        "intent": "x", "tool": "coordinador_centro_control", "args": {}, "rationale": "r",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "x",
+            "tool": "coordinador_centro_control",
+            "args": {},
+            "rationale": "r",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
     full_plan = NexoPlan(
         steps=[
@@ -209,9 +230,14 @@ async def test_filter_expert_refuses_non_coordinador_tool():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
     registry.register(_stub_tool("get_delivery_compliance_metrics", "non-Nexo"))
-    fake_response = json.dumps({
-        "intent": "x", "tool": "get_delivery_compliance_metrics", "args": {}, "rationale": "r",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "x",
+            "tool": "get_delivery_compliance_metrics",
+            "args": {},
+            "rationale": "r",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
     update = await filter_expert_node(state, registry=registry, model=model)
@@ -223,9 +249,14 @@ async def test_filter_expert_refuses_non_coordinador_tool():
 async def test_filter_expert_emits_plan_created_event_on_first_step():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
-    fake_response = json.dumps({
-        "intent": "x", "tool": "coordinador_centro_control", "args": {}, "rationale": "r",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "x",
+            "tool": "coordinador_centro_control",
+            "args": {},
+            "rationale": "r",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
     update = await filter_expert_node(state, registry=registry, model=model)
@@ -240,12 +271,14 @@ async def test_filter_expert_refuses_unknown_tool():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "L1"))
 
-    fake_response = json.dumps({
-        "intent": "x",
-        "tool": "coordinador_does_not_exist",
-        "args": {},
-        "rationale": "r",
-    })
+    fake_response = json.dumps(
+        {
+            "intent": "x",
+            "tool": "coordinador_does_not_exist",
+            "args": {},
+            "rationale": "r",
+        }
+    )
     model = FakeListChatModel(responses=[fake_response])
 
     state = {

--- a/miot-harness/tests/test_freshness_judge.py
+++ b/miot-harness/tests/test_freshness_judge.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from miot_harness.agents.freshness_judge import FRESHNESS_FRESH, FRESHNESS_REFUSE, FRESHNESS_WARN, freshness_judge_node
+from miot_harness.agents.freshness_judge import (
+    FRESHNESS_FRESH,
+    FRESHNESS_REFUSE,
+    FRESHNESS_WARN,
+    freshness_judge_node,
+)
 from miot_harness.config import HarnessSettings
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
@@ -45,7 +50,9 @@ def test_fresh_evidence_passes_through():
 def test_warn_zone_marks_is_stale_and_emits_warning_event():
     state = {
         "ctx": _ctx(),
-        "evidence": [_ev(datetime.now(UTC) - timedelta(minutes=45))],  # > warn (30) but < refuse (240)
+        "evidence": [
+            _ev(datetime.now(UTC) - timedelta(minutes=45))
+        ],  # > warn (30) but < refuse (240)
         "turn_count": 1,
     }
     events: list[HarnessEvent] = []

--- a/miot-harness/tests/test_nexo_graph.py
+++ b/miot-harness/tests/test_nexo_graph.py
@@ -60,20 +60,28 @@ def _registry_with_centro() -> tuple[ToolRegistry, datetime]:
 def _models(filter_step_tool: str = "coordinador_centro_control") -> dict[str, Any]:
     """Scripted FakeListChatModels for each LLM seat in the staged graph."""
     return {
-        "filter_expert": FakeListChatModel(responses=[
-            json.dumps({
-                "intent": "fetch operational summary",
-                "tool": filter_step_tool,
-                "args": {},
-                "rationale": "broad question",
-            }),
-        ]),
-        "domain_analyst": FakeListChatModel(responses=[
-            json.dumps({"verdict": "ready", "reasoning": "have evidence"}),
-        ]),
-        "synthesizer": FakeListChatModel(responses=[
-            "Operativo: 3 ETA en riesgo. Snapshot al instante.",
-        ]),
+        "filter_expert": FakeListChatModel(
+            responses=[
+                json.dumps(
+                    {
+                        "intent": "fetch operational summary",
+                        "tool": filter_step_tool,
+                        "args": {},
+                        "rationale": "broad question",
+                    }
+                ),
+            ]
+        ),
+        "domain_analyst": FakeListChatModel(
+            responses=[
+                json.dumps({"verdict": "ready", "reasoning": "have evidence"}),
+            ]
+        ),
+        "synthesizer": FakeListChatModel(
+            responses=[
+                "Operativo: 3 ETA en riesgo. Snapshot al instante.",
+            ]
+        ),
         "critic": FakeListChatModel(responses=[]),
         "summarizer": FakeListChatModel(responses=[]),
     }
@@ -149,4 +157,8 @@ async def test_stale_data_routes_through_synth_failure_path():
 
     # Synth failure path emits a localized refusal and never asks the synth model
     assert final.get("answer")
-    assert "stale" in final["answer"].lower() or "snapshot" in final["answer"].lower() or "stale" in (final.get("failure") or "").lower()
+    assert (
+        "stale" in final["answer"].lower()
+        or "snapshot" in final["answer"].lower()
+        or "stale" in (final.get("failure") or "").lower()
+    )

--- a/miot-harness/tests/test_nexo_supervisor.py
+++ b/miot-harness/tests/test_nexo_supervisor.py
@@ -67,7 +67,15 @@ def test_analyst_requests_more_data_loops_back_to_filter_expert():
         "plan": plan,
         "pending_step_index": 1,
         "evidence": [
-            NexoEvidence(step_id="s", tool="t", source="x", refreshed_at=None, output={}, sample_size=0, is_stale=False)
+            NexoEvidence(
+                step_id="s",
+                tool="t",
+                source="x",
+                refreshed_at=None,
+                output={},
+                sample_size=0,
+                is_stale=False,
+            )
         ],
         "turn_count": 2,
         "next_action": "need_more_tools",
@@ -80,7 +88,15 @@ def test_analyst_ready_routes_to_synthesizer():
         "user_message": "?",
         "ctx": _ctx(),
         "evidence": [
-            NexoEvidence(step_id="s", tool="t", source="x", refreshed_at=None, output={}, sample_size=0, is_stale=False)
+            NexoEvidence(
+                step_id="s",
+                tool="t",
+                source="x",
+                refreshed_at=None,
+                output={},
+                sample_size=0,
+                is_stale=False,
+            )
         ],
         "turn_count": 3,
         "next_action": "ready_to_synthesize",
@@ -116,7 +132,15 @@ def test_turn_cap_forces_synthesizer():
         "user_message": "?",
         "ctx": _ctx(),
         "evidence": [
-            NexoEvidence(step_id="s", tool="t", source="x", refreshed_at=None, output={}, sample_size=0, is_stale=False)
+            NexoEvidence(
+                step_id="s",
+                tool="t",
+                source="x",
+                refreshed_at=None,
+                output={},
+                sample_size=0,
+                is_stale=False,
+            )
         ],
         "turn_count": 8,
         "next_action": "need_more_tools",
@@ -144,7 +168,15 @@ def test_default_after_freshness_judge_routes_to_analyst():
         "plan": plan,
         "pending_step_index": 1,
         "evidence": [
-            NexoEvidence(step_id="s", tool="t", source="x", refreshed_at=None, output={}, sample_size=0, is_stale=False)
+            NexoEvidence(
+                step_id="s",
+                tool="t",
+                source="x",
+                refreshed_at=None,
+                output={},
+                sample_size=0,
+                is_stale=False,
+            )
         ],
         "turn_count": 2,
         "next_action": "analyze",

--- a/miot-harness/tests/test_plan.py
+++ b/miot-harness/tests/test_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Annotated, get_type_hints
+from typing import get_type_hints
 
 import pytest
 from pydantic import ValidationError
@@ -26,20 +26,14 @@ def test_nexo_step_auto_id():
 
 
 def test_nexo_plan_steps_max_length_four():
-    steps = [
-        NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r")
-        for i in range(4)
-    ]
+    steps = [NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(4)]
     plan = NexoPlan(steps=steps)
     assert len(plan.steps) == 4
     assert plan.final_format == "answer"
 
     with pytest.raises(ValidationError):
         NexoPlan(
-            steps=[
-                NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r")
-                for i in range(5)
-            ]
+            steps=[NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(5)]
         )
 
 
@@ -88,9 +82,7 @@ def test_nexo_state_evidence_uses_add_reducer():
         "evidence field must be Annotated to provide a LangGraph reducer"
     )
     metadata = evidence_hint.__metadata__
-    assert operator.add in metadata, (
-        "evidence reducer must be operator.add (or list_append alias)"
-    )
+    assert operator.add in metadata, "evidence reducer must be operator.add (or list_append alias)"
 
 
 def test_nexo_state_required_fields_present():

--- a/miot-harness/tests/test_router.py
+++ b/miot-harness/tests/test_router.py
@@ -34,7 +34,9 @@ def test_eta_word_boundary_does_not_match_etapa(router: IntentRouter):
     'etapa', 'meta', and 'completada' don't trigger the Nexo path."""
     for false_positive in ("etapa siguiente", "meta cumplida", "completada"):
         result = router.route(false_positive)
-        assert result.route != HarnessRoute.NEXO_QUERY, f"unexpected NEXO match for {false_positive!r}"
+        assert result.route != HarnessRoute.NEXO_QUERY, (
+            f"unexpected NEXO match for {false_positive!r}"
+        )
 
 
 def test_storytelling_still_routes_correctly(router: IntentRouter):

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/miot-harness/tests/test_supervisor_nexo_branch.py
+++ b/miot-harness/tests/test_supervisor_nexo_branch.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -14,7 +13,9 @@ from miot_harness.storytelling.module import StorytellingModule
 from miot_harness.tools.registry import ToolRegistry, build_default_registry
 
 
-def _supervisor(tmp_path, nexo_graph=None, *, registry: ToolRegistry | None = None) -> HarnessSupervisor:
+def _supervisor(
+    tmp_path, nexo_graph=None, *, registry: ToolRegistry | None = None
+) -> HarnessSupervisor:
     return HarnessSupervisor(
         router=IntentRouter(),
         tools=registry if registry is not None else ToolRegistry(),
@@ -30,10 +31,12 @@ async def test_nexo_route_invokes_graph_when_present(tmp_path):
     invoke the compiled nexo graph and surface the answer + events."""
     fake_event = HarnessEvent(run_id="r", type="answer.completed", message="done", data={})
     fake_graph = type("FakeGraph", (), {})()
-    fake_graph.ainvoke = AsyncMock(return_value={
-        "answer": "Operativo OK",
-        "_events": [fake_event],
-    })
+    fake_graph.ainvoke = AsyncMock(
+        return_value={
+            "answer": "Operativo OK",
+            "_events": [fake_event],
+        }
+    )
     sup = _supervisor(tmp_path, nexo_graph=fake_graph)
 
     record = await sup.run(UserRequest(message="estado coordinador?", tenant_id="mintral"))

--- a/miot-harness/tests/test_tool_registry.py
+++ b/miot-harness/tests/test_tool_registry.py
@@ -12,4 +12,3 @@ def test_default_registry_contains_first_slice_tools() -> None:
         "get_delivery_compliance_metrics",
         "get_workflow_bottlenecks",
     ]
-


### PR DESCRIPTION
## Why

Pre-existing failures on freshly-merged trunk (#445) would block any future
pre-flight gate that runs `ruff` / `mypy` / `pytest -q` as hard gates — for
example the upcoming RALPH-LOOP T00 step before the deploy work in plan
\`13-server-deployment\`.

Failing checks observed on trunk before this PR:
- \`ruff check src tests\` → 52 errors (12 auto-fixable)
- \`uv run mypy\` → fails at the package marker check (\`Package 'miot_harness' cannot be type checked due to missing py.typed\`)
- \`uv run pytest -q\` → 1 failed (\`test_get_chat_model_returns_openai_for_gpt\` — \`get_settings\` was \`@lru_cache\`'d, so monkeypatch'd env vars after cache-warming had no effect)

## What

Single-commit cleanup. **No behavior changes.** Scoped to \`miot-harness/\`.

1. **\`ruff format\`** across the package (39 files, pure whitespace).
2. **Lint residue** — manually reflowed 8 long lines, tightened 4 broad \`pytest.raises(Exception)\` to specific types (\`RuntimeError\`, \`pydantic.ValidationError\`), \`# noqa: E402\` on 2 intentionally-late conditional imports.
3. **\`py.typed\` marker** added so mypy actually inspects the package. This surfaced **32 latent strict-mode errors**, all fixed in the same commit:
   - \`pyproject.toml\`: \`ignore_missing_imports\` for \`asyncpg\` + \`yaml\`.
   - \`chat_models.py\`: wrap api keys in \`pydantic.SecretStr\` for \`ChatAnthropic\` / \`ChatOpenAI\`.
   - \`api/server.py\`: type the lifespan factory + inner async lifespan.
   - \`evals/run_golden.py\`: annotate the \`_check\` / \`_call\` closures.
   - \`integrations/nexo/tool_factory.py\`: widen \`common\` to \`dict[str, Any]\`, cast \`create_model()\` returns to \`type[BaseModel]\`, parameterize \`HarnessTool[BaseModel, BaseModel]\`, drop one stale \`# type: ignore\`.
   - \`runtime/nexo_graph.py\`: every node closure now \`(NexoState) -> dict[str, Any]\`, \`cast\` to \`dict\` at the seam to downstream node functions; route map coerced to \`dict[Hashable, str]\`.
4. **Test fixture for \`get_settings.lru_cache\`** in \`test_chat_models.py\` (autouse \`cache_clear\` before/after each test). Removed redundant manual \`cache_clear()\` calls. Tightened the missing-key test to \`raises(RuntimeError)\`.

## Verification

All on this branch:
- \`uv run ruff check src tests\` → **All checks passed.**
- \`uv run mypy\` → **Success: no issues found in 51 source files.**
- \`uv run pytest -q\` → **139 passed, 1 skipped.**

## Out of scope

- No Dockerfile, no CI workflow YAML, no deploy work — those land in follow-ups per \`13-server-deployment/\`.
- No new dependencies. \`uv.lock\` is unchanged.
- No public API changes.

## Reviewer notes

Diff is large (49 files) but ~80% is pure \`ruff format\` whitespace. The semantic substance is in 15 files:
- \`pyproject.toml\`, \`src/miot_harness/py.typed\`, \`agents/chat_models.py\`, \`api/server.py\`, \`evals/run_golden.py\`, \`integrations/nexo/tool_factory.py\`, \`runtime/nexo_graph.py\`
- \`tests/test_chat_models.py\`, \`tests/test_config.py\`, \`tests/test_events.py\`, \`tests/integrations/nexo/test_tool_factory.py\`, \`tests/integrations/nexo/test_introspect_pg.py\`, \`tests/test_filter_expert.py\`
- plus minor reflows in \`agents/freshness_judge.py\` and \`integrations/nexo/boot.py\`

Suggested review order: read the commit message (it's structured by the four categories above), then look at each semantic file. Skip the format-only ones unless the formatter output looks suspicious.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI entrypoint with `demo` subcommand for testing.
  * Added `widget_drafts` and `approval_proposals` fields to story artifacts.
  * Added `get_delivery_compliance_metrics` and `get_workflow_bottlenecks` tools.
  * Added `JsonRunStore.load()` method to retrieve run records.
  * Added `PermissionResult.deny()` class method for permission handling.

* **Bug Fixes**
  * Improved API key handling with secure string wrapping.

* **Improvements**
  * Enhanced type annotations throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->