### PR TITLE
docs: add ASK MIOT Harness section under Platform

### DIFF
--- a/turbo-repo/apps/docs/content/en/platform/_meta.ts
+++ b/turbo-repo/apps/docs/content/en/platform/_meta.ts
@@ -4,6 +4,7 @@ export default {
   'ingestion-layer': 'Ingestion Layer',
   'telemetry-pipeline': 'Telemetry Pipeline',
   'symptoms-engine': 'Symptoms Engine',
+  'ask-miot-harness': 'ASK MIOT Harness',
   'control-tower-architecture': 'Control Tower Architecture',
   notifications: 'Notifications',
   'security-model': 'Security Model',

--- a/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/_meta.ts
+++ b/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/_meta.ts
@@ -1,0 +1,5 @@
+export default {
+  index: 'Overview',
+  architecture: 'Architecture',
+  'run-modes': 'Run Modes'
+}

--- a/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/architecture.mdx
+++ b/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/architecture.mdx
@@ -1,0 +1,43 @@
+# Architecture
+
+The harness is organized as a supervisor that routes each request to a specialist agent or graph. The language model contributes planning and narration; the harness contributes structure, data access, and control.
+
+## Request Flow
+
+1. **Intent routing** — an incoming request is classified into one of a small set of routes. An LLM-based router handles the default `auto` mode; when its confidence is low, a deterministic keyword router decides instead, so a request is never silently misrouted.
+2. **Dispatch** — the supervisor sends the request down the matching route (see [Run Modes](/platform/ask-miot-harness/run-modes)).
+3. **Execution** — the route runs its agents, calls typed tools, and assembles an answer.
+4. **Response** — the answer is returned as a Storytelling artifact with references to its supporting evidence.
+
+## Specialist Agents
+
+A data-backed answer is produced by a small graph of focused agents:
+
+- **Filter Expert** — selects the single curated data function that best matches the question.
+- **Domain Analyst** — inspects the returned data, including how fresh the underlying snapshot is.
+- **Synthesizer** — writes the final narrative answer.
+- **Critic** — reviews the answer for correctness before it is returned. Optional, because it doubles model spend per run.
+- **Summarizer** — trims prior conversation turns so multi-turn context stays within a fixed token budget.
+
+Each agent can be assigned its own model tier — a cheap, high-throughput model for routing and summarizing, a stronger reasoning model for analysis and synthesis.
+
+## Data Tools
+
+The harness does not let the model write SQL freely. Instead, at startup it introspects the connected database and builds one typed tool per curated data function it finds. Every tool:
+
+- runs inside a read-only transaction,
+- is locked to a single tenant, and
+- is registered in a central tool registry the supervisor draws from.
+
+For free-form exploration, a separate set of composable primitives lets an agent describe, select, and explain queries within a safety gate that rejects mutations and refuses queries whose estimated cost is too high.
+
+## Control and Safety
+
+- **Tenant lock** — data tools are pinned to one tenant; confidential data routes refuse requests from other tenants.
+- **Read-only by default** — data access runs in read-only transactions; mutating actions require explicit approval.
+- **Fail-closed boot** — if the data integration cannot verify access control or data freshness at startup, it disables itself rather than serving unverified answers.
+- **Deep Agents adapter** — the LangChain Deep Agents integration sits behind an adapter, so the harness keeps its own tool, permission, and audit contracts.
+
+## Observability
+
+Every run can emit tracing spans tagged with the run mode and tenant. When telemetry is enabled, those spans flow to an observability backend, giving per-tenant and per-mode cost and latency breakdowns.

--- a/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/index.mdx
+++ b/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/index.mdx
@@ -1,0 +1,34 @@
+# ASK MIOT Harness
+
+The ASK MIOT Harness is a Python-first backend runtime that orchestrates multi-agent answers over ModularIoT operational data. It lets a language model plan and narrate while the harness retains control of typed tools, tenant context, permission checks, approvals, durable run state, and Storytelling artifacts.
+
+## Purpose
+
+ModularIoT collects large volumes of telemetry, symptoms, and shipping data. The harness turns natural-language questions about that data into grounded, evidence-backed answers — without giving the model unmediated access to the database or to mutating operations.
+
+It builds on LangChain Deep Agents, but wraps them in a controlled runtime: the model can reason and compose a plan, yet every tool call, data read, and dashboard change flows through the harness's own tool, permission, and audit contracts.
+
+## What the Harness Owns
+
+- **Typed tools** — curated read and write operations the model may call, instead of raw SQL or API access.
+- **Tenant and user context** — taken from authenticated server context, never from model-provided text.
+- **Permission checks** — read-only tools run freely; mutating tools return approval requests and only apply after a user decision.
+- **Durable run state** — every run is recorded so it can be inspected, resumed, and audited.
+- **Storytelling artifacts** — answers are strict JSON objects with references to the evidence behind them.
+
+## First Vertical Slice
+
+The pilot target is a single end-to-end question:
+
+> Tell me the story of delivery compliance this month and suggest one dashboard widget.
+
+Answering it exercises the full path: intent routing, curated data tools, freshness checks, narrative synthesis, and an approval-gated dashboard change.
+
+## Data Integration
+
+The harness reads ModularIoT operational data — the Coordinador database — through a standard Postgres connection string. When no database is configured, the harness still serves non-data runs with mocked tools, so it can run in local and demo environments without a live connection.
+
+## In This Section
+
+- **Architecture** — the supervisor and specialist agents, the intent router, and how data tools are built and gated.
+- **Run Modes** — the four dispatch paths (`auto`, `canned`, `meta`, `agentic`) and when to use each.

--- a/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/run-modes.mdx
+++ b/turbo-repo/apps/docs/content/en/platform/ask-miot-harness/run-modes.mdx
@@ -1,0 +1,34 @@
+# Run Modes
+
+Every request runs in one of four modes. The mode selects which dispatch path the supervisor takes — not what the question is about.
+
+| Mode      | Route          | Reads data | LLM calls per run | Best for |
+|-----------|----------------|------------|-------------------|----------|
+| `auto`    | router-decided | depends    | depends           | Default — the intent router picks one of the modes below. |
+| `canned`  | curated query  | Yes        | Several           | "What does the data say right now?" |
+| `meta`    | metadata       | No         | One               | "What data exists, and how is it calculated?" |
+| `agentic` | exploration    | Yes        | Variable          | Free-form exploration across multiple queries. |
+
+`auto` is the default. The explicit modes bypass the intent router entirely, which is useful for operations (deterministic dispatch), testing (pin a route so a test does not drift), and cost control.
+
+## `auto`
+
+The intent router classifies the request and forwards it to one of the other modes. Most callers use `auto` and never set a mode explicitly.
+
+## `canned` — answer *from* the data
+
+Routes through the curated data graph: the filter expert picks one curated data function, the harness runs it, the analyst checks freshness, the synthesizer writes the answer, and the critic reviews it when enabled. This mode reads confidential operational data, so it is refused for tenants outside the configured tenant lock.
+
+Use it for "what is the current state?" questions.
+
+## `meta` — answer *about* the data
+
+Answers questions about the data catalog — what data exists, what a field means, how a metric is calculated — without running any query. Because it issues no SQL, "no data access" is a structural guarantee. It is the cheapest mode and is available to any tenant, since catalog information is not confidential.
+
+## `agentic` — explore the data
+
+Instead of being limited to one curated function, the planner can string together composable primitives — describe, select, grep, explain — within a safety gate that rejects mutations and refuses overly expensive queries. The critic is on by default here, because the agent has more freedom to compose queries. It reads confidential data, so it is subject to the same tenant lock as `canned`.
+
+## Cost Separation
+
+Each run is tagged with its mode, so cost and latency can be broken down per mode and per tenant. `meta` runs are roughly an order of magnitude cheaper than `canned` runs — useful when offering, for example, unlimited metadata questions alongside metered data queries.


### PR DESCRIPTION
## Summary

The ASK MIOT Harness (`miot-harness`) — the Python-first multi-agent backend runtime — was not documented anywhere on the docs site. This PR adds a new **ASK MIOT Harness** subsection nested under **Platform**, EN only, as a lean first pass.

## Pages

`content/en/platform/ask-miot-harness/`:

- **Overview** (`index.mdx`) — what the harness is and owns (typed tools, tenant context, permissions, durable runs, Storytelling artifacts), the first vertical slice, data integration.
- **Architecture** (`architecture.mdx`) — request flow, the supervisor + specialist agents, how data tools are built and gated, control/safety, observability.
- **Run Modes** (`run-modes.mdx`) — the `auto` / `canned` / `meta` / `agentic` dispatch paths and when to use each.

Plus a nav entry in `content/en/platform/_meta.ts` (between Symptoms Engine and Control Tower Architecture).

## Conventions

- Plain MDX with a `# Title`, no frontmatter — matches existing pages.
- Directory subsection with its own `_meta.ts`, like `symptoms-engine/`.
- Absolute-from-locale-root internal links (`/platform/ask-miot-harness/run-modes`).
- Content kept product-level — no internal file paths or env var names — so it reads as documentation, not a README.

## Out of scope (follow-ups)

- Spanish translation (`content/es/...`).
- Configuration reference page (env vars, `MIOT_HARNESS_NEXO_DSN`).
- API reference for the harness HTTP surface.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)