### PR TITLE
fix(calendar): keep the selected resource resolvable in assignment dropdowns

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
@@ -23,7 +23,9 @@ const MAX_LIMIT = 200;
  *   ?rutMandante=<rut>
  *   &delegacion=<code>
  *   [&resourceType=DRIVER|TRUCK|TRAILER|CARRIER]
+ *   [&carrierId=<resource_id>]
  *   [&q=<search>]
+ *   [&ids=<resource_id>[,<resource_id>...]]  pin these rows onto page 0
  *   [&offset=<int>]  default 0
  *   [&limit=<int>]   default 50, max 200
  *   [&refresh=1]     bypass the in-memory cache
@@ -36,6 +38,13 @@ const MAX_LIMIT = 200;
  * `q` matches `resource_name` and `identifier` (case-insensitive substring).
  * The response always echoes the unfiltered total so the client can render
  * "X / Y" counters alongside the filtered page.
+ *
+ * `ids` lets the caller pin specific rows (typically the currently-selected
+ * carrier / driver / truck / trailer) so they stay resolvable for the combobox
+ * trigger even when `q`/pagination would otherwise hide them. Pinned rows are
+ * returned in a separate `pinned` array on the first page only (offset 0), are
+ * matched on exact `resource_id`, bypass the `q` filter, and are de-duped
+ * against the page slice.
  */
 export async function GET(request: Request) {
   const authResult = await requireAuth();
@@ -47,6 +56,13 @@ export async function GET(request: Request) {
   const resourceTypeRaw = searchParams.get("resourceType")?.trim().toUpperCase();
   const carrierId = searchParams.get("carrierId")?.trim() || undefined;
   const q = searchParams.get("q")?.trim() ?? "";
+  const idsRaw = searchParams.get("ids")?.trim();
+  const pinIds = idsRaw
+    ? idsRaw
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    : [];
   const offsetRaw = searchParams.get("offset");
   const limitRaw = searchParams.get("limit");
   const refresh = searchParams.get("refresh") === "1";
@@ -96,8 +112,25 @@ export async function GET(request: Request) {
     const filtered = applyQuery(allRows, q);
     const page = filtered.slice(offset, offset + limit);
 
+    // Pin the requested rows (currently-selected resources) onto the first
+    // page so the client can always resolve the combobox's selected option,
+    // even when `q`/pagination would otherwise hide it. Matched on exact
+    // `resource_id` against the full (unfiltered) set and de-duped against the
+    // current page so a row never appears twice.
+    const pageIds = new Set(page.map((row) => row.resource_id));
+    const pinned: PgrestAccreditedResourceRow[] =
+      offset === 0 && pinIds.length > 0
+        ? pinIds
+            .map((id) => allRows.find((row) => row.resource_id === id))
+            .filter(
+              (row): row is PgrestAccreditedResourceRow =>
+                row != null && !pageIds.has(row.resource_id)
+            )
+        : [];
+
     return NextResponse.json({
       data: page,
+      pinned,
       total: allRows.length,
       filteredTotal: filtered.length,
       offset,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -283,6 +283,7 @@ export function AssignmentForm({
     delegacion: mintralDelegacionOrigen,
     resourceType: "CARRIER",
     query: carrierQuery,
+    selectedIds: value.carrier ? [value.carrier] : undefined,
   });
 
   const {
@@ -295,6 +296,9 @@ export function AssignmentForm({
     resourceType: "DRIVER",
     carrierId: value.carrier,
     query: driverQuery,
+    // The driver feed backs both the primary and the second-driver dropdown,
+    // so pin whichever of the two is currently selected.
+    selectedIds: [value.driver, value.secondDriver].filter(Boolean),
     enabled: Boolean(value.carrier),
   });
 
@@ -308,6 +312,7 @@ export function AssignmentForm({
     resourceType: "TRUCK",
     carrierId: value.carrier,
     query: truckQuery,
+    selectedIds: value.truck ? [value.truck] : undefined,
     enabled: Boolean(value.carrier),
   });
 
@@ -321,6 +326,7 @@ export function AssignmentForm({
     resourceType: "TRAILER",
     carrierId: value.carrier,
     query: trailerQuery,
+    selectedIds: value.trailer ? [value.trailer] : undefined,
     enabled: Boolean(value.carrier && value.hasTrailer),
   });
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/base-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/base-search-dropdown.tsx
@@ -510,6 +510,14 @@ export function BaseSearchDropdown<
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [activeFilter, setActiveFilter] =
     useState<ActiveFilter<TMatchType> | null>(null);
+  // Remembers the resolved option for the current `selectedId` so the trigger
+  // can still render its label after the backing `items` page stops including
+  // it — e.g. picking an off-page search result, or before the server-pinned
+  // row arrives on reopen. Without this the trigger falls back to the
+  // placeholder, making a successful selection look like it failed.
+  const [lastSelectedItem, setLastSelectedItem] = useState<TOption | null>(
+    null
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -531,6 +539,14 @@ export function BaseSearchDropdown<
   useEffect(() => {
     if (onQueryChange) onQueryChange(debouncedQuery);
   }, [onQueryChange, debouncedQuery]);
+
+  // Cache the option object for the active selection while it's present in
+  // `items`, so it survives the list being re-fetched for a new query/page.
+  useEffect(() => {
+    if (!selectedId) return;
+    const found = items.find((item) => item.id === selectedId);
+    if (found) setLastSelectedItem(found);
+  }, [items, selectedId]);
 
   // Calculate grouped results when no filter is active
   const groupedResults = useMemo(
@@ -700,7 +716,9 @@ export function BaseSearchDropdown<
     ]
   );
 
-  const selectedItem = items.find((item) => item.id === selectedId);
+  const selectedItem =
+    items.find((item) => item.id === selectedId) ??
+    (lastSelectedItem?.id === selectedId ? lastSelectedItem : undefined);
 
   const toggleDropdown = useCallback(() => {
     if (disabled) return;

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -28,6 +28,13 @@ export type AccreditedResourceType = AccreditedResource["resource_type"];
 
 interface AccreditedResourcesPage {
   data: AccreditedResource[];
+  /**
+   * Rows pinned by the server because the caller passed `selectedIds` — only
+   * populated on the first page. Carries the currently-selected option(s) so
+   * the combobox can render its label even when that row falls outside the
+   * filtered/paginated window. May overlap `data` across pages; deduped below.
+   */
+  pinned?: AccreditedResource[];
   total: number;
   filteredTotal: number;
   offset: number;
@@ -50,6 +57,13 @@ interface UseAccreditedResourcesOpts {
   carrierId?: string | null;
   /** Case-insensitive substring, matched against resource_name and identifier. */
   query?: string;
+  /**
+   * Resource ids to pin onto the result regardless of `query`/pagination —
+   * pass the currently-selected option id(s) so the combobox can always render
+   * its selected label even when that row is outside the filtered page. Falsy
+   * entries are ignored.
+   */
+  selectedIds?: readonly string[];
   pageSize?: number;
   /**
    * When false, the hook stays idle regardless of the other args. Use this to
@@ -76,11 +90,16 @@ export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
     resourceType,
     carrierId,
     query = "",
+    selectedIds,
     pageSize = DEFAULT_PAGE_SIZE,
     enabled = true,
   } = opts;
 
   const canFetch = Boolean(enabled && rutMandante && delegacion);
+
+  // Stable, comma-joined form of the pin set so it can sit in the SWR key and
+  // the `getKey` dependency list without churning on every render.
+  const idsParam = (selectedIds ?? []).filter(Boolean).join(",");
 
   const getKey = useCallback(
     (pageIndex: number, previousPage: AccreditedResourcesPage | null) => {
@@ -92,11 +111,21 @@ export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
       if (resourceType) params.set("resourceType", resourceType);
       if (carrierId) params.set("carrierId", carrierId);
       if (query) params.set("q", query);
+      if (idsParam) params.set("ids", idsParam);
       params.set("offset", String(pageIndex * pageSize));
       params.set("limit", String(pageSize));
       return `/app/api/calendar/accredited-resources?${params.toString()}`;
     },
-    [canFetch, rutMandante, delegacion, resourceType, carrierId, query, pageSize]
+    [
+      canFetch,
+      rutMandante,
+      delegacion,
+      resourceType,
+      carrierId,
+      query,
+      idsParam,
+      pageSize,
+    ]
   );
 
   const { data, error, size, setSize, isLoading, isValidating, mutate } =
@@ -106,10 +135,16 @@ export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
       errorRetryCount: 2,
     });
 
-  const resources = useMemo<AccreditedResource[]>(
-    () => (data ?? []).flatMap((page) => page.data),
-    [data]
-  );
+  const resources = useMemo<AccreditedResource[]>(() => {
+    const pages = data ?? [];
+    const rows = pages.flatMap((page) => page.data);
+    const pinned = pages[0]?.pinned ?? [];
+    if (pinned.length === 0) return rows;
+    // Pinned rows lead so the selected option is always present and stable;
+    // drop any later page-row that duplicates one of them.
+    const pinnedIds = new Set(pinned.map((r) => r.resource_id));
+    return [...pinned, ...rows.filter((r) => !pinnedIds.has(r.resource_id))];
+  }, [data]);
 
   const lastPage = data && data.length > 0 ? data.at(-1) : null;
   const hasMore = lastPage ? lastPage.hasMore : false;


### PR DESCRIPTION
Closes #457

## Problem

In the calendar planning sidebar **Asignación** tab, the Transportista / Conductor / Conductor 2 / Camión / Remolque dropdowns failed to display the currently-selected resource whenever it fell outside the first loaded page of its list:

1. **Search → pick → "nothing happens".** Searching for a resource past the first page and clicking it stored the value internally, but the trigger immediately reverted to the placeholder.
2. **Cold reopen of an assigned service showed empty dropdowns.** Persisted carrier/driver/truck/trailer IDs that weren't in the first 50 rows rendered as the placeholder — and since drivers/trucks are scoped by the carrier, the whole chain looked broken.

## Root cause

`BaseSearchDropdown` (server-backed mode here) derives the trigger label from the currently-loaded `items` array only. `useAccreditedResources` (`useSWRInfinite`) holds just the page(s) fetched for the *active* query; selecting/closing resets the query, which re-fetches page 0 unfiltered — so a selected resource outside that window can no longer be resolved.

## Fix

- **`accredited-resources/route.ts`** — new `ids=` query param: pins those rows (resolved against the full cached set, bypassing `q`) into a `pinned` array on the first page, de-duped against the page slice.
- **`accredited-resources.service.ts`** — new `selectedIds` option threaded into the SWR key; `resources` now leads with `pinned` and drops later page-rows that duplicate a pinned one.
- **`assignment-form.tsx`** — passes the selected id(s) for each feed; the driver feed pins both `driver` and `secondDriver` since it backs both driver dropdowns.
- **`base-search-dropdown.tsx`** — `lastSelectedItem` cache so the trigger doesn't flicker to the placeholder during the re-fetch (belt-and-suspenders on top of the server pin).

## Testing

- `tsc --noEmit` — clean
- `eslint` on the changed files — clean
- No existing tests reference these modules.
- Manual: verify (a) searching for an off-page carrier/driver/truck/trailer, clicking it, and seeing it stick; (b) reopening the Asignación tab on a service that already has an assignment shows the saved resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected accredited resources (carriers, drivers, trucks, trailers) now "pin" to the top of search results, remaining visible during pagination.
  * Selected resource labels persist in dropdowns even when the item temporarily leaves the paginated view.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->