### PR TITLE
feat(calendar): show clientRut in service bento (#485)

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/trip-information/trip-data.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/trip-information/trip-data.tsx
@@ -134,6 +134,11 @@ export default function TripData({
     },
     {
       icon: <FaTruck className="w-4 h-4" />,
+      label: msg.cards.clientRut,
+      value: task.mintral_clientRut ?? "-",
+    },
+    {
+      icon: <FaTruck className="w-4 h-4" />,
       label: (msg!.cards as I18nRecord).transportNumberCode as string,
       value: (task.mintral_servicePrincipalNumber as string) ?? "-",
     },

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2669,6 +2669,7 @@
     "transportNumberCode": "Transport Number",
     "patente": "License Plate",
     "supplierPrveCodigo": "Carrier Code",
+    "clientRut": "Client RUT",
     "driverContactInfo": "Contact information",
     "email": "Email",
     "status": "Status",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2714,6 +2714,7 @@
     "patente": "Patente",
     "supplierPrveCodigo": "Código transportista",
     "clientCode": "Código cliente",
+    "clientRut": "RUT Cliente",
     "clientName": "Cliente",
     "serviceCode": "Código servicio",
     "origin": "Origen",


### PR DESCRIPTION
Closes #485.

Adds a **"RUT Cliente" / "Client RUT"** row to the trip-data bento next to the existing **Cliente** row.

## Changes

* `task-forms/.../trip-information/trip-data.tsx` — one new entry in the `data` array after `clientName`. Reads `task.mintral_clientRut`.
* `lang/es.json` + `lang/en.json` — new `cards.clientRut` key at the top-level `cards` block. Labels reused from existing translations under `pages.shippingDetailsTaskForm.clientRut`.

## Why no backend dependency

`mintral_clientRut` is an existing Activiti process variable, populated on every trip ingest via `MintralModel.PROP_CLIENT_RUT` ↔ `service_client_rut` in `jsonKeyMapperV2`. It's been there long before #479 — every running and future instance already carries it.

## Sonar pattern

The new line uses plain `msg.cards.clientRut` / `task.mintral_clientRut ?? "-"` — no `as` casts, no `!` non-null assertion — to stay clean under S4325. The surrounding existing entries keep their casts but they're outside this PR's diff. Same pre-existing label-nesting issue noted on #479 still applies to the historical rows (out of scope here).

## Test plan

- [ ] Open any planner trip in the bento; confirm the new row sits below "Cliente" and above "N° de transporte".
- [ ] Pick a trip whose client RUT you know upstream; confirm the value displays.
- [ ] Confirm `-` shows for trips with no client RUT recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)