### PR TITLE
fix(529): pin Quarkus Flyway extension to miot_core (PR #530 follow-up)

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -31,6 +31,13 @@ quarkus.datasource.jdbc.max-size=5
 # Migration is handled programmatically by FlywayMigrator based on active components
 quarkus.flyway.migrate-at-start=false
 quarkus.flyway.out-of-order=true
+# Pin the Quarkus Flyway extension's metadata table to miot_core so any
+# *-at-start action (migrate / validate / baseline / repair) inadvertently
+# enabled via env (QUARKUS_FLYWAY_MIGRATE_AT_START=true on a deployment, etc.)
+# never touches the `public` schema. Mirrors FlywayMigrator's own .schemas()
+# call so both Flyway instances (extension + programmatic) agree.
+quarkus.flyway.schemas=miot_core
+quarkus.flyway.default-schema=miot_core
 miot.flyway.base-locations=db/migration/core,db/migration/resource
 
 # --- Hibernate ---


### PR DESCRIPTION
Follow-up to #530. Re-opens #529 because **#530 by itself does not unblock prod.**

## What I missed in #530

#530 only pinned the schema on the **programmatic** `FlywayMigrator`
builder. But the prod stack trace shows the failure comes from the
**Quarkus Flyway extension** itself:

```
at io.quarkus.flyway.runtime.FlywayRecorder.doStartActions(FlywayRecorder.java:150)
```

`application.properties` sets `quarkus.flyway.migrate-at-start=false`,
so the extension *should* be a no-op — but on the prod modulith pod
something (almost certainly `QUARKUS_FLYWAY_MIGRATE_AT_START=true` set
via env / ConfigMap) overrides it. The extension then runs its own
Flyway instance against the JDBC connection's default schema = `public`,
which #530 left untouched.

## Fix

Two lines in `miot-cli/src/main/resources/application.properties`:

```properties
quarkus.flyway.schemas=miot_core
quarkus.flyway.default-schema=miot_core
```

Both Flyway instances (extension + programmatic) now agree on
`miot_core` as the metadata schema.

## Local reproduction (and validation of the fix)

Ran an end-to-end repro against `postgis/postgis:16-3.4` seeded with
`CREATE TABLE public.stray_table (id int);` plus postgis's own
`spatial_ref_sys` (two non-Flyway tables in `public`):

| Build | Behaviour |
|---|---|
| `trunk` (pre-#530) | ❌ `Schema history table "public"."flyway_schema_history" does not exist yet` → `Found non-empty schema(s) "public" but no schema history table` — **same prod error** |
| `trunk + #530 only` (programmatic FlywayMigrator fix) | ❌ identical failure — extension still hits `public` |
| **this PR** (#530 + application.properties pin) | ✅ `Creating Schema History table "miot_core"."flyway_schema_history"` → 11+ migrations run cleanly through v0.4.x. (Stops at v0.5.0 only because my local postgres lacks the `pg_partman` extension prod has; this is repro-environment-only, not the fix.) |

## DB ops from #530 still apply

`miot_core.flyway_schema_history` doesn't exist on prod yet, so the
operator still needs to copy `public.flyway_schema_history` →
`miot_core.flyway_schema_history` **before** rolling this PR. The
SQL is in #530's description (it's still the same migration plan,
just with the additional code change now actually doing what we
wanted #530 to do).

## Test plan

- [x] Local repro proves the prod error reproduces and is fixed end-to-end.
- [ ] Reviewer: dry-run the DB ops on a staging copy.
- [ ] Reviewer: confirm `QUARKUS_FLYWAY_MIGRATE_AT_START=true` is in fact set on the prod deployment (this PR is a no-op without that override; with the override, it's the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)