### PR TITLE
fix(calendar): use router.replace when exiting viewer preview

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -486,12 +486,13 @@ export function PlanningSidebarClient({
   // Strip the `?as=viewer` override (used by planners previewing the
   // viewer experience) without touching any other URL params. The page
   // re-renders in full-edit mode, mirroring the existing chip-menu
-  // "Salir de previsualización" action.
+  // "Salir de previsualización" action. Uses `replace` so the browser
+  // Back button doesn't bounce the user back into preview.
   const exitViewerPreview = useCallback(() => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
     params.delete("as");
     const query = params.toString();
-    router.push(query ? `${pathname}?${query}` : pathname);
+    router.replace(query ? `${pathname}?${query}` : pathname);
   }, [router, pathname, searchParams]);
 
   const handleSubmit = () => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -183,7 +183,8 @@ export function ServiceContextMenu({
   // right-click a second time after the URL flip to inspect the chip.
   const handleTogglePreview = () => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
-    if (forceViewer) {
+    const wasForcingViewer = forceViewer;
+    if (wasForcingViewer) {
       params.delete("as");
     } else {
       params.set("as", "viewer");
@@ -192,7 +193,14 @@ export function ServiceContextMenu({
       }
     }
     const query = params.toString();
-    router.push(query ? `${pathname}?${query}` : pathname);
+    const url = query ? `${pathname}?${query}` : pathname;
+    // Replace on exit so Back doesn't bounce the user back into preview;
+    // push on entry so Back is a natural escape hatch out of preview.
+    if (wasForcingViewer) {
+      router.replace(url);
+    } else {
+      router.push(url);
+    }
     onClose();
   };
 


### PR DESCRIPTION
The exit-from-preview branch in handleTogglePreview and exitViewerPreview both used router.push, leaving the ?as=viewer entry in browser history. Pressing Back bounced the user straight back into preview mode.

Switch to router.replace on the exit path in both call sites; entering preview still uses push so Back remains a natural escape hatch out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation flow when exiting preview mode in the planning calendar. The browser back button will now skip the preview state and navigate correctly, preventing users from accidentally returning to preview mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->