### PR TITLE
feat(calendar): persist remove-assignment to backend

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -26,6 +26,7 @@ import {
   deactivateCalendarTimeWindow,
   createBooking,
   moveBooking,
+  updateBooking,
   cancelBooking,
   listBookings,
   updateServiceCategory,
@@ -45,6 +46,7 @@ import {
   asTaskStageFromColumn,
   getNextTransition,
   getUnplanTransition,
+  getUnassignTransition,
 } from "@/features/calendar/services/task-stage-transitions";
 import { ShowNotification } from "@/features/notifications/notification";
 import {
@@ -905,6 +907,13 @@ interface PlanningSelectionContextType {
   getAvailableAndenes: (date: Date, hour: number, minutes: number) => number[];
   isSidebarOpen: boolean;
   removeService: (serviceId: string) => Promise<void>;
+  /**
+   * Clear the driver/transport assignment from a planned service: reverse
+   * the workflow task back to `planService`, drop the assignment tuple from
+   * the booking's `resource_data`, notify the coordinator (stage
+   * "unassigned") and clear the local assignment fields.
+   */
+  removeAssignment: (serviceId: string) => Promise<void>;
   startReassignment: (plannedService: PlannedService) => void;
   cancelReassignment: () => void;
   /** Start assignment-only mode - opens sidebar with only Asignación tab available */
@@ -1854,6 +1863,86 @@ export function PlanningSelectionProvider({
   );
 
   /**
+   * Remove the driver/transport assignment from a planned service. The
+   * inverse of the "Asignar" arm of `confirmService`: it reverses the
+   * workflow task, drops the assignment tuple from the booking, and tells
+   * the coordinator to revert the service to its planned activity state.
+   */
+  const removeAssignment = useCallback(
+    async (serviceId: string) => {
+      // Persist-boundary permission guard — see confirmService for context.
+      if (!canMutateBookings) {
+        throw new Error(
+          "removeAssignment: caller lacks GROUP_PLANNING and GROUP_ASSIGNMENT"
+        );
+      }
+
+      const planned = plannedServices.find((p) => p.service.id === serviceId);
+      if (!planned) return;
+
+      // Reverse the workflow task BEFORE touching the booking. Assigning
+      // advanced the task `planService → assignDriver`; this steps it back.
+      // Resolve the live task by `mintral_serviceCode` against the kanban —
+      // never a stored taskId. A failed transition aborts the whole op so
+      // the assignment stays visible and the user can retry, mirroring
+      // `removeService`.
+      const liveTask = getLiveTask(planned.service.mintral_serviceCode);
+      if (liveTask) {
+        const transition = getUnassignTransition(liveTask.stage);
+        if (transition) {
+          await advanceWorkflowTask(liveTask.taskId, transition);
+        }
+      }
+
+      // Drop the assignment tuple from `cld_bookings.resource_data` so
+      // reopening the sidebar starts clean. Uses the plain booking PUT —
+      // not `moveBooking` — because the move route would re-derive the
+      // binding stage as "planned"; the explicit "unassigned" call below
+      // is the stage the coordinator dispatches on.
+      const clearedService: SelectedService = {
+        ...planned.service,
+        assignedCarrier: undefined,
+        assignedDriver: undefined,
+        assignedDriver2: undefined,
+        assignedTruck: undefined,
+        assignedTrailer: undefined,
+      };
+      const bookingId = bookingIds.get(serviceId);
+      if (bookingId) {
+        await updateBooking(bookingId, {
+          resource: buildResource(clearedService, planned.slot),
+        });
+      }
+
+      // Tell the coordinator the service is back to its planned state.
+      // Best-effort: a failure leaves a stale binding the next planner
+      // action on this calendar overwrites — don't block the user-visible
+      // removal on it.
+      const numeroServicio = planned.service.mintral_serviceCode;
+      if (numeroServicio && calendarId) {
+        await notifyCalendarBinding({
+          numero_servicio: numeroServicio,
+          calendar_id: calendarId,
+          stage: "unassigned",
+        }).catch((err) =>
+          console.warn("Failed to notify calendar binding (unassigned):", err)
+        );
+      }
+
+      // Clear the assignment tuple locally for immediate feedback.
+      setPlannedServices((prev) =>
+        prev.map((p) =>
+          p.service.id === serviceId
+            ? { ...p, service: clearedService }
+            : p
+        )
+      );
+      setBookingVersion((v) => v + 1);
+    },
+    [bookingIds, plannedServices, getLiveTask, calendarId, canMutateBookings]
+  );
+
+  /**
    * Start reassignment mode - keeps service in original slot until confirmed
    * The service remains visible in its original position with a visual indicator
    */
@@ -2030,6 +2119,7 @@ export function PlanningSelectionProvider({
       getAvailableAndenes,
       isSidebarOpen,
       removeService,
+      removeAssignment,
       startReassignment,
       cancelReassignment,
       startAssignment,
@@ -2079,6 +2169,7 @@ export function PlanningSelectionProvider({
       getAvailableAndenes,
       isSidebarOpen,
       removeService,
+      removeAssignment,
       startReassignment,
       cancelReassignment,
       startAssignment,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -50,10 +50,10 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     getRemainingQuota,
     isSlotBlocked,
     removeService,
+    removeAssignment,
     startReassignment,
     startAssignment,
     reassigningService,
-    updateServiceAssignment,
     selectChipSlot,
     selectChipResource,
     inspectPlannedService,
@@ -61,21 +61,6 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
     clearChipSelection,
     andenesCount,
   } = usePlanningSelection();
-
-  // Clear every assignment slot on the planned service — carrier, drivers,
-  // truck and trailer — so reopening the sidebar for this entry starts clean.
-  const removeAssignment = useCallback(
-    async (serviceId: string) => {
-      updateServiceAssignment(serviceId, {
-        assignedCarrier: undefined,
-        assignedDriver: undefined,
-        assignedDriver2: undefined,
-        assignedTruck: undefined,
-        assignedTrailer: undefined,
-      });
-    },
-    [updateServiceAssignment]
-  );
 
   // Use shared hook for context menu and delete modal
   const serviceActions = useServiceActions({

--- a/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
@@ -43,6 +43,24 @@ export function getUnplanTransition(
 }
 
 /**
+ * Workflow transition fired when the planner removes a driver/transport
+ * assignment ("Eliminar Asignación"). Assigning advances the task
+ * `planService → assignDriver` via "Asignar Conductor/Transporte", so the
+ * only stage that can be unassigned is `assignDriver`; the BPMN's
+ * "Planificar Servicio" outcome steps it back to `planService`. Returning
+ * undefined for any other stage means the task is left untouched.
+ */
+const UNASSIGN_TRANSITIONS: Partial<Record<TaskStage, string>> = {
+  assignDriver: "Planificar Servicio",
+};
+
+export function getUnassignTransition(
+  stage: TaskStage | undefined
+): string | undefined {
+  return stage ? UNASSIGN_TRANSITIONS[stage] : undefined;
+}
+
+/**
  * Kanban column keys that the planning calendar cares about. The kanban
  * board API returns tasks grouped by these keys, which double as our
  * `TaskStage` identifiers everywhere in the planning UI.


### PR DESCRIPTION
## Summary

- Fixes the calendar planning **remove assignment** feature, which was UI-complete but had a stubbed persistence path — `removeAssignment` only mutated React state, so cleared assignments were lost on reload and the coordinator was never notified.
- `removeAssignment` now mirrors the inverse of `confirmService`'s "Asignar" arm: reverses the Alfresco workflow task `assignDriver → planService`, drops the assignment tuple from the booking's `resource_data` via the plain booking `PUT` (chosen over `moveBooking` so the binding stage isn't re-derived as `planned`), and notifies the coordinator with `stage="unassigned"`.
- Moved `removeAssignment` from `use-planning-grid.ts` into `planning-selection-context.tsx`, where it has access to `bookingIds` / `getLiveTask` / `calendarId`, alongside `removeService` and `confirmService`.
- Added `getUnassignTransition` to `task-stage-transitions.ts`, mapping only `assignDriver → "Planificar Servicio"` so a service already past assignment can't be silently unassigned.

The coordinator-side `unassigned` binding stage handler lives in `ecm-coordinator` (not in this repo) and is assumed to already exist. The coordinator notification is best-effort with a `console.warn` on failure, matching `removeService`'s `stage="none"` call.

Closes #506

## Test plan

- [ ] Assign carrier/driver/truck to a planned service, then use the chip context-menu "Eliminar asignación" → confirm; verify the assignment clears and the success toast shows
- [ ] Reload the page and confirm the assignment does not reappear (booking `resource_data` persisted clean)
- [ ] Verify the service's kanban stage returns to `planService`
- [ ] Verify the coordinator receives a `stage="unassigned"` binding call
- [ ] Confirm a service already past `assignDriver` does not have its workflow task touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to remove service assignments from the planning calendar, with automatic status updates and coordinator notifications when assignments are cleared.
  * Enhanced workflow transitions to properly support unassignment operations across various service stages, ensuring consistent state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->