### PR TITLE
fix(app): redirect to sign-in page after Auth0 federated logout

### DIFF
--- a/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
@@ -120,7 +120,7 @@ export async function getAuth0LogoutUrl(
     return null;
   }
 
-  // Default returnTo is the sign-in page
+  // Caller passes the sign-in page URL; fall back to the app base URL only if absent.
   const returnToUrl = returnTo || `${process.env.NEXTAUTH_URL || ""}`;
 
   // Auth0 logout endpoint: https://YOUR_DOMAIN/v2/logout

--- a/turbo-repo/apps/app/src/features/layout/components/user-dropdown/user-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/user-dropdown/user-dropdown.tsx
@@ -12,8 +12,11 @@ import { UserDropdownProps } from "./user-dropdown.types";
 import { getAuth0LogoutUrl } from "@/features/auth/services/auth.service";
 
 async function handleSignOut(lang: string) {
+  // Land back on the current-language sign-in page after federated logout.
+  const signInUrl = `${globalThis.location.origin}/app/${lang}/sign-in`;
+
   // Get Auth0 logout URL before signing out of NextAuth
-  const auth0LogoutUrl = await getAuth0LogoutUrl();
+  const auth0LogoutUrl = await getAuth0LogoutUrl(signInUrl);
 
   // Sign out of NextAuth first
   await signOut({ redirect: false });
@@ -23,7 +26,7 @@ async function handleSignOut(lang: string) {
     globalThis.location.href = auth0LogoutUrl;
   } else {
     // Fallback to sign-in page if Auth0 is not configured
-    globalThis.location.href = `/app/${lang}/sign-in`;
+    globalThis.location.href = signInUrl;
   }
 }
 


### PR DESCRIPTION
handleSignOut called getAuth0LogoutUrl() without a returnTo, so Auth0 sent the user back to the bare NEXTAUTH_URL (/app), which has no usable page and rendered a 404. Pass the current-language sign-in URL as returnTo so logout lands on /app/{lang}/sign-in, matching the credentials-only fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified sign-out URL documentation for better clarity.

* **Bug Fixes**
  * Improved sign-out redirect behavior to handle sign-in URL routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->