### PR TITLE
feat(calendar): show planned service category badge across views

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -5,6 +5,7 @@ import { IoPerson, IoPeople } from "react-icons/io5";
 import type { PlannedService } from "./planning-selection-context";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
+import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 /**
  * Get the CSS classes for a planned service chip based on urgencia status
@@ -123,10 +124,17 @@ export function PlannedServiceChip({
         <span className="font-bold truncate text-left">
           {plannedService.service.id}
         </span>
-        <div className="flex items-center gap-0.5 text-[10px] font-normal opacity-80 truncate">
-          <span className="truncate">{origen}</span>
-          <span className="shrink-0">→</span>
-          <span className="truncate">{destino}</span>
+        <div className="flex items-center gap-1 text-[10px] font-normal">
+          <span className="flex items-center gap-0.5 min-w-0 flex-1 opacity-80">
+            <span className="truncate">{origen}</span>
+            <span className="shrink-0">→</span>
+            <span className="truncate">{destino}</span>
+          </span>
+          <ServiceCategoryBadge
+            code={plannedService.service.serviceCategory}
+            variant="ghost"
+            className="shrink-0 px-1 text-[9px] font-semibold leading-none"
+          />
         </div>
       </div>
       {/* Right: Driver icon centered vertically */}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -15,6 +15,7 @@ import { categorizeIncidencias } from "./incidencias.types";
 import { formatPercent } from "./planning-format";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
+import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 // Set Spanish locale for dayjs
 dayjs.locale("es");
@@ -151,8 +152,15 @@ export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
         </h4>
 
         {/* Flags row */}
-        {hasFlags && (
+        {(hasFlags || service.serviceCategory) && (
           <div className="flex flex-wrap items-center gap-1 pointer-events-auto">
+            {/* Service category - shown alongside incidencia flags */}
+            <ServiceCategoryBadge
+              code={service.serviceCategory}
+              variant="soft"
+              className="px-2 py-0.5 text-xs cursor-help"
+            />
+
             {/* Primary incidencias - always visible */}
             {primary.map(({ key, config }) => {
               const tooltip =

--- a/turbo-repo/apps/app/src/features/common/components/custom-card/custom-card.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/custom-card/custom-card.tsx
@@ -13,6 +13,8 @@ export interface InformationBadge {
     | "pink"
     | "indigo";
   icon?: FC<SVGProps<SVGSVGElement>>;
+  /** Optional native tooltip shown on hover (e.g. an abbreviation's full text). */
+  title?: string;
 }
 
 export default function CustomCard({
@@ -55,6 +57,7 @@ export default function CustomCard({
                     color={badge.color || "gray"}
                     icon={badge.icon}
                     size="sm"
+                    title={badge.title}
                   >
                     {badge.text}
                   </Badge>

--- a/turbo-repo/apps/app/src/features/common/components/service-category-badge/service-category-badge.test.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/service-category-badge/service-category-badge.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ServiceCategoryBadge } from "./service-category-badge";
+
+const useServiceCategoryName = vi.fn();
+
+vi.mock("@/features/common/providers/client-api.provider", () => ({
+  useServiceCategoryName: (code: string | null | undefined) =>
+    useServiceCategoryName(code),
+}));
+
+describe("ServiceCategoryBadge", () => {
+  beforeEach(() => {
+    useServiceCategoryName.mockReset();
+  });
+
+  it("renders the category initials and a tooltip with the full name", () => {
+    useServiceCategoryName.mockReturnValue({
+      name: "Servicio Programado",
+      isLoading: false,
+    });
+    render(<ServiceCategoryBadge code="ST001" />);
+    const badge = screen.getByText("SP");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Servicio Programado");
+  });
+
+  it("prefixes the tooltip with the provided label", () => {
+    useServiceCategoryName.mockReturnValue({
+      name: "Servicio Programado",
+      isLoading: false,
+    });
+    render(
+      <ServiceCategoryBadge code="ST001" tooltipLabel="Categoría de servicio" />
+    );
+    expect(screen.getByText("SP")).toHaveAttribute(
+      "title",
+      "Categoría de servicio: Servicio Programado"
+    );
+  });
+
+  it("renders nothing when the code cannot be resolved", () => {
+    useServiceCategoryName.mockReturnValue({
+      name: undefined,
+      isLoading: false,
+    });
+    const { container } = render(<ServiceCategoryBadge code="ST404" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when no code is provided", () => {
+    useServiceCategoryName.mockReturnValue({
+      name: undefined,
+      isLoading: false,
+    });
+    const { container } = render(<ServiceCategoryBadge code={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/turbo-repo/apps/app/src/features/common/components/service-category-badge/service-category-badge.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/service-category-badge/service-category-badge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { twMerge } from "tailwind-merge";
+import { useServiceCategoryName } from "@/features/common/providers/client-api.provider";
+import { serviceCategoryInitials } from "@/features/common/utils/service-category";
+
+type ServiceCategoryBadgeVariant = "soft" | "solid" | "ghost";
+
+const VARIANT_CLASSES: Record<ServiceCategoryBadgeVariant, string> = {
+  // Soft tinted pill — default, sits well on neutral card backgrounds.
+  soft: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300",
+  // Solid badge with a contrasting outline — for floating corner badges.
+  solid: "bg-indigo-500 text-white border border-white dark:border-gray-900",
+  // Borderless, inherits the surrounding text color — for tight inline rows.
+  ghost: "border border-current/30 text-current",
+};
+
+interface ServiceCategoryBadgeProps {
+  /** Service-type code stored on the task/booking (e.g. "ST001"). */
+  readonly code: string | null | undefined;
+  /** Visual style. Defaults to `soft`. */
+  readonly variant?: ServiceCategoryBadgeVariant;
+  /** Extra classes, merged after the variant styling. */
+  readonly className?: string;
+  /**
+   * Optional label prefixed to the hover tooltip, e.g. "Categoría de servicio"
+   * → tooltip becomes "Categoría de servicio: Servicio Programado".
+   */
+  readonly tooltipLabel?: string;
+}
+
+/**
+ * Compact badge showing the Spanish initials of a planned service's category.
+ *
+ * Renders `null` when the code is missing or cannot be resolved to a name, so
+ * callers can fall back to another indicator (e.g. the kanban "F" badge).
+ */
+export function ServiceCategoryBadge({
+  code,
+  variant = "soft",
+  className,
+  tooltipLabel,
+}: ServiceCategoryBadgeProps) {
+  const { name } = useServiceCategoryName(code);
+  if (!name) return null;
+  const initials = serviceCategoryInitials(name);
+  if (!initials) return null;
+  return (
+    <span
+      title={tooltipLabel ? `${tooltipLabel}: ${name}` : name}
+      className={twMerge(
+        "inline-flex items-center justify-center rounded-full px-1.5 text-[10px] font-bold leading-none",
+        VARIANT_CLASSES[variant],
+        className
+      )}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -1930,6 +1930,29 @@ export function useServiceTypes() {
   };
 }
 
+/**
+ * Resolve a service-type code (e.g. "ST001") to its display name.
+ *
+ * Unlike {@link useServiceTypes} this does not drop inactive types, so a task
+ * referencing a now-retired category still renders its label. Backed by the
+ * same SWR cache key, so it adds no extra requests when used alongside it.
+ */
+export function useServiceCategoryName(code: string | null | undefined): {
+  name: string | undefined;
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useSWR<ServiceType[], FetcherError>(
+    "/app/api/service-types",
+    fetcher,
+    { errorRetryCount: 3, errorRetryInterval: 5000 }
+  );
+  const name = useMemo(() => {
+    if (!code) return undefined;
+    return (data ?? []).find((t) => t.code === code)?.name;
+  }, [data, code]);
+  return { name, isLoading };
+}
+
 export async function updateServiceCategory(
   taskId: string,
   serviceTypeCode: string

--- a/turbo-repo/apps/app/src/features/common/utils/service-category.test.ts
+++ b/turbo-repo/apps/app/src/features/common/utils/service-category.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { serviceCategoryInitials } from "./service-category";
+
+describe("serviceCategoryInitials", () => {
+  it("returns the initials of a two-word name", () => {
+    expect(serviceCategoryInitials("Servicio Programado")).toBe("SP");
+  });
+
+  it("uppercases the result", () => {
+    expect(serviceCategoryInitials("carga peligrosa")).toBe("CP");
+  });
+
+  it("uses only the first two words for longer names", () => {
+    expect(serviceCategoryInitials("Transporte de Carga General")).toBe("TD");
+  });
+
+  it("collapses extra whitespace", () => {
+    expect(serviceCategoryInitials("  carga   peligrosa ")).toBe("CP");
+  });
+
+  it("preserves accented initials", () => {
+    expect(serviceCategoryInitials("Útil Programado")).toBe("ÚP");
+  });
+
+  it("falls back to the first two characters for a single word", () => {
+    expect(serviceCategoryInitials("Faena")).toBe("FA");
+  });
+
+  it("returns the single character for a one-letter word", () => {
+    expect(serviceCategoryInitials("X")).toBe("X");
+  });
+
+  it("returns an empty string for empty or nullish input", () => {
+    expect(serviceCategoryInitials("")).toBe("");
+    expect(serviceCategoryInitials("   ")).toBe("");
+    expect(serviceCategoryInitials(null)).toBe("");
+    expect(serviceCategoryInitials(undefined)).toBe("");
+  });
+});

--- a/turbo-repo/apps/app/src/features/common/utils/service-category.ts
+++ b/turbo-repo/apps/app/src/features/common/utils/service-category.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for displaying a planned service's category compactly.
+ *
+ * Service categories are stored on tasks/bookings as a service-type *code*
+ * (e.g. "ST001"); the human-readable name is resolved from the service-types
+ * catalog. Across cards and chips we only have room for a short token, so we
+ * derive the Spanish initials of the (two-word) category name.
+ */
+
+/**
+ * Derive a short uppercase token from a service category name.
+ *
+ *  "Servicio Programado"   → "SP"
+ *  "Faena"                 → "FA"
+ *  "  carga   peligrosa "  → "CP"
+ *  ""                      → ""
+ *
+ * Names with three or more words only contribute their first two words.
+ */
+export function serviceCategoryInitials(
+  name: string | null | undefined
+): string {
+  if (!name) return "";
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.test.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import KanbanCard from "./kanban-card";
+import type { KanbanBoardTask } from "../../types/common.types";
+
+const useServiceCategoryName = vi.fn();
+
+vi.mock("@/features/common/providers/client-api.provider", () => ({
+  useServiceCategoryName: (code: string | null | undefined) =>
+    useServiceCategoryName(code),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<{ href: string }>) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) =>
+    React.createElement("img", props),
+}));
+
+function makeTask(overrides: Partial<KanbanBoardTask> = {}): KanbanBoardTask {
+  return {
+    id: "task-1",
+    name: "SVC-001",
+    description: "",
+    completed: false,
+    daysLeft: 0,
+    serviceKind: "",
+    executionType: "",
+    members: [],
+    hoReference: "",
+    isEditable: true,
+    ...overrides,
+  };
+}
+
+function renderCompactCard(task: KanbanBoardTask) {
+  return render(
+    <KanbanCard task={task} table_name="board" compactKanbanView dict={{}} />
+  );
+}
+
+describe("KanbanCard service category / faena indicator", () => {
+  beforeEach(() => {
+    useServiceCategoryName.mockReset();
+    useServiceCategoryName.mockReturnValue({
+      name: undefined,
+      isLoading: false,
+    });
+  });
+
+  it("shows the F indicator for faena services without a category", () => {
+    renderCompactCard(makeTask({ executionType: "F" }));
+    expect(screen.getByText("F")).toBeInTheDocument();
+  });
+
+  it("does not show the F indicator for non-faena services", () => {
+    renderCompactCard(makeTask({ executionType: "T" }));
+    expect(screen.queryByText("F")).not.toBeInTheDocument();
+  });
+
+  it("replaces the F indicator with the category initials when a category is set", () => {
+    useServiceCategoryName.mockReturnValue({
+      name: "Servicio Programado",
+      isLoading: false,
+    });
+    renderCompactCard(
+      makeTask({ executionType: "F", mintral_serviceCategory: "ST001" })
+    );
+    expect(screen.getByText("SP")).toBeInTheDocument();
+    expect(screen.queryByText("F")).not.toBeInTheDocument();
+  });
+
+  it("does not fall back to F while the category is still resolving", () => {
+    // Category code present but catalog not yet loaded → render nothing, not "F".
+    renderCompactCard(
+      makeTask({ executionType: "F", mintral_serviceCategory: "ST001" })
+    );
+    expect(screen.queryByText("F")).not.toBeInTheDocument();
+    expect(screen.queryByText("SP")).not.toBeInTheDocument();
+  });
+});

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
@@ -7,6 +7,7 @@ import { tr } from "@/features/i18n/tr.service";
 import DepartureDateShip from "../departure-date-ship/departure-date-ship";
 import DownloadSignedDocument from "../download-signed-document/download-signed-document";
 import { Tooltip } from "flowbite-react";
+import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 export default function KanbanCard({
   task,
@@ -25,6 +26,12 @@ export default function KanbanCard({
     cursor = "!cursor-wait";
   }
 
+  // The service category badge replaces the "F" (faena) indicator when set.
+  // While the category catalog is still loading the badge renders nothing, so
+  // we suppress the "F" fallback whenever a category code is present at all.
+  const hasServiceCategory = Boolean(task.mintral_serviceCategory);
+  const showFaenaBadge = !hasServiceCategory && task.executionType === "F";
+
   return (
     <div
       key={task.id}
@@ -37,11 +44,19 @@ export default function KanbanCard({
     >
       <div className="absolute inset-0 bg-gradient-to-r bg-black/10 dark:bg-white/10 translate-x-[-100%] group-hover:translate-x-0 transition-transform duration-1000 ease-out pointer-events-none" />
       <div className="relative z-10">
-        {task.executionType === "F" && !compactKanbanView && (
+        {!compactKanbanView && (hasServiceCategory || showFaenaBadge) && (
           <div className="relative">
-            <div className="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-red-500 border-white rounded-full -top-2 -end-2 dark:border-gray-900">
-              F
-            </div>
+            {hasServiceCategory ? (
+              <ServiceCategoryBadge
+                code={task.mintral_serviceCategory}
+                variant="solid"
+                className="absolute -top-2 -end-2 h-6 min-w-6 text-xs"
+              />
+            ) : (
+              <div className="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-red-500 border-white rounded-full -top-2 -end-2 dark:border-gray-900">
+                F
+              </div>
+            )}
           </div>
         )}
         <div className="flex items-center justify-between">
@@ -61,10 +76,18 @@ export default function KanbanCard({
                     >
                       {task.name}
                     </strong>
-                    {task.executionType === "F" && (
-                      <span className="inline-flex items-center justify-center w-5 h-5 ms-2 text-xs font-semibold text-white bg-red-500 rounded-full">
-                        F
-                      </span>
+                    {hasServiceCategory ? (
+                      <ServiceCategoryBadge
+                        code={task.mintral_serviceCategory}
+                        variant="solid"
+                        className="ms-2 h-5 min-w-5 text-xs border-0"
+                      />
+                    ) : (
+                      showFaenaBadge && (
+                        <span className="inline-flex items-center justify-center w-5 h-5 ms-2 text-xs font-semibold text-white bg-red-500 rounded-full">
+                          F
+                        </span>
+                      )
                     )}
                   </div>
                 </div>

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/trip-information/trip-information.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/trip-information/trip-information.tsx
@@ -4,8 +4,14 @@ import { I18nDictionary } from "@/features/i18n/i18n.service.types";
 import { TaskResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
 import TripData from "./trip-data";
 import CustomCard from "@/features/common/components/custom-card/custom-card";
-import { HiExclamationCircle, HiOutlineClock } from "react-icons/hi";
+import {
+  HiExclamationCircle,
+  HiOutlineClock,
+  HiOutlineTag,
+} from "react-icons/hi";
 import { logError } from "@/lib/logger";
+import { useServiceCategoryName } from "@/features/common/providers/client-api.provider";
+import { serviceCategoryInitials } from "@/features/common/utils/service-category";
 
 export default function TripInformation({
   task,
@@ -35,6 +41,12 @@ export default function TripInformation({
     originIsSitransValue = originIsSitrans === true ? "internal" : "external";
   }
 
+  const serviceCategoryCode = task.mintral_serviceCategory as
+    | string
+    | undefined;
+  const { name: serviceCategoryName } =
+    useServiceCategoryName(serviceCategoryCode);
+
   const badges: Array<{
     text: string;
     color:
@@ -47,6 +59,7 @@ export default function TripInformation({
       | "pink"
       | "indigo";
     icon: any;
+    title?: string;
   }> = [];
 
   if (originIsSitrans !== null && originIsSitrans !== undefined) {
@@ -57,6 +70,18 @@ export default function TripInformation({
       color: "gray" as const,
       icon: HiOutlineClock,
     });
+  }
+
+  if (serviceCategoryName) {
+    const initials = serviceCategoryInitials(serviceCategoryName);
+    if (initials) {
+      badges.push({
+        text: initials,
+        color: "indigo" as const,
+        icon: HiOutlineTag,
+        title: `${msg.bento.serviceCategory}: ${serviceCategoryName}`,
+      });
+    }
   }
 
   if (task.mintral_priorityCode === "UR") {

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2468,6 +2468,7 @@
     "internal": "Internal start",
     "external": "External start",
     "urgency": "Urgency",
+    "serviceCategory": "Service category",
     "today": "Today",
     "yesterday": "Yesterday",
     "trip": "Trip",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2498,6 +2498,7 @@
     "internal": "Inicio Interno",
     "external": "Inicio Externo",
     "urgency": "Urgente",
+    "serviceCategory": "Categoría de servicio",
     "today": "Hoy",
     "yesterday": "Ayer",
     "trip": "Viaje",


### PR DESCRIPTION
## What

Surfaces the **service category** chosen when planning a service in the calendar module. Previously the planning sidebar let you pick a category (persisted on the task as `mintral_serviceCategory`, a service-type code) but it was never shown again. Now it appears as a compact badge — the **Spanish initials** of the category name (two words → two letters, e.g. *"Servicio Programado"* → `SP`) — with the full name as a hover tooltip, across:

- **Bento box** (task edit page) — in the trip-information card, next to the *Urgente* badge.
- **Kanban cards** (compact + expanded) — replaces the red **F** (faena) indicator when a category is set; keeps **F** when there is no category. The **F** fallback is also suppressed while the catalog is still loading (so it doesn't flash).
- **Calendar view chips** — on the second line, right-aligned (alongside the origin → destination route).
- **Planning sidebar `ServiceEvent` card** — alongside the incidencia / urgencia flags.

## How

- New `serviceCategoryInitials(name)` helper + `ServiceCategoryBadge` component (`soft` / `solid` / `ghost` variants). The badge renders `null` when the code is missing or unresolved, so callers can fall back.
- New `useServiceCategoryName(code)` hook in `client-api.provider.ts` — resolves the stored code to a name off the existing `/app/api/service-types` SWR cache key (no extra requests), and unlike `useServiceTypes` does **not** drop inactive types, so a now-retired category still renders.
- `CustomCard`'s `InformationBadge` gained an optional `title` (for the bento tooltip).
- New i18n key `bento.serviceCategory` (es/en).

## Notes / limitations

- Kanban cards, calendar chips and `ServiceEvent` only carry the category *code*, so the label depends on the service-types catalog being reachable; an unresolvable code renders nothing (kanban falls back to **F**).
- Only bookings/tasks saved after the planning form set a category will show it.

## Tests

- `serviceCategoryInitials`: two/one word, extra whitespace, accents, empty/null.
- `ServiceCategoryBadge`: initials + tooltip, label prefix, `null` when no code / unresolved.
- `kanban-card`: **F** shown for faena-without-category, absent for non-faena, initials replace **F** when a category is set, no **F** flash while resolving.
- `tsc --noEmit` clean; `eslint` clean (one pre-existing `icon: any` warning in the bento badges array); 16 new tests pass.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service category badges now display throughout the app (planning chips, events, kanban cards, trip information) with initials and hover tooltips for easy identification.

* **Tests**
  * Added comprehensive test coverage for service category functionality and related UI components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->