### PR TITLE
fix(calendar): stop dimming unavailable truck/trailer rows in selector

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
@@ -181,7 +181,6 @@ function TrailerCard({
   onClick,
   onMouseEnter,
 }: CardRenderProps<TrailerOption>) {
-  const isAvailable = trailer.estado === "disponible";
   const isGpsIntegrado = trailer.gpsIntegrado;
   const isOnline = trailer.estadoGps === "online";
   const subtitle = tr(
@@ -193,7 +192,6 @@ function TrailerCard({
     <VehicleCardButton
       isHighlighted={isHighlighted}
       isSelected={isSelected}
-      isAvailable={isAvailable}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
     >

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/truck-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/truck-search-dropdown.tsx
@@ -303,7 +303,6 @@ function TruckCard({
     <VehicleCardButton
       isHighlighted={isHighlighted}
       isSelected={isSelected}
-      isAvailable={isAvailable}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
     >

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/vehicle-card-shared.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/vehicle-card-shared.tsx
@@ -116,7 +116,6 @@ export function GpsStatusColumn({
 interface VehicleCardButtonProps {
   readonly isHighlighted: boolean;
   readonly isSelected: boolean;
-  readonly isAvailable: boolean;
   readonly onClick: () => void;
   readonly onMouseEnter: () => void;
   readonly children: React.ReactNode;
@@ -125,7 +124,6 @@ interface VehicleCardButtonProps {
 export function VehicleCardButton({
   isHighlighted,
   isSelected,
-  isAvailable,
   onClick,
   onMouseEnter,
   children,
@@ -138,8 +136,7 @@ export function VehicleCardButton({
       className={twMerge(
         "w-full text-left p-3 transition-colors",
         isHighlighted && "bg-blue-50 dark:bg-blue-900/30",
-        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50",
-        !isAvailable && "opacity-60"
+        isSelected && !isHighlighted && "bg-gray-50 dark:bg-gray-700/50"
       )}
     >
       {children}


### PR DESCRIPTION
## Summary

- Drop `opacity-60` (and the now-unused `isAvailable` prop) from the shared `VehicleCardButton` so truck and trailer search-result rows render at full opacity, matching the driver and carrier selectors.
- Availability is still communicated by the green "Habilitado" / amber "No habilitado" badge in the truck card header, so no information is lost.

Closes #487

## Test plan

- [x] Open the planning sidebar's truck selector with at least one `ocupado` truck in the list — row should no longer appear dimmed.
- [x] Same check for the trailer selector.
- [x] Compare visually against driver and carrier selectors — all four should now look consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined vehicle card components in assignment search dropdowns. Availability status is now managed through the dropdown selection logic rather than individual card indicators, simplifying the interface layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->