### PR TITLE
fix(calendar): surface truck location on assignment map preview

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "../../utils/alfresco-crud-client";
 import {
+  decodeEwkbPoint,
   fetchAccreditedResources,
   invalidateAccreditedResourcesCache,
   type AccreditedResourceType,
@@ -129,8 +130,8 @@ export async function GET(request: Request) {
         : [];
 
     return NextResponse.json({
-      data: page,
-      pinned,
+      data: page.map(decodeTruckPosition),
+      pinned: pinned.map(decodeTruckPosition),
       total: allRows.length,
       filteredTotal: filtered.length,
       offset,
@@ -167,4 +168,25 @@ function applyQuery(
       name?.includes(needle) === true || identifier?.includes(needle) === true
     );
   });
+}
+
+/**
+ * Decode `row.location` (SRID-prefixed EWKB hex from
+ * `fn_rd_accredited_resources`) into `latitude`/`longitude` for TRUCK rows.
+ * Non-TRUCK rows, trucks without a position, and rows with malformed EWKB
+ * pass through unchanged — the client treats absent coordinates as "no
+ * pin". Heading is not in the upstream row today, so it defaults to 0.
+ */
+function decodeTruckPosition(
+  row: PgrestAccreditedResourceRow
+): PgrestAccreditedResourceRow {
+  if (row.resource_type !== "TRUCK") return row;
+  const point = decodeEwkbPoint(row.location);
+  if (!point) return row;
+  return {
+    ...row,
+    latitude: point.latitude,
+    longitude: point.longitude,
+    heading: 0,
+  };
 }

--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -495,8 +495,27 @@ export interface PgrestAccreditedResourceRow {
   is_acredited: "ACREDITED" | "NOT ACREDITED";
   trip_count: number | null;
   last_trip: string | null;
+  /**
+   * GPS integration flag from the upstream catalog (TRUCK rows only).
+   * `INTEGRATED` means the asset has telemetry plumbing wired up, regardless
+   * of whether a recent position is on file.
+   */
+  integration: "INTEGRATED" | "NOT INTEGRATED" | null;
+  /**
+   * Last-known position as EWKB hex (SRID-prefixed point, 4326) for TRUCK
+   * rows. Null when the asset has no position recorded. Decoded server-side
+   * by `decodeEwkbPoint`; the calendar route surfaces the resulting
+   * `latitude`/`longitude` to the client.
+   */
+  location: string | null;
   symptoms: Record<string, number> | null;
   updated_at: string | null;
+  // Server-decoded coordinates (TRUCK rows only) — derived from `location`
+  // at the route boundary so the client doesn't need a WKB decoder. Absent
+  // on non-TRUCK rows or when `location` is null/malformed.
+  latitude?: number | null;
+  longitude?: number | null;
+  heading?: number | null;
 }
 
 /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -101,7 +101,7 @@ function TruckMapDisplay({ truck }: TruckMapDisplayProps) {
     <div className="mt-2 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div className="h-48 w-full">
         <MapVisualization
-          mapStyle="streets"
+          mapStyle="satellite"
           layers={layers}
           mapRef={mapRef}
           onZoomChange={handleZoomChange}
@@ -186,29 +186,35 @@ function carrierRowToOption(row: AccreditedResource): CarrierOption {
 
 /**
  * Map an `ams.fn_rd_accredited_resources` TRUCK row onto the existing
- * `TruckOption` shape. The upstream function does not carry GPS/telemetry
- * fields, so `gpsIntegrado`, `estadoGps`, lat/lng and `heading` default to a
- * "no signal" baseline. `estado` piggybacks on `is_acredited` (ACREDITED →
- * `disponible`, NOT ACREDITED → `ocupado`) to reuse the existing UI badge
- * without introducing a parallel state flag.
+ * `TruckOption` shape. The upstream row carries `integration` (GPS plumbing
+ * flag) and `location` (EWKB hex of the last-known position); the route
+ * handler decodes the latter into `latitude`/`longitude` so the dropdown's
+ * map preview can drop a pin. `gpsIntegrado` is driven by `integration`
+ * (independent of whether a recent position is on file); `estadoGps`
+ * reflects coordinate availability — `online` only when we have something
+ * to plot. `estado` piggybacks on `is_acredited` (ACREDITED → `disponible`,
+ * NOT ACREDITED → `ocupado`) to reuse the existing UI badge.
  */
 function truckRowToOption(row: AccreditedResource): TruckOption {
   const plate = row.identifier ?? "";
   const symptoms = row.symptoms ?? {};
+  const latitude = row.latitude ?? null;
+  const longitude = row.longitude ?? null;
+  const hasPosition = latitude != null && longitude != null;
   return {
     id: row.resource_id,
     plate,
     marca: row.resource_name ?? "",
     tipo: "truck",
     estado: row.is_acredited === "ACREDITED" ? "disponible" : "ocupado",
-    gpsIntegrado: false,
-    estadoGps: "offline",
+    gpsIntegrado: row.integration === "INTEGRATED",
+    estadoGps: hasPosition ? "online" : "offline",
     viajesPrevios: row.trip_count ?? 0,
     ultimoViaje: formatLastTrip(row.last_trip),
     perdidasSenal: symptoms[SYMPTOM_LOST_SIGNAL] ?? 0,
-    latitude: null,
-    longitude: null,
-    heading: 0,
+    latitude,
+    longitude,
+    heading: row.heading ?? 0,
   };
 }
 

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -20,8 +20,16 @@ export interface AccreditedResource {
   is_acredited: "ACREDITED" | "NOT ACREDITED";
   trip_count: number | null;
   last_trip: string | null;
+  /** GPS integration flag (TRUCK rows). Independent of whether a position is on file. */
+  integration: "INTEGRATED" | "NOT INTEGRATED" | null;
   symptoms: Record<string, number> | null;
   updated_at: string | null;
+  // Server-decoded last-known position for TRUCK rows (from row.location
+  // EWKB hex, decoded at the route boundary). Absent when no position is
+  // available or the row is not a TRUCK.
+  latitude?: number | null;
+  longitude?: number | null;
+  heading?: number | null;
 }
 
 export type AccreditedResourceType = AccreditedResource["resource_type"];


### PR DESCRIPTION
## Summary

- The `PgrestAccreditedResourceRow` type was stale: missing `integration` and `location` (EWKB hex), which `ams.fn_rd_accredited_resources` already returns per TRUCK row. `truckRowToOption` therefore hardcoded null lat/lng and the assignment map preview never rendered a pin (e.g. `1633173-V` → `TKRD64`).
- Decode `row.location` via `decodeEwkbPoint` at the calendar route boundary for both `data` and `pinned` arrays, no extra pgrest round-trip needed. Drive `gpsIntegrado` from `row.integration === "INTEGRATED"` (independent of recent position) and `estadoGps` from coordinate presence.
- Switch the map preview style from `streets` → `satellite` (Mapbox `satellite-streets-v11`) so the pin sits over imagery with street-label overlays.

Closes #490

## Test plan

- [x] Open `Asignar` on a service whose truck has telemetry (e.g. `1633173-V` / `TKRD64`); confirm GPS integrado: ✓ Integrado, Estado GPS: 🟢 Online, and a pin renders at the last-known position over satellite tiles.
- [x] Open `Asignar` on a truck with `integration = INTEGRATED` but no `location`; confirm GPS badge stays integrated while the map stays empty (no crash).
- [x] Open `Asignar` on a `NOT INTEGRATED` truck; confirm GPS shows ✗ No Integrado and the map stays empty.
- [x] Confirm `npm run check-types` passes for the app workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Truck GPS location data now displayed with latitude, longitude, and heading information.
  * Truck integration status is now tracked and visible.
  * GPS status (online/offline) automatically determined from location data availability.

* **UI/UX**
  * Truck map preview updated to use satellite view for improved location visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->