### PR TITLE
fix(calendar): forward mintral_serviceKind so assignment reaches Alerce

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -590,6 +590,13 @@ export interface SelectedService {
   lugarCarguio: string;
   destino: string;
   tipoViaje: TripType;
+  /**
+   * Raw Alfresco `mintral_serviceKind` value (e.g. "Sider", "Doble Sider").
+   * Unlike `tipoViaje` — a lossy display projection — this is forwarded
+   * verbatim on the booking payload so the bookings route can populate the
+   * coordinator binding's `tipo_servicio` and reach the assigned stage.
+   */
+  mintral_serviceKind?: string;
   ocupacion: number; // percentage 0-100
   permanencia: string;
   leadTime: LeadTimeData;
@@ -959,6 +966,7 @@ const StoredServiceSchema = z
     lugarCarguio: z.string().optional(),
     destino: z.string().optional(),
     tipoViaje: z.enum(["Sider", "Doble Sider", "Rampla"]).optional(),
+    mintral_serviceKind: z.string().optional(),
     ocupacion: z.number().optional(),
     permanencia: z.string().optional(),
     leadTime: z

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -135,6 +135,7 @@ function transformTaskToService(task: KanbanBoardTask): SelectedService {
     lugarCarguio: "", // Not available in KanbanBoardTask
     destino: task.destination || "",
     tipoViaje,
+    mintral_serviceKind: task.serviceKind || undefined,
     ocupacion: 100 * (task.mintral_loadMaxUtilization ?? 0),
     loadMaxUtilization:
       task.mintral_loadMaxUtilization == null


### PR DESCRIPTION
## What

Forward the Alfresco `mintral_serviceKind` value on the calendar booking payload so the bookings route can reach the **assigned** binding stage and trigger the Alerce `ModificacionRecursoServicios` push.

Closes #455.

## Why

`POST /app/api/calendar/bookings` → `extractCalendarBindingPayload()` reads `mintral_serviceKind` off `resource.data` to set `tipo_servicio` and emit `stage: "assigned"`. When it's missing, the stage is downgraded to `"planned"` and Alerce is never called — so assigning carrier/driver/truck to a planned service silently failed to propagate.

The planner builds `resource.data` by spreading a `SelectedService`, which only carried `tipoViaje` (a lossy display projection of `task.serviceKind`) and `serviceCategory` — never `mintral_serviceKind`. Verified on a live booking (resource `1629011-V`): it had `assignedCarrier/Driver/Truck` + `tipoViaje: "Sider"` but no `mintral_serviceKind`.

## Changes

- `planning-selection-context.tsx` — add `mintral_serviceKind?: string` to `SelectedService` + `StoredServiceSchema`.
- `planning-sidebar-client.tsx` — `transformTaskToService` sets `mintral_serviceKind: task.serviceKind || undefined`; it then rides along via `buildBookingRequest`'s `...service` spread into `resource.data`.

## Testing

- `tsc --noEmit` clean (no new errors).
- Manual: re-run "Asignar" on a planned service; the resulting booking's `resource.data` now contains `mintral_serviceKind`, and the dev-server log shows `Calendar binding call completed` with `stage: "assigned"`. *(please confirm in the running env)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service kind information is now properly captured and included in booking operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/456)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->