### PR TITLE
fix(534): tolerate applied-but-missing/future component migrations in extension validate()

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -45,6 +45,17 @@ quarkus.flyway.default-schema=miot_core
 # MIOT_COMPONENT_<X>_ENABLED=false leaves the migration JAR on the
 # classpath and the extension still tries to apply it.
 quarkus.flyway.locations=classpath:db/migration/core,classpath:db/migration/resource
+# The extension's history table is shared with FlywayMigrator (which
+# applies fleet / driver / tracking / integrations entries). Without
+# this, the extension's own validate() would fail with "applied
+# migration not resolved locally" on any component-scoped row, because
+# those SQL files are intentionally outside `quarkus.flyway.locations`.
+# Two categories must be tolerated:
+#   *:missing → component versions BELOW max resolved (e.g. fleet 0.2.x
+#               when core's last is 0.3.0)
+#   *:future  → component versions ABOVE max resolved (e.g. driver 0.4.x
+#               beyond core's 0.3.0)
+quarkus.flyway.ignore-migration-patterns=*:missing,*:future
 miot.flyway.base-locations=db/migration/core,db/migration/resource
 
 # --- Hibernate ---


### PR DESCRIPTION
Closes #534.

Hopefully the actual last piece. After #530 (FlywayMigrator schema
pin) + #531 (extension schema pin) + #533 (extension locations pin),
the modulith pod still fails to start when the DB already has applied
fleet (`0.2.x`) and driver (`0.4.x`) entries that the extension's
narrowed location list can no longer see:

```
FlywayValidateException: Validate failed: Migrations have failed validation
Detected applied migration not resolved locally: 0.2.0
Detected applied migration not resolved locally: 0.2.1
Detected applied migration not resolved locally: 0.2.2
Detected applied migration not resolved locally: 0.4.0
Detected applied migration not resolved locally: 0.4.1
```

## Why this still happens

The extension and `FlywayMigrator` share **one** history table but each
has a narrower view of migrations:

- Extension scans `db/migration/core` + `db/migration/resource` only.
  Max resolved: `0.3.0`.
- DB already has applied: `0.1.0..0.4.1` (fleet + driver were enabled
  in a prior deploy, before #533).
- Extension's strict `validate()` cross-checks history vs. what it
  resolves → trips on every row outside its narrowed scan.

`FlywayMigrator` itself works around this exact case via
`.ignoreMigrationPatterns("*:missing")` — the extension just needs the
matching config knob.

## Fix

One line:

```properties
quarkus.flyway.ignore-migration-patterns=*:missing,*:future
```

Two categories matter, not one:

| Bucket    | Example                       | Why                              |
|-----------|-------------------------------|----------------------------------|
| `*:missing` | fleet `0.2.x` (< core `0.3.0`)  | applied **below** extension's max |
| `*:future`  | driver `0.4.x` (> core `0.3.0`) | applied **above** extension's max |

`*:missing` alone leaves `0.4.x` failing (caught this on first repro).

## Validation

Verified against the **live prod DB via SSH tunnel** that the
history shape is exactly what we expected:

```
$ psql ... -c "SELECT installed_rank, version, description FROM miot_core.flyway_schema_history ORDER BY installed_rank"
 installed_rank | version |               description
----------------+---------+------------------------------------------
              0 |         | << Flyway Schema Creation >>
              1 | 0.1.0   | create core schema
              2 | 0.1.1   | create organizations
              3 | 0.1.2   | add organization hierarchy
              4 | 0.1.3   | add tax id and org modules
              5 | 0.2.0   | create fleet schema
              6 | 0.2.1   | add fleet directory tables
              7 | 0.2.2   | add asset id to trucks
              8 | 0.3.0   | create resource schema
              9 | 0.4.0   | create driver schema
             10 | 0.4.1   | add driver address and status constraint
```

Seeded a local docker postgres with the same 11 rows, ran the trunk
jar (#530+#531+#533) → reproduces the prod error verbatim. Then ran
this PR's jar against the same DB:

```
INFO  [DbValidate] Successfully validated 11 migrations (execution time 00:00.034s)
INFO  [io.quarkus] miot-cli 1.0.0-SNAPSHOT on JVM started in 1.495s. Listening on: http://0.0.0.0:8180
```

## Test plan

- [x] Local validation against a postgres seeded with the exact prod
      `miot_core.flyway_schema_history` (11 rows): trunk fails, this
      PR succeeds.
- [x] `cd quarkus-srv && ./mvnw -pl miot-cli -am test` — 33/33 green.
- [ ] Reviewer: confirm `MIOT_COMPONENT_FLEET_ENABLED` /
      `MIOT_COMPONENT_DRIVER_ENABLED` are intentionally `false` (or
      not set) on the new pod — that's the policy this PR encodes
      ("component history may pre-exist but the component itself
      isn't running in this deployment").

## Other prod findings worth follow-up (not in this PR)

- `public` has 9 non-Flyway tables (citus extension views + some
  app-specific stuff like `expediciones_tareas`, `timelapse_sessions`).
  This is the original "non-empty public" trigger from #529; now
  contained by the schema pinning, but the original drop-into-public
  forensics is still unanswered.
- A second `flyway_schema_history` exists in `miot_calendar` — that's
  a separate app (`miot-calendar`) and unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)