### PR TITLE
feat(522,quarkus): harness proxy — Q0+Q1+Q2 (test infra + POST + GET)

### DIFF
--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -64,6 +64,17 @@
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
@@ -2,9 +2,11 @@ package com.microboxlabs.miot.core.api;
 
 import io.smallrye.mutiny.Uni;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -46,4 +48,13 @@ public interface HarnessClient {
             @HeaderParam("X-Miot-User-Email") String userEmail,
             @HeaderParam("X-Miot-Auth-Mode") String authMode,
             Map<String, Object> body);
+
+    @GET
+    @Path("/runs/{runId}")
+    Uni<Response> getRun(
+            @PathParam("runId") String runId,
+            @HeaderParam("Authorization") String authorization,
+            @HeaderParam("X-Miot-Tenant-Client-Id") String tenantClientId,
+            @HeaderParam("X-Miot-User-Email") String userEmail,
+            @HeaderParam("X-Miot-Auth-Mode") String authMode);
 }

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
@@ -1,0 +1,49 @@
+package com.microboxlabs.miot.core.api;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * Reactive REST Client for {@code miot-harness}. The {@code "harness"}
+ * binding name matches {@code quarkus.rest-client."harness".url}.
+ *
+ * <p>{@link HarnessProxyResource} forwards the caller's Auth0 bearer
+ * token plus four {@code X-Miot-*} identity headers verbatim:
+ * tenant-client-id (from {@code TenantContext}), user-email (web flow
+ * only), and auth-mode ({@code "web"} vs {@code "m2m"}).
+ *
+ * <p>Methods return {@code Uni<Response>} so upstream status codes
+ * (notably 202 from {@code /runs:start}) propagate to the caller
+ * unchanged.
+ */
+@RegisterRestClient(configKey = "harness")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface HarnessClient {
+
+    @POST
+    @Path("/runs")
+    Uni<Response> createRun(
+            @HeaderParam("Authorization") String authorization,
+            @HeaderParam("X-Miot-Tenant-Client-Id") String tenantClientId,
+            @HeaderParam("X-Miot-User-Email") String userEmail,
+            @HeaderParam("X-Miot-Auth-Mode") String authMode,
+            Map<String, Object> body);
+
+    @POST
+    @Path("/runs:start")
+    Uni<Response> startRun(
+            @HeaderParam("Authorization") String authorization,
+            @HeaderParam("X-Miot-Tenant-Client-Id") String tenantClientId,
+            @HeaderParam("X-Miot-User-Email") String userEmail,
+            @HeaderParam("X-Miot-Auth-Mode") String authMode,
+            Map<String, Object> body);
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -5,11 +5,13 @@ import com.microboxlabs.miot.core.auth.TenantContext;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
@@ -70,6 +72,17 @@ public class HarnessProxyResource {
         return forward(authorization, body, harness::startRun);
     }
 
+    @GET
+    @Path("/runs/{runId}")
+    public Uni<Response> getRun(@PathParam("slug") String slug,
+                                @PathParam("runId") String runId,
+                                @HeaderParam("Authorization") String authorization) {
+        String tenantClientId = tenantContext.getClientId();
+        String userEmail = organizationContext.getUserEmail();
+        String authMode = userEmail != null ? "web" : "m2m";
+        return passThrough(harness.getRun(runId, authorization, tenantClientId, userEmail, authMode));
+    }
+
     private Uni<Response> forward(String authorization,
                                   Map<String, Object> body,
                                   HarnessCall call) {
@@ -78,8 +91,20 @@ public class HarnessProxyResource {
         // Web tokens carry an email claim; M2M tokens don't. Flagging
         // the mode explicitly spares the harness from re-deriving it.
         String authMode = userEmail != null ? "web" : "m2m";
-        return call.apply(authorization, tenantClientId, userEmail, authMode, body)
-                .map(upstream -> Response.fromResponse(upstream).build());
+        return passThrough(call.apply(authorization, tenantClientId, userEmail, authMode, body));
+    }
+
+    /**
+     * Pass upstream status + body through unchanged. Quarkus REST
+     * Reactive throws {@link WebApplicationException} for any non-2xx
+     * harness response; unwrap it so the original status (404, 500, …)
+     * reaches the caller instead of becoming a proxy-side 500.
+     */
+    private static Uni<Response> passThrough(Uni<Response> upstream) {
+        return upstream
+                .onFailure(WebApplicationException.class)
+                .recoverWithItem(err -> ((WebApplicationException) err).getResponse())
+                .map(r -> Response.fromResponse(r).build());
     }
 
     @FunctionalInterface

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -1,0 +1,93 @@
+package com.microboxlabs.miot.core.api;
+
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+/**
+ * Auth0-gated proxy for miot-harness's {@code /runs} endpoints.
+ *
+ * <p>The {@code /api/v1/orgs/{slug}/...} prefix makes
+ * {@code OrganizationRequestFilter} resolve the org membership before
+ * this handler ever runs, so the auth + membership invariants live in
+ * one place. The proxy then forwards the caller's bearer token plus
+ * {@code X-Miot-*} identity headers to the harness so the harness can
+ * enforce its own tenant + user invariants without re-parsing the JWT.
+ *
+ * <p>Q1 covers POST {@code /runs} and POST {@code /runs:start};
+ * GET {@code /runs/{runId}} is Q2 and the SSE relay is Q3.
+ */
+@Path("/api/v1/orgs/{slug}/harness")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Harness", description = "Proxy to the miot-harness LLM runs API")
+@SecurityRequirement(name = "oidc")
+public class HarnessProxyResource {
+
+    private final HarnessClient harness;
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+
+    @Inject
+    public HarnessProxyResource(@RestClient HarnessClient harness,
+                                TenantContext tenantContext,
+                                OrganizationContext organizationContext) {
+        this.harness = harness;
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+    }
+
+    @POST
+    @Path("/runs")
+    public Uni<Response> createRun(@PathParam("slug") String slug,
+                                   @HeaderParam("Authorization") String authorization,
+                                   Map<String, Object> body) {
+        return forward(authorization, body, harness::createRun);
+    }
+
+    // Quarkus REST Reactive does not register a literal ':' in @Path values,
+    // so the action segment is declared via a regex path parameter that
+    // matches exactly "runs:start". The captured value is unused.
+    @POST
+    @Path("/{startAction:runs:start}")
+    public Uni<Response> startRun(@PathParam("slug") String slug,
+                                  @PathParam("startAction") String startAction,
+                                  @HeaderParam("Authorization") String authorization,
+                                  Map<String, Object> body) {
+        return forward(authorization, body, harness::startRun);
+    }
+
+    private Uni<Response> forward(String authorization,
+                                  Map<String, Object> body,
+                                  HarnessCall call) {
+        String tenantClientId = tenantContext.getClientId();
+        String userEmail = organizationContext.getUserEmail();
+        // Web tokens carry an email claim; M2M tokens don't. Flagging
+        // the mode explicitly spares the harness from re-deriving it.
+        String authMode = userEmail != null ? "web" : "m2m";
+        return call.apply(authorization, tenantClientId, userEmail, authMode, body)
+                .map(upstream -> Response.fromResponse(upstream).build());
+    }
+
+    @FunctionalInterface
+    private interface HarnessCall {
+        Uni<Response> apply(String authorization,
+                            String tenantClientId,
+                            String userEmail,
+                            String authMode,
+                            Map<String, Object> body);
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -108,8 +108,6 @@ public class HarnessProxyResource {
     }
 
     private static Response unwrapResponse(Throwable err) {
-        // onFailure(WebApplicationException.class) above narrows the throwable;
-        // the instanceof pattern keeps the compiler happy without a redundant cast.
         if (err instanceof WebApplicationException wae) {
             return wae.getResponse();
         }

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -103,8 +103,17 @@ public class HarnessProxyResource {
     private static Uni<Response> passThrough(Uni<Response> upstream) {
         return upstream
                 .onFailure(WebApplicationException.class)
-                .recoverWithItem(err -> ((WebApplicationException) err).getResponse())
+                .recoverWithItem(HarnessProxyResource::unwrapResponse)
                 .map(r -> Response.fromResponse(r).build());
+    }
+
+    private static Response unwrapResponse(Throwable err) {
+        // onFailure(WebApplicationException.class) above narrows the throwable;
+        // the instanceof pattern keeps the compiler happy without a redundant cast.
+        if (err instanceof WebApplicationException wae) {
+            return wae.getResponse();
+        }
+        throw new IllegalStateException("Expected WebApplicationException from upstream", err);
     }
 
     @FunctionalInterface

--- a/quarkus-srv/miot-core/src/main/resources/application.properties
+++ b/quarkus-srv/miot-core/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# miot-core REST client bindings.
+#
+# Consumed by HarnessProxyResource. Default points at the in-cluster
+# Kubernetes service name; MIOT_HARNESS_BASE_URL overrides for local
+# dev or staging. Test-mode overrides live in HarnessProxyTestProfile
+# (points at the WireMock instance the test resource lifecycle starts).
+quarkus.rest-client."harness".url=${MIOT_HARNESS_BASE_URL:http://miot-harness:8000}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceGetTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceGetTest.java
@@ -1,0 +1,132 @@
+package com.microboxlabs.miot.core.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile.WireMockLifecycle;
+import com.microboxlabs.miot.core.auth.StubAlfrescoMembershipClient;
+import com.microboxlabs.miot.core.auth.TestTokenFactory;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code HarnessProxyResource#getRun} forwards the upstream
+ * harness response (body + status) unchanged, and sits behind the
+ * same {@code DualJwtAuthMechanism} + {@code OrganizationRequestFilter}
+ * chain Q1 already exercises on the POST path.
+ */
+@QuarkusTest
+@TestProfile(HarnessProxyTestProfile.class)
+class HarnessProxyResourceGetTest {
+
+    private static final String ORG_SLUG = "harness-get-test-org";
+    private static final String ORG_GROUP = "GROUP_harness_get_test";
+    private static final String ORG_TENANT = "harness-get-tenant";
+    private static final String NON_MEMBER = "intruder@test.example";
+    private static final String RUN_ID_OK = "run_ok";
+    private static final String RUN_ID_MISSING = "run_missing";
+    private static final String FAKE_RECORD =
+            "{\"run_id\":\"run_ok\",\"status\":\"completed\",\"answer\":\"42\"}";
+
+    @Inject
+    AgroalDataSource ds;
+
+    @BeforeEach
+    void seedOrgAndStubs() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "INSERT INTO miot_core.organizations "
+                        + "(slug, name, alfresco_group_id, tenant_client_id, active) "
+                        + "VALUES (?, ?, ?, ?, true)")) {
+            st.setString(1, ORG_SLUG);
+            st.setString(2, "Harness Get Test Org");
+            st.setString(3, ORG_GROUP);
+            st.setString(4, ORG_TENANT);
+            st.executeUpdate();
+        }
+        WireMockLifecycle.server().resetAll();
+        WireMockLifecycle.server().stubFor(
+                WireMock.get(WireMock.urlEqualTo("/runs/" + RUN_ID_OK))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(FAKE_RECORD)));
+        WireMockLifecycle.server().stubFor(
+                WireMock.get(WireMock.urlEqualTo("/runs/" + RUN_ID_MISSING))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"detail\":\"Run not found\"}")));
+    }
+
+    @AfterEach
+    void cleanupOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "DELETE FROM miot_core.organizations WHERE slug = ?")) {
+            st.setString(1, ORG_SLUG);
+            st.executeUpdate();
+        }
+    }
+
+    @Test
+    void memberGetRunReturnsProxiedBody() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        Response resp = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK);
+        assertThat(resp.statusCode(), is(200));
+        assertThat(resp.body().asString(), containsString("\"run_id\":\"run_ok\""));
+        assertThat(resp.body().asString(), containsString("\"status\":\"completed\""));
+        WireMockLifecycle.server().verify(WireMock.getRequestedFor(
+                WireMock.urlEqualTo("/runs/" + RUN_ID_OK))
+                .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT))
+                .withHeader("X-Miot-User-Email",
+                        WireMock.equalTo(StubAlfrescoMembershipClient.MEMBER_EMAIL))
+                .withHeader("X-Miot-Auth-Mode", WireMock.equalTo("web")));
+    }
+
+    @Test
+    void memberGetMissingRunPasses404Through() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_MISSING)
+                .statusCode();
+        assertThat("upstream 404 must pass through the proxy", status, is(404));
+    }
+
+    @Test
+    void nonMemberHits403WithoutCallingUpstream() {
+        String token = TestTokenFactory.signWebToken(NON_MEMBER);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK)
+                .statusCode();
+        assertThat(status, is(403));
+        WireMockLifecycle.server().verify(0,
+                WireMock.getRequestedFor(WireMock.urlEqualTo("/runs/" + RUN_ID_OK)));
+    }
+
+    @Test
+    void noTokenHits401() {
+        int status = given()
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK)
+                .statusCode();
+        assertThat(status, is(401));
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
@@ -116,7 +116,11 @@ class HarnessProxyResourcePostTest {
         assertThat("upstream 202 must pass through the proxy", status, is(202));
         WireMockLifecycle.server().verify(
                 WireMock.postRequestedFor(WireMock.urlEqualTo("/runs:start"))
-                        .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT)));
+                        .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT))
+                        .withHeader("X-Miot-User-Email",
+                                WireMock.equalTo(StubAlfrescoMembershipClient.MEMBER_EMAIL))
+                        .withHeader("X-Miot-Auth-Mode", WireMock.equalTo("web"))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token)));
     }
 
     @Test

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
@@ -1,0 +1,160 @@
+package com.microboxlabs.miot.core.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile.WireMockLifecycle;
+import com.microboxlabs.miot.core.auth.StubAlfrescoMembershipClient;
+import com.microboxlabs.miot.core.auth.TestTokenFactory;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code HarnessProxyResource}'s POST endpoints sit behind the
+ * {@code DualJwtAuthMechanism} + {@code OrganizationRequestFilter}
+ * chain and forward the {@code X-Miot-*} identity headers to the harness.
+ *
+ * <p>Stubs the upstream harness with WireMock (started by
+ * {@link WireMockLifecycle} from Q0) and asserts:
+ * <ul>
+ *   <li>member POST {@code /runs} → 200 + WireMock saw the right tenant header</li>
+ *   <li>member POST {@code /runs:start} → 202 (upstream status passes through)</li>
+ *   <li>non-member → 403 (filter denies before reaching WireMock)</li>
+ *   <li>no token / expired token → 401 (mechanism denies)</li>
+ * </ul>
+ */
+@QuarkusTest
+@TestProfile(HarnessProxyTestProfile.class)
+class HarnessProxyResourcePostTest {
+
+    private static final String ORG_SLUG = "harness-post-test-org";
+    private static final String ORG_GROUP = "GROUP_harness_post_test";
+    private static final String ORG_TENANT = "harness-post-tenant";
+    private static final String NON_MEMBER = "intruder@test.example";
+    private static final String RUNS_PATH = "/api/v1/orgs/" + ORG_SLUG + "/harness/runs";
+    private static final String RUNS_START_PATH =
+            "/api/v1/orgs/" + ORG_SLUG + "/harness/runs:start";
+
+    @Inject
+    AgroalDataSource ds;
+
+    @BeforeEach
+    void seedOrgAndStubs() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "INSERT INTO miot_core.organizations "
+                        + "(slug, name, alfresco_group_id, tenant_client_id, active) "
+                        + "VALUES (?, ?, ?, ?, true)")) {
+            st.setString(1, ORG_SLUG);
+            st.setString(2, "Harness Post Test Org");
+            st.setString(3, ORG_GROUP);
+            st.setString(4, ORG_TENANT);
+            st.executeUpdate();
+        }
+        WireMockLifecycle.server().resetAll();
+        WireMockLifecycle.server().stubFor(WireMock.post(WireMock.urlEqualTo("/runs"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"run_id\":\"run_fake_create\"}")));
+        WireMockLifecycle.server().stubFor(WireMock.post(WireMock.urlEqualTo("/runs:start"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(202)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"run_id\":\"run_fake_start\"}")));
+    }
+
+    @AfterEach
+    void cleanupOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "DELETE FROM miot_core.organizations WHERE slug = ?")) {
+            st.setString(1, ORG_SLUG);
+            st.executeUpdate();
+        }
+    }
+
+    @Test
+    void memberPostRunsHits200AndForwardsTenantHeader() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{\"prompt\":\"hello\"}")
+                .when()
+                .post(RUNS_PATH)
+                .statusCode();
+        assertThat(status, is(200));
+        WireMockLifecycle.server().verify(
+                WireMock.postRequestedFor(WireMock.urlEqualTo("/runs"))
+                        .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT))
+                        .withHeader("X-Miot-User-Email",
+                                WireMock.equalTo(StubAlfrescoMembershipClient.MEMBER_EMAIL))
+                        .withHeader("X-Miot-Auth-Mode", WireMock.equalTo("web"))
+                        .withHeader("Authorization", WireMock.equalTo("Bearer " + token)));
+    }
+
+    @Test
+    void memberPostRunsStartHits202() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .urlEncodingEnabled(false)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{\"prompt\":\"hello\"}")
+                .when()
+                .post(RUNS_START_PATH)
+                .statusCode();
+        assertThat("upstream 202 must pass through the proxy", status, is(202));
+        WireMockLifecycle.server().verify(
+                WireMock.postRequestedFor(WireMock.urlEqualTo("/runs:start"))
+                        .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT)));
+    }
+
+    @Test
+    void nonMemberHits403() {
+        String token = TestTokenFactory.signWebToken(NON_MEMBER);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{}")
+                .when()
+                .post(RUNS_PATH)
+                .statusCode();
+        assertThat(status, is(403));
+        WireMockLifecycle.server().verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/runs")));
+    }
+
+    @Test
+    void noTokenHits401() {
+        int status = given()
+                .contentType("application/json")
+                .body("{}")
+                .when()
+                .post(RUNS_PATH)
+                .statusCode();
+        assertThat(status, is(401));
+    }
+
+    @Test
+    void expiredTokenHits401() {
+        String token = TestTokenFactory.signExpiredWebToken(
+                StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{}")
+                .when()
+                .post(RUNS_PATH)
+                .statusCode();
+        assertThat(status, is(401));
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/AuthTestInfrastructureTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/AuthTestInfrastructureTest.java
@@ -1,0 +1,106 @@
+package com.microboxlabs.miot.core.auth;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the Q0 auth test infrastructure works end-to-end against the
+ * real {@code DualJwtAuthMechanism} + {@code OrganizationRequestFilter}
+ * trust chain that Q1..Q3 will reuse.
+ *
+ * <p>Hits an existing org-scoped endpoint ({@code OrgMembersResource})
+ * with three forged tokens:
+ * <ul>
+ *   <li>valid web token for {@code member@test.example} → 200 (stub approves)</li>
+ *   <li>valid web token for any other email → 403 (stub denies)</li>
+ *   <li>expired web token → 401 ({@code DualJwtAuthMechanism} rejects)</li>
+ * </ul>
+ *
+ * <p>Seeds a single {@code organizations} row via the JDBC datasource so
+ * the test stays out of Hibernate Reactive's session model. DB comes
+ * from Quarkus DevServices Postgres (Docker required).
+ */
+@QuarkusTest
+@TestProfile(HarnessProxyTestProfile.class)
+class AuthTestInfrastructureTest {
+
+    private static final String ORG_SLUG = "auth-infra-test-org";
+    private static final String ORG_GROUP = "GROUP_auth_infra_test";
+    private static final String ORG_TENANT = "auth-infra-tenant";
+    private static final String NON_MEMBER = "intruder@test.example";
+    private static final String MEMBERS_PATH = "/api/v1/orgs/" + ORG_SLUG + "/members";
+
+    @Inject
+    AgroalDataSource ds;
+
+    @BeforeEach
+    void seedOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "INSERT INTO miot_core.organizations "
+                        + "(slug, name, alfresco_group_id, tenant_client_id, active) "
+                        + "VALUES (?, ?, ?, ?, true)")) {
+            st.setString(1, ORG_SLUG);
+            st.setString(2, "Auth Infra Test Org");
+            st.setString(3, ORG_GROUP);
+            st.setString(4, ORG_TENANT);
+            st.executeUpdate();
+        }
+    }
+
+    @AfterEach
+    void cleanupOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "DELETE FROM miot_core.organizations WHERE slug = ?")) {
+            st.setString(1, ORG_SLUG);
+            st.executeUpdate();
+        }
+    }
+
+    @Test
+    void memberWebTokenHits200() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get(MEMBERS_PATH)
+                .statusCode();
+        assertThat("member should be allowed past OrganizationRequestFilter",
+                status, is(200));
+    }
+
+    @Test
+    void nonMemberWebTokenHits403() {
+        String token = TestTokenFactory.signWebToken(NON_MEMBER);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get(MEMBERS_PATH)
+                .statusCode();
+        assertThat("non-member should be rejected by OrganizationRequestFilter",
+                status, is(403));
+    }
+
+    @Test
+    void expiredWebTokenHits401() {
+        String token = TestTokenFactory.signExpiredWebToken(
+                StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get(MEMBERS_PATH)
+                .statusCode();
+        assertThat("expired token must be rejected by DualJwtAuthMechanism",
+                status, is(401));
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
@@ -28,9 +28,6 @@ import java.util.Map;
  */
 public class HarnessProxyTestProfile implements QuarkusTestProfile {
 
-    /** Fixed port for the test WireMock instance. */
-    public static final int WIREMOCK_PORT = 18089;
-
     @Override
     public Map<String, String> getConfigOverrides() {
         Map<String, String> overrides = new HashMap<>();
@@ -44,10 +41,9 @@ public class HarnessProxyTestProfile implements QuarkusTestProfile {
         overrides.put("miot.auth.hs256-secret", TestTokenFactory.HS256_SECRET);
         overrides.put("miot.auth.hs256-audience", TestTokenFactory.M2M_AUDIENCE);
 
-        // Harness REST client binding (used from Q1 onward; declared in Q0 so the
-        // binding name + URL placeholder are stable across rungs).
-        overrides.put("quarkus.rest-client.\"harness\".url",
-                "http://localhost:" + WIREMOCK_PORT);
+        // The "harness" REST client URL is injected by WireMockLifecycle.start()
+        // at runtime because the WireMock port is ephemeral — fixed ports
+        // collide with anything else holding the port on the host.
 
         // Force the @DefaultBean stub Alfresco directory/group-admin clients to win.
         // @LookupUnlessProperty(stringValue="stub") only gates programmatic lookups,
@@ -84,9 +80,12 @@ public class HarnessProxyTestProfile implements QuarkusTestProfile {
     }
 
     /**
-     * Starts/stops a {@link WireMockServer} on {@link #WIREMOCK_PORT}. The
-     * server is exposed via {@link #server()} so later rungs (Q1..Q3) can
-     * stub harness routes without owning the lifecycle.
+     * Starts/stops a {@link WireMockServer} on an ephemeral port (so multiple
+     * Quarkus test JVMs on the same host don't collide on a fixed port).
+     * The resolved {@code "harness"} REST-client URL is returned from
+     * {@link #start()} so Quarkus picks the dynamic port up at config time;
+     * the server itself is exposed via {@link #server()} so later rungs
+     * (Q1..Q3) can stub harness routes without owning the lifecycle.
      */
     public static class WireMockLifecycle implements QuarkusTestResourceLifecycleManager {
 
@@ -99,9 +98,11 @@ public class HarnessProxyTestProfile implements QuarkusTestProfile {
 
         @Override
         public Map<String, String> start() {
-            server = new WireMockServer(WireMockConfiguration.options().port(WIREMOCK_PORT));
+            server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
             server.start();
-            return Map.of();
+            return Map.of(
+                    "quarkus.rest-client.\"harness\".url",
+                    "http://localhost:" + server.port());
         }
 
         @Override

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
@@ -1,0 +1,115 @@
+package com.microboxlabs.miot.core.auth;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared {@code @QuarkusTest} profile that wires the auth chain to
+ * {@link MockOidcResource} and the {@code "harness"} REST client to a
+ * test-scoped WireMock instance.
+ *
+ * <p>Config overrides:
+ * <ul>
+ *   <li>{@code miot.auth.*} → values matching {@link TestTokenFactory}'s tokens</li>
+ *   <li>{@code miot.auth.jwks-url} → MockOidcResource on the same Quarkus test port</li>
+ *   <li>{@code quarkus.rest-client."harness".url} → port {@link WireMockLifecycle} listens on</li>
+ *   <li>{@code quarkus.http.auth.permission.*} → mirrors prod (authenticated /api/*)</li>
+ *   <li>Datasource: relies on Quarkus DevServices Postgres + Flyway core migrations</li>
+ * </ul>
+ *
+ * <p>The WireMock server lifecycle is owned by the inner
+ * {@link WireMockLifecycle} so all five Q0 files stay under
+ * {@code src/test/java/.../auth/}.
+ */
+public class HarnessProxyTestProfile implements QuarkusTestProfile {
+
+    /** Fixed port for the test WireMock instance. */
+    public static final int WIREMOCK_PORT = 18089;
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> overrides = new HashMap<>();
+
+        // Auth: DualJwtAuthMechanism reaches MockOidcResource on the same test JVM.
+        overrides.put("miot.auth.rs256-issuer", TestTokenFactory.ISSUER);
+        overrides.put("miot.auth.rs256-audience", TestTokenFactory.WEB_AUDIENCE);
+        overrides.put("miot.auth.jwks-url",
+                "http://localhost:${quarkus.http.test-port:8081}/_test/oidc/jwks");
+        overrides.put("miot.auth.hs256-issuer", TestTokenFactory.ISSUER);
+        overrides.put("miot.auth.hs256-secret", TestTokenFactory.HS256_SECRET);
+        overrides.put("miot.auth.hs256-audience", TestTokenFactory.M2M_AUDIENCE);
+
+        // Harness REST client binding (used from Q1 onward; declared in Q0 so the
+        // binding name + URL placeholder are stable across rungs).
+        overrides.put("quarkus.rest-client.\"harness\".url",
+                "http://localhost:" + WIREMOCK_PORT);
+
+        // Force the @DefaultBean stub Alfresco directory/group-admin clients to win.
+        // @LookupUnlessProperty(stringValue="stub") only gates programmatic lookups,
+        // not direct @Inject, so the real REST-client-backed beans would otherwise
+        // win and trip an unconfigured-baseUri 500 on the happy path.
+        overrides.put("miot.alfresco.auth", "stub");
+        overrides.put("quarkus.arc.exclude-types",
+                "com.microboxlabs.miot.core.alfresco.RealAlfrescoDirectoryClient,"
+                        + "com.microboxlabs.miot.core.alfresco.RealAlfrescoGroupAdminClient");
+
+        // Permission policy: miot-core has no application.properties; without
+        // these /api/* would be permit-all and the 401/403 split would not fire.
+        overrides.put("quarkus.http.auth.permission.api.paths", "/api/*");
+        overrides.put("quarkus.http.auth.permission.api.policy", "authenticated");
+        overrides.put("quarkus.http.auth.permission.public.paths", "/_test/*,/q/*");
+        overrides.put("quarkus.http.auth.permission.public.policy", "permit");
+
+        // DB: DevServices Postgres + Flyway runs the miot_core migrations on start.
+        overrides.put("quarkus.datasource.db-kind", "postgresql");
+        overrides.put("quarkus.flyway.migrate-at-start", "true");
+        overrides.put("quarkus.flyway.locations", "db/migration/core");
+        overrides.put("quarkus.flyway.schemas", "miot_core");
+        overrides.put("quarkus.flyway.create-schemas", "true");
+        overrides.put("quarkus.hibernate-orm.schema-management.strategy", "none");
+        overrides.put("quarkus.hibernate-orm.physical-naming-strategy",
+                "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+
+        return overrides;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(new TestResourceEntry(WireMockLifecycle.class));
+    }
+
+    /**
+     * Starts/stops a {@link WireMockServer} on {@link #WIREMOCK_PORT}. The
+     * server is exposed via {@link #server()} so later rungs (Q1..Q3) can
+     * stub harness routes without owning the lifecycle.
+     */
+    public static class WireMockLifecycle implements QuarkusTestResourceLifecycleManager {
+
+        private static volatile WireMockServer server;
+
+        /** Returns the shared WireMock instance (null before start/after stop). */
+        public static WireMockServer server() {
+            return server;
+        }
+
+        @Override
+        public Map<String, String> start() {
+            server = new WireMockServer(WireMockConfiguration.options().port(WIREMOCK_PORT));
+            server.start();
+            return Map.of();
+        }
+
+        @Override
+        public void stop() {
+            if (server != null) {
+                server.stop();
+                server = null;
+            }
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/MockOidcResource.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/MockOidcResource.java
@@ -1,0 +1,51 @@
+package com.microboxlabs.miot.core.auth;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.math.BigInteger;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fake OIDC endpoint mounted under {@code /_test/oidc} for @QuarkusTest runs.
+ * Serves the JWKS document that {@code DualJwtAuthMechanism}'s {@code HttpsJwks}
+ * resolver fetches when verifying tokens forged by {@link TestTokenFactory}.
+ *
+ * <p>Only present on the test classpath. {@link HarnessProxyTestProfile} sets
+ * {@code miot.auth.jwks-url} to {@code http://localhost:<test-port>/_test/oidc/jwks}
+ * so the mechanism reaches this resource on the same JVM it runs in.
+ */
+@ApplicationScoped
+@Path("/_test/oidc")
+@Produces(MediaType.APPLICATION_JSON)
+public class MockOidcResource {
+
+    @GET
+    @Path("/jwks")
+    public Map<String, Object> jwks() {
+        Base64.Encoder b64Url = Base64.getUrlEncoder().withoutPadding();
+        Map<String, Object> key = new LinkedHashMap<>();
+        key.put("kty", "RSA");
+        key.put("use", "sig");
+        key.put("alg", "RS256");
+        key.put("kid", TestTokenFactory.KID);
+        key.put("n", b64Url.encodeToString(unsignedBytes(TestTokenFactory.modulus())));
+        key.put("e", b64Url.encodeToString(unsignedBytes(TestTokenFactory.exponent())));
+        return Map.of("keys", List.of(key));
+    }
+
+    private static byte[] unsignedBytes(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            byte[] trimmed = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+            return trimmed;
+        }
+        return bytes;
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/StubAlfrescoMembershipClient.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/StubAlfrescoMembershipClient.java
@@ -1,0 +1,39 @@
+package com.microboxlabs.miot.core.auth;
+
+import com.microboxlabs.miot.core.alfresco.IAlfrescoMembershipClient;
+import io.smallrye.mutiny.Uni;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * Test-only Alfresco membership stub. Approves a single fixed email
+ * ({@link #MEMBER_EMAIL}) and denies everything else, so the
+ * {@code OrganizationRequestFilter} web-user branch produces a clean
+ * 200 vs 403 split in {@link AuthTestInfrastructureTest} and the rungs
+ * that follow.
+ *
+ * <p>Activated via {@code @Alternative @Priority(1)} (auto-selected by ArC),
+ * overriding the production {@code @DefaultBean} stub in
+ * {@code com.microboxlabs.miot.core.alfresco}.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class StubAlfrescoMembershipClient implements IAlfrescoMembershipClient {
+
+    public static final String MEMBER_EMAIL = "member@test.example";
+    public static final String MEMBER_ROLE = "SITE_MANAGER";
+
+    @Override
+    public Uni<Boolean> isMember(String personId, String groupId) {
+        return Uni.createFrom().item(MEMBER_EMAIL.equalsIgnoreCase(personId));
+    }
+
+    @Override
+    public Uni<String> getRole(String personId, String groupId) {
+        return MEMBER_EMAIL.equalsIgnoreCase(personId)
+                ? Uni.createFrom().item(MEMBER_ROLE)
+                : Uni.createFrom().nullItem();
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/TestTokenFactory.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/TestTokenFactory.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.core.auth;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPublicKey;
@@ -91,7 +92,7 @@ public final class TestTokenFactory {
     private static String signHs256(JwtClaims claims) {
         JsonWebSignature jws = new JsonWebSignature();
         jws.setPayload(claims.toJson());
-        jws.setKey(new HmacKey(HS256_SECRET.getBytes()));
+        jws.setKey(new HmacKey(HS256_SECRET.getBytes(StandardCharsets.UTF_8)));
         jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256);
         try {
             return jws.getCompactSerialization();

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/TestTokenFactory.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/TestTokenFactory.java
@@ -1,0 +1,118 @@
+package com.microboxlabs.miot.core.auth;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.UUID;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.NumericDate;
+import org.jose4j.keys.HmacKey;
+
+/**
+ * Test-only helper that forges Auth0-shaped JWTs against an in-process keypair.
+ * The matching JWKS is published by {@link MockOidcResource}; both share the
+ * single static {@link #RS256_KEYPAIR} so verification round-trips work.
+ *
+ * <p>Web tokens are signed RS256 (matches {@code miot.auth.rs256-*} config);
+ * M2M tokens are signed HS256 with {@link #HS256_SECRET} (matches
+ * {@code miot.auth.hs256-*}). Claim shape mirrors what
+ * {@code DualJwtAuthMechanism} and {@code OrganizationRequestFilter} consume.
+ */
+public final class TestTokenFactory {
+
+    public static final String KID = "test-rs256-kid";
+    public static final String ISSUER = "https://mock-oidc.test/";
+    public static final String WEB_AUDIENCE = "https://api.miot.test/web";
+    public static final String M2M_AUDIENCE = "https://api.miot.test/m2m";
+    public static final String HS256_SECRET = "test-hs256-secret-please-rotate-32-bytes-min!";
+
+    static final KeyPair RS256_KEYPAIR = generateRsa();
+
+    private TestTokenFactory() {}
+
+    public static RSAPublicKey publicKey() {
+        return (RSAPublicKey) RS256_KEYPAIR.getPublic();
+    }
+
+    public static String signWebToken(String email) {
+        return signWebToken(email, Instant.now().plusSeconds(300));
+    }
+
+    public static String signExpiredWebToken(String email) {
+        return signWebToken(email, Instant.now().minusSeconds(60));
+    }
+
+    public static String signWebToken(String email, Instant expiration) {
+        JwtClaims claims = baseClaims(WEB_AUDIENCE, expiration);
+        claims.setSubject("auth0|" + email);
+        claims.setStringClaim("email", email);
+        claims.setStringClaim("azp", "web-client-id");
+        return signRs256(claims);
+    }
+
+    public static String signM2mToken(String clientId) {
+        return signM2mToken(clientId, Instant.now().plusSeconds(300));
+    }
+
+    public static String signM2mToken(String clientId, Instant expiration) {
+        JwtClaims claims = baseClaims(M2M_AUDIENCE, expiration);
+        claims.setSubject(clientId + "@clients");
+        claims.setStringClaim("azp", clientId);
+        return signHs256(claims);
+    }
+
+    private static JwtClaims baseClaims(String audience, Instant expiration) {
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(ISSUER);
+        claims.setAudience(audience);
+        claims.setIssuedAt(NumericDate.fromSeconds(Instant.now().getEpochSecond()));
+        claims.setExpirationTime(NumericDate.fromSeconds(expiration.getEpochSecond()));
+        claims.setJwtId(UUID.randomUUID().toString());
+        return claims;
+    }
+
+    private static String signRs256(JwtClaims claims) {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(RS256_KEYPAIR.getPrivate());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        jws.setKeyIdHeaderValue(KID);
+        try {
+            return jws.getCompactSerialization();
+        } catch (Exception e) {
+            throw new IllegalStateException("RS256 sign failed", e);
+        }
+    }
+
+    private static String signHs256(JwtClaims claims) {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(new HmacKey(HS256_SECRET.getBytes()));
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256);
+        try {
+            return jws.getCompactSerialization();
+        } catch (Exception e) {
+            throw new IllegalStateException("HS256 sign failed", e);
+        }
+    }
+
+    private static KeyPair generateRsa() {
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(2048);
+            return kpg.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate test RSA keypair", e);
+        }
+    }
+
+    /** Public exponent / modulus accessor used by {@link MockOidcResource#jwks()}. */
+    static BigInteger modulus() { return publicKey().getModulus(); }
+
+    /** Public exponent accessor used by {@link MockOidcResource#jwks()}. */
+    static BigInteger exponent() { return publicKey().getPublicExponent(); }
+}


### PR DESCRIPTION
## Summary

Quarkus side of the Auth0 JWT proxy to `miot-harness`, refs #522. Ships
the **non-streaming** rungs (Q0+Q1+Q2) of the
`harness_auth0_jwt_quarkus` sub-ladder. Q3 (SSE relay) is intentionally
deferred — it has an architecture choice (Vertx WebClient vs REST Client
Reactive `@RestStreamElementType` vs 307+HS256 fallback) that needs
human sign-off before code.

- **Q0 — `@QuarkusTest` auth test infrastructure.** First `@QuarkusTest`
  in `miot-core`. In-process RSA keypair (`TestTokenFactory`), JWKS
  endpoint (`MockOidcResource`), `HarnessProxyTestProfile` (DevServices
  Postgres + Flyway core migrations + WireMock lifecycle), test-scope
  `StubAlfrescoMembershipClient`. `AuthTestInfrastructureTest` proves
  200 / 403 / 401 through the real `DualJwtAuthMechanism` +
  `OrganizationRequestFilter`.
- **Q1 — POST `/runs` + `/runs:start`.** `HarnessClient`
  (`@RegisterRestClient configKey="harness"`) + `HarnessProxyResource`
  at `/api/v1/orgs/{slug}/harness/*`. Forwards `Authorization` +
  `X-Miot-Tenant-Client-Id` + `X-Miot-User-Email` + `X-Miot-Auth-Mode`
  (`web` vs `m2m`) to the harness. WireMock test verifies the headers
  end-to-end and 202 pass-through on `/runs:start`.
- **Q2 — GET `/runs/{runId}`.** Same header forwarding. Shared
  `passThrough()` helper unwraps `ClientWebApplicationException` so
  upstream 4xx/5xx (e.g. 404 missing run) reach the caller unchanged
  instead of becoming a proxy-side 500.

### Notes on the non-obvious bits

- `quarkus-rest-client-jackson` is already on the classpath and IS the
  reactive REST client in Quarkus 3.x — the BOM renamed the older
  `quarkus-rest-client-reactive-jackson` artifact.
- `@LookupUnlessProperty` only gates **programmatic** lookups, not
  `@Inject`. `HarnessProxyTestProfile` therefore uses
  `quarkus.arc.exclude-types` to suppress the Real Alfresco beans so
  the `@DefaultBean` stubs win in tests.
- Quarkus REST Reactive does not register a literal `:` in `@Path`
  values; `/runs:start` uses the `{startAction:runs:start}` regex form,
  and the test calls RestAssured with `urlEncodingEnabled(false)` so
  the colon doesn't get percent-encoded on the wire.

### What's not in this PR

- Q3 — SSE relay for `/runs/{runId}/stream`. Tracked in the sub-ladder
  at `.cursor/plans/ai-first/harness_auth0_jwt_quarkus/GOAL-LADDER.md`.
- No changes to `miot-harness/` from this branch (out of scope per the
  goal-loop contract — the harness arm ships from
  `based/522-harness-auth0-jwt`).
- No changes to the production `DualJwtAuthMechanism` /
  `OrganizationRequestFilter` / `M2MAuth` (the working trust model is
  reused as-is).

## Test plan

- [x] `cd quarkus-srv && ./mvnw -q -pl miot-core -am test` — 25/25 green
      (1 pre-existing unit test + 12 new `@QuarkusTest` assertions
      across `AuthTestInfrastructureTest`, `HarnessProxyResourcePostTest`,
      `HarnessProxyResourceGetTest`).
- [x] `cd quarkus-srv && ./mvnw -q -pl miot-core -DskipTests package` —
      build smoke clean.
- [ ] Reviewer: confirm Docker is available where CI runs (DevServices
      Postgres is required for the `@QuarkusTest` rungs).
- [ ] Reviewer: spot-check the `passThrough()` helper handles every
      `WebApplicationException` subclass we care about (we lean on the
      base type catching `ClientWebApplicationException`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated proxy endpoints to create, start, and retrieve harness runs for organization members.

* **Tests**
  * Added comprehensive test infrastructure for authentication, authorization, and API integration validation.

* **Chores**
  * Added test dependencies and configuration for harness service integration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->