### PR TITLE
fix(calendar): split planning chip click + right-click selection

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -53,6 +53,12 @@ export function getDriverCount(service: PlannedService["service"]): 0 | 1 | 2 {
 interface PlannedServiceChipProps {
   readonly plannedService: PlannedService;
   readonly isBeingReassigned?: boolean;
+  /**
+   * Visual-only "this chip is selected" mark, set by right-clicking the
+   * chip. Renders a static corner ring (same color family as the reassign
+   * ring, no pulse) and is independent of slot/sidebar selection.
+   */
+  readonly isSelected?: boolean;
   readonly onContextMenu: (e: React.MouseEvent, ps: PlannedService) => void;
   /** Optional left-click handler — opens the sidebar in view/read-only mode. */
   readonly onClick?: (ps: PlannedService) => void;
@@ -68,6 +74,7 @@ interface PlannedServiceChipProps {
 export function PlannedServiceChip({
   plannedService,
   isBeingReassigned = false,
+  isSelected = false,
   onContextMenu,
   onClick,
   className,
@@ -115,6 +122,11 @@ export function PlannedServiceChip({
         getPlannedServiceChipClassName(hasUrgencia),
         isBeingReassigned &&
           "ring-2 ring-amber-500 ring-offset-1 animate-pulse",
+        // Reassign takes visual precedence: only apply the right-click
+        // highlight when the chip isn't already pulsing for reassignment.
+        !isBeingReassigned &&
+          isSelected &&
+          "ring-2 ring-amber-500 ring-offset-1",
         className
       )}
       title={`${plannedService.service.id} - ${tr("pages.planning.sidebar.contextMenu.chipTitle", dict)}`}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-grid-shell.tsx
@@ -81,9 +81,10 @@ export function buildPlanningGridShellProps(params: {
       isShiftSelected,
       getServicesForShift,
       isWindowFull,
-      onChipClick: pg.viewPlannedService,
+      onChipClick: pg.selectChipSlot,
       onChipContextMenu: pg.handleContextMenu,
       reassigningServiceId: pg.reassigningService?.service.service.id,
+      isChipSelected: pg.isChipSelected,
       dict,
     },
     gridOverlays: {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -899,11 +899,23 @@ interface PlanningSelectionContextType {
   /** Cancel assignment-only mode */
   cancelAssignment: () => void;
   /**
-   * Open the sidebar in view-only mode for an already-planned service. Sets
-   * the service and slot without entering reassign/assign mode — the form
-   * renders the existing values and suppresses its action buttons.
+   * Left-click on a chip: select only the chip's underlying slot, clearing
+   * any previously selected service. The sidebar opens in "add to slot" mode
+   * — identical to clicking the empty area of that slot. The existing
+   * planned service is left untouched and is *not* preselected; use the
+   * right-click context menu (selectChipResource) to interact with it.
    */
-  viewPlannedService: (plannedService: PlannedService) => void;
+  selectChipSlot: (plannedService: PlannedService) => void;
+  /**
+   * Right-click on a chip: highlight the chip itself without touching slot
+   * or service selection — the sidebar is NOT opened. Pairs with the chip
+   * context menu, which opens immediately after.
+   */
+  selectChipResource: (plannedService: PlannedService) => void;
+  /** True when the given service id is the chip currently highlighted via right-click. */
+  isChipSelected: (serviceId: string) => boolean;
+  /** Drop the chip highlight without touching slot/service selection. */
+  clearChipSelection: () => void;
   /**
    * Patch the assignment tuple (carrier/drivers/truck/trailer) on a planned
    * service. Any omitted field is left untouched; passing `undefined`
@@ -1042,6 +1054,13 @@ export function PlanningSelectionProvider({
   const [selectedSlot, setSelectedSlot] = useState<SelectedSlot | null>(null);
   const [selectedService, setSelectedService] =
     useState<SelectedService | null>(null);
+  // Visual-only "this chip is selected" mark set by right-clicking a chip.
+  // Deliberately separate from `selectedService` because right-click must
+  // not open the sidebar — only `selectedSlot`/`selectedService` toggle
+  // `isSidebarOpen`. Slot left-click and any sidebar close clears this.
+  const [selectedChipServiceId, setSelectedChipServiceId] = useState<
+    string | null
+  >(null);
   const [plannedServices, setPlannedServices] = useState<PlannedService[]>([]);
   // Unified state: single array for all time slots
   const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([]);
@@ -1716,6 +1735,7 @@ export function PlanningSelectionProvider({
     setSelectedService(null);
     setReassigningService(null);
     setAssigningService(null);
+    setSelectedChipServiceId(null);
   }, []);
 
   const clearSelection = useCallback(() => {
@@ -1723,6 +1743,7 @@ export function PlanningSelectionProvider({
     setSelectedService(null);
     setReassigningService(null);
     setAssigningService(null);
+    setSelectedChipServiceId(null);
   }, []);
 
   /**
@@ -1845,16 +1866,36 @@ export function PlanningSelectionProvider({
     setSelectedService(null);
   }, []);
 
-  // Open the sidebar to inspect a planned service without entering an edit
-  // mode. Left-clicking a chip routes here; the form reads `selectedSlot` and
-  // `selectedService`, sees no reassign/assign mode, and (when the slot is
-  // past) renders with mutations disabled.
-  const viewPlannedService = useCallback((plannedService: PlannedService) => {
+  // Left-click on a chip: select only the underlying slot. Clears any
+  // previously selected service so the sidebar opens in "add to slot" mode,
+  // identical to clicking the empty portion of the slot — never carries the
+  // chip's service into the form. Also clears any chip highlight from a
+  // prior right-click so the two selection states stay mutually exclusive.
+  const selectChipSlot = useCallback((plannedService: PlannedService) => {
     setReassigningService(null);
     setAssigningService(null);
-    setSelectedService(plannedService.service);
+    setSelectedService(null);
+    setSelectedChipServiceId(null);
     setSelectedSlot(plannedService.slot);
   }, []);
+
+  // Right-click on a chip: highlight only the chip itself. Does NOT touch
+  // `selectedService`/`selectedSlot` (so the sidebar stays where it was)
+  // — the chip context menu opens immediately after via use-planning-grid.
+  // The highlight persists until a left-click clears it or the sidebar
+  // closes.
+  const selectChipResource = useCallback((plannedService: PlannedService) => {
+    setSelectedChipServiceId(plannedService.service.id);
+  }, []);
+
+  const clearChipSelection = useCallback(() => {
+    setSelectedChipServiceId(null);
+  }, []);
+
+  const isChipSelected = useCallback(
+    (serviceId: string) => selectedChipServiceId === serviceId,
+    [selectedChipServiceId]
+  );
 
   /**
    * Patch a planned service's assignment tuple client-side.
@@ -1930,7 +1971,10 @@ export function PlanningSelectionProvider({
       cancelReassignment,
       startAssignment,
       cancelAssignment,
-      viewPlannedService,
+      selectChipSlot,
+      selectChipResource,
+      isChipSelected,
+      clearChipSelection,
       updateServiceAssignment,
       bookingsLoadError,
       backendSlots,
@@ -1975,7 +2019,10 @@ export function PlanningSelectionProvider({
       cancelReassignment,
       startAssignment,
       cancelAssignment,
-      viewPlannedService,
+      selectChipSlot,
+      selectChipResource,
+      isChipSelected,
+      clearChipSelection,
       updateServiceAssignment,
       bookingsLoadError,
       backendSlots,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/shift-overlay-layer.tsx
@@ -13,6 +13,7 @@ import type {
   I18nDictionary,
   I18nRecord,
 } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
 
 interface Props {
   readonly shifts: readonly PositionedShift[];
@@ -33,6 +34,8 @@ interface Props {
     ps: PlannedService
   ) => void;
   readonly reassigningServiceId?: string;
+  /** Predicate driving the chip's right-click highlight ring. */
+  readonly isChipSelected?: (serviceId: string) => boolean;
   readonly dict: I18nDictionary | I18nRecord;
 }
 
@@ -57,6 +60,7 @@ export function ShiftOverlayLayer({
   onChipClick,
   onChipContextMenu,
   reassigningServiceId,
+  isChipSelected,
   dict,
 }: Props) {
   return (
@@ -102,7 +106,7 @@ export function ShiftOverlayLayer({
         );
         const labelHM = formatHM(s.slotHour, s.slotMinutes);
         const title = windowFull
-          ? "Window is at capacity for this day — not assignable"
+          ? tr("pages.planning.grid.windowFullTooltip", dict)
           : `${labelHM} – ${formatHM(
               Math.floor(s.endsAtMin / 60),
               s.endsAtMin % 60
@@ -156,6 +160,7 @@ export function ShiftOverlayLayer({
                     key={ps.service.id}
                     plannedService={ps}
                     isBeingReassigned={reassigningServiceId === ps.service.id}
+                    isSelected={isChipSelected?.(ps.service.id) ?? false}
                     onContextMenu={onChipContextMenu ?? noop}
                     onClick={onChipClick}
                     className="w-full"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -53,7 +53,10 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     startAssignment,
     reassigningService,
     updateServiceAssignment,
-    viewPlannedService,
+    selectChipSlot,
+    selectChipResource,
+    isChipSelected,
+    clearChipSelection,
     andenesCount,
   } = usePlanningSelection();
 
@@ -79,6 +82,26 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     startReassignment,
     startAssignment,
   });
+
+  // Right-click on a chip highlights it (corner ring) AND opens the context
+  // menu. The highlight is purely visual — `selectChipResource` does not
+  // touch slot/service selection, so the sidebar stays as-is.
+  const handleChipContextMenu = useCallback(
+    (e: React.MouseEvent, plannedService: PlannedService) => {
+      selectChipResource(plannedService);
+      serviceActions.handleContextMenu(e, plannedService);
+    },
+    [selectChipResource, serviceActions]
+  );
+
+  // The chip highlight lives alongside the context menu — closing the menu
+  // (outside click, Escape, or picking an action) drops the highlight too.
+  // Actions that transition into reassign/assign mode pick up their own
+  // visual treatment from there, so there's no flash of "nothing selected".
+  const handleCloseChipContextMenu = useCallback(() => {
+    serviceActions.handleCloseContextMenu();
+    clearChipSelection();
+  }, [serviceActions, clearChipSelection]);
 
   const timeSlots = useMemo(
     () => generateTimeSlots(startHour, endHour),
@@ -178,11 +201,18 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     // Reassignment
     reassigningService,
 
-    // View-only inspection of a planned service (left-click on chip)
-    viewPlannedService,
+    // Left-click on a chip: select only the slot (clears any prior service).
+    selectChipSlot,
 
-    // Service actions (context menu, delete modals)
+    // Predicate the chip uses to render its right-click highlight ring.
+    isChipSelected,
+
+    // Service actions (context menu, delete modals). Spread first, then
+    // override the open/close handlers with the wrapped versions that also
+    // manage the chip's right-click highlight.
     ...serviceActions,
+    handleContextMenu: handleChipContextMenu,
+    handleCloseContextMenu: handleCloseChipContextMenu,
   };
 }
 

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -163,6 +163,9 @@
         "shipping": "Planning",
         "finished": "Finished"
       },
+      "grid": {
+        "windowFullTooltip": "Window is at capacity for this day — not assignable"
+      },
       "taskCounter": {
         "activeCount": "{count} visibles"
       },

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -163,6 +163,9 @@
         "shipping": "Planificación",
         "finished": "Finalizados"
       },
+      "grid": {
+        "windowFullTooltip": "La ventana alcanzó su capacidad para este día — no es asignable"
+      },
       "taskCounter": {
         "activeCount": "{count} visibles"
       },


### PR DESCRIPTION
## Summary
- **Left-click on a planning chip** → selects only the underlying slot. Sidebar opens in "add to slot" mode, identical to clicking the empty area of that slot. The chip's existing resource is no longer preselected as a side effect.
- **Right-click on a chip** → highlights only the chip with a static corner ring (same color family as the reassign visual, no pulse) and opens the existing context menu. Sidebar stays untouched.
- The chip highlight clears when the context menu closes (outside click, Escape, or after picking an action — reassign/assign immediately swap to their own visual treatment).
- Also bundles a small i18n cleanup: the hard-coded "Window at capacity" tooltip in `shift-overlay-layer.tsx` now reads from `pages.planning.grid.windowFullTooltip`, with EN/ES translations added.

## Implementation
- `planning-selection-context.tsx` — adds a `selectedChipServiceId` state used purely as a visual mark. Deliberately separate from `selectedService` because `isSidebarOpen` is derived from `selectedSlot || selectedService` and right-click must not open the sidebar. Replaces the old `viewPlannedService` with two single-purpose helpers (`selectChipSlot`, `selectChipResource`) plus `isChipSelected` / `clearChipSelection`. `closeSidebar` / `clearSelection` / `selectChipSlot` all reset the highlight to keep slot and chip selection mutually exclusive.
- `use-planning-grid.ts` — wraps `handleContextMenu` so right-click paints the highlight; wraps `handleCloseContextMenu` so any menu-close path drops it.
- `planning-grid-shell.tsx`, `shift-overlay-layer.tsx`, `planned-service-chip.tsx` — thread an `isSelected` predicate through the overlay layer to the chip; chip renders a static amber ring (yielding to the reassign pulse when both happen to be true).

Closes #466

## Test plan
- [x] Left-click a chip → sidebar opens in slot mode (no service preselected); the slot's overlay shows the standard selection ring; the chip itself has no extra ring.
- [x] Right-click a chip → chip gets a static amber corner ring AND the context menu opens; sidebar stays as it was.
- [x] Click outside the open context menu → menu closes and the chip ring clears.
- [x] Press Escape with the menu open → same behavior.
- [x] Pick **Replan** in the menu → menu closes, chip transitions to the reassign pulse (no flash of static ring after).
- [x] Right-click chip A, then right-click chip B → highlight moves to B; A is no longer highlighted.
- [x] Right-click a chip, then left-click an empty slot → chip ring clears; slot ring appears.
- [x] Tooltip on a full-window slot reads from the i18n catalog and switches correctly between EN and ES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Planned service chips now support visual selection highlighting
  * Added left-click and right-click interaction handlers for chip operations
  * New tooltip indicating planning window capacity

* **Localization**
  * Added capacity notification message in English and Spanish

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/467)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->