### PR TITLE
fix(calendar): persist assignment tuple onto bookings via in-place update

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
@@ -5,6 +5,7 @@ import {
 import { requireAuth } from "../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -30,5 +31,57 @@ export async function DELETE(
     const status = error instanceof MiotCalendarApiError ? error.status : 500;
     logger.error({ err: error }, "Failed to cancel booking");
     return NextResponse.json({ error: "Failed to cancel booking" }, { status });
+  }
+}
+
+const PutBodySchema = z.object({
+  resource: z.object({
+    id: z.string().min(1),
+    type: z.string().optional(),
+    label: z.string().optional(),
+    data: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ bookingId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { bookingId } = await params;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = PutBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "resource with a non-empty id is required" },
+      { status: 400 }
+    );
+  }
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  try {
+    const booking = await client.bookings.update(bookingId, {
+      resource: parsed.data.resource,
+    });
+    return NextResponse.json(booking);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error, bookingId }, "Failed to update booking");
+    return NextResponse.json({ error: "Failed to update booking" }, { status });
   }
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -25,6 +25,7 @@ import {
   updateCalendarTimeWindow,
   deactivateCalendarTimeWindow,
   createBooking,
+  updateBooking,
   cancelBooking,
   listBookings,
   updateServiceCategory,
@@ -772,9 +773,24 @@ async function persistPlannedBooking({
   }
 
   try {
-    const booking = await createBooking(
-      buildBookingRequest(calendarId, service, slot)
-    );
+    const bookingRequest = buildBookingRequest(calendarId, service, slot);
+    const booking = await createBooking(bookingRequest);
+
+    // Re-confirming a service in the same slot (e.g. "Asignar" on an
+    // already-planned service) hits the bookings POST 409 path, which resolves
+    // to the *existing* booking without applying the new resource.data — and so
+    // `booking.id === oldBookingId`. Push the payload onto it explicitly so the
+    // change (e.g. the assignment tuple) survives a refresh, and skip the
+    // old-booking cancel below since it would delete the booking we just kept.
+    const reusedExistingBooking =
+      oldBookingId !== undefined && booking.id === oldBookingId;
+    if (reusedExistingBooking) {
+      // On failure the pre-existing booking is left intact (with stale data);
+      // rethrow so the outer catch rolls back the optimistic UI. We never
+      // cancel it here — it is the service's current plan.
+      await updateBooking(booking.id, { resource: bookingRequest.resource });
+    }
+
     await syncServiceCategoryWithWorkflow(service, booking.id, liveTaskId);
     if (taskAdvance) {
       await advanceWorkflowTask(taskAdvance.taskId, taskAdvance.transitionId);
@@ -786,7 +802,7 @@ async function persistPlannedBooking({
       return next;
     });
 
-    if (oldBookingId) {
+    if (oldBookingId && !reusedExistingBooking) {
       await cancelBookingWithWarning(
         oldBookingId,
         "Failed to cancel old booking:"

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -54,6 +54,7 @@ import type {
   TimeWindowResponse,
   TimeWindowRequest,
   BookingRequest,
+  BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
   SlotResponse,
@@ -1776,6 +1777,28 @@ export async function advanceWorkflowTask(
         : (err.error?.message ?? "Failed to advance workflow task");
     throw new Error(message);
   }
+}
+
+/**
+ * Update an existing booking's resource payload in place (same slot). Used to
+ * push a changed payload — e.g. the assignment tuple — onto a booking that
+ * already exists, since the bookings POST resolves a same-slot conflict by
+ * returning the existing booking without applying the new data.
+ */
+export async function updateBooking(
+  bookingId: string,
+  body: BookingUpdateRequest
+): Promise<BookingResponse> {
+  const response = await fetch(`/app/api/calendar/bookings/${bookingId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.error ?? "Failed to update booking");
+  }
+  return response.json();
 }
 
 /**

--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
@@ -4,6 +4,7 @@ import type {
   BookingRequest,
   BookingResponse,
   BookingListResponse,
+  BookingUpdateRequest,
 } from "../types.js";
 import { createMockFetch } from "./test-utils.js";
 
@@ -118,6 +119,37 @@ describe("bookings", () => {
 
       const headers = call.init.headers as Record<string, string>;
       expect(headers["X-User-Id"]).toBeUndefined();
+    });
+  });
+
+  describe("update", () => {
+    const updateRequest: BookingUpdateRequest = {
+      resource: {
+        id: "r-1",
+        type: "room",
+        label: "Room A (assigned)",
+        data: { assignedCarrier: "c-1" },
+      },
+    };
+
+    it("sends PUT to bookings/:id with body", async () => {
+      const { fn, call } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.bookings.update("b-1", updateRequest);
+
+      expect(call.init.method).toBe("PUT");
+      expect(call.url).toBe(`${BASE_URL}${BOOKINGS_PATH}/b-1`);
+      expect(call.init.body).toBe(JSON.stringify(updateRequest));
+    });
+
+    it("returns the updated booking", async () => {
+      const { fn } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.bookings.update("b-1", updateRequest);
+
+      expect(result).toEqual(sampleBooking);
     });
   });
 

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -5,6 +5,7 @@ export type {
   ResourceData,
   SlotData,
   BookingRequest,
+  BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
   CalendarGroupRequest,

--- a/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
@@ -3,6 +3,7 @@ import type {
   BookingListResponse,
   BookingRequest,
   BookingResponse,
+  BookingUpdateRequest,
 } from "../types.js";
 
 const BASE = "/api/v1/miot-calendar/bookings";
@@ -31,6 +32,17 @@ export function createBookingsApi(fetcher: Fetcher) {
           ? { "X-User-Id": options.userId }
           : undefined,
       });
+    },
+
+    /**
+     * Update an existing booking's resource payload in place. The slot is not
+     * changed; move a booking by cancelling and recreating it.
+     */
+    update(
+      id: string,
+      body: BookingUpdateRequest,
+    ): Promise<BookingResponse> {
+      return fetcher("PUT", `${BASE}/${id}`, { body });
     },
 
     cancel(id: string): Promise<void> {

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -25,6 +25,10 @@ export interface BookingRequest {
   slot: SlotData;
 }
 
+export interface BookingUpdateRequest {
+  resource: ResourceData;
+}
+
 export interface BookingResponse {
   id: string;
   calendarId: string;


### PR DESCRIPTION
## Summary
- Assigning a carrier/driver/truck/trailer tuple to an already-planned service didn't survive a page refresh — the service reverted to "planned". `persistPlannedBooking` persists the tuple by POSTing a "new" booking carrying it in `resource.data` then cancelling the old one, but for an "Asignar" the slot is unchanged, so the calendar backend resolves the `409` by returning the *existing* booking unchanged and the new data is dropped.
- **`packages/miot-calendar-client`** (`0.8.0 → 0.8.1`): add `bookings.update(id, { resource })` → `PUT /api/v1/miot-calendar/bookings/{id}`; export `BookingUpdateRequest`. Depends on the backend endpoint in microboxlabs/miot-calendar#25.
- **`apps/app`**: `PUT` handler in `api/calendar/bookings/[bookingId]/route.ts` (zod-validates `{ resource: { id, type?, label?, data? } }`); `updateBooking()` in `client-api.provider`; in `persistPlannedBooking`, when the POST resolved to the existing booking (`booking.id === oldBookingId`) push the payload onto it via `updateBooking` and skip the old-booking cancel (which would otherwise delete the booking we just kept). On update failure: rethrow → rollback the optimistic UI, never cancel the pre-existing plan.

## Notes / dependencies
- Base is `based/245-calendar-binding-tracking-fe` (PR #440) — the frontend builds on that work.
- Runtime requires the backend `PUT /bookings/{id}` from microboxlabs/miot-calendar#25 to be merged & deployed; until then the in-place update path returns 5xx → optimistic UI rolls back (same as today, no regression).

## Out of scope (noted in #450)
- `api/calendar/bookings/route.ts` silently downgrades `stage=assigned` → `planned` when `mintral_serviceKind` is missing — the coordinator/Alerce side of the assignment then never fires.
- "Asignación" sidebar tab is disabled unless `hasPermission(["GROUP_ASSIGNMENT"])`.

## Test plan
- [x] `miot-calendar-client`: `npm run build` + `npm test` (81 pass, incl. 2 new `update` tests) + lint + `tsc --noEmit` clean
- [x] app: `tsc --noEmit` — no errors in changed files; `eslint` on changed files → 0 errors
- [x] Manual (needs miot-calendar#25 deployed): plan a service → "Asignar" → fill carrier/driver/truck → confirm → refresh → still shows assigned; verify `resource.data.assignedCarrier` persisted via `miot calendar bookings by-resource <id>`

Refs microboxlabs/ecm-coordinator#245, microboxlabs/miot-calendar#25
Closes #450