### PR TITLE
feat(calendar): server-side q substring search in planner sidebar

### DIFF
--- a/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
@@ -47,7 +47,10 @@ export async function GET(req: NextRequest) {
   // query won't prefix-match that column otherwise. Mirrors the `service=`
   // normalization a few lines down so the autocomplete and the structured
   // chip filter behave the same way for digit-only input.
-  const q = rawQ ? (/^\d+$/.test(rawQ) ? `v${rawQ}` : rawQ) : undefined;
+  let q: string | undefined;
+  if (rawQ) {
+    q = /^\d+$/.test(rawQ) ? `v${rawQ}` : rawQ;
+  }
 
   let data: Record<string, KanbanBoard> = {};
   let total = 0;

--- a/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
@@ -42,6 +42,12 @@ export async function GET(req: NextRequest) {
   const date_range_from = url.searchParams.get("date_range_from");
   const date_range_to = url.searchParams.get("date_range_to");
   const calendarId = url.searchParams.get("calendarId");
+  const rawQ = url.searchParams.get("q");
+  // Mintral service IDs are stored as `v<digits>`; a purely numeric typed
+  // query won't prefix-match that column otherwise. Mirrors the `service=`
+  // normalization a few lines down so the autocomplete and the structured
+  // chip filter behave the same way for digit-only input.
+  const q = rawQ ? (/^\d+$/.test(rawQ) ? `v${rawQ}` : rawQ) : undefined;
 
   let data: Record<string, KanbanBoard> = {};
   let total = 0;
@@ -64,6 +70,7 @@ export async function GET(req: NextRequest) {
       order: order ?? undefined,
       date_range_from: date_range_from ?? undefined,
       date_range_to: date_range_to ?? undefined,
+      q,
     },
   };
 
@@ -95,6 +102,7 @@ export async function GET(req: NextRequest) {
               order: order ?? undefined,
               date_range_from: date_range_from ?? undefined,
               date_range_to: date_range_to ?? undefined,
+              q,
             },
           });
         }),

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-search-autocomplete.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-search-autocomplete.tsx
@@ -28,6 +28,10 @@ export interface PlanningSearchAutocompleteProps {
   onSelect?: (service: SelectedService) => void;
   onMatchTypeSelect?: (matchType: MatchType, query: string) => void;
   onClear?: () => void;
+  // Fired with the debounced query (after MIN_CHARACTERS threshold; empty
+  // string before that). The parent threads this into the tasks request as
+  // `q=` so search reaches services beyond the current page.
+  onQueryChange?: (q: string) => void;
   hasActiveFilter?: boolean;
   isLoading?: boolean;
 }
@@ -37,14 +41,18 @@ const MIN_CHARACTERS = 2;
 const MAX_DROPDOWN_HEIGHT = 300;
 
 /**
- * Searchable fields configuration for service matching
+ * Searchable fields configuration for service matching.
+ *
+ * `lugarCarguio` is intentionally omitted: the field is hard-coded to ""
+ * in transformTaskToService because it isn't on `KanbanBoardTask`, so it
+ * could never produce matches. The MatchType union still includes it for
+ * the chip-state path until the workflow surfaces real data.
  */
 const SEARCHABLE_FIELDS: readonly MatchType[] = [
   "id",
   "cliente",
   "origen",
   "destino",
-  "lugarCarguio",
   "permanencia",
   "tipoViaje",
 ] as const;
@@ -177,6 +185,7 @@ export function PlanningSearchAutocomplete({
   onSelect,
   onMatchTypeSelect,
   onClear,
+  onQueryChange,
   hasActiveFilter = false,
   isLoading: externalIsLoading = false,
 }: Readonly<PlanningSearchAutocompleteProps>) {
@@ -208,6 +217,11 @@ export function PlanningSearchAutocomplete({
 
     return () => clearTimeout(timer);
   }, [query]);
+
+  // Surface the debounced query to the parent so it can re-fetch with `q=`.
+  useEffect(() => {
+    onQueryChange?.(debouncedQuery);
+  }, [debouncedQuery, onQueryChange]);
 
   // Search logic: group by match type and count matches
   const searchResults = useMemo(() => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -210,6 +210,9 @@ export function PlanningSidebarClient({
   const [searchTags, setSearchTags] = useState<
     Array<{ matchType: PlanningSearchMatchType; value: string }>
   >([]);
+  // Debounced text from the autocomplete. Flows into `apiParams` as `q=` so
+  // the backend prefix-search reaches services beyond the loaded page.
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Seed search tags from the active calendar's stored filter (origin /
   // destination delegate codes). Re-seed only when the filter signature
@@ -275,13 +278,17 @@ export function PlanningSidebarClient({
       params.push(`calendarId=${calendarId}`);
     }
 
+    if (searchQuery) {
+      params.push(`q=${encodeURIComponent(searchQuery)}`);
+    }
+
     // Server-side sort preset (ecm-coordinator #238): C309 urgency first,
     // then mintral_deliveryComplianceRate ASC. Resolves the pagination
     // correctness gap of the previous client-side sort.
     params.push("orderBy=mintral_calendarPlanningPriority");
 
     return params.join("&");
-  }, [searchTags, calendarId]);
+  }, [searchTags, calendarId, searchQuery]);
 
   // Fetch tasks from API
   const {
@@ -763,6 +770,7 @@ export function PlanningSidebarClient({
               onSelect={handleSearchSelect}
               onMatchTypeSelect={handleMatchTypeSelect}
               onClear={handleSearchClear}
+              onQueryChange={setSearchQuery}
               hasActiveFilter={searchTags.length > 0}
               isLoading={isLoadingTasks}
             />

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
@@ -235,6 +235,7 @@ export type FinishedWorkflowsRequest = {
     order?: string;
     date_range_from?: string;
     date_range_to?: string;
+    q?: string;
   };
 };
 


### PR DESCRIPTION
## Summary

The planner sidebar autocomplete filtered locally over the in-memory
`services` array, so services beyond the loaded page (`page=1, size=100`)
were invisible to search. This wires the autocomplete's debounced query
into the tasks request as `q=` so a typed substring reaches the full
unbooked set on the backend.

## Changes

- **`route.ts`** — accepts `q` query param. Numeric-only input is
  normalized to `v${q}` so it prefix-matches `mintral_key` (which is
  stored as `v<digits>`); mirrors the existing `service=` handling a
  few lines down. The same `q` flows through both `getUnbookedTasks`
  and `getFinishedWorkflows`.
- **`alfresco-api.types.ts`** — `q?: string` on the
  `FinishedWorkflowsRequest.filter` shape so typecheck passes. The
  unbooked path's filter is already `Record<string, unknown>`.
- **`PlanningSearchAutocomplete`** — new `onQueryChange?` prop, fires
  with the debounced query whenever it changes. Drops `lugarCarguio`
  from `SEARCHABLE_FIELDS` (Phase 3 smallest fix): the field is
  hard-coded to `""` in `transformTaskToService` because it isn't on
  `KanbanBoardTask`, so it could never produce matches — advertising
  it was noise.
- **`planning-sidebar-client.tsx`** — owns the `searchQuery` state,
  appends `q=` to `apiParams` when present, wires
  `onQueryChange={setSearchQuery}`.

## How it composes

The match-type breakdown still works — it now counts over the
server-filtered subset rather than the page-1 slice. Picking a match
type clears the input (existing autocomplete behavior), which fires
`onQueryChange("")`; the next request drops `q=` and applies the
structured chip filter (`service=`, `customer=`, etc.) instead.

The `q=` filter ANDs with all other structured filters (including the
auto-seeded `origin=`/`destination=` chips from
`activeCalendar.filter`). Same shape as the rest of the planner's
filter composition; no override semantics.

## Depends on

Already shipped:
- ecm-coordinator: \`feat(tasks): server-side q substring search across
  identity + location vars\` (commit \`941ee893\`, on trunk via
  \`292cd720\`, deployed to \`coordinador.mintral.cl\`).
- rest-api: companion Bruno examples on trunk via \`f86fce4\`.

## Test plan

- [x] \`npx turbo run check-types --filter=@modulariot/app\` clean
- [x] Open the planner sidebar on a calendar with >100 unbooked
      services; type a substring that matches a service beyond row 100
      and confirm it appears in the dropdown.
- [x] Verify numeric-only input (\`1518744\`) finds the corresponding
      \`v1518744\` service (proxy prepends \`v\`).
- [x] Verify chip-add flow (typed query → pick match type → chip) still
      issues the structured filter without leaking \`q=\`.
- [x] Verify clearing the input or removing all chips returns the full
      unbooked set.
- [x] Sanity-check that auto-seeded origin/destination chips still
      compose (e.g. SCL calendar still scopes \`q\` to SCL services —
      same AND behavior as the rest of the filter UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)