### PR TITLE
feat(calendar): order incidencia badges by hierarchy tier

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.ts
@@ -13,8 +13,15 @@ export interface IncidenciaConfig {
 }
 
 /**
- * Dictionary with optional overrides - unlisted incidencias use defaults
- * Only add entries when special styling or primary visibility is required
+ * Dictionary with optional overrides - unlisted incidencias use defaults.
+ * Priorities mirror the backend `mintral_calendarPlanningPriority` tier
+ * hierarchy in ecm-coordinator MintralModel.INCIDENT_TIER_BY_CODE so per-card
+ * badge stacking matches the sidebar's global list order.
+ *
+ *   tier 1 (priority 1): C309
+ *   tier 2 (priority 2): C307, C314, C319, C320, C326, C329
+ *   tier 3 (priority 3): C308
+ *   tier 4 (default 999): everything else
  */
 export const INCIDENCIA_DICTIONARY: Record<string, IncidenciaConfig> = {
   urgencia: {
@@ -29,7 +36,15 @@ export const INCIDENCIA_DICTIONARY: Record<string, IncidenciaConfig> = {
     priority: 2,
     visibility: "primary",
   },
-  // c4, c5, c7, etc. not listed = use defaults (gray, secondary, priority 999)
+  // Tier-2 codes — primary visibility, default color (gray) until a design
+  // refresh adds an orange palette token.
+  C314: { priority: 2, visibility: "primary" },
+  C319: { priority: 2, visibility: "primary" },
+  C320: { priority: 2, visibility: "primary" },
+  C326: { priority: 2, visibility: "primary" },
+  C329: { priority: 2, visibility: "primary" },
+  // Tier-3 code — primary visibility, default color.
+  C308: { priority: 3, visibility: "primary" },
 };
 
 /**


### PR DESCRIPTION
## Summary

Extends `INCIDENCIA_DICTIONARY` in `apps/app/src/features/calendar/components/planning/incidencias.types.ts` so per-card badge stacking mirrors the backend tier hierarchy from `mintral_calendarPlanningPriority` (microboxlabs/ecm-coordinator#247, already merged & deployed).

| Tier | Priority | Codes |
|------|----------|-------|
| 1 | 1 | C309 (existing `urgencia` entry, purple) |
| 2 | 2 | C307 (existing `shutdown` entry, red), **C314, C319, C320, C326, C329** (new) |
| 3 | 3 | **C308** (new) |
| 4 | 999 (default) | everything else |

The new entries set `visibility: "primary"` so the codes don't get hidden behind the "+N more" overflow chip alongside C309 and C307. Colors are intentionally unchanged — `urgencia` stays purple, `shutdown` stays red, new codes fall to the default gray. A future design pass can introduce an orange palette token if planners want visual parity with the spec image.

Lookup path: `categorizeIncidencias` receives bare codes (`C314`, `C308`, …) from `planning-sidebar-form.tsx:573` after the FE strips the `mintral_incident_` prefix. The new entries are keyed directly by code, so direct dictionary lookup resolves them — no `LABEL_TO_KEY_MAP` work needed.

The global sidebar list order is driven entirely by the backend preset and is unaffected by this PR.

Closes #474.

## Test plan

- [x] `npm run check-types -- --filter=@modulariot/app` — clean.
- [x] `npm run lint -- --filter=@modulariot/app` — 0 errors (678 pre-existing warnings unrelated).
- [x] Manual smoke: open the calendar planner sidebar against a service with `mintral_incident_C308` set (one exists in prod on `planService` per the BE validation). The C308 badge should render as a primary badge (visible without expanding "+N more").
- [x] Service with multiple incidences (e.g. C309 + C314) — C309 badge appears first, C314 second, both as primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced incident code configuration in the calendar planning feature. Added support for additional incident codes (C314, C319, C320, C326, C329, C308) with improved prioritization and visibility settings, optimizing how incidents are displayed and organized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/477)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->