### PR TITLE
harness(api): add /health/ready endpoint for kubelet readinessProbe

### DIFF
--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -7,7 +7,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from traceloop.sdk import Traceloop
@@ -213,6 +213,29 @@ def create_app() -> FastAPI:
             "env": settings.env,
             "nexo": {
                 "enabled": app.state.nexo_enabled,
+                "tools": list(app.state.nexo_registered),
+                "snapshot_age_minutes": app.state.nexo_snapshot_age_minutes,
+            },
+        }
+
+    @app.get("/health/ready")
+    async def health_ready(response: Response) -> dict[str, object]:
+        # Readiness contract (kubelet readinessProbe target): Nexo is
+        # "required" iff a DSN is configured. When required-but-not-enabled
+        # the lifespan logs critical and continues serving, but the pod
+        # should not receive traffic until tools register and the snapshot
+        # passes the refuse-gate.
+        nexo_required = settings.nexo_dsn is not None
+        nexo_enabled = bool(app.state.nexo_enabled)
+        ready = (not nexo_required) or nexo_enabled
+        if not ready:
+            response.status_code = 503
+        return {
+            "status": "ready" if ready else "not_ready",
+            "env": settings.env,
+            "nexo": {
+                "required": nexo_required,
+                "enabled": nexo_enabled,
                 "tools": list(app.state.nexo_registered),
                 "snapshot_age_minutes": app.state.nexo_snapshot_age_minutes,
             },

--- a/miot-harness/tests/api/test_health.py
+++ b/miot-harness/tests/api/test_health.py
@@ -1,8 +1,9 @@
-"""Tests for the GET /health endpoint shape (T01)."""
+"""Tests for the GET /health and /health/ready endpoint shapes (T01)."""
 
 from __future__ import annotations
 
 from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -59,3 +60,77 @@ def test_health_reflects_simulated_nexo_enabled_state() -> None:
         "coordinador_servicios",
     ]
     assert nexo["snapshot_age_minutes"] == 12.5
+
+
+def test_health_ready_without_nexo_dsn_is_ready() -> None:
+    """No DSN configured -> Nexo not required -> readiness probe passes."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/health/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    nexo = body["nexo"]
+    assert nexo["required"] is False
+    assert nexo["enabled"] is False
+    assert nexo["tools"] == []
+    assert nexo["snapshot_age_minutes"] is None
+
+
+def test_health_ready_with_dsn_but_nexo_disabled_returns_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DSN configured but lifespan failed to enable Nexo (tunnel down,
+    tools didn't register, snapshot too stale, etc.) -> readiness MUST
+    fail so the Service doesn't route traffic to a half-booted pod."""
+    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    get_settings.cache_clear()
+
+    # Mirror tests/test_server_lifespan.py — mock pool creation to raise
+    # so lifespan exercises the "Nexo disabled despite DSN" path without
+    # attempting a real connect.
+    with patch(
+        "miot_harness.api.server.create_nexo_pool",
+        new=AsyncMock(side_effect=ConnectionRefusedError("tunnel down")),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/health/ready")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "not_ready"
+    nexo = body["nexo"]
+    assert nexo["required"] is True
+    assert nexo["enabled"] is False
+
+
+def test_health_ready_reflects_simulated_nexo_enabled_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DSN configured AND lifespan brought Nexo up -> readiness passes.
+
+    Lifespan is stubbed-failed (so the chat-model factory isn't invoked,
+    keeping the test hermetic); the enabled state is simulated by post-
+    lifespan mutation of app.state, identical to how
+    `test_health_reflects_simulated_nexo_enabled_state` exercises /health.
+    """
+    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    get_settings.cache_clear()
+    with patch(
+        "miot_harness.api.server.create_nexo_pool",
+        new=AsyncMock(side_effect=ConnectionRefusedError("tunnel down")),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            app.state.nexo_enabled = True
+            app.state.nexo_registered = ["coordinador_centro_control"]
+            app.state.nexo_snapshot_age_minutes = 7.5
+            resp = client.get("/health/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    nexo = body["nexo"]
+    assert nexo["required"] is True
+    assert nexo["enabled"] is True
+    assert nexo["tools"] == ["coordinador_centro_control"]
+    assert nexo["snapshot_age_minutes"] == 7.5


### PR DESCRIPTION
## Summary

- Adds `GET /health/ready` to `miot_harness.api.server` so the Helm chart's `readinessProbe.httpGet.path: /health/ready` points at a real endpoint instead of a 404.
- Readiness contract mirrors the lifespan boot signal: **ready** when Nexo isn't required (`MIOT_HARNESS_NEXO_DSN` unset) or when it's required and `app.state.nexo_enabled` is True; **503 not_ready** when DSN is set but the lifespan didn't bring Nexo up (tunnel down, snapshot stale past the refuse-gate, tool registration failure).
- Body includes `nexo.required`, `nexo.enabled`, `nexo.tools`, `nexo.snapshot_age_minutes` so operators can `curl` to see *why* a pod is not ready.

Closes #519

## Test plan

- [x] `pytest tests/api tests/test_server_lifespan.py` — 14 passed, 1 skipped (pre-existing SSE skip).
- [x] New unit tests in `tests/api/test_health.py` cover: no DSN → 200, DSN set + pool fails → 503, DSN set + simulated-enabled → 200. Hermetic — `create_nexo_pool` mocked, no real network connect.
- [x] Built the image and verified live: `GET /health -> 200` and `GET /health/ready -> 200 {"status":"ready", "nexo":{"required":false,...}}`.
- [x] CI green on this branch.
- [x] No Helm chart change needed — `charts/miot-harness/values.yaml` already points the readiness probe at `/health/ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness probe endpoint that reports the service's readiness status. The probe returns detailed information about required dependencies and their current state, enabling orchestration systems to determine if the service is ready to accept traffic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->