### PR TITLE
fix(calendar): route reassignment through bookings.move endpoint

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -29,8 +29,12 @@ const MoveBodySchema = z.object({
     })
     .optional(),
 });
+type MoveBody = z.infer<typeof MoveBodySchema>;
 
 type CalendarClient = ReturnType<typeof createMiotCalendarClient>;
+type Result<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: NextResponse };
 
 /**
  * Reverse-move compensation: re-issue a move using the pre-move snapshot so
@@ -58,6 +62,86 @@ async function compensateMove(
   }
 }
 
+async function parseMoveBody(request: Request): Promise<Result<MoveBody>> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return {
+      ok: false,
+      error: NextResponse.json(
+        { error: "Invalid request body" },
+        { status: 400 }
+      ),
+    };
+  }
+  const parsed = MoveBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: NextResponse.json(
+        { error: "slot { date, hour, minutes } is required" },
+        { status: 400 }
+      ),
+    };
+  }
+  return { ok: true, value: parsed.data };
+}
+
+/**
+ * Snapshot the pre-move state so we can reverse the move if the downstream
+ * calendar-binding call fails. The booking id is stable across a move so
+ * this is just one extra GET, not a wholly different write.
+ */
+async function snapshotBooking(
+  client: CalendarClient,
+  bookingId: string
+): Promise<Result<BookingResponse>> {
+  try {
+    return { ok: true, value: await client.bookings.get(bookingId) };
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    if (status === 404) {
+      return {
+        ok: false,
+        error: NextResponse.json(
+          { error: "Booking not found" },
+          { status: 404 }
+        ),
+      };
+    }
+    logger.error({ err: error, bookingId }, "Failed to load booking for move");
+    return {
+      ok: false,
+      error: NextResponse.json(
+        { error: "Failed to load booking" },
+        { status }
+      ),
+    };
+  }
+}
+
+async function executeMove(
+  client: CalendarClient,
+  bookingId: string,
+  body: MoveBody
+): Promise<Result<BookingResponse>> {
+  try {
+    return { ok: true, value: await client.bookings.move(bookingId, body) };
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    const message =
+      error instanceof MiotCalendarApiError
+        ? error.message
+        : "Failed to move booking";
+    logger.error({ err: error, bookingId }, "Failed to move booking");
+    return {
+      ok: false,
+      error: NextResponse.json({ error: message }, { status }),
+    };
+  }
+}
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ bookingId: string }> }
@@ -67,23 +151,8 @@ export async function POST(
 
   const { bookingId } = await params;
 
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 }
-    );
-  }
-
-  const parsed = MoveBodySchema.safeParse(rawBody);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "slot { date, hour, minutes } is required" },
-      { status: 400 }
-    );
-  }
+  const body = await parseMoveBody(request);
+  if (!body.ok) return body.error;
 
   const client = createMiotCalendarClient({
     baseUrl: MIOT_CALENDAR_URL,
@@ -92,44 +161,12 @@ export async function POST(
     },
   });
 
-  // Snapshot the pre-move state so we can reverse the move if the downstream
-  // calendar-binding call fails. The booking id is stable across a move so
-  // this is just one extra GET, not a wholly different write.
-  let original: BookingResponse;
-  try {
-    original = await client.bookings.get(bookingId);
-  } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    if (status === 404) {
-      return NextResponse.json(
-        { error: "Booking not found" },
-        { status: 404 }
-      );
-    }
-    logger.error({ err: error, bookingId }, "Failed to load booking for move");
-    return NextResponse.json(
-      { error: "Failed to load booking" },
-      { status }
-    );
-  }
+  const snapshot = await snapshotBooking(client, bookingId);
+  if (!snapshot.ok) return snapshot.error;
 
-  // Run the move.
-  let moved: BookingResponse;
-  try {
-    moved = await client.bookings.move(bookingId, parsed.data);
-  } catch (error) {
-    const status = error instanceof MiotCalendarApiError ? error.status : 500;
-    logger.error({ err: error, bookingId }, "Failed to move booking");
-    return NextResponse.json(
-      {
-        error:
-          error instanceof MiotCalendarApiError
-            ? error.message
-            : "Failed to move booking",
-      },
-      { status }
-    );
-  }
+  const move = await executeMove(client, bookingId, body.value);
+  if (!move.ok) return move.error;
+  const moved = move.value;
 
   // Notify the coordinator about the (possibly refreshed) calendar binding.
   // Stage is derived from `resource.data` exactly like the create path — the
@@ -140,28 +177,26 @@ export async function POST(
     calendarId: moved.calendarId,
     resource: { data: moved.resource.data },
   });
-  if (bindingPayload) {
-    const bindingResult = await runCalendarBinding(
-      authResult.session,
-      bindingPayload
-    );
-    if (!bindingResult.ok) {
-      const compensation = await compensateMove(
-        client,
-        bookingId,
-        original,
-        bindingResult.message
-      );
-      return NextResponse.json(
-        {
-          error: bindingResult.message,
-          calendarBindingFailed: true,
-          bookingCompensated: compensation.compensated,
-        },
-        { status: bindingResult.status }
-      );
-    }
-  }
+  if (!bindingPayload) return NextResponse.json(moved);
 
-  return NextResponse.json(moved);
+  const bindingResult = await runCalendarBinding(
+    authResult.session,
+    bindingPayload
+  );
+  if (bindingResult.ok) return NextResponse.json(moved);
+
+  const compensation = await compensateMove(
+    client,
+    bookingId,
+    snapshot.value,
+    bindingResult.message
+  );
+  return NextResponse.json(
+    {
+      error: bindingResult.message,
+      calendarBindingFailed: true,
+      bookingCompensated: compensation.compensated,
+    },
+    { status: bindingResult.status }
+  );
 }

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -1,0 +1,167 @@
+import {
+  createMiotCalendarClient,
+  MiotCalendarApiError,
+  type BookingResponse,
+} from "@microboxlabs/miot-calendar-client";
+import { requireAuth } from "../../../../utils/alfresco-crud-client";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { z } from "zod";
+import {
+  extractCalendarBindingPayload,
+  runCalendarBinding,
+} from "../../binding-helpers";
+
+const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+
+const MoveBodySchema = z.object({
+  slot: z.object({
+    date: z.string().min(1),
+    hour: z.number().int().min(0).max(23),
+    minutes: z.number().int().min(0).max(59),
+  }),
+  resource: z
+    .object({
+      id: z.string().min(1),
+      type: z.string().optional(),
+      label: z.string().optional(),
+      data: z.record(z.string(), z.unknown()).optional(),
+    })
+    .optional(),
+});
+
+type CalendarClient = ReturnType<typeof createMiotCalendarClient>;
+
+/**
+ * Reverse-move compensation: re-issue a move using the pre-move snapshot so
+ * the booking lands back where it started. Only logs on failure — the caller
+ * still surfaces the original (binding) error to the user.
+ */
+async function compensateMove(
+  client: CalendarClient,
+  bookingId: string,
+  original: BookingResponse,
+  cause: unknown
+): Promise<{ compensated: boolean }> {
+  try {
+    await client.bookings.move(bookingId, {
+      slot: original.slot,
+      resource: original.resource,
+    });
+    return { compensated: true };
+  } catch (error) {
+    logger.error(
+      { err: error, bookingId, cause },
+      "Failed to compensate move after calendar-binding failure — manual cleanup may be required"
+    );
+    return { compensated: false };
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ bookingId: string }> }
+) {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) return authResult.response;
+
+  const { bookingId } = await params;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  const parsed = MoveBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "slot { date, hour, minutes } is required" },
+      { status: 400 }
+    );
+  }
+
+  const client = createMiotCalendarClient({
+    baseUrl: MIOT_CALENDAR_URL,
+    headers: {
+      Authorization: `Bearer ${authResult.session.user?.rawJWT ?? authResult.session.user?.ticket ?? ""}`,
+    },
+  });
+
+  // Snapshot the pre-move state so we can reverse the move if the downstream
+  // calendar-binding call fails. The booking id is stable across a move so
+  // this is just one extra GET, not a wholly different write.
+  let original: BookingResponse;
+  try {
+    original = await client.bookings.get(bookingId);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    if (status === 404) {
+      return NextResponse.json(
+        { error: "Booking not found" },
+        { status: 404 }
+      );
+    }
+    logger.error({ err: error, bookingId }, "Failed to load booking for move");
+    return NextResponse.json(
+      { error: "Failed to load booking" },
+      { status }
+    );
+  }
+
+  // Run the move.
+  let moved: BookingResponse;
+  try {
+    moved = await client.bookings.move(bookingId, parsed.data);
+  } catch (error) {
+    const status = error instanceof MiotCalendarApiError ? error.status : 500;
+    logger.error({ err: error, bookingId }, "Failed to move booking");
+    return NextResponse.json(
+      {
+        error:
+          error instanceof MiotCalendarApiError
+            ? error.message
+            : "Failed to move booking",
+      },
+      { status }
+    );
+  }
+
+  // Notify the coordinator about the (possibly refreshed) calendar binding.
+  // Stage is derived from `resource.data` exactly like the create path — the
+  // planner sets carrier+driver+truck during the "Asignar" gate, so a move
+  // that crosses that gate must announce the new stage. On binding failure
+  // we reverse the move so the user sees a consistent state.
+  const bindingPayload = extractCalendarBindingPayload({
+    calendarId: moved.calendarId,
+    resource: { data: moved.resource.data },
+  });
+  if (bindingPayload) {
+    const bindingResult = await runCalendarBinding(
+      authResult.session,
+      bindingPayload
+    );
+    if (!bindingResult.ok) {
+      const compensation = await compensateMove(
+        client,
+        bookingId,
+        original,
+        bindingResult.message
+      );
+      return NextResponse.json(
+        {
+          error: bindingResult.message,
+          calendarBindingFailed: true,
+          bookingCompensated: compensation.compensated,
+        },
+        { status: bindingResult.status }
+      );
+    }
+  }
+
+  return NextResponse.json(moved);
+}

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/binding-helpers.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/binding-helpers.ts
@@ -1,0 +1,106 @@
+import { logger } from "@/lib/logger";
+import {
+  notifyCalendarBinding,
+  type CalendarBindingPayload,
+  type CalendarBindingStage,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import type { Session } from "next-auth";
+
+/**
+ * Minimal shape of a planner-driven booking payload — enough to derive the
+ * calendar-binding call. Both `POST /bookings` and `POST /bookings/{id}/move`
+ * accept supersets of this; this is the only piece the binding-extractor
+ * actually reads.
+ */
+export type BindingSourceBody = {
+  calendarId: string;
+  resource?: {
+    data?: Record<string, unknown>;
+  };
+};
+
+/**
+ * Build the calendar-binding payload from a planner-driven booking write.
+ * Returns null when the booking isn't planner-driven (no
+ * `mintral_serviceCode` / `mintral_serviceKind` on the resource data).
+ *
+ * `stage` is selected by the planner UI's actual gate, not the dropdown
+ * defaults: carrier+driver+truck all set → `assigned`; otherwise → `planned`.
+ * Mirrors `planning-sidebar-form.tsx`'s "Asignar" button enable rule.
+ */
+export function extractCalendarBindingPayload(
+  body: BindingSourceBody
+): CalendarBindingPayload | null {
+  const data = body.resource?.data;
+  if (!data || typeof data !== "object") return null;
+
+  const numeroServicio = readString(data, "mintral_serviceCode");
+  if (!numeroServicio) return null;
+
+  const carrierId = readString(data, "assignedCarrier");
+  const driverId = readString(data, "assignedDriver");
+  const truckId = readString(data, "assignedTruck");
+  const isAssignment = Boolean(carrierId && driverId && truckId);
+
+  const stage: CalendarBindingStage = isAssignment ? "assigned" : "planned";
+  const payload: CalendarBindingPayload = {
+    numero_servicio: numeroServicio,
+    calendar_id: body.calendarId,
+    stage,
+  };
+
+  if (isAssignment) {
+    const serviceKindRaw = readString(data, "mintral_serviceKind");
+    // Webscript requires tipo_servicio for assigned. Without it, fall back
+    // to a planned-stage call so the booking still records the calendar
+    // binding without trying to push an incomplete Alerce request.
+    if (!serviceKindRaw) {
+      return { ...payload, stage: "planned" };
+    }
+    payload.tipo_servicio = serviceKindRaw.toUpperCase();
+    payload.carrier_id = carrierId;
+    payload.driver_id = driverId;
+    payload.truck_id = truckId;
+    payload.driver2_id = readString(data, "assignedDriver2") || null;
+    payload.trailer_id = readString(data, "assignedTrailer") || null;
+  }
+
+  return payload;
+}
+
+function readString(data: Record<string, unknown>, key: string): string {
+  const value = data[key];
+  return typeof value === "string" ? value : "";
+}
+
+export async function runCalendarBinding(
+  session: Session,
+  payload: CalendarBindingPayload
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  try {
+    const result = await notifyCalendarBinding(session, payload);
+    logger.info(
+      {
+        numeroServicio: payload.numero_servicio,
+        calendarId: payload.calendar_id,
+        stage: payload.stage,
+        status: result.status,
+      },
+      "Calendar binding call completed"
+    );
+    return { ok: true };
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        numeroServicio: payload.numero_servicio,
+        calendarId: payload.calendar_id,
+        stage: payload.stage,
+      },
+      "Failed to call calendar binding"
+    );
+    const message =
+      error instanceof Error ? error.message : "Failed to update calendar binding";
+    return { ok: false, status: 502, message };
+  }
+}

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -37,6 +37,12 @@ type AppBookingRequest = {
   };
   slot: BookingSlot;
   /**
+   * Existing booking id to exclude from the window-capacity count. Set during
+   * reassignment so the validator doesn't double-count the booking being moved
+   * (the cancel of the old booking runs after the new one is created).
+   */
+  excludeBookingId?: string;
+  /**
    * Optional Alfresco workflow advance to run as part of the same operation.
    * Booking is written first; if the task transition fails, the booking
    * created in this request is canceled (compensation). When the booking

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -6,13 +6,12 @@ import {
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
-import {
-  endTask,
-  notifyCalendarBinding,
-  type CalendarBindingPayload,
-  type CalendarBindingStage,
-} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { endTask } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import type { Session } from "next-auth";
+import {
+  extractCalendarBindingPayload,
+  runCalendarBinding,
+} from "./binding-helpers";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -36,12 +35,6 @@ type AppBookingRequest = {
     data?: Record<string, unknown>;
   };
   slot: BookingSlot;
-  /**
-   * Existing booking id to exclude from the window-capacity count. Set during
-   * reassignment so the validator doesn't double-count the booking being moved
-   * (the cancel of the old booking runs after the new one is created).
-   */
-  excludeBookingId?: string;
   /**
    * Optional Alfresco workflow advance to run as part of the same operation.
    * Booking is written first; if the task transition fails, the booking
@@ -187,91 +180,6 @@ async function runTaskAdvance(
   }
 }
 
-/**
- * Build the calendar-binding payload from the booking request. Returns null
- * when the booking isn't planner-driven (no `mintral_serviceCode` /
- * `mintral_serviceKind` on the resource data).
- *
- * `stage` is selected by the planner UI's actual gate, not the dropdown
- * defaults: carrier+driver+truck all set → `assigned`; otherwise → `planned`.
- * Mirrors `planning-sidebar-form.tsx`'s "Asignar" button enable rule.
- */
-function extractCalendarBindingPayload(
-  body: AppBookingRequest
-): CalendarBindingPayload | null {
-  const data = body.resource?.data;
-  if (!data || typeof data !== "object") return null;
-
-  const numeroServicio = readString(data, "mintral_serviceCode");
-  if (!numeroServicio) return null;
-
-  const carrierId = readString(data, "assignedCarrier");
-  const driverId = readString(data, "assignedDriver");
-  const truckId = readString(data, "assignedTruck");
-  const isAssignment = Boolean(carrierId && driverId && truckId);
-
-  const stage: CalendarBindingStage = isAssignment ? "assigned" : "planned";
-  const payload: CalendarBindingPayload = {
-    numero_servicio: numeroServicio,
-    calendar_id: body.calendarId,
-    stage,
-  };
-
-  if (isAssignment) {
-    const serviceKindRaw = readString(data, "mintral_serviceKind");
-    // Webscript requires tipo_servicio for assigned. Without it, fall back
-    // to a planned-stage call so the booking still records the calendar
-    // binding without trying to push an incomplete Alerce request.
-    if (!serviceKindRaw) {
-      return { ...payload, stage: "planned" };
-    }
-    payload.tipo_servicio = serviceKindRaw.toUpperCase();
-    payload.carrier_id = carrierId;
-    payload.driver_id = driverId;
-    payload.truck_id = truckId;
-    payload.driver2_id = readString(data, "assignedDriver2") || null;
-    payload.trailer_id = readString(data, "assignedTrailer") || null;
-  }
-
-  return payload;
-}
-
-function readString(data: Record<string, unknown>, key: string): string {
-  const value = data[key];
-  return typeof value === "string" ? value : "";
-}
-
-async function runCalendarBinding(
-  session: Session,
-  payload: CalendarBindingPayload
-): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
-  try {
-    const result = await notifyCalendarBinding(session, payload);
-    logger.info(
-      {
-        numeroServicio: payload.numero_servicio,
-        calendarId: payload.calendar_id,
-        stage: payload.stage,
-        status: result.status,
-      },
-      "Calendar binding call completed"
-    );
-    return { ok: true };
-  } catch (error) {
-    logger.error(
-      {
-        err: error,
-        numeroServicio: payload.numero_servicio,
-        calendarId: payload.calendar_id,
-        stage: payload.stage,
-      },
-      "Failed to call calendar binding"
-    );
-    const message =
-      error instanceof Error ? error.message : "Failed to update calendar binding";
-    return { ok: false, status: 502, message };
-  }
-}
 
 export async function POST(request: Request) {
   const authResult = await requireAuth();

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -738,7 +738,8 @@ interface PersistPlannedBookingParams {
 function buildBookingRequest(
   calendarId: string,
   service: SelectedService,
-  slot: SelectedSlot
+  slot: SelectedSlot,
+  oldBookingId: string | undefined
 ): BookingRequest {
   return {
     calendarId,
@@ -756,6 +757,10 @@ function buildBookingRequest(
       hour: slot.hour,
       minutes: slot.minutes,
     },
+    // During reassignment the server runs the window-capacity check before the old
+    // booking is cancelled, so without this exclude any in-window move would be
+    // rejected (the moved booking would be counted twice).
+    ...(oldBookingId ? { excludeBookingId: oldBookingId } : {}),
   };
 }
 
@@ -790,7 +795,7 @@ async function persistPlannedBooking({
   }
 
   try {
-    const bookingRequest = buildBookingRequest(calendarId, service, slot);
+    const bookingRequest = buildBookingRequest(calendarId, service, slot, oldBookingId);
     const booking = await createBooking(bookingRequest);
 
     // Re-confirming a service in the same slot (e.g. "Asignar" on an

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -25,7 +25,7 @@ import {
   updateCalendarTimeWindow,
   deactivateCalendarTimeWindow,
   createBooking,
-  updateBooking,
+  moveBooking,
   cancelBooking,
   listBookings,
   updateServiceCategory,
@@ -36,7 +36,11 @@ import type { BookingTaskAdvance } from "@/features/common/providers/client-api.
 import { parseUrlDate } from "@/features/calendar/services/calendar.service";
 import type { SlotResponse } from "@microboxlabs/miot-calendar-client";
 import { z } from "zod";
-import type { BookingRequest } from "@microboxlabs/miot-calendar-client";
+import type {
+  BookingRequest,
+  BookingResponse,
+  MoveBookingRequest,
+} from "@microboxlabs/miot-calendar-client";
 import {
   asTaskStageFromColumn,
   getNextTransition,
@@ -735,32 +739,48 @@ interface PersistPlannedBookingParams {
   refreshSlots: () => void;
 }
 
+function buildResource(service: SelectedService, slot: SelectedSlot) {
+  return {
+    id: service.id,
+    type: "service",
+    label: service.cliente,
+    data: {
+      ...service,
+      ...(slot.anden === undefined ? {} : { _anden: slot.anden }),
+    },
+  };
+}
+
 function buildBookingRequest(
   calendarId: string,
   service: SelectedService,
-  slot: SelectedSlot,
-  oldBookingId: string | undefined
+  slot: SelectedSlot
 ): BookingRequest {
   return {
     calendarId,
-    resource: {
-      id: service.id,
-      type: "service",
-      label: service.cliente,
-      data: {
-        ...service,
-        ...(slot.anden === undefined ? {} : { _anden: slot.anden }),
-      },
-    },
+    resource: buildResource(service, slot),
     slot: {
       date: dayjs(slot.date).format("YYYY-MM-DD"),
       hour: slot.hour,
       minutes: slot.minutes,
     },
-    // During reassignment the server runs the window-capacity check before the old
-    // booking is cancelled, so without this exclude any in-window move would be
-    // rejected (the moved booking would be counted twice).
-    ...(oldBookingId ? { excludeBookingId: oldBookingId } : {}),
+  };
+}
+
+// Move payload for an existing booking — slot + a fresh resource snapshot so
+// any planner-side overrides (serviceCategory, assignment tuple, _anden, …)
+// land in `cld_bookings.resource_data` as part of the same write.
+function buildMoveRequest(
+  service: SelectedService,
+  slot: SelectedSlot
+): MoveBookingRequest {
+  return {
+    slot: {
+      date: dayjs(slot.date).format("YYYY-MM-DD"),
+      hour: slot.hour,
+      minutes: slot.minutes,
+    },
+    resource: buildResource(service, slot),
   };
 }
 
@@ -795,23 +815,17 @@ async function persistPlannedBooking({
   }
 
   try {
-    const bookingRequest = buildBookingRequest(calendarId, service, slot, oldBookingId);
-    const booking = await createBooking(bookingRequest);
-
-    // Re-confirming a service in the same slot (e.g. "Asignar" on an
-    // already-planned service) hits the bookings POST 409 path, which resolves
-    // to the *existing* booking without applying the new resource.data — and so
-    // `booking.id === oldBookingId`. Push the payload onto it explicitly so the
-    // change (e.g. the assignment tuple) survives a refresh, and skip the
-    // old-booking cancel below since it would delete the booking we just kept.
-    const reusedExistingBooking =
-      oldBookingId !== undefined && booking.id === oldBookingId;
-    if (reusedExistingBooking) {
-      // On failure the pre-existing booking is left intact (with stale data);
-      // rethrow so the outer catch rolls back the optimistic UI. We never
-      // cancel it here — it is the service's current plan.
-      await updateBooking(booking.id, { resource: bookingRequest.resource });
-    }
+    // Existing booking → atomic in-place move via POST /bookings/{id}/move.
+    // The booking id is preserved; a same-slot call collapses to a
+    // payload-only update on the server. This subsumes both the planner's
+    // "Reasignar" flow (different slot) and the "Asignar" flow on an
+    // already-planned service (same slot, refreshed assignment tuple).
+    //
+    // No follow-up cancel is needed — the row is re-pointed in place, not
+    // create-then-delete. The bookingIds map keeps the same id.
+    const booking: BookingResponse = oldBookingId
+      ? await moveBooking(oldBookingId, buildMoveRequest(service, slot))
+      : await createBooking(buildBookingRequest(calendarId, service, slot));
 
     await syncServiceCategoryWithWorkflow(service, booking.id, liveTaskId);
     if (taskAdvance) {
@@ -824,17 +838,10 @@ async function persistPlannedBooking({
       return next;
     });
 
-    if (oldBookingId && !reusedExistingBooking) {
-      await cancelBookingWithWarning(
-        oldBookingId,
-        "Failed to cancel old booking:"
-      );
-    }
-
     refreshSlots();
     setBookingVersion((v) => v + 1);
   } catch (err) {
-    console.warn("Failed to create booking:", err);
+    console.warn("Failed to persist booking:", err);
     rollbackPlannedService(
       setPlannedServices,
       service.id,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -34,13 +34,13 @@ import {
 } from "@/features/common/providers/client-api.provider";
 import type { BookingTaskAdvance } from "@/features/common/providers/client-api.provider";
 import { parseUrlDate } from "@/features/calendar/services/calendar.service";
-import type { SlotResponse } from "@microboxlabs/miot-calendar-client";
-import { z } from "zod";
 import type {
   BookingRequest,
   BookingResponse,
   MoveBookingRequest,
+  SlotResponse,
 } from "@microboxlabs/miot-calendar-client";
+import { z } from "zod";
 import {
   asTaskStageFromColumn,
   getNextTransition,

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -57,6 +57,7 @@ import type {
   BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
+  MoveBookingRequest,
   SlotResponse,
   SlotListResponse,
 } from "@microboxlabs/miot-calendar-client";
@@ -1797,6 +1798,32 @@ export async function updateBooking(
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));
     throw new Error(err.error ?? "Failed to update booking");
+  }
+  return response.json();
+}
+
+/**
+ * Atomically reassign a booking. The server re-points the booking row at the
+ * new slot (and optionally refreshes its resource payload) in one transaction
+ * — the booking id is preserved, no row is created or deleted. A same-slot
+ * call collapses to a payload-only update, which is why the planner can route
+ * both "Reasignar" and "Asignar"-on-already-planned through here.
+ */
+export async function moveBooking(
+  bookingId: string,
+  body: MoveBookingRequest
+): Promise<BookingResponse> {
+  const response = await fetch(
+    `/app/api/calendar/bookings/${bookingId}/move`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.error ?? "Failed to move booking");
   }
   return response.json();
 }

--- a/turbo-repo/packages/miot-calendar-client/package.json
+++ b/turbo-repo/packages/miot-calendar-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-calendar-client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
@@ -5,6 +5,7 @@ import type {
   BookingResponse,
   BookingListResponse,
   BookingUpdateRequest,
+  MoveBookingRequest,
 } from "../types.js";
 import { createMockFetch } from "./test-utils.js";
 
@@ -111,19 +112,6 @@ describe("bookings", () => {
       expect(headers["X-User-Id"]).toBe("user-42");
     });
 
-    it("forwards excludeBookingId in the request body when set", async () => {
-      const { fn, call } = createMockFetch(sampleBooking);
-      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
-
-      const reassignRequest: BookingRequest = {
-        ...bookingRequest,
-        excludeBookingId: "old-booking-id",
-      };
-      await client.bookings.create(reassignRequest);
-
-      expect(call.init.body).toBe(JSON.stringify(reassignRequest));
-    });
-
     it("does not send X-User-Id when userId is not provided", async () => {
       const { fn, call } = createMockFetch(sampleBooking);
       const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
@@ -161,6 +149,45 @@ describe("bookings", () => {
       const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
 
       const result = await client.bookings.update("b-1", updateRequest);
+
+      expect(result).toEqual(sampleBooking);
+    });
+  });
+
+  describe("move", () => {
+    const moveRequest: MoveBookingRequest = {
+      slot: { date: "2025-06-01", hour: 11, minutes: 0 },
+    };
+
+    it("sends POST to bookings/:id/move with body", async () => {
+      const { fn, call } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      await client.bookings.move("b-1", moveRequest);
+
+      expect(call.init.method).toBe("POST");
+      expect(call.url).toBe(`${BASE_URL}${BOOKINGS_PATH}/b-1/move`);
+      expect(call.init.body).toBe(JSON.stringify(moveRequest));
+    });
+
+    it("forwards an optional resource payload", async () => {
+      const { fn, call } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const withResource: MoveBookingRequest = {
+        slot: { date: "2025-06-01", hour: 11, minutes: 0 },
+        resource: { id: "r-1", type: "room", label: "Room A (moved)" },
+      };
+      await client.bookings.move("b-1", withResource);
+
+      expect(call.init.body).toBe(JSON.stringify(withResource));
+    });
+
+    it("returns the moved booking", async () => {
+      const { fn } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const result = await client.bookings.move("b-1", moveRequest);
 
       expect(result).toEqual(sampleBooking);
     });

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
@@ -111,6 +111,19 @@ describe("bookings", () => {
       expect(headers["X-User-Id"]).toBe("user-42");
     });
 
+    it("forwards excludeBookingId in the request body when set", async () => {
+      const { fn, call } = createMockFetch(sampleBooking);
+      const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });
+
+      const reassignRequest: BookingRequest = {
+        ...bookingRequest,
+        excludeBookingId: "old-booking-id",
+      };
+      await client.bookings.create(reassignRequest);
+
+      expect(call.init.body).toBe(JSON.stringify(reassignRequest));
+    });
+
     it("does not send X-User-Id when userId is not provided", async () => {
       const { fn, call } = createMockFetch(sampleBooking);
       const client = createMiotCalendarClient({ baseUrl: BASE_URL, fetch: fn });

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -8,6 +8,7 @@ export type {
   BookingUpdateRequest,
   BookingResponse,
   BookingListResponse,
+  MoveBookingRequest,
   CalendarGroupRequest,
   CalendarGroupResponse,
   CalendarFilter,

--- a/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
@@ -4,6 +4,7 @@ import type {
   BookingRequest,
   BookingResponse,
   BookingUpdateRequest,
+  MoveBookingRequest,
 } from "../types.js";
 
 const BASE = "/api/v1/miot-calendar/bookings";
@@ -36,13 +37,27 @@ export function createBookingsApi(fetcher: Fetcher) {
 
     /**
      * Update an existing booking's resource payload in place. The slot is not
-     * changed; move a booking by cancelling and recreating it.
+     * changed; use {@link move} to move a booking (or update its payload as
+     * part of a move).
      */
     update(
       id: string,
       body: BookingUpdateRequest,
     ): Promise<BookingResponse> {
       return fetcher("PUT", `${BASE}/${id}`, { body });
+    },
+
+    /**
+     * Move a booking to a different slot in the same calendar (and optionally
+     * refresh its resource payload) as a single transactional operation. The
+     * booking id is preserved across the move; a same-slot call collapses to
+     * a payload-only update.
+     */
+    move(
+      id: string,
+      body: MoveBookingRequest,
+    ): Promise<BookingResponse> {
+      return fetcher("POST", `${BASE}/${id}/move`, { body });
     },
 
     cancel(id: string): Promise<void> {

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -41,6 +41,13 @@ export interface BookingRequest {
   calendarId: string;
   resource: ResourceData;
   slot: SlotData;
+  /**
+   * Existing booking id to exclude from the window-capacity count. Used during
+   * reassignment: the new booking is created before the old one is cancelled,
+   * so the validator would otherwise count the moved booking twice and reject
+   * any window-internal move into a full window.
+   */
+  excludeBookingId?: string;
 }
 
 export interface BookingUpdateRequest {

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -41,17 +41,26 @@ export interface BookingRequest {
   calendarId: string;
   resource: ResourceData;
   slot: SlotData;
-  /**
-   * Existing booking id to exclude from the window-capacity count. Used during
-   * reassignment: the new booking is created before the old one is cancelled,
-   * so the validator would otherwise count the moved booking twice and reject
-   * any window-internal move into a full window.
-   */
-  excludeBookingId?: string;
 }
 
 export interface BookingUpdateRequest {
   resource: ResourceData;
+}
+
+/**
+ * Move an existing booking to a different slot in the same calendar (and
+ * optionally refresh its resource payload) as a single transactional call.
+ * The booking id is preserved; no row is created or deleted. A same-slot
+ * request collapses to a payload-only update.
+ */
+export interface MoveBookingRequest {
+  slot: SlotData;
+  /**
+   * Optional resource payload. When provided, `resource.id` must match the
+   * booking's current resource id (a booking can't be repointed to a
+   * different resource).
+   */
+  resource?: ResourceData;
 }
 
 export interface BookingResponse {


### PR DESCRIPTION
## Summary
- Routes the planner's reassignment through the new backend `POST /bookings/{id}/move` endpoint, collapsing the previous two-call flow (`POST /bookings` + `DELETE /bookings/{old}`) into one atomic request.
- Drops the prior `excludeBookingId` band-aid — there's nothing to exclude when no row is being created.
- Same-slot calls collapse to a payload-only update on the server, so the planner's "Asignar"-on-already-planned re-confirm also routes through `move` and the old `POST → 409 → PUT` dance is gone.

## Why

Reassignment was two REST calls — `POST /bookings` then `DELETE /bookings/{old}`. That's (a) non-atomic (any failure between create and cancel leaves a ghost booking) and (b) tripped the cap check on the create because the old booking was still alive. The band-aid in the first commit on this PR worked around (b) by passing `excludeBookingId` so the validator subtracted the moved booking from the count, but did nothing for (a) and left a hack field that only made sense for one specific client flow.

The companion backend PR (**microboxlabs/miot-calendar#32**) replaces all of that with a single transactional move endpoint. This PR is the client wiring.

Closes #468.

## What changed

**`@microboxlabs/miot-calendar-client`**
- New `MoveBookingRequest` type and `bookings.move(id, body)` method.
- Drop `BookingRequest.excludeBookingId` and its test; add three round-trip tests for `move` (with slot only, with optional resource, returning the booking).

**`apps/app` — Next.js**
- New route: `POST /api/calendar/bookings/[bookingId]/move`. Snapshots the booking with a `GET`, runs the move, recomputes the calendar-binding payload from the post-move `resource.data`, calls the coordinator, and on binding failure issues a reverse-move so the booking lands back at its original slot — same compensation pattern the create path already uses, adapted to in-place moves.
- Extract `extractCalendarBindingPayload` / `runCalendarBinding` from `bookings/route.ts` into a sibling `binding-helpers.ts` shared by both routes. `AppBookingRequest` no longer carries `excludeBookingId`.
- `client-api.provider.ts`: add `moveBooking(id, body)` helper next to `createBooking`.

**`apps/app` — planner**
- `persistPlannedBooking` branches on `oldBookingId`: present → `moveBooking` (covers both "Reasignar" with a slot change and "Asignar"-on-already-planned with the same slot, since the server-side `move` handles both); absent → existing `createBooking` path.
- The booking id is stable across a move, so the `bookingIds` map keeps the same id and the trailing `cancelBookingWithWarning(oldBookingId)` is gone.
- `buildBookingRequest` reverts to its no-`oldBookingId` form; new `buildMoveRequest` produces the move payload. Both share `buildResource`.
- Drop the `updateBooking` import (the same-slot `POST → 409 → PUT` fallback is no longer needed).

## Test plan
- [x] `vitest run` in `@microboxlabs/miot-calendar-client` — 84/84 (existing 81 + 3 move tests).
- [x] `tsc --noEmit` in `apps/app` — clean.
- [x] After the backend PR lands, e2e in the planner:
  - At Mañana 9/9: move a chip within the window → success, count stays 9/9.
  - At Mañana 8/9: move a chip out to a different window → source drops to 7/9, target +1.
  - "Asignar" on already-planned chip (refresh assignment tuple) → succeeds without a slot change.
  - Kill the network mid-move → no ghost; booking stays at original slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to move/reassign existing bookings to different time slots in a single transactional operation.
  * Implemented calendar binding updates for moved bookings with automatic rollback if binding fails.

* **Tests**
  * Added test coverage for the move booking functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->