### PR TITLE
fix(532): pin quarkus.flyway.locations to core+resource only

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -38,6 +38,13 @@ quarkus.flyway.out-of-order=true
 # call so both Flyway instances (extension + programmatic) agree.
 quarkus.flyway.schemas=miot_core
 quarkus.flyway.default-schema=miot_core
+# Pin the extension's location scan to the always-on schemas. Per-component
+# migrations (fleet, driver, tracking, integrations) live under
+# FlywayMigrator's component-flag control and must NOT be picked up by the
+# extension's classpath scan — otherwise turning a component off via
+# MIOT_COMPONENT_<X>_ENABLED=false leaves the migration JAR on the
+# classpath and the extension still tries to apply it.
+quarkus.flyway.locations=classpath:db/migration/core,classpath:db/migration/resource
 miot.flyway.base-locations=db/migration/core,db/migration/resource
 
 # --- Hibernate ---


### PR DESCRIPTION
Closes #532.

Third (last, I hope) piece of the Flyway extension vs. FlywayMigrator
contention that started with #529. Where #530 pinned the schema and
#531 pinned the schema for the *extension's* Flyway too — this PR
pins the **location scan** so the extension only sees migrations
that are always safe to apply.

## Why the previous two PRs weren't enough

Even with the schema pinning in place, the Quarkus Flyway extension's
default `quarkus.flyway.locations=classpath:db/migration` picks up
**every** `db/migration/**/V*.sql` baked into the modulith jar. So
on the latest pod (`prod-mintral-miot-modulith-67c86ffd99-9hlmn`) the
extension marches happily through 0.1.0 → 0.4.x, then hits:

```
Failed to execute script V0.5.0__create_tracking_schema.sql
ERROR: permission denied to create extension "postgis"
  Hint: Must be superuser to create this extension.
```

`MIOT_COMPONENT_TRACKING_ENABLED=false` doesn't help: that flag only
gates the programmatic `FlywayMigrator`. The extension never asked.

## Fix

One line in `miot-cli/application.properties`:

```properties
quarkus.flyway.locations=classpath:db/migration/core,classpath:db/migration/resource
```

Mirrors `miot.flyway.base-locations` which already lists exactly the
two always-on schemas. Per-component migrations (fleet, driver,
tracking, integrations) remain 100% under `FlywayMigrator`'s
component-flag control — turning a component off via env now
actually skips its migrations.

## Validation

Same local repro as #531 (postgis-enabled postgres seeded with a
stray `public.stray_table`, `QUARKUS_FLYWAY_MIGRATE_AT_START=true`):

| Build | Behaviour |
|---|---|
| trunk+#530+#531 | ❌ extension scans tracking, fails on `CREATE EXTENSION postgis` |
| **this PR** | ✅ extension applies 0.1.0..0.1.3 (core) + 0.3.0 (resource), skips fleet/driver/tracking, app starts: `Listening on: http://0.0.0.0:8180` |

- [x] Local repro proves prod error is fixed end-to-end.
- [x] `cd quarkus-srv && ./mvnw -pl miot-cli -am test` — 33/33 green
      across all upstream modules.
- [x] Reviewer: when prod *is* ready for tracking, pre-install
      extensions out-of-band first:
      ```sql
      CREATE EXTENSION postgis;
      CREATE SCHEMA IF NOT EXISTS partman;
      CREATE EXTENSION pg_partman WITH SCHEMA partman;
      ```
      so the per-component tracking migration's
      `CREATE EXTENSION IF NOT EXISTS` becomes a no-op for the
      non-superuser app role.

## Forensics still open

The stray-table-in-`public` mystery (what dropped tables there
originally, pre-#529) is still unresolved. Separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration configuration to prevent auto-discovery of unused component migrations when features are disabled, improving system reliability during selective component deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->