### PR TITLE
feat(calendar): add read-only viewer role (GROUP_CALENDAR_VIEWER)

### DIFF
--- a/turbo-repo/.cursor/plans/calendar_readonly_role.plan.md
+++ b/turbo-repo/.cursor/plans/calendar_readonly_role.plan.md
@@ -1,0 +1,189 @@
+# Plan: Calendar read-only role (`GROUP_CALENDAR_VIEWER`)
+
+## Status (2026-05-18)
+
+| Phase | Status | Notes |
+|---|---|---|
+| 1. Permission plumbing | ✅ done | `pages.ts` updated; three-way comment block added. |
+| 2. Viewer-aware grid + chip handlers | ✅ done | `inspectPlannedService` added to context; chip left-click no-ops for viewers; right-click populates sidebar. No live drag/drop existed to gate. |
+| 3. Generalize `isReadOnlyView` in sidebar form | ✅ done | Viewer banner key added (en/es). Tabs allow inspection in read-only mode. |
+| 4. Context menu (header-only for viewers) | ✅ done | No code change required — existing per-group gates already produce a header-only menu when neither plan nor assign is granted. Comment added. |
+| 5. Persist-boundary guard | ✅ done | `confirmService` + `removeService` throw if caller lacks both groups. |
+| 6. Backend enforcement | ✅ done | New `requireAnyGroup` helper. POST `/bookings`, POST `/bookings/{id}/move`, DELETE/PUT `/bookings/{id}` all 403 viewers. GET stays open. |
+| 7. Alfresco group + docs | ⏳ partial | Inline docs done; **operational step pending**: create `GROUP_CALENDAR_VIEWER` per tenant in Alfresco and assign users. Cannot be done from this commit. |
+
+## URL override for previewing read-only mode
+
+Added after Phase 6: a `?as=viewer` query param lets a user who holds **both** `GROUP_CALENDAR_VIEWER` and one of the mutating groups force the viewer experience without giving up their permissions. The check lives in a single hook — `features/calendar/components/planning/use-calendar-view-mode.ts` — used by `use-planning-grid`, `planning-sidebar-form`, and the persist-boundary guard in `planning-selection-context`. The override collapses effective `canPlan` / `canAssign` to false, so every downstream gate flips into read-only with no further wiring.
+
+Without `GROUP_CALENDAR_VIEWER` the param is silently ignored — it cannot be used to escape missing permissions. The backend (`requireAnyGroup`) is unchanged: it sees the user's real Alfresco groups and remains authoritative. The override is a client-side preview tool, not a security control.
+
+Test path:
+- `…/calendar/{id}/planning?as=viewer` → forces viewer UI for users with all three groups (planner + assigner + viewer) or any subset that includes viewer.
+- Strip the param → returns to the user's real permissions.
+
+## Operational hand-off (Phase 7 remainder)
+
+1. Create the Alfresco group `GROUP_CALENDAR_VIEWER` for each tenant that needs read-only calendar access. Same scoping pattern as `GROUP_PLANNING` / `GROUP_ASSIGNMENT`.
+2. Assign target users to the new group via the existing collaborator-management flow.
+3. Smoke-test in browser: viewer should see the Calendar nav entry, right-click a chip to inspect, and never be able to mutate. The backend will 403 any attempted mutation regardless.
+
+
+
+## Goal
+
+Introduce a calendar viewer role that can:
+
+- See the calendar nav entry and open the planning view.
+- Right-click any planned chip to inspect its details (sidebar opens with the chip's data; minimal context menu).
+- Inspect existing assignment + planning fields in the sidebar (rendered as **disabled inputs**, same layout as today).
+
+…and cannot:
+
+- Open the sidebar on an empty slot (left-click on grid does nothing for viewers — there is nothing to inspect).
+- Left-click a chip to select it (only right-click works, mirroring the "inspection-first" mental model).
+- Trigger any mutation: drag/drop, Asignar, Replanificar, Eliminar, Eliminar asignación, tab Submit buttons, or any underlying create/move/delete booking call.
+
+## Why this design
+
+- The calendar feature already splits permissions into `GROUP_PLANNING` (slot/click + Planificación tab + reassign/delete) and `GROUP_ASSIGNMENT` (Asignación tab + assign actions). A third orthogonal viewer role drops in cleanly.
+- The "past day" `isReadOnlyView` flag (`planning-sidebar-form.tsx:320-323`) already proves the visual pattern: existing form layout with mutation surfaces suppressed. We generalize that flag rather than building a parallel view.
+- Adding a new Alfresco group keeps Alfresco as the source of truth and matches every other tenant gate in the codebase (no special-cased "absence of groups" logic, no opening calendar to any authenticated user).
+- Backend enforcement on the Next.js API routes is the actual safety boundary — UI gating alone leaves the booking endpoints open today (they only check `requireAuth()`).
+
+## Scope decisions (locked in)
+
+| Decision | Choice |
+|---|---|
+| New Alfresco group | `GROUP_CALENDAR_VIEWER` |
+| Chip UX for viewer | Left-click: no-op. Right-click: open sidebar populated with the chip + show a minimal context menu. |
+| Sidebar appearance | Existing layout, all inputs `disabled`. Submit/cancel/Asignar/Replanificar/Eliminar buttons hidden. |
+| Backend enforcement scope (this plan) | Next.js API routes only (`/api/calendar/bookings`, `/move`, assignment, delete). Quarkus audit deferred (separate ticket if mutations live there). |
+| Role scoping | Same multi-tenancy semantics as `GROUP_PLANNING` / `GROUP_ASSIGNMENT`. No new per-calendar granularity. |
+
+## Phases
+
+Work one phase at a time. Do not start phase N+1 until phase N is committed and verified.
+
+### Phase 1 — Permission plumbing
+
+**Files**
+
+- `turbo-repo/apps/app/src/features/layout/models/pages.ts:36` — append `"GROUP_CALENDAR_VIEWER"` to the calendar entry's `requiredGroups` so viewers see the nav item.
+- Optionally introduce a constant export `CALENDAR_GROUPS = ["GROUP_PLANNING", "GROUP_ASSIGNMENT", "GROUP_CALENDAR_VIEWER"]` in a small auth-constants module if/when reused. Skip if only two call sites need it.
+
+**Acceptance**
+
+- A user whose Alfresco groups are exactly `["GROUP_CALENDAR_VIEWER"]` sees the Calendar entry in the sidebar.
+- Existing users with `GROUP_PLANNING` or `GROUP_ASSIGNMENT` see the entry as before.
+
+### Phase 2 — Grid: viewer-aware slot + chip handlers
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts`
+
+- Add `canView = !isLoadingPermissions && hasPermission(["GROUP_CALENDAR_VIEWER"])` next to the existing `canPlan` derivation.
+- `handleSelectSlot` (line 116-122): keep the `if (!canPlan) return;` guard. Empty-slot left-click stays a no-op for viewers (intentional — viewers have nothing to inspect on an empty cell).
+- Export `canView` from the hook for downstream consumers.
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx` (chip component — search for the click/contextmenu handlers)
+
+- Left-click handler: short-circuit if `!canPlan` (so viewers can't `selectChipSlot`). Today this routes through `selectChipSlot` from the grid hook.
+- Right-click handler: when `!canPlan && canView`, in addition to `selectChipResource` (visual highlight) and the existing context-menu open, also populate the sidebar with the chip's data. The cleanest path is to introduce a `inspectPlannedService(plannedService)` action on `planning-selection-context` that sets both `selectedSlot` (from the chip's slot) and a "viewing only" service reference — without entering reassign or assign mode.
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx`
+
+- Add `inspectPlannedService(plannedService)` to the context that sets the slot + populates the sidebar's displayed service tuple. Does NOT touch booking state, does NOT call any persist function. Pure read.
+
+**Drag/drop**: identify the drag handlers on chips and grid cells (look for `onDragStart`, `onDrop`, `dnd-kit` usage). Guard with `canPlan` — viewers should not be able to initiate or accept drag.
+
+**Acceptance**
+
+- As `GROUP_CALENDAR_VIEWER` only: left-click on empty cell does nothing. Left-click on a chip does nothing. Right-click on a chip opens the right sidebar populated with that chip + opens the context menu.
+- As `GROUP_PLANNING` user: behavior unchanged from today.
+- Drag/drop is disabled for viewers (chips not draggable, cells not drop targets).
+
+### Phase 3 — Sidebar: generalize `isReadOnlyView` and disable inputs
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx`
+
+- Extend the existing `isReadOnlyView` (line 320-323) to also evaluate true when `canView && !canPlan && !canAssign`. Keep the past-day branch unchanged.
+- For every `<input>`, `<select>`, dropdown / picker control inside the Planificación and Asignación tab content, add `disabled={isReadOnlyView}` (or pass through a prop on child components). Disabled styling is already wired via Flowbite.
+- Tab triggers (lines 875, 881): for viewers, render both tabs as enabled-but-non-mutating. The current `disabled={!canPlan}` / `disabled={!canAssign}` logic should be widened: if the user is in viewer mode, show tab content read-only instead of disabling the tab outright. Concretely: render tab content gated by `canPlan || isReadOnlyView` / `canAssign || isReadOnlyView`.
+- Submit / Asignar / Cancelar action buttons (lines 920-939 and the planning tab's equivalent): hide when `isReadOnlyView` is true. Past-day path already does this — confirm the same hides apply for the viewer path.
+
+**Acceptance**
+
+- As viewer, opening the sidebar via right-click renders both tabs with all fields populated and disabled. No submit / cancel / mutation buttons visible.
+- As viewer, switching tabs works and shows the inspectable data on each tab.
+- As `GROUP_PLANNING` user clicking a past-day slot: unchanged from today (already read-only).
+- As `GROUP_PLANNING` user clicking a future slot: tabs editable, mutation buttons visible.
+
+### Phase 4 — Context menu for viewer
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx`
+
+- Add `canView` to the permission set computed at the top.
+- Today the menu renders only buttons gated by `canPlan` / `canAssign`. For a pure viewer the menu would render with only the header. Options:
+  - **(a)** Skip the menu entirely for viewers — but the user explicitly asked for "right click shows context menu". So:
+  - **(b)** Keep the menu open with only the header (service ID) visible and no action buttons. This is consistent and minimal.
+  - **(c)** Add a single "Cerrar" (Close) item for clarity.
+- Pick **(b)** by default; revisit only if QA finds it confusing.
+
+**Acceptance**
+
+- Viewer right-click renders the menu with the service ID header and no action buttons.
+- All existing button visibility (Asignar / Replanificar / Eliminar / Eliminar asignación) behaves identically for users who have the underlying groups.
+
+### Phase 5 — Defense at the persist boundary (frontend)
+
+**File**: `turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx`
+
+- In `persistPlannedBooking` (line 800) and at every entry point that calls into it (look for `createBooking`, `moveBooking` invocations around lines 826-828), add an early guard: if the current user lacks both `GROUP_PLANNING` and `GROUP_ASSIGNMENT`, throw with a clear "Permission denied — viewer role" error and roll back local state. This catches any UI-bypass bug (a stale handler, a future contributor wiring a button without checking) before the network call leaves the browser.
+
+**Acceptance**
+
+- Hand-test: monkey-patch `canPlan` to true in devtools as a viewer, try to submit — the persist call throws and the local state rolls back.
+
+### Phase 6 — Backend enforcement (Next.js API)
+
+**Files** (verify exact paths during implementation):
+
+- `turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts`
+- `turbo-repo/apps/app/src/app/api/calendar/bookings/[id]/move/route.ts` (if separate file)
+- Any assignment / delete-assignment endpoints alongside.
+
+**Changes**
+
+- Augment `requireAuth()` calls with a `requireAnyGroup(["GROUP_PLANNING"])` for plan mutations (create, move that changes slot/time) and `requireAnyGroup(["GROUP_ASSIGNMENT"])` for assignment-only mutations. Reject with 403 otherwise.
+- If a generic helper does not exist, add `requireAnyGroup(groups: string[])` next to `requireAuth` (look in `features/auth/server` or similar). One small helper that fetches the caller's groups (already available via `getGroupsForPerson` per the explore report) and checks intersection.
+- A pure `GROUP_CALENDAR_VIEWER` user calling these endpoints directly receives 403.
+
+**Acceptance**
+
+- Curl test as viewer (or a Vitest with mocked session): POST /api/calendar/bookings returns 403.
+- Curl test as `GROUP_PLANNING` user: succeeds as today.
+- Existing happy-path e2e (if any) still passes.
+
+### Phase 7 — Alfresco group + docs
+
+- Create `GROUP_CALENDAR_VIEWER` in Alfresco for each tenant that needs it (manual step or via the org admin tooling — confirm the operational process before commit).
+- Update `CLAUDE.md` (or the equivalent group reference) with the new role and its semantics.
+- Add a short note to `pages.ts` near the calendar entry explaining the three-way split: `GROUP_PLANNING` (full), `GROUP_ASSIGNMENT` (assignment-only), `GROUP_CALENDAR_VIEWER` (read-only inspection).
+
+**Acceptance**
+
+- A QA tenant has the group created and a test user assigned. End-to-end flow validated in browser.
+
+## Non-goals
+
+- Quarkus-side authorization audit — separate ticket. Confirm whether `quarkus-srv` mutates bookings; if yes, repeat the Phase 6 pattern there.
+- Per-calendar granularity (viewer of calendar A but not calendar B). Same scoping as the other two groups; not in scope.
+- New visual styling for the viewer mode (banner, tinted background). Existing disabled-field styling is sufficient. Add later if QA pushes back.
+- Read-only access to other modules (kanban, fleet, etc.). Out of scope.
+
+## Risks & open questions
+
+- **Drag/drop discovery**: I have not yet pinpointed every drag-and-drop entry point. Phase 2 implementation needs to grep for `onDrag`, `onDrop`, `useDraggable`, `useDroppable`, `dnd-kit` and confirm each is gated.
+- **`requireAnyGroup` helper**: confirm it doesn't already exist before adding. Search `features/auth/server` and adjacent.
+- **Context menu UX (b vs c)**: a header-only menu may feel "broken". If QA flags it, switch to option (c) — single "Cerrar" item — without re-planning.
+- **`canView` ⇒ `canPlan || canAssign || GROUP_CALENDAR_VIEWER`?** Decide during Phase 2 whether `canView` is "any of the three" (more reusable) or strictly "viewer-only". The plan currently treats it as viewer-only; widen if a downstream consumer needs the union.

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -3,7 +3,7 @@ import {
   MiotCalendarApiError,
   type BookingResponse,
 } from "@microboxlabs/miot-calendar-client";
-import { requireAuth } from "../../../../utils/alfresco-crud-client";
+import { requireAnyGroup } from "../../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
@@ -13,6 +13,12 @@ import {
 } from "../../binding-helpers";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
+
+// Same gate as the create/cancel routes — see ../../route.ts.
+const BOOKING_MUTATION_GROUPS = [
+  "GROUP_PLANNING",
+  "GROUP_ASSIGNMENT",
+] as const;
 
 const MoveBodySchema = z.object({
   slot: z.object({
@@ -146,8 +152,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ bookingId: string }> }
 ) {
-  const authResult = await requireAuth();
-  if (!authResult.authenticated) return authResult.response;
+  const authResult = await requireAnyGroup(BOOKING_MUTATION_GROUPS);
+  if (!authResult.authorized) return authResult.response;
 
   const { bookingId } = await params;
 

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/route.ts
@@ -2,19 +2,25 @@ import {
   createMiotCalendarClient,
   MiotCalendarApiError,
 } from "@microboxlabs/miot-calendar-client";
-import { requireAuth } from "../../../utils/alfresco-crud-client";
+import { requireAnyGroup } from "../../../utils/alfresco-crud-client";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
+// Same gate as the create/move routes — see ../route.ts.
+const BOOKING_MUTATION_GROUPS = [
+  "GROUP_PLANNING",
+  "GROUP_ASSIGNMENT",
+] as const;
+
 export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ bookingId: string }> }
 ) {
-  const authResult = await requireAuth();
-  if (!authResult.authenticated) return authResult.response;
+  const authResult = await requireAnyGroup(BOOKING_MUTATION_GROUPS);
+  if (!authResult.authorized) return authResult.response;
 
   const { bookingId } = await params;
   const client = createMiotCalendarClient({
@@ -47,8 +53,8 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ bookingId: string }> }
 ) {
-  const authResult = await requireAuth();
-  if (!authResult.authenticated) return authResult.response;
+  const authResult = await requireAnyGroup(BOOKING_MUTATION_GROUPS);
+  if (!authResult.authorized) return authResult.response;
 
   const { bookingId } = await params;
 

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -3,7 +3,21 @@ import {
   MiotCalendarApiError,
   type BookingResponse,
 } from "@microboxlabs/miot-calendar-client";
-import { requireAuth } from "../../utils/alfresco-crud-client";
+import {
+  requireAuth,
+  requireAnyGroup,
+} from "../../utils/alfresco-crud-client";
+
+// Booking mutations are gated on either GROUP_PLANNING (slot/time changes)
+// or GROUP_ASSIGNMENT (carrier/driver/truck changes) — pure
+// GROUP_CALENDAR_VIEWER users are rejected with 403. The route doesn't try
+// to split the two further: by the time a request reaches the calendar
+// backend the payload may carry both kinds of change in one move, and the
+// UI never sends a viewer-shaped request anyway. GET stays on requireAuth.
+const BOOKING_MUTATION_GROUPS = [
+  "GROUP_PLANNING",
+  "GROUP_ASSIGNMENT",
+] as const;
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { endTask } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
@@ -182,8 +196,8 @@ async function runTaskAdvance(
 
 
 export async function POST(request: Request) {
-  const authResult = await requireAuth();
-  if (!authResult.authenticated) return authResult.response;
+  const authResult = await requireAnyGroup(BOOKING_MUTATION_GROUPS);
+  if (!authResult.authorized) return authResult.response;
 
   const body: AppBookingRequest = await request.json();
   const client = createMiotCalendarClient({

--- a/turbo-repo/apps/app/src/app/api/utils/alfresco-crud-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/alfresco-crud-client.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import type { Session } from "next-auth";
 import { auth } from "@/auth";
-import { prepareAlfrescoAuth } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import {
+  prepareAlfrescoAuth,
+  getGroupsForPerson,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { logger } from "@/lib/logger";
 
 const ALFRESCO_API_URL = process.env.ECM_API_URL || "";
@@ -59,6 +62,56 @@ export async function requireAuth(): Promise<AuthResult> {
   }
 
   return { authenticated: true, session };
+}
+
+/**
+ * Result of an authorize-by-group check
+ */
+type AnyGroupResult =
+  | { authorized: true; session: Session; userGroups: string[] }
+  | { authorized: false; response: NextResponse };
+
+/**
+ * Authenticate, fetch the caller's Alfresco groups, and authorize if at
+ * least one group matches `allowedGroups`. Layered on top of `requireAuth`:
+ * the 401 path is identical, plus a 403 when authenticated but missing
+ * every allowed group. Use this on any mutating API route that should
+ * reject pure GROUP_CALENDAR_VIEWER (or other read-only) users.
+ *
+ * The membership lookup runs every request — there is no in-memory cache
+ * here. That matches the pattern in `task/unclaim/route.ts` and keeps the
+ * helper free of cross-request state; if Alfresco group lookups ever
+ * become a hot path, fold caching into `getGroupsForPerson` itself.
+ */
+export async function requireAnyGroup(
+  allowedGroups: readonly string[]
+): Promise<AnyGroupResult> {
+  const authResult = await requireAuth();
+  if (!authResult.authenticated) {
+    return { authorized: false, response: authResult.response };
+  }
+
+  const userGroups = await getGroupsForPerson(authResult.session);
+  const hasAccess = userGroups.some((g) => allowedGroups.includes(g));
+  if (!hasAccess) {
+    logger.warn(
+      { userEmail: authResult.session.user?.email, allowedGroups },
+      "Forbidden: caller lacks every required group"
+    );
+    return {
+      authorized: false,
+      response: NextResponse.json(
+        { error: "Forbidden: missing required group" },
+        { status: 403 }
+      ),
+    };
+  }
+
+  return {
+    authorized: true,
+    session: authResult.session,
+    userGroups,
+  };
 }
 
 /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -53,6 +53,7 @@ import {
   TimeWindowResponseSchema,
 } from "@/features/calendar/services/time-window.service";
 import { tr } from "@/features/i18n/tr.service";
+import { useCalendarViewMode } from "./use-calendar-view-mode";
 import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
 
 dayjs.extend(isoWeek);
@@ -924,6 +925,14 @@ interface PlanningSelectionContextType {
    * context menu, which opens immediately after.
    */
   selectChipResource: (plannedService: PlannedService) => void;
+  /**
+   * Open the sidebar populated with an existing chip's planning + assignment
+   * data for inspection. Used by the calendar viewer role (no plan/assign
+   * permissions): right-clicking a chip both pops the context menu and
+   * pre-fills the sidebar via this call, so the sidebar's read-only render
+   * has values to show. Clears reassign/assign mode and highlights the chip.
+   */
+  inspectPlannedService: (plannedService: PlannedService) => void;
   /** True when the given service id is the chip currently highlighted via right-click. */
   isChipSelected: (serviceId: string) => boolean;
   /** Drop the chip highlight without touching slot/service selection. */
@@ -1087,6 +1096,17 @@ export function PlanningSelectionProvider({
     null
   );
   const [bookingVersion, setBookingVersion] = useState(0);
+
+  // Last line of defense against viewer-role UI bypass. Every booking
+  // mutation (create / move / cancel) must come from a user with at least
+  // one of the two mutating groups — checked again at the persist boundary
+  // inside `confirmService` and `removeService`. UI gating is the primary
+  // control; this guard catches stale handlers and future contributors
+  // wiring a button without the matching permission check. The `?as=viewer`
+  // override also collapses canPlan/canAssign to false, so a planner
+  // previewing viewer mode is treated as a viewer here too.
+  const { canPlan, canAssign, isLoadingPermissions } = useCalendarViewMode();
+  const canMutateBookings = !isLoadingPermissions && (canPlan || canAssign);
 
   // Load calendar parallelism from the backend
   const { calendars } = useCalendars();
@@ -1639,6 +1659,14 @@ export function PlanningSelectionProvider({
       finalSlot?: SelectedSlot,
       serviceOverrides?: Partial<SelectedService>
     ): Promise<boolean> => {
+      // Persist-boundary permission guard. UI surfaces are gated upstream
+      // for viewers — a successful call here implies a UI-bypass bug, so
+      // throw rather than silently no-op.
+      if (!canMutateBookings) {
+        throw new Error(
+          "confirmService: caller lacks GROUP_PLANNING and GROUP_ASSIGNMENT"
+        );
+      }
       // Use finalSlot if provided, otherwise fall back to selectedSlot
       const slotToUse = finalSlot ?? selectedSlot;
 
@@ -1733,6 +1761,7 @@ export function PlanningSelectionProvider({
       bookingIds,
       refreshSlots,
       getLiveTask,
+      canMutateBookings,
     ]
   );
 
@@ -1763,6 +1792,12 @@ export function PlanningSelectionProvider({
    */
   const removeService = useCallback(
     async (serviceId: string) => {
+      // Persist-boundary permission guard — see confirmService for context.
+      if (!canMutateBookings) {
+        throw new Error(
+          "removeService: caller lacks GROUP_PLANNING and GROUP_ASSIGNMENT"
+        );
+      }
       // Move the workflow task back toward planService BEFORE cancelling the
       // booking. Resolve the live task by `mintral_serviceCode` against the
       // kanban index — never trust a stored taskId, because Alfresco mints a
@@ -1815,7 +1850,7 @@ export function PlanningSelectionProvider({
       // Bump version so the service list re-fetches (including newly unbooked)
       setBookingVersion((v) => v + 1);
     },
-    [bookingIds, plannedServices, getLiveTask, calendarId]
+    [bookingIds, plannedServices, getLiveTask, calendarId, canMutateBookings]
   );
 
   /**
@@ -1899,6 +1934,22 @@ export function PlanningSelectionProvider({
   const selectChipResource = useCallback((plannedService: PlannedService) => {
     setSelectedChipServiceId(plannedService.service.id);
   }, []);
+
+  // Viewer-only inspection entry point. Mirrors `startAssignment` in that it
+  // pre-fills both slot and service so the sidebar has data to render, but
+  // does not enter assign/reassign mode — the sidebar's read-only path
+  // suppresses every mutation surface. Wired from `use-planning-grid` when
+  // the caller has `GROUP_CALENDAR_VIEWER` and neither plan nor assign.
+  const inspectPlannedService = useCallback(
+    (plannedService: PlannedService) => {
+      setReassigningService(null);
+      setAssigningService(null);
+      setSelectedChipServiceId(plannedService.service.id);
+      setSelectedService(plannedService.service);
+      setSelectedSlot(plannedService.slot);
+    },
+    []
+  );
 
   const clearChipSelection = useCallback(() => {
     setSelectedChipServiceId(null);
@@ -1985,6 +2036,7 @@ export function PlanningSelectionProvider({
       cancelAssignment,
       selectChipSlot,
       selectChipResource,
+      inspectPlannedService,
       isChipSelected,
       clearChipSelection,
       updateServiceAssignment,
@@ -2033,6 +2085,7 @@ export function PlanningSelectionProvider({
       cancelAssignment,
       selectChipSlot,
       selectChipResource,
+      inspectPlannedService,
       isChipSelected,
       clearChipSelection,
       updateServiceAssignment,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -6,6 +6,7 @@ import "dayjs/locale/es";
 import "dayjs/locale/en";
 import { HiArrowLeft, HiX, HiSwitchHorizontal } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { I18nDictionary } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
@@ -18,6 +19,7 @@ import { PlanningSidebarForm } from "./planning-sidebar-form";
 import { ServiceEvent } from "./service-event";
 import { PlanningSearchAutocomplete } from "./planning-search-autocomplete";
 import { PlanningSearchTags } from "./planning-search-tags";
+import { useCalendarViewMode } from "./use-calendar-view-mode";
 import {
   useCalendars,
   useMyTasks,
@@ -476,16 +478,42 @@ export function PlanningSidebarClient({
     allServices,
   ]);
 
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { forceViewer } = useCalendarViewMode();
+
+  // Strip the `?as=viewer` override (used by planners previewing the
+  // viewer experience) without touching any other URL params. The page
+  // re-renders in full-edit mode, mirroring the existing chip-menu
+  // "Salir de previsualización" action.
+  const exitViewerPreview = useCallback(() => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.delete("as");
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
+  }, [router, pathname, searchParams]);
+
   const handleSubmit = () => {
     closeSidebar();
   };
 
   const handleBack = () => {
+    // In viewer-preview mode the only way out today is the chip-menu
+    // toggle. Make the sidebar's back button exit preview too, so the
+    // close affordance feels symmetric to assign/reassign mode where
+    // the header X cancels the special mode.
+    if (forceViewer) {
+      exitViewerPreview();
+    }
     clearService(); // Go back to services list, keep sidebar open
     // Keep filters and tags when going back - user can still see filtered results
   };
 
   const handleCancel = () => {
+    if (forceViewer) {
+      exitViewerPreview();
+    }
     closeSidebar(); // Close the entire sidebar
   };
 
@@ -597,10 +625,14 @@ export function PlanningSidebarClient({
       }
     : stateSnapshotRef.current;
 
-  // Determine which header button to show based on current mode
+  // Determine which header button to show based on current mode. Viewer-
+  // preview mode is treated as a "special mode" alongside reassign/assign:
+  // the header surfaces an X that exits the mode (strips `?as=viewer`),
+  // mirroring how Cancelar exits assignment/reassignment.
   const isInSpecialMode =
     displayState.reassigningService !== null ||
-    displayState.assigningService !== null;
+    displayState.assigningService !== null ||
+    forceViewer;
   const showCloseButton = !displayState.isFormActive || isInSpecialMode;
 
   const headerButton = showCloseButton ? (

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -37,7 +37,7 @@ import {
   AssignmentForm,
   type AssignmentFormData,
 } from "./sidebar-tabs";
-import { usePermissions } from "@/features/auth/hooks/use-permissions";
+import { useCalendarViewMode } from "./use-calendar-view-mode";
 import {
   TabButtons,
   type TabItem,
@@ -303,24 +303,26 @@ export function PlanningSidebarForm({
     getOccupiedAndenes,
   } = usePlanningSelection();
 
-  const { hasPermission, isLoading: isLoadingPermissions } = usePermissions();
-  // Fail-closed: only enable tabs when permissions are confirmed loaded
-  const canAssign =
-    !isLoadingPermissions && hasPermission(["GROUP_ASSIGNMENT"]);
-  const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
+  // Effective view-mode — already accounts for `?as=viewer` for users
+  // with GROUP_CALENDAR_VIEWER. Fail-closed during permission load.
+  const { canPlan, canAssign, isViewerOnly, isLoadingPermissions } =
+    useCalendarViewMode();
 
-  // View-only mode: the sidebar was opened by left-clicking a past-day chip
-  // without entering reassign/assign. Form controls stay visible so the
-  // existing values can be inspected, but every mutation path — inputs and
-  // action buttons — is suppressed. The right-click context menu on past
-  // chips is intentionally still available so users can Replanificar /
-  // Asignar / Eliminar for reconciliation; picking either reassign or assign
-  // sets `reassigningService` / `assigningService`, which drops the flag
-  // below and returns the form to edit mode.
+  // View-only mode: the sidebar was opened either by (a) left-clicking a
+  // past-day chip without entering reassign/assign, or (b) a pure
+  // GROUP_CALENDAR_VIEWER right-clicking a chip to inspect it. Form controls
+  // stay visible so the existing values can be inspected, but every mutation
+  // path — inputs and action buttons — is suppressed. For past-day slots the
+  // right-click context menu still exposes Replanificar / Asignar / Eliminar
+  // so planners can reconcile after the fact; picking either reassign or
+  // assign sets `reassigningService` / `assigningService`, which drops the
+  // flag below and returns the form to edit mode. Viewers never reach those
+  // entries because the menu hides them when canPlan/canAssign are false.
   const isReadOnlyView = useMemo(() => {
     if (!selectedSlot || reassigningService || assigningService) return false;
+    if (isViewerOnly) return true;
     return dayjs(selectedSlot.date).isBefore(dayjs().startOf("day"), "day");
-  }, [selectedSlot, reassigningService, assigningService]);
+  }, [selectedSlot, reassigningService, assigningService, isViewerOnly]);
 
   // Tab state management
   type TabType = "planificacion" | "assignment";
@@ -451,6 +453,10 @@ export function PlanningSidebarForm({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isSubmitting) return;
+    // Defense against Enter-key submission while the form is in read-only
+    // mode. The visible submit button is already hidden by isReadOnlyView,
+    // but the <form> element can still receive a submit event from inputs.
+    if (isReadOnlyView) return;
 
     // Build the final slot with the chosen time and andén
     let finalSlot: SelectedSlot | undefined;
@@ -514,6 +520,7 @@ export function PlanningSidebarForm({
     if (!assigningService || isSubmitting) {
       return;
     }
+    if (isReadOnlyView) return;
 
     const overrides = assignmentOverrides(assignmentData);
     setIsSubmitting(true);
@@ -640,7 +647,12 @@ export function PlanningSidebarForm({
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {isReadOnlyView && (
         <div className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700/50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
-          {tr("pages.planning.sidebar.form.readOnlyBanner", dict)}
+          {tr(
+            isViewerOnly
+              ? "pages.planning.sidebar.form.viewerBanner"
+              : "pages.planning.sidebar.form.readOnlyBanner",
+            dict
+          )}
         </div>
       )}
       <fieldset
@@ -862,7 +874,12 @@ export function PlanningSidebarForm({
             </p>
           </FormSection>
         )}
-      {/* Custom Tabs */}
+      </fieldset>
+      {/* Custom Tabs. Kept outside the disabled fieldset so viewers can
+          still switch between Planificación and Asignación for inspection
+          — `<fieldset disabled>` would otherwise disable the tab buttons
+          themselves. The tab *content* is re-wrapped below in its own
+          disabled fieldset so the actual inputs remain non-mutating. */}
       <div className="flex flex-col gap-2">
         <TabButtons
           pill
@@ -872,13 +889,15 @@ export function PlanningSidebarForm({
                 id: "planificacion",
                 label: tr("pages.planning.sidebar.form.planningTab", dict),
                 icon: <HiCalendar />,
-                disabled: !canPlan,
+                // Viewers can still tab through to inspect each section's
+                // values; mutation surfaces are suppressed by isReadOnlyView.
+                disabled: !canPlan && !isReadOnlyView,
               },
               {
                 id: "assignment",
                 label: tr("pages.planning.sidebar.form.assignmentTab", dict),
                 icon: <HiUserAdd />,
-                disabled: !canAssign,
+                disabled: !canAssign && !isReadOnlyView,
               },
             ] as TabItem<TabType>[]
           }
@@ -886,8 +905,14 @@ export function PlanningSidebarForm({
           onTabChange={setActiveTab}
         />
 
-        {/* Tab Content */}
-        {activeTab === "planificacion" && canPlan && (
+        {/* Tab Content — wrapped in its own disabled fieldset so the
+            individual inputs/selects are non-mutating in read-only mode,
+            without freezing the tab switcher above. */}
+        <fieldset
+          disabled={isReadOnlyView}
+          className="flex flex-col gap-2 min-w-0 border-0 p-0 m-0"
+        >
+        {activeTab === "planificacion" && (canPlan || isReadOnlyView) && (
           <PlanningTabContent
             dict={dict}
             selectedService={selectedService}
@@ -905,7 +930,7 @@ export function PlanningSidebarForm({
             isSubmitting={isSubmitting}
           />
         )}
-        {activeTab === "assignment" && canAssign && (
+        {activeTab === "assignment" && (canAssign || isReadOnlyView) && (
           <>
             <AssignmentForm
               value={assignmentData}
@@ -939,8 +964,8 @@ export function PlanningSidebarForm({
             )}
           </>
         )}
+        </fieldset>
         </div>
-      </fieldset>
 
       {/* Actions */}
     </form>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -2,13 +2,17 @@
 
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { HiSwitchHorizontal, HiTrash, HiUserAdd } from "react-icons/hi";
+import { HiEye, HiSwitchHorizontal, HiTrash, HiUserAdd } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
-import type { PlannedService } from "./planning-selection-context";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  usePlanningSelection,
+  type PlannedService,
+} from "./planning-selection-context";
 import { Button } from "flowbite-react";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
-import { usePermissions } from "@/features/auth/hooks/use-permissions";
+import { useCalendarViewMode } from "./use-calendar-view-mode";
 
 export interface ContextMenuPosition {
   x: number;
@@ -78,14 +82,16 @@ export function ServiceContextMenu({
   dict,
 }: Readonly<ServiceContextMenuProps>) {
   const menuRef = useRef<HTMLDivElement>(null);
-  const { hasPermission, isLoading: isLoadingPermissions } = usePermissions();
+  // Effective view-mode — already accounts for `?as=viewer` for users with
+  // GROUP_CALENDAR_VIEWER. Fail-closed: both flags are false while
+  // permissions load and while the override is active.
+  const { canPlan, canAssign, forceViewer, canTogglePreview } =
+    useCalendarViewMode();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { inspectPlannedService } = usePlanningSelection();
 
-  // Check if user has assignment permission to show assignment buttons
-  // Fail-closed: only show buttons when permissions are confirmed loaded
-  const canAssign =
-    !isLoadingPermissions && hasPermission(["GROUP_ASSIGNMENT"]);
-  // Check if user has planning permission to show replan/delete buttons
-  const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
   const canDeleteAssignment =
     plannedService !== null &&
     canAssign &&
@@ -93,12 +99,15 @@ export function ServiceContextMenu({
 
   // Estimated menu dimensions for initial position calculation
   // Height varies based on number of visible buttons
-  const MENU_WIDTH = 180;
+  const MENU_WIDTH = 200;
   const MENU_HEADER_HEIGHT = 32;
   const MENU_BUTTON_HEIGHT = 38;
   const MENU_PADDING = 8;
   const buttonCount =
-    (canAssign ? 1 : 0) + (canDeleteAssignment ? 1 : 0) + (canPlan ? 2 : 0);
+    (canAssign ? 1 : 0) +
+    (canDeleteAssignment ? 1 : 0) +
+    (canPlan ? 2 : 0) +
+    (canTogglePreview ? 1 : 0);
   const MENU_HEIGHT =
     MENU_HEADER_HEIGHT + MENU_PADDING + buttonCount * MENU_BUTTON_HEIGHT;
 
@@ -164,6 +173,29 @@ export function ServiceContextMenu({
     onClose();
   };
 
+  // Flip the `?as=viewer` URL param without losing any other params
+  // (`date`, `view`, `groupCode`, etc.). Push, don't replace, so back
+  // navigates out of the preview. Closes the menu so the click feels
+  // discrete; the page re-renders with the new mode on the next tick.
+  // When entering preview (not exiting), also populate the sidebar with
+  // the right-clicked chip's data so the read-only view has content to
+  // show on the same gesture — without this, the user would have to
+  // right-click a second time after the URL flip to inspect the chip.
+  const handleTogglePreview = () => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    if (forceViewer) {
+      params.delete("as");
+    } else {
+      params.set("as", "viewer");
+      if (plannedService) {
+        inspectPlannedService(plannedService);
+      }
+    }
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
+    onClose();
+  };
+
   return createPortal(
     <div
       ref={menuRef}
@@ -190,7 +222,10 @@ export function ServiceContextMenu({
         </span>
       </div>
 
-      {/* Menu items */}
+      {/* Menu items. For a pure GROUP_CALENDAR_VIEWER, every gate below is
+          false and only the service-ID header above renders — intentional
+          confirmation that the chip was selected, paired with the sidebar
+          opening via inspectPlannedService in use-planning-grid. */}
       <div className="py-1">
         {canAssign && (
           <Button
@@ -240,6 +275,25 @@ export function ServiceContextMenu({
             <HiTrash className="w-4 h-4" />
             <span>
               {tr("pages.planning.sidebar.contextMenu.deletePlanning", dict)}
+            </span>
+          </Button>
+        )}
+
+        {canTogglePreview && (
+          <Button
+            color={"alternative"}
+            type="button"
+            onClick={handleTogglePreview}
+            className="border-0 rounded-none w-full justify-start gap-2 border-t border-gray-200 dark:border-gray-700"
+          >
+            <HiEye className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            <span>
+              {tr(
+                forceViewer
+                  ? "pages.planning.sidebar.contextMenu.exitPreview"
+                  : "pages.planning.sidebar.contextMenu.previewAsViewer",
+                dict
+              )}
             </span>
           </Button>
         )}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-calendar-view-mode.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-calendar-view-mode.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { usePermissions } from "@/features/auth/hooks/use-permissions";
+
+/**
+ * Single source of truth for "what mode is the calendar in" — combines the
+ * caller's Alfresco groups with the `?as=viewer` URL override.
+ *
+ * The override lets a user who holds both GROUP_CALENDAR_VIEWER and one of
+ * the mutating groups (GROUP_PLANNING / GROUP_ASSIGNMENT) preview the
+ * read-only experience without giving up their real permissions. For users
+ * who lack GROUP_CALENDAR_VIEWER the param is silently ignored, so it
+ * cannot be used to bypass missing permissions.
+ *
+ * `?view=…` is reserved for the day/week/month switcher (see
+ * planning-header.tsx and planning-calendar.tsx) — do not reuse that name.
+ *
+ * `canPlan` / `canAssign` are returned as *effective* values: when the
+ * override is on, both flip to false, which propagates through every
+ * existing gate (sidebar tab disables, chip click handlers, persist-
+ * boundary guard) without further wiring. The raw permission bits live in
+ * the Alfresco membership response and are not exposed here — if you ever
+ * need them, call `usePermissions` directly.
+ */
+export function useCalendarViewMode() {
+  const { hasPermission, isLoading } = usePermissions();
+  const searchParams = useSearchParams();
+
+  const rawCanPlan = !isLoading && hasPermission(["GROUP_PLANNING"]);
+  const rawCanAssign = !isLoading && hasPermission(["GROUP_ASSIGNMENT"]);
+  const canView = !isLoading && hasPermission(["GROUP_CALENDAR_VIEWER"]);
+
+  const forceViewer = canView && searchParams?.get("as") === "viewer";
+
+  const canPlan = rawCanPlan && !forceViewer;
+  const canAssign = rawCanAssign && !forceViewer;
+  // Either the user is a pure viewer (no mutating groups) or they
+  // explicitly asked for the preview via the URL override.
+  const isViewerOnly =
+    canView && (forceViewer || (!rawCanPlan && !rawCanAssign));
+  // A "preview toggle" only makes sense for users who can actually flip
+  // between the two modes — i.e. they hold the viewer group *and* at
+  // least one mutating group. Pure viewers have nothing to toggle into;
+  // planners without the viewer group are not allowed to preview.
+  const canTogglePreview = canView && (rawCanPlan || rawCanAssign);
+
+  return {
+    canPlan,
+    canAssign,
+    canView,
+    forceViewer,
+    isViewerOnly,
+    canTogglePreview,
+    isLoadingPermissions: isLoading,
+  };
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo } from "react";
 import dayjs from "dayjs";
-import { usePermissions } from "@/features/auth/hooks/use-permissions";
 import {
   isTimeWindow,
   usePlanningSelection,
@@ -11,6 +10,7 @@ import {
 } from "./planning-selection-context";
 import type { PositionedShift } from "./shift-layout";
 import { useServiceActions } from "./use-service-actions";
+import { useCalendarViewMode } from "./use-calendar-view-mode";
 import { generateTimeSlots } from "@/features/calendar/services/calendar.service";
 
 // ============================================================================
@@ -36,9 +36,10 @@ interface SlotIdentifier {
 export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
   const { startHour = 8, endHour = 22 } = options;
 
-  const { hasPermission, isLoading: isLoadingPermissions } = usePermissions();
-  // Fail-closed: block interactions until permission check completes
-  const canPlan = !isLoadingPermissions && hasPermission(["GROUP_PLANNING"]);
+  // Effective view-mode for the calendar — already honors the
+  // `?as=viewer` URL override for users with GROUP_CALENDAR_VIEWER.
+  // Fail-closed: every flag is false while permissions load.
+  const { canPlan, canAssign, canView, isViewerOnly } = useCalendarViewMode();
 
   const {
     selectedSlot,
@@ -55,6 +56,7 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     updateServiceAssignment,
     selectChipSlot,
     selectChipResource,
+    inspectPlannedService,
     isChipSelected,
     clearChipSelection,
     andenesCount,
@@ -85,13 +87,29 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
 
   // Right-click on a chip highlights it (corner ring) AND opens the context
   // menu. The highlight is purely visual — `selectChipResource` does not
-  // touch slot/service selection, so the sidebar stays as-is.
+  // touch slot/service selection, so the sidebar stays as-is. For pure
+  // viewers (GROUP_CALENDAR_VIEWER only) we also call `inspectPlannedService`
+  // because right-click is their sole entry to the sidebar; for planners
+  // the sidebar opens via the menu's "Abrir servicio (Solo Lectura)"
+  // action instead, which flips the URL and inspects in one step.
   const handleChipContextMenu = useCallback(
     (e: React.MouseEvent, plannedService: PlannedService) => {
       selectChipResource(plannedService);
+      if (isViewerOnly) {
+        inspectPlannedService(plannedService);
+      }
       serviceActions.handleContextMenu(e, plannedService);
     },
-    [selectChipResource, serviceActions]
+    [selectChipResource, inspectPlannedService, isViewerOnly, serviceActions]
+  );
+
+  // Left-click on a chip opens the sidebar in "add to slot" mode for users
+  // who can plan. Viewers have nothing actionable there — chip data is
+  // already reachable via right-click — so the handler is dropped entirely,
+  // which also flips the chip's cursor to `cursor-context-menu`.
+  const handleChipClick = useMemo(
+    () => (isViewerOnly ? undefined : selectChipSlot),
+    [isViewerOnly, selectChipSlot]
   );
 
   // The chip highlight lives alongside the context menu — closing the menu
@@ -168,6 +186,9 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
   return {
     // Permission
     canPlan,
+    canAssign,
+    canView,
+    isViewerOnly,
 
     // Slot selection
     selectedSlot,
@@ -202,7 +223,9 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     reassigningService,
 
     // Left-click on a chip: select only the slot (clears any prior service).
-    selectChipSlot,
+    // Viewer-only callers receive `undefined`, dropping the chip's onClick so
+    // left-click becomes a no-op and the cursor switches to context-menu.
+    selectChipSlot: handleChipClick,
 
     // Predicate the chip uses to render its right-click highlight ring.
     isChipSelected,

--- a/turbo-repo/apps/app/src/features/layout/models/pages.ts
+++ b/turbo-repo/apps/app/src/features/layout/models/pages.ts
@@ -33,7 +33,18 @@ export const pages: SidebarItem[] = [
       },
     ],
     totals: {},
-    requiredGroups: ["GROUP_ASSIGNMENT", "GROUP_PLANNING"],
+    // Three-way role split for the calendar feature (OR-evaluated):
+    //  - GROUP_PLANNING        → slot/time changes, reassign, delete planning
+    //  - GROUP_ASSIGNMENT      → carrier/driver/truck/trailer assignment
+    //  - GROUP_CALENDAR_VIEWER → inspect-only; right-click a chip to open
+    //    the sidebar in read-only mode. UI gating in
+    //    features/calendar/components/planning + the matching backend gate
+    //    in api/calendar/bookings/* enforce that viewers never mutate.
+    requiredGroups: [
+      "GROUP_ASSIGNMENT",
+      "GROUP_PLANNING",
+      "GROUP_CALENDAR_VIEWER",
+    ],
   },
   {
     icon: ClipboardIcon,

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -293,6 +293,7 @@
           "cancelReassignment": "Cancel",
           "confirmReassignment": "Reassign",
           "readOnlyBanner": "Past service — read-only",
+          "viewerBanner": "Read-only mode — no permission to modify the plan",
           "loadUtilization": "Load Utilization",
           "constraint": "Constraint",
           "maxUtilization": "Total",
@@ -341,7 +342,9 @@
           "delete": "Delete",
           "deleteConfirmTitle": "Confirm deletion",
           "deleteConfirmMessage": "Are you sure you want to delete the assignment for service {serviceId}?",
-          "cancelReassignment": "Cancel reassignment"
+          "cancelReassignment": "Cancel reassignment",
+          "previewAsViewer": "Open service (Read-only)",
+          "exitPreview": "Exit preview"
         },
         "notifications": {
           "reassigned": "Service reassigned successfully",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -293,6 +293,7 @@
           "cancelReassignment": "Cancelar",
           "confirmReassignment": "Reasignar",
           "readOnlyBanner": "Servicio pasado — solo lectura",
+          "viewerBanner": "Modo solo lectura — sin permisos para modificar el plan",
           "loadUtilization": "Utilización de carga",
           "constraint": "Restricción",
           "maxUtilization": "Total",
@@ -341,7 +342,9 @@
           "delete": "Eliminar",
           "deleteConfirmTitle": "Confirmar eliminación",
           "deleteConfirmMessage": "¿Está seguro de eliminar la asignación del servicio {serviceId}?",
-          "cancelReassignment": "Cancelar reasignación"
+          "cancelReassignment": "Cancelar reasignación",
+          "previewAsViewer": "Abrir servicio (Solo Lectura)",
+          "exitPreview": "Salir de previsualización"
         },
         "notifications": {
           "reassigned": "Servicio reasignado exitosamente",


### PR DESCRIPTION
Closes #494

## Summary

Adds a new `GROUP_CALENDAR_VIEWER` Alfresco group that lets users inspect planned services in the calendar without being able to modify them. Pure viewers (no `GROUP_PLANNING` / `GROUP_ASSIGNMENT`) get a fully read-only experience; planners who also hold the viewer group can preview that experience via a chip-menu **"Abrir servicio (Solo Lectura)"** action that toggles `?as=viewer` and opens the sidebar populated with the chip in one click.

## What changed

**Frontend gating**
- `pages.ts` — calendar nav entry accepts `GROUP_CALENDAR_VIEWER` alongside the existing two mutating groups (OR semantics).
- New `use-calendar-view-mode` hook — single source of truth combining Alfresco groups with the `?as=viewer` URL override. The override is only honored for users who hold `GROUP_CALENDAR_VIEWER`, so it cannot be used to bypass missing permissions.
- `use-planning-grid` — viewer-only right-click opens the sidebar populated via `inspectPlannedService`; planner right-click still shows only the context menu (unchanged behavior).
- `planning-sidebar-form` — `isReadOnlyView` generalized to cover viewer mode; viewer-specific banner ("Modo solo lectura — sin permisos para modificar el plan"); tab content moved into its own disabled fieldset so the tab switcher stays clickable in read-only mode.
- `service-context-menu` — new "Abrir servicio (Solo Lectura)" item that flips the URL and populates the sidebar in one gesture. Collapses to "Salir de previsualización" when already in preview.
- `planning-sidebar-client` — `forceViewer` treated as a special mode (alongside reassign/assign). The X close button strips `?as=viewer` and closes the sidebar in one action.

**Defense in depth**
- `planning-selection-context` — `persistPlannedBooking` / `removeService` throw if the caller lacks both mutating groups (catches stale handlers and UI-bypass bugs).
- New `requireAnyGroup` helper in `api/utils/alfresco-crud-client` — applied to POST `/api/calendar/bookings`, POST `/bookings/{id}/move`, and DELETE/PUT `/bookings/{id}`. Viewers receive 403; GET stays open.

## Operational hand-off

- Create `GROUP_CALENDAR_VIEWER` in Alfresco for each tenant that needs it.
- Assign target users via the existing collaborator-management flow.

## Plan file

`turbo-repo/.cursor/plans/calendar_readonly_role.plan.md` — full 7-phase plan with status and design rationale.

## Test plan

- [ ] Pure viewer (only `GROUP_CALENDAR_VIEWER`): Calendar nav visible, left-click does nothing, right-click opens read-only sidebar + header-only context menu, all mutation surfaces hidden, tabs switchable for inspection.
- [ ] Planner with viewer group: "Abrir servicio (Solo Lectura)" in chip menu flips `?as=viewer` and opens the sidebar populated; X closes the sidebar AND strips the URL param.
- [ ] Planner without viewer group: chip right-click shows only the original three actions (no "Abrir servicio" item), `?as=viewer` is silently ignored if added manually.
- [ ] Backend: \`curl\` POST to `/api/calendar/bookings` as viewer returns 403; planner unchanged. GET still returns bookings for viewers.
- [ ] Tab switching works in read-only mode (Planificación ↔ Asignación) with inputs disabled and no submit buttons rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a read-only calendar viewer role, allowing designated users to inspect bookings and service details without modification permissions. Read-only users see disabled input fields and cannot perform booking mutations (create, move, or delete operations).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->