### PR TITLE
feat: Kanban UI refactor — separated lanes, lane actions menu, ⌘K search, group avatar

### DIFF
--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/kbd-hint.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/kbd-hint.tsx
@@ -1,0 +1,11 @@
+/**
+ * Small ⌘K affordance shown inside the search field. Matches the Mintral design
+ * kit hint; the actual shortcut is wired globally in {@link SearchBar}.
+ */
+export function KbdHint() {
+  return (
+    <kbd className="hidden items-center rounded border border-gray-200 bg-gray-100 px-1.5 font-mono text-[10px] font-medium text-gray-400 lg:inline-flex dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400">
+      ⌘K
+    </kbd>
+  );
+}

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-searchbar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-searchbar.tsx
@@ -9,6 +9,7 @@ import Tags from "./tags";
 // import DateRangePicker from "@/features/common/components/date-picker/date-range-picker";
 import { ParamType } from "./navegation_params";
 import CustomSelector from "@/features/common/components/custom-dropdown/custom-selector";
+import { KbdHint } from "./kbd-hint";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import { logger } from "@/lib/logger";
@@ -149,6 +150,7 @@ export default function ParametrizedSearchBar({
         <TextInput
           className="w-full lg:w-96"
           icon={HiSearch}
+          rightIcon={KbdHint}
           id="search"
           placeholder={messages.search}
           defaultValue={searchParams.get("search") || ""}

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/search-bar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/search-bar.tsx
@@ -5,7 +5,8 @@ import { useDebouncedCallback } from "use-debounce";
 import { usePathname, useRouter } from "next/navigation";
 import { getNavegationParams } from "./navegation_params";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
-import React from "react";
+import React, { useEffect } from "react";
+import { KbdHint } from "./kbd-hint";
 
 export default function SearchBar({
   messages,
@@ -18,6 +19,25 @@ export default function SearchBar({
 }) {
   const router = useRouter();
   const pathName = usePathname();
+
+  // ⌘K / Ctrl+K focuses the search field from anywhere; Esc blurs it.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        const el = document.getElementById("search") as HTMLInputElement | null;
+        el?.focus();
+        el?.select();
+      } else if (e.key === "Escape") {
+        const el = document.getElementById("search") as HTMLInputElement | null;
+        if (el && document.activeElement === el) {
+          el.blur();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   const handleSearch = useDebouncedCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,6 +69,7 @@ export default function SearchBar({
         <TextInput
           className="w-full lg:w-96"
           icon={HiSearch}
+          rightIcon={KbdHint}
           id="search"
           name="search"
           placeholder={messages.search}

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/search-bar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/search-bar.tsx
@@ -35,8 +35,8 @@ export default function SearchBar({
         }
       }
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    globalThis.addEventListener("keydown", onKeyDown);
+    return () => globalThis.removeEventListener("keydown", onKeyDown);
   }, []);
 
   const handleSearch = useDebouncedCallback(

--- a/turbo-repo/apps/app/src/features/new-feature-notification/new-features.tsx
+++ b/turbo-repo/apps/app/src/features/new-feature-notification/new-features.tsx
@@ -1,5 +1,5 @@
 import { I18nRecord } from "../i18n/i18n.service.types";
-import SidebarSlider from "./slider-components/sidebar-slider";
+import KanbanSlider from "./slider-components/kanban-slider";
 
 export enum typeDescriptor {
   Slidable, // It has multiple "Slides" of information
@@ -30,7 +30,7 @@ export enum typeDescriptor {
 //
 function getFeatureDescriptors({ dict }: { dict: I18nRecord }) {
   return {
-    "": SidebarSlider(dict),
+    "": KanbanSlider(dict),
   };
 }
 

--- a/turbo-repo/apps/app/src/features/new-feature-notification/slider-components/kanban-slider.tsx
+++ b/turbo-repo/apps/app/src/features/new-feature-notification/slider-components/kanban-slider.tsx
@@ -1,0 +1,203 @@
+import { tr } from "../../i18n/tr.service";
+import Fadeable from "../slider-components/fadeable";
+import { typeDescriptor } from "../new-features";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import {
+  HiViewBoards,
+  HiDotsHorizontal,
+  HiSearch,
+  HiAdjustments,
+  HiSortAscending,
+  HiFilter,
+  HiChevronDoubleLeft,
+  HiRefresh,
+} from "react-icons/hi";
+
+function ActionChip({
+  icon: Icon,
+  label,
+  delayMs,
+  isActive,
+}: Readonly<{
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  delayMs: number;
+  isActive: boolean;
+}>) {
+  return (
+    <Fadeable isActive={isActive} delayMs={delayMs} className="px-0!">
+      <div className="flex flex-col items-center gap-1">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
+          <Icon className="h-4 w-4" />
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+      </div>
+    </Fadeable>
+  );
+}
+
+export default function KanbanSlider(dict: I18nRecord) {
+  const s = (key: string) => tr(`new_functionality.slider.kanban.${key}`, dict);
+
+  return {
+    id: "2.0",
+    image: null,
+    description: (isActive: boolean) => [
+      // Slide 1 — Title announcement
+      <div
+        key="kanban-slide-1"
+        className="flex h-full w-full flex-col items-center justify-center gap-4 px-6"
+      >
+        <Fadeable isActive={isActive} delayMs={200} className="w-full">
+          <div className="flex justify-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-100 dark:bg-blue-900/30">
+              <HiViewBoards className="h-8 w-8 text-blue-600 dark:text-blue-400" />
+            </div>
+          </div>
+        </Fadeable>
+        <Fadeable isActive={isActive} delayMs={500} className="w-full">
+          <h2 className="text-center text-2xl font-bold text-gray-900 dark:text-white">
+            {s("slide1_title")}
+          </h2>
+        </Fadeable>
+        <Fadeable isActive={isActive} delayMs={800} className="w-full">
+          <p className="text-center text-lg text-gray-500 dark:text-gray-300">
+            {s("slide1_subtitle")}
+          </p>
+        </Fadeable>
+      </div>,
+
+      // Slide 2 — Separated lanes + per-lane actions
+      <div
+        key="kanban-slide-2"
+        className="flex h-full w-full flex-col items-center justify-center gap-6 px-6"
+      >
+        <Fadeable isActive={isActive} delayMs={200} className="w-full">
+          <h3 className="text-center text-xl font-bold text-gray-900 dark:text-white">
+            {s("slide2_title")}
+          </h3>
+        </Fadeable>
+
+        <Fadeable isActive={isActive} delayMs={400} className="w-full">
+          <div className="mx-auto w-56 rounded-lg bg-gray-100 p-3 dark:bg-gray-800">
+            <div className="mb-2.5 flex items-center justify-between border-b border-gray-300 pb-2 dark:border-gray-700">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-300">
+                {s("slide2_lane")}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <span className="rounded-full bg-gray-200 px-[7px] text-[11px] font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                  2
+                </span>
+                <HiDotsHorizontal className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <div className="rounded-md bg-white p-2 text-xs font-semibold text-gray-900 shadow dark:bg-gray-700 dark:text-gray-100">
+                1625094-V
+              </div>
+              <div className="rounded-md bg-white p-2 text-xs font-semibold text-gray-900 shadow dark:bg-gray-700 dark:text-gray-100">
+                1524620-V
+              </div>
+            </div>
+          </div>
+        </Fadeable>
+
+        <div className="flex w-full max-w-xs justify-center gap-4">
+          <ActionChip
+            icon={HiAdjustments}
+            label={s("slide2_density")}
+            isActive={isActive}
+            delayMs={700}
+          />
+          <ActionChip
+            icon={HiSortAscending}
+            label={s("slide2_sort")}
+            isActive={isActive}
+            delayMs={850}
+          />
+          <ActionChip
+            icon={HiFilter}
+            label={s("slide2_filter")}
+            isActive={isActive}
+            delayMs={1000}
+          />
+          <ActionChip
+            icon={HiChevronDoubleLeft}
+            label={s("slide2_collapse")}
+            isActive={isActive}
+            delayMs={1150}
+          />
+        </div>
+      </div>,
+
+      // Slide 3 — ⌘K search
+      <div
+        key="kanban-slide-3"
+        className="flex h-full w-full flex-col items-center justify-center gap-6 px-6"
+      >
+        <Fadeable isActive={isActive} delayMs={200} className="w-full">
+          <h3 className="text-center text-xl font-bold text-gray-900 dark:text-white">
+            {s("slide3_title")}
+          </h3>
+        </Fadeable>
+
+        <Fadeable isActive={isActive} delayMs={500} className="w-full">
+          <div className="mx-auto flex max-w-70 items-center gap-2 rounded-lg border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-800">
+            <HiSearch className="h-4 w-4 shrink-0 text-gray-400" />
+            <span className="flex-1 text-sm text-gray-400">
+              {s("slide3_placeholder")}
+            </span>
+            <kbd className="rounded border border-gray-200 bg-gray-100 px-1.5 font-mono text-[10px] text-gray-400 dark:border-gray-600 dark:bg-gray-700">
+              ⌘K
+            </kbd>
+          </div>
+        </Fadeable>
+
+        <Fadeable isActive={isActive} delayMs={800} className="w-full">
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+            {s("slide3_desc")}
+          </p>
+        </Fadeable>
+      </div>,
+
+      // Slide 4 — Persisted view
+      <div
+        key="kanban-slide-4"
+        className="flex h-full w-full flex-col items-center justify-center gap-6 px-6"
+      >
+        <Fadeable isActive={isActive} delayMs={200} className="w-full">
+          <h3 className="text-center text-xl font-bold text-gray-900 dark:text-white">
+            {s("slide4_title")}
+          </h3>
+        </Fadeable>
+
+        <Fadeable isActive={isActive} delayMs={500} className="w-full">
+          <div className="flex items-center justify-center gap-4">
+            {/* collapsed lane */}
+            <div className="h-20 w-7 rounded-lg bg-gray-100 dark:bg-gray-800" />
+            {/* expanded lane with cards */}
+            <div className="flex h-20 w-20 flex-col gap-1 rounded-lg bg-gray-100 p-1.5 dark:bg-gray-800">
+              <div className="h-2 w-2/3 rounded bg-gray-300 dark:bg-gray-600" />
+              <div className="h-4 w-full rounded bg-white shadow dark:bg-gray-700" />
+              <div className="h-4 w-full rounded bg-white shadow dark:bg-gray-700" />
+            </div>
+            <HiRefresh className="h-6 w-6 text-blue-500 dark:text-blue-400" />
+            <div className="h-20 w-7 rounded-lg bg-gray-100 dark:bg-gray-800" />
+            <div className="flex h-20 w-20 flex-col gap-1 rounded-lg bg-gray-100 p-1.5 dark:bg-gray-800">
+              <div className="h-2 w-2/3 rounded bg-gray-300 dark:bg-gray-600" />
+              <div className="h-4 w-full rounded bg-white shadow dark:bg-gray-700" />
+              <div className="h-4 w-full rounded bg-white shadow dark:bg-gray-700" />
+            </div>
+          </div>
+        </Fadeable>
+
+        <Fadeable isActive={isActive} delayMs={800} className="w-full">
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+            {s("slide4_desc")}
+          </p>
+        </Fadeable>
+      </div>,
+    ],
+    type: typeDescriptor.Slidable,
+  };
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/TaskCounter.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/TaskCounter.tsx
@@ -10,9 +10,14 @@ export function TaskCounter({
   count,
   dict,
 }: PropsWithI18nDict<TaskCounterProps>) {
+  const label = tr("taskCounter.activeCount", dict, { count: count.toString() });
   return (
-    <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
-      {tr("taskCounter.activeCount", dict, { count: count.toString() })}
-    </div>
+    <span
+      title={label}
+      aria-label={label}
+      className="inline-flex shrink-0 items-center justify-center rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+    >
+      {count}
+    </span>
   );
 }

--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -167,13 +167,9 @@ export default function PageContent({
     }
   };
 
-  const totalVisible = list.reduce(
-    (sum, board) =>
-      (showFinishedTasks ? board.finished : !board.finished)
-        ? sum + board.tasks.length
-        : sum,
-    0
-  );
+  const totalVisible = list
+    .filter((board) => (showFinishedTasks ? board.finished : !board.finished))
+    .reduce((sum, board) => sum + board.tasks.length, 0);
 
   return (
     <div className="w-full h-full flex flex-col overflow-hidden">

--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -176,7 +176,7 @@ export default function PageContent({
   return (
     <div className="w-full h-full flex flex-col overflow-hidden">
       <div className="inline-block align-middle relative">
-        <div className="p-5 flex items-center justify-between sticky top-0 bg-white dark:bg-gray-900 dark:text-white w-full">
+        <div className="h-[60px] px-6 flex items-center justify-between sticky top-0 z-10 bg-white dark:bg-gray-900 dark:text-white w-full border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-3">
             <ClientBreadcrumb
               path={[
@@ -189,7 +189,7 @@ export default function PageContent({
               dict={dictionary.base}
             />
             {activeView === "kanban" && (
-              <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+              <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2.5 py-[3px] text-[11px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
                 {tr("taskCounter.activeCount", dictionary.base, {
                   count: totalVisible.toString(),
                 })}

--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -1,48 +1,15 @@
 "use client";
 
-import {
-  Button,
-  Label,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Pagination,
-  Textarea,
-  TextInput,
-} from "flowbite-react";
-import Image from "next/image";
-import Link from "next/link";
-import type { FC } from "react";
+import { Pagination } from "flowbite-react";
 import { useState, useEffect, useRef } from "react";
+import { HiClipboardList } from "react-icons/hi";
 import {
-  HiArchive,
-  HiClipboardCopy,
-  HiClipboardList,
-  HiDocumentText,
-  HiDotsHorizontal,
-  HiEye,
-  HiPaperClip,
-  HiPencilAlt,
-  HiPlus,
-  HiPlusSm,
-} from "react-icons/hi";
-import { TaskCounter } from "@/features/shipping/components/TaskCounter";
-import {
-  useMyTasksCount,
   useMyTasks,
   useSearchTasks,
 } from "@/features/common/providers/client-api.provider";
-import { PiCaretUpDownBold } from "react-icons/pi";
-import { ReactSortable } from "react-sortablejs";
-import {
-  KanbanBoard,
-  KanbanBoardTask,
-  KanbanPageData,
-  Task,
-} from "../types/common.types";
-import KanbanCard from "./kanban-card/kanban-card";
-import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { KanbanBoard, KanbanPageData, Task } from "../types/common.types";
+import { LaneColumn } from "./lane/lane-column";
+import { useLaneViewState } from "../hooks/use-lane-view-state";
 import { tr } from "@/features/i18n/tr.service";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -72,6 +39,7 @@ export default function PageContent({
   userGroups: string[];
 }) {
   const { activeView, handleViewChange } = useViewPreference("kanban");
+  const { getLaneState, updateLaneState } = useLaneViewState();
   const [list, setList] = useState<KanbanBoard[]>(kanbanBoards);
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -173,10 +141,6 @@ export default function PageContent({
     );
   }
 
-  const countTasks = (tasks: Task[]): number => {
-    return tasks.length;
-  };
-
   const handleMouseEnter = (task: Task) => {
     if (!isLoading) {
       hoverTimeoutRef.current = window.setTimeout(() => {
@@ -201,18 +165,37 @@ export default function PageContent({
     }
   };
 
+  const totalVisible = list.reduce(
+    (sum, board) =>
+      (showFinishedTasks ? board.finished : !board.finished)
+        ? sum + board.tasks.length
+        : sum,
+    0
+  );
+
   return (
     <div className="w-full h-full flex flex-col overflow-hidden">
       <div className="inline-block align-middle relative">
         <div className="p-5 flex items-center justify-between sticky top-0 bg-white dark:bg-gray-900 dark:text-white w-full">
-          <ClientBreadcrumb
-            path={[
-              "breadcrumb.tasks",
-              showFinishedTasks ? "breadcrumb.finished" : "breadcrumb.shipping",
-            ]}
-            rootIcon={<HiClipboardList className="mr-2 h-4 w-4" />}
-            dict={dictionary.base}
-          />
+          <div className="flex items-center gap-3">
+            <ClientBreadcrumb
+              path={[
+                "breadcrumb.tasks",
+                showFinishedTasks
+                  ? "breadcrumb.finished"
+                  : "breadcrumb.shipping",
+              ]}
+              rootIcon={<HiClipboardList className="mr-2 h-4 w-4" />}
+              dict={dictionary.base}
+            />
+            {activeView === "kanban" && (
+              <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                {tr("taskCounter.activeCount", dictionary.base, {
+                  count: totalVisible.toString(),
+                })}
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-1">
             <CompactKanbanViewSwitcher
               kanbanView={activeView === "kanban"}
@@ -228,10 +211,14 @@ export default function PageContent({
           </div>
         </div>
       </div>
-      <div className="h-screen w-full overflow-auto">
+      <div
+        className={`h-screen w-full overflow-auto ${
+          activeView === "kanban" ? "bg-gray-50 dark:bg-gray-900" : ""
+        }`}
+      >
         {activeView === "kanban" ? (
           <div
-            className={`flex items-start justify-start ${compactKanbanView ? "mx-2 gap-2" : "mx-4 gap-4"} `}
+            className={`flex items-start justify-start py-4 ${compactKanbanView ? "mx-2 gap-2" : "mx-4 gap-4"} `}
           >
             <ModalTooltip
               lang={lang}
@@ -242,87 +229,24 @@ export default function PageContent({
               isFinished={false}
             />
             {list.map((board) => {
-              if (showFinishedTasks) {
-                if (!board.finished) {
-                  return null;
-                }
-              } else {
-                if (board.finished) {
-                  return null;
-                }
+              if (showFinishedTasks ? !board.finished : board.finished) {
+                return null;
               }
               return (
-                <div key={board.id}>
-                  <div
-                    className={`mb-4 text-gray-900 dark:text-gray-300 text-center flex flex-col ${compactKanbanView ? "text-base font-semibold gap-2" : "h-[4.5rem] text-base font-semibold"}`}
-                    style={{
-                      width: compactKanbanView ? "11rem" : "16rem",
-                      height: compactKanbanView ? "5rem" : "3rem",
-                    }}
-                  >
-                    <div className="flex-1">
-                      {tr(
-                        `kanban.${board.title}${compactKanbanView && (dictionary.base.kanban as I18nRecord)[board.title + "Compact"] ? "Compact" : ""}`,
-                        dictionary.base
-                      )}
-                    </div>
-                    <TaskCounter
-                      count={countTasks(board.tasks)}
-                      dict={dictionary.base}
-                    />
-                  </div>
-                  <div className="mb-6 space-y-4">
-                    <ReactSortable
-                      animation={100}
-                      forceFallback
-                      group="kanban"
-                      list={board.tasks}
-                      setList={(tasks: KanbanBoardTask[]) =>
-                        setList((list) => {
-                          const newList = [...list];
-                          const index = newList.findIndex(
-                            (item) => item.id === board.id
-                          );
-                          newList[index].tasks = tasks;
-                          return newList;
-                        })
-                      }
-                      disabled={true}
-                      className={`flex flex-col ${
-                        compactKanbanView ? "gap-1" : "gap-4"
-                      }`}
-                    >
-                      {board.tasks.map((task) => {
-                        return (
-                          <div
-                            key={task.id}
-                            className={`w-full h-fit group relative ${isLoading ? "cursor-wait" : ""}`}
-                            role="button"
-                            tabIndex={0}
-                            onMouseEnter={() => handleMouseEnter(task)}
-                            onMouseLeave={handleMouseLeave}
-                            onClick={handleCardClick}
-                            onKeyDown={(e) => {
-                              e.preventDefault();
-                            }}
-                            aria-label={`Task ${task.id}`}
-                          >
-                            <KanbanCard
-                              key={task.id}
-                              task={task}
-                              dict={dictionary.base}
-                              table_name={board.title}
-                              compactKanbanView={compactKanbanView}
-                              showFinishedTasks={showFinishedTasks}
-                              isLoading={isLoading}
-                            />
-                          </div>
-                        );
-                      })}
-                    </ReactSortable>
-                  </div>
-                  <AddAnotherCardModal />
-                </div>
+                <LaneColumn
+                  key={board.id}
+                  board={board}
+                  compactKanbanView={compactKanbanView}
+                  showFinishedTasks={showFinishedTasks}
+                  isLoading={isLoading}
+                  dict={dictionary.base}
+                  laneState={getLaneState(board.title)}
+                  onLaneUpdate={(patch) => updateLaneState(board.title, patch)}
+                  setList={setList}
+                  onCardMouseEnter={handleMouseEnter}
+                  onCardMouseLeave={handleMouseLeave}
+                  onCardClick={handleCardClick}
+                />
               );
             })}
           </div>
@@ -368,331 +292,3 @@ export default function PageContent({
     </div>
   );
 }
-
-export const EditCardModal: FC = function () {
-  const [isOpen, setOpen] = useState(false);
-
-  return (
-    <>
-      <button
-        onClick={() => setOpen(true)}
-        className="rounded-lg p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
-      >
-        <span className="sr-only">Edit card</span>
-        <HiPencilAlt className="h-5 w-5" />
-      </button>
-      <Modal onClose={() => setOpen(false)} show={isOpen}>
-        <ModalHeader>Edit task</ModalHeader>
-        <ModalBody>
-          <div className="mb-3 text-2xl font-semibold leading-none text-gray-900 dark:text-white">
-            Redesign Themesberg Homepage
-          </div>
-          <div className="mb-5 flex flex-col items-start justify-center space-y-3">
-            <div className="text-sm text-gray-500 dark:text-gray-400">
-              Added by&nbsp;
-              <Link
-                href="#"
-                className="cursor-pointer text-primary-700 no-underline hover:underline dark:text-primary-500"
-              >
-                Bonnie Green
-              </Link>
-              , 22 hours ago
-            </div>
-            <div className="flex flex-row flex-wrap">
-              <div className="flex items-center justify-start">
-                <Link
-                  href="#"
-                  data-tooltip-target="bonnie-tooltip"
-                  className="-mr-3"
-                >
-                  <Image
-                    alt="Bonnie Green"
-                    height={28}
-                    src="/images/users/bonnie-green.png"
-                    width={28}
-                    className="rounded-full border-2 border-white dark:border-gray-800"
-                  />
-                </Link>
-                <div
-                  id="bonnie-tooltip"
-                  role="tooltip"
-                  className="invisible absolute z-10 inline-block rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300"
-                >
-                  Bonnie Green
-                </div>
-                <Link
-                  href="#"
-                  data-tooltip-target="roberta-tooltip"
-                  className="-mr-3"
-                >
-                  <Image
-                    alt="Roberta Casas"
-                    height={28}
-                    src="/images/users/roberta-casas.png"
-                    width={28}
-                    className="h-7 w-7 rounded-full border-2 border-white dark:border-gray-800"
-                  />
-                </Link>
-                <div
-                  id="roberta-tooltip"
-                  role="tooltip"
-                  className="invisible absolute z-10 inline-block rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300"
-                >
-                  Roberta Casas
-                </div>
-                <Link
-                  href="#"
-                  data-tooltip-target="michael-tooltip"
-                  className="-mr-3"
-                >
-                  <Image
-                    alt="Michael Gough"
-                    height={28}
-                    src="/images/users/michael-gough.png"
-                    width={28}
-                    className="rounded-full border-2 border-white dark:border-gray-800"
-                  />
-                </Link>
-                <div
-                  id="michael-tooltip"
-                  role="tooltip"
-                  className="invisible absolute z-10 inline-block rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300"
-                >
-                  Michael Gough
-                </div>
-              </div>
-              <Button
-                color="gray"
-                className="ml-5 font-bold dark:bg-gray-600 [&>*]:px-2.5 [&>*]:py-1"
-              >
-                <div className="flex items-center gap-x-2 text-xs">
-                  <HiPlusSm className="h-4 w-4" />
-                  Join
-                </div>
-              </Button>
-              <Button
-                color="gray"
-                className="ml-3 font-bold dark:bg-gray-600 [&>*]:px-2.5 [&>*]:py-1"
-              >
-                <div className="flex items-center gap-x-2 text-xs">
-                  <HiPaperClip className="h-4 w-4" />
-                  Attachment
-                </div>
-              </Button>
-            </div>
-          </div>
-          <div className="mb-2 inline-flex items-center text-center text-lg font-semibold text-gray-900 dark:text-white">
-            <HiDocumentText className="mr-1 h-5 w-5" />
-            Description
-          </div>
-          <div className="mb-4 space-y-2 text-base text-gray-500 dark:text-gray-400">
-            <p>
-              I&apos;m made some wireframes that we would like you to follow
-              since we are building it in Google&apos;s Material Design (Please
-              learn more about this and see how to improve standard material
-              design into something beautiful). But besides that, you can just
-              do it how you like.
-            </p>
-            <p>
-              Next Friday should be done. Next Monday we should deliver the
-              first iteration. Make sure, we have a good result to be delivered
-              by the day.
-            </p>
-            <div className="w-max cursor-pointer text-sm font-semibold text-primary-700 hover:underline dark:text-primary-500">
-              Show Full Description
-            </div>
-          </div>
-          <div className="mb-4 w-full rounded-lg border border-gray-100 bg-gray-100 dark:border-gray-600 dark:bg-gray-700">
-            <div className="p-4">
-              <Label htmlFor="compose-mail" className="sr-only">
-                Your comment
-              </Label>
-              <Textarea
-                id="compose-mail"
-                placeholder="Write a comment..."
-                rows={4}
-                className="border-none px-0 text-base focus:ring-0"
-              />
-            </div>
-            <div className="flex items-center justify-between border-t p-4 dark:border-gray-600">
-              <button
-                type="button"
-                className="inline-flex items-center rounded-lg bg-primary-700 px-3 py-1.5 text-center text-xs font-semibold text-white hover:bg-primary-800"
-              >
-                <HiPaperClip className="mr-1 h-4 w-4" />
-                Post comment
-              </button>
-              <div className="flex space-x-1 pl-0 sm:pl-2">
-                <Link
-                  href="#"
-                  className="inline-flex cursor-pointer justify-center rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-600 dark:hover:text-white"
-                >
-                  <HiPaperClip className="h-6 w-6" />
-                </Link>
-                <Link
-                  href="#"
-                  className="inline-flex cursor-pointer justify-center rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-600 dark:hover:text-white"
-                >
-                  <svg
-                    className="h-6 w-6"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                </Link>
-              </div>
-            </div>
-          </div>
-          <div className="flex flex-col space-y-2">
-            <div className="flex items-center space-x-3">
-              <Link href="#" className="shrink-0">
-                <Image
-                  alt="Micheal Gough"
-                  height={28}
-                  src="/images/users/michael-gough.png"
-                  width={28}
-                  className="rounded-full"
-                />
-              </Link>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
-                  Micheal Gough
-                </p>
-                <p className="truncate text-sm font-normal text-gray-500 dark:text-gray-400">
-                  Product Manager
-                </p>
-              </div>
-              <Link
-                href="#"
-                className="rounded-lg p-1 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
-              >
-                <HiDotsHorizontal className="h-4 w-4" />
-              </Link>
-            </div>
-            <ul className="list-outside list-disc pl-6 text-xs text-gray-500 dark:text-gray-400">
-              <li>
-                Latest clicks/conversions. Where you currently have the logo for
-                merchant, we should instead have a logo that represent the
-                referring traffic sources (ex. Google or Facebook). So
-                we&apos;re actually missing a column that should say
-                &quot;Source&quot;. And there should be no icon for the
-                merchants.
-              </li>
-            </ul>
-          </div>
-        </ModalBody>
-        <ModalFooter>
-          <div className="grid w-full grid-cols-2 items-center gap-3 sm:grid-cols-5">
-            <Button color="blue" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <HiClipboardList className="h-5 w-5" />
-                Save
-              </div>
-            </Button>
-            <Button color="gray" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <PiCaretUpDownBold className="h-5 w-5" />
-                Move
-              </div>
-            </Button>
-            <Button color="gray" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <HiClipboardCopy className="h-5 w-5" />
-                Copy
-              </div>
-            </Button>
-            <Button color="gray" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <HiArchive className="h-5 w-5" />
-                Archive
-              </div>
-            </Button>
-            <Button color="gray" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <HiEye className="h-5 w-5" />
-                Watch
-              </div>
-            </Button>
-          </div>
-        </ModalFooter>
-      </Modal>
-    </>
-  );
-};
-
-const AddAnotherCardModal: FC = function () {
-  const [isOpen, setOpen] = useState(false);
-
-  return (
-    <>
-      <Modal onClose={() => setOpen(false)} show={isOpen}>
-        <ModalHeader>Add new task</ModalHeader>
-        <ModalBody>
-          <form>
-            <div className="mb-6 grid grid-cols-1 gap-y-2">
-              <Label htmlFor="taskName">Task name</Label>
-              <TextInput
-                id="taskName"
-                name="taskName"
-                placeholder="Redesign homepage"
-              />
-            </div>
-            <div className="mb-4 grid grid-cols-1 gap-y-2">
-              <Label htmlFor="description">Enter a description</Label>
-              <Textarea
-                id="description"
-                name="description"
-                placeholder="On line 672 you ..."
-                rows={6}
-              />
-            </div>
-            <div className="flex w-full items-center justify-center">
-              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-              <label className="flex h-32 w-full cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-gray-300 text-gray-500 hover:border-gray-300 hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:hover:text-white">
-                <div className="flex items-center justify-center space-x-2">
-                  <svg
-                    className="h-8 w-8"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  <p className="text-base">Drop files to upload</p>
-                </div>
-                <input type="file" className="hidden" />
-              </label>
-            </div>
-          </form>
-        </ModalBody>
-        <ModalFooter>
-          <div className="flex items-center gap-x-3">
-            <Button color="blue" onClick={() => setOpen(false)}>
-              <div className="flex items-center gap-x-2">
-                <HiPlus className="text-lg" />
-                Add card
-              </div>
-            </Button>
-            <Button color="gray" onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
-        </ModalFooter>
-      </Modal>
-    </>
-  );
-};

--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -22,6 +22,7 @@ import {
 import { ClientBreadcrumb } from "@/features/common/components/Breadcrumb/ClientBreadcrumb";
 import { ViewSwitcher } from "@/features/common/components/view-switcher/view-switcher";
 import { useViewPreference } from "../hooks/use-view-preference";
+import { useCompactViewPreference } from "../hooks/use-compact-view-preference";
 import { TableView } from "./views/table-view";
 import { transformBoardsToTableData } from "../utils/transform-data";
 import { configureLocale } from "@/features/common/services/days.service";
@@ -44,7 +45,8 @@ export default function PageContent({
   const router = useRouter();
   const searchParams = useSearchParams();
   const [page, setPage] = useState(1);
-  const [compactKanbanView, setCompactKanbanView] = useState(true);
+  const [compactKanbanView, setCompactKanbanView] =
+    useCompactViewPreference(true);
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const hoverTimeoutRef = useRef<number | null>(null);

--- a/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.test.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GroupAvatar } from "./group-avatar";
+
+// The Tooltip relies on floating-ui (ResizeObserver/positioning) which is not
+// what we are testing here; render its children directly.
+vi.mock("flowbite-react", () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+describe("GroupAvatar", () => {
+  it("renders initials from a two-word group name", () => {
+    render(<GroupAvatar group={{ id: "GROUP_ops", name: "Operations Faena" }} />);
+    expect(screen.getByText("OF")).toBeInTheDocument();
+  });
+
+  it("renders the first two letters for a single-word group name", () => {
+    render(<GroupAvatar group={{ id: "GROUP_tower", name: "Tower" }} />);
+    expect(screen.getByText("TO")).toBeInTheDocument();
+  });
+
+  it("exposes the full group name as an accessible label", () => {
+    render(<GroupAvatar group={{ id: "g1", name: "Control Tower" }} />);
+    expect(screen.getByLabelText("Control Tower")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no group is provided", () => {
+    const { container } = render(<GroupAvatar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.tsx
@@ -11,7 +11,7 @@ interface GroupAvatarProps {
 function hashHue(value: string): number {
   let hash = 0;
   for (let i = 0; i < value.length; i++) {
-    hash = (hash * 31 + value.charCodeAt(i)) % 360;
+    hash = (hash * 31 + (value.codePointAt(i) ?? 0)) % 360;
   }
   return hash;
 }
@@ -20,7 +20,7 @@ function groupInitials(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return "?";
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return (parts[0][0] + (parts.at(-1) ?? "")[0]).toUpperCase();
 }
 
 /**
@@ -28,7 +28,7 @@ function groupInitials(name: string): string {
  * Shipping tasks have no single assignee, so the group — not a person — is the
  * accurate owner to surface. Renders nothing when no group is available.
  */
-export function GroupAvatar({ group, size = 28 }: GroupAvatarProps) {
+export function GroupAvatar({ group, size = 28 }: Readonly<GroupAvatarProps>) {
   if (!group) {
     return null;
   }

--- a/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/group-avatar/group-avatar.tsx
@@ -1,0 +1,51 @@
+import { Tooltip } from "flowbite-react";
+import type { KanbanTaskGroup } from "../../types/common.types";
+
+interface GroupAvatarProps {
+  group?: KanbanTaskGroup;
+  size?: number;
+}
+
+/** Stable hue (0–359) derived from the group key, so a group always gets the
+ * same colour without needing a configured palette. */
+function hashHue(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) % 360;
+  }
+  return hash;
+}
+
+function groupInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Renders a pooled task's candidate **group** as a coloured initials badge.
+ * Shipping tasks have no single assignee, so the group — not a person — is the
+ * accurate owner to surface. Renders nothing when no group is available.
+ */
+export function GroupAvatar({ group, size = 28 }: GroupAvatarProps) {
+  if (!group) {
+    return null;
+  }
+  const hue = hashHue(group.id || group.name);
+  return (
+    <Tooltip content={group.name}>
+      <span
+        aria-label={group.name}
+        className="inline-flex items-center justify-center rounded-full text-xs font-semibold text-white ring-2 ring-white dark:ring-gray-800"
+        style={{
+          width: size,
+          height: size,
+          backgroundColor: `hsl(${hue} 60% 45%)`,
+        }}
+      >
+        {groupInitials(group.name)}
+      </span>
+    </Tooltip>
+  );
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
-import { Fragment } from "react";
 import Link from "next/link";
 import type { KanBanCardProps } from "./kanban-card.types";
+import { GroupAvatar } from "../group-avatar/group-avatar";
 import { PropsWithI18nDict } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import DepartureDateShip from "../departure-date-ship/departure-date-ship";
@@ -38,7 +38,7 @@ export default function KanbanCard({
       className={`relative rounded-lg hover:shadow-lg overflow-hidden ${
         compactKanbanView ? "p-1 " : "p-5 w-full"
       }
-      ${task.mintral_priorityCode === "UR" ? "bg-purple-100 dark:bg-indigo-800 shadow" : "bg-white shadow dark:bg-gray-800"}
+      ${task.mintral_priorityCode === "UR" ? "bg-purple-100 dark:bg-indigo-800 shadow" : "bg-white shadow dark:bg-gray-700"}
       ${cursor}
       `}
     >
@@ -171,22 +171,7 @@ export default function KanbanCard({
                   )}
                 </div>
                 <div className="flex items-center justify-start">
-                  {task.members.map((member) => (
-                    <Fragment key={member.id}>
-                      <Link href="#" className="-mr-3" prefetch={false}>
-                        <Image
-                          alt={member.name}
-                          height={28}
-                          src={`/app/images/users/${member.avatar}`}
-                          width={28}
-                          className="rounded-full border-2 border-white dark:border-gray-800"
-                        />
-                      </Link>
-                      <div className="invisible absolute z-50 inline-block rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700">
-                        {member.name}
-                      </div>
-                    </Fragment>
-                  ))}
+                  <GroupAvatar group={task.candidateGroup} />
                 </div>
                 <DepartureDateShip
                   dict={dict}

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
@@ -17,6 +17,8 @@ export default function KanbanCard({
   showFinishedTasks,
   isLoading = false,
   onCardClick,
+  onCardMouseEnter,
+  onCardMouseLeave,
 }: PropsWithI18nDict<KanBanCardProps>) {
   let cursor = "hover:shadow-lg cursor-pointer";
 
@@ -65,6 +67,8 @@ export default function KanbanCard({
             href={`/task/edit/${task.id}`}
             className="w-full"
             onClick={onCardClick}
+            onMouseEnter={onCardMouseEnter}
+            onMouseLeave={onCardMouseLeave}
           >
             <div className="text-base text-gray-900 dark:text-gray-200">
               {compactKanbanView ? (

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.tsx
@@ -16,6 +16,7 @@ export default function KanbanCard({
   dict,
   showFinishedTasks,
   isLoading = false,
+  onCardClick,
 }: PropsWithI18nDict<KanBanCardProps>) {
   let cursor = "hover:shadow-lg cursor-pointer";
 
@@ -60,7 +61,11 @@ export default function KanbanCard({
           </div>
         )}
         <div className="flex items-center justify-between">
-          <Link href={`/task/edit/${task.id}`} className="w-full">
+          <Link
+            href={`/task/edit/${task.id}`}
+            className="w-full"
+            onClick={onCardClick}
+          >
             <div className="text-base text-gray-900 dark:text-gray-200">
               {compactKanbanView ? (
                 <div className="flex justify-between gap-2">

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.types.ts
@@ -6,4 +6,5 @@ export type KanBanCardProps = {
   compactKanbanView: boolean;
   showFinishedTasks?: boolean;
   isLoading?: boolean;
+  onCardClick?: () => void;
 };

--- a/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/kanban-card/kanban-card.types.ts
@@ -7,4 +7,6 @@ export type KanBanCardProps = {
   showFinishedTasks?: boolean;
   isLoading?: boolean;
   onCardClick?: () => void;
+  onCardMouseEnter?: () => void;
+  onCardMouseLeave?: () => void;
 };

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -159,7 +159,7 @@ export function LaneColumn({
             renderTrigger={() => (
               <button
                 type="button"
-                className="rounded p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                className="cursor-pointer rounded p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                 aria-label={tr("kanban.lane.menuLabel", dict)}
               >
                 <HiDotsHorizontal className="h-4 w-4" />

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { Dispatch, SetStateAction } from "react";
+import { ReactSortable } from "react-sortablejs";
+import {
+  Dropdown,
+  DropdownHeader,
+  DropdownItem,
+  Tooltip,
+} from "flowbite-react";
+import { HiCheck, HiDotsHorizontal } from "react-icons/hi";
+import { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { KanbanBoard, KanbanBoardTask, Task } from "../../types/common.types";
+import {
+  LaneFilter,
+  LaneSort,
+  LaneViewState,
+} from "../../hooks/use-lane-view-state";
+import KanbanCard from "../kanban-card/kanban-card";
+import { TaskCounter } from "../TaskCounter";
+
+interface LaneColumnProps {
+  board: KanbanBoard;
+  compactKanbanView: boolean;
+  showFinishedTasks: boolean;
+  isLoading: boolean;
+  dict: I18nRecord;
+  laneState: LaneViewState;
+  onLaneUpdate: (patch: Partial<LaneViewState>) => void;
+  setList: Dispatch<SetStateAction<KanbanBoard[]>>;
+  onCardMouseEnter: (task: Task) => void;
+  onCardMouseLeave: () => void;
+  onCardClick: () => void;
+}
+
+function departureValue(task: KanbanBoardTask): number {
+  const raw = task.departureDate ?? task.expectedDepartureDate;
+  const time = raw ? new Date(raw).getTime() : NaN;
+  // Tasks without a date sort to the end.
+  return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
+}
+
+function sortTasks(tasks: KanbanBoardTask[], sort: LaneSort): KanbanBoardTask[] {
+  if (sort === "none") return tasks;
+  const copy = [...tasks];
+  switch (sort) {
+    case "priority":
+      return copy.sort(
+        (a, b) =>
+          (a.mintral_priorityCode === "UR" ? 0 : 1) -
+          (b.mintral_priorityCode === "UR" ? 0 : 1)
+      );
+    case "eta":
+      return copy.sort((a, b) => departureValue(a) - departureValue(b));
+    case "code":
+      return copy.sort((a, b) =>
+        (a.mintral_serviceCode ?? "").localeCompare(b.mintral_serviceCode ?? "")
+      );
+    default:
+      return copy;
+  }
+}
+
+function filterTasks(
+  tasks: KanbanBoardTask[],
+  filter: LaneFilter
+): KanbanBoardTask[] {
+  switch (filter) {
+    case "urgent":
+      return tasks.filter((t) => t.mintral_priorityCode === "UR");
+    case "actionable":
+      return tasks.filter((t) => t.isEditable);
+    default:
+      return tasks;
+  }
+}
+
+/**
+ * A single kanban lane rendered as a visually-separated panel. Columns map 1:1
+ * to workflow stages, so the lane is presentation-only: drag is disabled and the
+ * per-lane menu (density / sort / filter / collapse) only affects the client
+ * view — it never mutates the workflow structure.
+ */
+export function LaneColumn({
+  board,
+  compactKanbanView,
+  showFinishedTasks,
+  isLoading,
+  dict,
+  laneState,
+  onLaneUpdate,
+  setList,
+  onCardMouseEnter,
+  onCardMouseLeave,
+  onCardClick,
+}: LaneColumnProps) {
+  const compact =
+    laneState.density === "inherit"
+      ? compactKanbanView
+      : laneState.density === "compact";
+
+  const title = tr(
+    `kanban.${board.title}${
+      compact && (dict.kanban as I18nRecord)?.[board.title + "Compact"]
+        ? "Compact"
+        : ""
+    }`,
+    dict
+  );
+
+  const visibleTasks = sortTasks(
+    filterTasks(board.tasks, laneState.filter),
+    laneState.sort
+  );
+
+  if (laneState.collapsed) {
+    return (
+      <Tooltip content={tr("kanban.lane.expand", dict)}>
+        <button
+          type="button"
+          onClick={() => onLaneUpdate({ collapsed: false })}
+          className="flex w-10 shrink-0 flex-col items-center gap-2 rounded-lg bg-gray-100 p-2 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+          aria-label={tr("kanban.lane.expand", dict)}
+        >
+          <TaskCounter count={visibleTasks.length} dict={dict} />
+          <span className="truncate text-xs font-semibold uppercase tracking-wide text-gray-700 [writing-mode:vertical-rl] dark:text-gray-300">
+            {title}
+          </span>
+        </button>
+      </Tooltip>
+    );
+  }
+
+  const checkIcon = (active: boolean) => (
+    <HiCheck
+      className={`h-4 w-4 ${active ? "text-primary-600" : "opacity-0"}`}
+    />
+  );
+
+  return (
+    <div
+      className={`flex shrink-0 flex-col rounded-lg bg-gray-100 p-3 dark:bg-gray-800 ${
+        compact ? "w-44" : "w-[280px]"
+      }`}
+    >
+      <div className="sticky top-0 z-10 mb-3 flex min-h-[2.5rem] items-start justify-between gap-2 bg-gray-100 dark:bg-gray-800">
+        <div className="flex min-w-0 flex-1 items-start gap-2">
+          <span className="line-clamp-2 min-w-0 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
+            {title}
+          </span>
+          <TaskCounter count={visibleTasks.length} dict={dict} />
+        </div>
+        <div className="-mt-1 shrink-0">
+          <Dropdown
+            inline
+            arrowIcon={false}
+            dismissOnClick={false}
+            label=""
+            renderTrigger={() => (
+              <button
+                type="button"
+                className="rounded p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                aria-label={tr("kanban.lane.menuLabel", dict)}
+              >
+                <HiDotsHorizontal className="h-4 w-4" />
+              </button>
+            )}
+          >
+            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+              {tr("kanban.lane.density", dict)}
+            </DropdownHeader>
+            <DropdownItem
+              icon={() => checkIcon(laneState.density === "inherit")}
+              onClick={() => onLaneUpdate({ density: "inherit" })}
+            >
+              {tr("kanban.lane.densityInherit", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.density === "compact")}
+              onClick={() => onLaneUpdate({ density: "compact" })}
+            >
+              {tr("kanban.lane.densityCompact", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.density === "expanded")}
+              onClick={() => onLaneUpdate({ density: "expanded" })}
+            >
+              {tr("kanban.lane.densityExpanded", dict)}
+            </DropdownItem>
+
+            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+              {tr("kanban.lane.sort", dict)}
+            </DropdownHeader>
+            <DropdownItem
+              icon={() => checkIcon(laneState.sort === "none")}
+              onClick={() => onLaneUpdate({ sort: "none" })}
+            >
+              {tr("kanban.lane.sortNone", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.sort === "priority")}
+              onClick={() => onLaneUpdate({ sort: "priority" })}
+            >
+              {tr("kanban.lane.sortPriority", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.sort === "eta")}
+              onClick={() => onLaneUpdate({ sort: "eta" })}
+            >
+              {tr("kanban.lane.sortEta", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.sort === "code")}
+              onClick={() => onLaneUpdate({ sort: "code" })}
+            >
+              {tr("kanban.lane.sortCode", dict)}
+            </DropdownItem>
+
+            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+              {tr("kanban.lane.filter", dict)}
+            </DropdownHeader>
+            <DropdownItem
+              icon={() => checkIcon(laneState.filter === "none")}
+              onClick={() => onLaneUpdate({ filter: "none" })}
+            >
+              {tr("kanban.lane.filterNone", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.filter === "urgent")}
+              onClick={() => onLaneUpdate({ filter: "urgent" })}
+            >
+              {tr("kanban.lane.filterUrgent", dict)}
+            </DropdownItem>
+            <DropdownItem
+              icon={() => checkIcon(laneState.filter === "actionable")}
+              onClick={() => onLaneUpdate({ filter: "actionable" })}
+            >
+              {tr("kanban.lane.filterActionable", dict)}
+            </DropdownItem>
+
+            <DropdownItem
+              className="border-t border-gray-100 dark:border-gray-600"
+              onClick={() => onLaneUpdate({ collapsed: true })}
+            >
+              {tr("kanban.lane.collapse", dict)}
+            </DropdownItem>
+          </Dropdown>
+        </div>
+      </div>
+      <ReactSortable
+        animation={100}
+        forceFallback
+        group="kanban"
+        list={visibleTasks}
+        setList={(tasks: KanbanBoardTask[]) =>
+          setList((list) => {
+            const newList = [...list];
+            const index = newList.findIndex((item) => item.id === board.id);
+            newList[index].tasks = tasks;
+            return newList;
+          })
+        }
+        disabled={true}
+        className={`flex flex-col ${compact ? "gap-1" : "gap-4"}`}
+      >
+        {visibleTasks.map((task) => (
+          <div
+            key={task.id}
+            className={`w-full h-fit group relative ${
+              isLoading ? "cursor-wait" : ""
+            }`}
+            role="button"
+            tabIndex={0}
+            onMouseEnter={() => onCardMouseEnter(task)}
+            onMouseLeave={onCardMouseLeave}
+            onClick={onCardClick}
+            onKeyDown={(e) => {
+              e.preventDefault();
+            }}
+            aria-label={`Task ${task.id}`}
+          >
+            <KanbanCard
+              task={task}
+              dict={dict}
+              table_name={board.title}
+              compactKanbanView={compact}
+              showFinishedTasks={showFinishedTasks}
+              isLoading={isLoading}
+            />
+          </div>
+        ))}
+      </ReactSortable>
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -134,7 +134,7 @@ export function LaneColumn({
 
   const checkIcon = (active: boolean) => (
     <HiCheck
-      className={`h-4 w-4 ${active ? "text-primary-600 dark:text-primary-400" : "opacity-0"}`}
+      className={`h-4 w-4 shrink-0 ${active ? "text-primary-600 dark:text-primary-300" : "opacity-0"}`}
     />
   );
 
@@ -155,7 +155,7 @@ export function LaneColumn({
             arrowIcon={false}
             dismissOnClick={false}
             label=""
-            className="z-50"
+            className="z-50 w-60 [&_li>*]:whitespace-nowrap"
             renderTrigger={() => (
               <button
                 type="button"

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -144,7 +144,7 @@ export function LaneColumn({
         compact ? "w-44" : "w-[280px]"
       }`}
     >
-      <div className="sticky top-0 z-10 mb-3 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
+      <div className="sticky top-0 z-20 mb-3 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <span className="line-clamp-2 min-w-0 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
             {title}
@@ -157,6 +157,7 @@ export function LaneColumn({
             arrowIcon={false}
             dismissOnClick={false}
             label=""
+            className="z-50"
             renderTrigger={() => (
               <button
                 type="button"

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -280,8 +280,6 @@ export function LaneColumn({
             className={`w-full h-fit group relative ${
               isLoading ? "cursor-wait" : ""
             }`}
-            onMouseEnter={() => onCardMouseEnter(task)}
-            onMouseLeave={onCardMouseLeave}
           >
             <KanbanCard
               task={task}
@@ -291,6 +289,8 @@ export function LaneColumn({
               showFinishedTasks={showFinishedTasks}
               isLoading={isLoading}
               onCardClick={onCardClick}
+              onCardMouseEnter={() => onCardMouseEnter(task)}
+              onCardMouseLeave={onCardMouseLeave}
             />
           </div>
         ))}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -144,7 +144,7 @@ export function LaneColumn({
         compact ? "w-44" : "w-[280px]"
       }`}
     >
-      <div className="sticky top-0 z-20 mb-3 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
+      <div className="sticky top-0 z-20 mb-2.5 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
         <span className="line-clamp-2 min-w-0 flex-1 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
           {title}
         </span>
@@ -261,7 +261,7 @@ export function LaneColumn({
           })
         }
         disabled={true}
-        className={`flex flex-col ${compact ? "gap-1" : "gap-4"}`}
+        className={`flex flex-col ${compact ? "gap-1" : "gap-2"}`}
       >
         {visibleTasks.map((task) => (
           <div

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -134,7 +134,7 @@ export function LaneColumn({
 
   const checkIcon = (active: boolean) => (
     <HiCheck
-      className={`h-4 w-4 ${active ? "text-primary-600" : "opacity-0"}`}
+      className={`h-4 w-4 ${active ? "text-primary-600 dark:text-primary-400" : "opacity-0"}`}
     />
   );
 

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -145,13 +145,11 @@ export function LaneColumn({
       }`}
     >
       <div className="sticky top-0 z-20 mb-3 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="line-clamp-2 min-w-0 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
-            {title}
-          </span>
+        <span className="line-clamp-2 min-w-0 flex-1 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
+          {title}
+        </span>
+        <div className="flex shrink-0 items-center gap-1.5">
           <TaskCounter count={visibleTasks.length} dict={dict} />
-        </div>
-        <div className="shrink-0">
           <Dropdown
             inline
             arrowIcon={false}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -120,7 +120,7 @@ export function LaneColumn({
         <button
           type="button"
           onClick={() => onLaneUpdate({ collapsed: false })}
-          className="flex w-10 shrink-0 flex-col items-center gap-2 rounded-lg bg-gray-100 p-2 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+          className="flex w-10 shrink-0 cursor-pointer flex-col items-center gap-2 rounded-lg bg-gray-100 p-2 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
           aria-label={tr("kanban.lane.expand", dict)}
         >
           <TaskCounter count={visibleTasks.length} dict={dict} />

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -43,7 +43,7 @@ interface LaneColumnProps {
 
 function departureValue(task: KanbanBoardTask): number {
   const raw = task.departureDate ?? task.expectedDepartureDate;
-  const time = raw ? new Date(raw).getTime() : NaN;
+  const time = raw ? new Date(raw).getTime() : Number.NaN;
   // Tasks without a date sort to the end.
   return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
 }
@@ -101,7 +101,7 @@ export function LaneColumn({
   onCardMouseEnter,
   onCardMouseLeave,
   onCardClick,
-}: LaneColumnProps) {
+}: Readonly<LaneColumnProps>) {
   const compact =
     laneState.density === "inherit"
       ? compactKanbanView
@@ -280,15 +280,9 @@ export function LaneColumn({
             className={`w-full h-fit group relative ${
               isLoading ? "cursor-wait" : ""
             }`}
-            role="button"
-            tabIndex={0}
             onMouseEnter={() => onCardMouseEnter(task)}
             onMouseLeave={onCardMouseLeave}
             onClick={onCardClick}
-            onKeyDown={(e) => {
-              e.preventDefault();
-            }}
-            aria-label={`Task ${task.id}`}
           >
             <KanbanCard
               task={task}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -8,7 +8,14 @@ import {
   DropdownItem,
   Tooltip,
 } from "flowbite-react";
-import { HiCheck, HiDotsHorizontal } from "react-icons/hi";
+import {
+  HiCheck,
+  HiDotsHorizontal,
+  HiAdjustments,
+  HiSortAscending,
+  HiFilter,
+  HiChevronDoubleLeft,
+} from "react-icons/hi";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import { KanbanBoard, KanbanBoardTask, Task } from "../../types/common.types";
@@ -166,7 +173,8 @@ export function LaneColumn({
               </button>
             )}
           >
-            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+            <DropdownHeader className="flex items-center gap-1.5 py-1 text-xs font-semibold uppercase text-gray-400">
+              <HiAdjustments className="h-3.5 w-3.5" />
               {tr("kanban.lane.density", dict)}
             </DropdownHeader>
             <DropdownItem
@@ -188,7 +196,8 @@ export function LaneColumn({
               {tr("kanban.lane.densityExpanded", dict)}
             </DropdownItem>
 
-            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+            <DropdownHeader className="flex items-center gap-1.5 py-1 text-xs font-semibold uppercase text-gray-400">
+              <HiSortAscending className="h-3.5 w-3.5" />
               {tr("kanban.lane.sort", dict)}
             </DropdownHeader>
             <DropdownItem
@@ -216,7 +225,8 @@ export function LaneColumn({
               {tr("kanban.lane.sortCode", dict)}
             </DropdownItem>
 
-            <DropdownHeader className="py-1 text-xs font-semibold uppercase text-gray-400">
+            <DropdownHeader className="flex items-center gap-1.5 py-1 text-xs font-semibold uppercase text-gray-400">
+              <HiFilter className="h-3.5 w-3.5" />
               {tr("kanban.lane.filter", dict)}
             </DropdownHeader>
             <DropdownItem
@@ -239,6 +249,7 @@ export function LaneColumn({
             </DropdownItem>
 
             <DropdownItem
+              icon={HiChevronDoubleLeft}
               className="border-t border-gray-100 dark:border-gray-600"
               onClick={() => onLaneUpdate({ collapsed: true })}
             >

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -144,14 +144,14 @@ export function LaneColumn({
         compact ? "w-44" : "w-[280px]"
       }`}
     >
-      <div className="sticky top-0 z-10 mb-3 flex min-h-[2.5rem] items-start justify-between gap-2 bg-gray-100 dark:bg-gray-800">
-        <div className="flex min-w-0 flex-1 items-start gap-2">
+      <div className="sticky top-0 z-10 mb-3 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <span className="line-clamp-2 min-w-0 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
             {title}
           </span>
           <TaskCounter count={visibleTasks.length} dict={dict} />
         </div>
-        <div className="-mt-1 shrink-0">
+        <div className="shrink-0">
           <Dropdown
             inline
             arrowIcon={false}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -282,7 +282,6 @@ export function LaneColumn({
             }`}
             onMouseEnter={() => onCardMouseEnter(task)}
             onMouseLeave={onCardMouseLeave}
-            onClick={onCardClick}
           >
             <KanbanCard
               task={task}
@@ -291,6 +290,7 @@ export function LaneColumn({
               compactKanbanView={compact}
               showFinishedTasks={showFinishedTasks}
               isLoading={isLoading}
+              onCardClick={onCardClick}
             />
           </div>
         ))}

--- a/turbo-repo/apps/app/src/features/shipping/hooks/use-compact-view-preference.ts
+++ b/turbo-repo/apps/app/src/features/shipping/hooks/use-compact-view-preference.ts
@@ -8,21 +8,21 @@ const STORAGE_KEY = "kanbanCompactView";
  * `initial` on first render and hydrates the saved value after mount.
  */
 export function useCompactViewPreference(initial = true) {
-  const [compact, setCompactState] = useState(initial);
+  const [compact, setCompact] = useState(initial);
 
   useEffect(() => {
     try {
       const saved = localStorage.getItem(STORAGE_KEY);
       if (saved !== null) {
-        setCompactState(saved === "true");
+        setCompact(saved === "true");
       }
     } catch {
       // Storage unavailable (private mode); keep the in-memory value.
     }
   }, []);
 
-  const setCompact = useCallback((value: boolean) => {
-    setCompactState(value);
+  const update = useCallback((value: boolean) => {
+    setCompact(value);
     try {
       localStorage.setItem(STORAGE_KEY, String(value));
     } catch {
@@ -30,5 +30,5 @@ export function useCompactViewPreference(initial = true) {
     }
   }, []);
 
-  return [compact, setCompact] as const;
+  return [compact, update] as const;
 }

--- a/turbo-repo/apps/app/src/features/shipping/hooks/use-compact-view-preference.ts
+++ b/turbo-repo/apps/app/src/features/shipping/hooks/use-compact-view-preference.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "kanbanCompactView";
+
+/**
+ * Persists the board-wide compact/expanded card toggle (the header "expand"
+ * action) to localStorage so the choice survives reloads. Starts from
+ * `initial` on first render and hydrates the saved value after mount.
+ */
+export function useCompactViewPreference(initial = true) {
+  const [compact, setCompactState] = useState(initial);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved !== null) {
+        setCompactState(saved === "true");
+      }
+    } catch {
+      // Storage unavailable (private mode); keep the in-memory value.
+    }
+  }, []);
+
+  const setCompact = useCallback((value: boolean) => {
+    setCompactState(value);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(value));
+    } catch {
+      // Ignore persistence failures and keep in-memory state.
+    }
+  }, []);
+
+  return [compact, setCompact] as const;
+}

--- a/turbo-repo/apps/app/src/features/shipping/hooks/use-lane-view-state.ts
+++ b/turbo-repo/apps/app/src/features/shipping/hooks/use-lane-view-state.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type LaneDensity = "inherit" | "compact" | "expanded";
+export type LaneSort = "none" | "priority" | "eta" | "code";
+export type LaneFilter = "none" | "urgent" | "actionable";
+
+export interface LaneViewState {
+  density: LaneDensity;
+  sort: LaneSort;
+  filter: LaneFilter;
+  collapsed: boolean;
+}
+
+export const DEFAULT_LANE_STATE: LaneViewState = {
+  density: "inherit",
+  sort: "none",
+  filter: "none",
+  collapsed: false,
+};
+
+const STORAGE_KEY = "kanbanLaneViewState";
+
+/**
+ * Per-lane view preferences (density / sort / filter / collapsed), keyed by the
+ * lane's stable workflow title rather than its numeric board id (ids repeat
+ * across the shipping/planning/delivery boards and would otherwise collide).
+ * View-only: nothing here writes back to the workflow.
+ */
+export function useLaneViewState() {
+  const [map, setMap] = useState<Record<string, LaneViewState>>({});
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        setMap(JSON.parse(raw) as Record<string, LaneViewState>);
+      }
+    } catch {
+      // Ignore malformed persisted state and start fresh.
+    }
+  }, []);
+
+  const getLaneState = useCallback(
+    (key: string): LaneViewState => map[key] ?? DEFAULT_LANE_STATE,
+    [map]
+  );
+
+  const updateLaneState = useCallback(
+    (key: string, patch: Partial<LaneViewState>) => {
+      setMap((prev) => {
+        const next = {
+          ...prev,
+          [key]: { ...(prev[key] ?? DEFAULT_LANE_STATE), ...patch },
+        };
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+          // Storage may be unavailable (private mode); keep in-memory state.
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  return { getLaneState, updateLaneState };
+}

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -1,4 +1,8 @@
-import { KanbanBoard, KanbanBoardTask } from "../types/common.types";
+import {
+  KanbanBoard,
+  KanbanBoardTask,
+  KanbanTaskGroup,
+} from "../types/common.types";
 import kanbanBoards from "../model/kanban.json";
 import kanbanPickingBoards from "../model/picking-kanban.json";
 import kanbanShippingV2Boards from "../model/kanban-shipping-v2.json";
@@ -51,7 +55,32 @@ export const taskShippingBoardMap: Record<string, string> = {
   "wfship2:planServiceTask": "planService",
 };
 
-function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {  
+/**
+ * Best-effort resolution of a pooled task's candidate group from the raw task
+ * record. The exact key depends on the backend surfacing the candidate group;
+ * we read the known/likely fields defensively and return undefined otherwise so
+ * the card simply omits the group marker until the proxy provides it.
+ *
+ * TODO(backend): have the task proxy expose the candidate group explicitly
+ * (id + display name) rather than relying on these fallbacks.
+ */
+function toCandidateGroup(
+  task: Record<string, unknown>
+): KanbanTaskGroup | undefined {
+  const raw =
+    (task.mintral_candidateGroup as string | undefined) ??
+    (task.bpm_groupAssignee as string | undefined) ??
+    (task.bpm_pooledActors as string | undefined);
+  if (!raw || typeof raw !== "string") {
+    return undefined;
+  }
+  // Alfresco group authorities look like "GROUP_<name>"; show the bare name.
+  const id = raw.split(",")[0].trim();
+  const name = id.replace(/^GROUP_/, "");
+  return id ? { id, name } : undefined;
+}
+
+function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
   const serviceCode = task.mintral_serviceCode as number;
   const serviceType = task.mintral_serviceType as string;
   const name = `${serviceCode}-${serviceType.toUpperCase()}`;
@@ -80,6 +109,7 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
     serviceType,
     executionType: task.mintral_executionType as string,
     members: [],
+    candidateGroup: toCandidateGroup(task),
     hoReference: task.mintral_hoReference as string,
     departureDate,
     arrivalDate: task.mintral_arrivalDate as string,

--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -61,8 +61,8 @@ export const taskShippingBoardMap: Record<string, string> = {
  * we read the known/likely fields defensively and return undefined otherwise so
  * the card simply omits the group marker until the proxy provides it.
  *
- * TODO(backend): have the task proxy expose the candidate group explicitly
- * (id + display name) rather than relying on these fallbacks.
+ * Backend follow-up (#553): have the task proxy expose the candidate group
+ * explicitly (id + display name) rather than relying on these fallbacks.
  */
 function toCandidateGroup(
   task: Record<string, unknown>

--- a/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/types/common.types.ts
@@ -53,6 +53,13 @@ export type KanbanBoardTask = {
   serviceType: string;
   executionType: string;
   members: KanbanBoardTaskMember[];
+  /**
+   * The pooled candidate group a task is offered to. Shipping tasks are pooled
+   * (no single assignee), so this group — not a person — is the meaningful owner
+   * shown on the card. Optional: the proxy only populates it once the backend
+   * surfaces the task's candidate group; absent until then.
+   */
+  candidateGroup?: KanbanTaskGroup;
   hoReference: string;
   title?: string;
   departureDate?: string;
@@ -84,6 +91,11 @@ export type KanbanBoardTaskMember = {
   id: number;
   name: string;
   avatar: string;
+};
+
+export type KanbanTaskGroup = {
+  id: string;
+  name: string;
 };
 
 export type KanbanPageData = {

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -54,6 +54,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Lane options",
+          "density": "Density",
+          "densityInherit": "Board default",
+          "densityCompact": "Compact",
+          "densityExpanded": "Expanded",
+          "sort": "Sort by",
+          "sortNone": "Default order",
+          "sortPriority": "Priority",
+          "sortEta": "Departure date",
+          "sortCode": "Service code",
+          "filter": "Filter",
+          "filterNone": "Show all",
+          "filterUrgent": "Only urgent",
+          "filterActionable": "Only actionable",
+          "collapse": "Collapse lane",
+          "expand": "Expand lane"
+        },
         "transportValidation": "Driver / Transport Validation",
         "transportValidationCompact": "Driver / Transport",
         "missionControlTripInit": "Mission Control: Start trip",
@@ -170,6 +188,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Lane options",
+          "density": "Density",
+          "densityInherit": "Board default",
+          "densityCompact": "Compact",
+          "densityExpanded": "Expanded",
+          "sort": "Sort by",
+          "sortNone": "Default order",
+          "sortPriority": "Priority",
+          "sortEta": "Departure date",
+          "sortCode": "Service code",
+          "filter": "Filter",
+          "filterNone": "Show all",
+          "filterUrgent": "Only urgent",
+          "filterActionable": "Only actionable",
+          "collapse": "Collapse lane",
+          "expand": "Expand lane"
+        },
         "consolidateLoad": "Consolidate Load",
         "separateDocuments": "Separate Documents",
         "planService": "Plan Service",
@@ -503,6 +539,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Lane options",
+          "density": "Density",
+          "densityInherit": "Board default",
+          "densityCompact": "Compact",
+          "densityExpanded": "Expanded",
+          "sort": "Sort by",
+          "sortNone": "Default order",
+          "sortPriority": "Priority",
+          "sortEta": "Departure date",
+          "sortCode": "Service code",
+          "filter": "Filter",
+          "filterNone": "Show all",
+          "filterUrgent": "Only urgent",
+          "filterActionable": "Only actionable",
+          "collapse": "Collapse lane",
+          "expand": "Expand lane"
+        },
         "transportValidation": "Driver / transport validation",
         "transportValidationCompact": "Transport validation",
         "missionControlTripInit": "Start trip",
@@ -650,6 +704,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Lane options",
+          "density": "Density",
+          "densityInherit": "Board default",
+          "densityCompact": "Compact",
+          "densityExpanded": "Expanded",
+          "sort": "Sort by",
+          "sortNone": "Default order",
+          "sortPriority": "Priority",
+          "sortEta": "Departure date",
+          "sortCode": "Service code",
+          "filter": "Filter",
+          "filterNone": "Show all",
+          "filterUrgent": "Only urgent",
+          "filterActionable": "Only actionable",
+          "collapse": "Collapse lane",
+          "expand": "Expand lane"
+        },
         "confirmDelivery": "Confirm delivery",
         "confirmDeliveryCompact": "Confirm delivery",
         "receiveDelivery": "Receive delivery",

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2986,9 +2986,9 @@
         "slide2_sort": "Sort",
         "slide2_filter": "Filter",
         "slide2_collapse": "Collapse",
-        "slide3_title": "Search with ⌘K",
+        "slide3_title": "Search with ⌘K / Ctrl+K",
         "slide3_placeholder": "Search trip, plate or driver…",
-        "slide3_desc": "Press ⌘K anywhere to jump straight to the search box.",
+        "slide3_desc": "Press ⌘K / Ctrl+K anywhere to jump straight to the search box.",
         "slide4_title": "Your View, Remembered",
         "slide4_desc": "Density, sorting, filters and collapsed lanes persist across reloads."
       },

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2977,6 +2977,21 @@
       "license_plate_and_date_range": "license plate and date range."
     },
     "slider": {
+      "kanban": {
+        "slide1_title": "Renewed Kanban Board",
+        "slide1_subtitle": "Cleaner lanes, faster controls.",
+        "slide2_title": "Per-Lane Actions",
+        "slide2_lane": "Start trip",
+        "slide2_density": "Density",
+        "slide2_sort": "Sort",
+        "slide2_filter": "Filter",
+        "slide2_collapse": "Collapse",
+        "slide3_title": "Search with ⌘K",
+        "slide3_placeholder": "Search trip, plate or driver…",
+        "slide3_desc": "Press ⌘K anywhere to jump straight to the search box.",
+        "slide4_title": "Your View, Remembered",
+        "slide4_desc": "Density, sorting, filters and collapsed lanes persist across reloads."
+      },
       "new_features_appeared": "A new feature has appeared.",
       "test_pulse_historic_feature": "Test the new Pulse Historic feature!!!",
       "description": "Filter pulses by license plate and date range to get a downloadable report based by past positions of the vehicles.",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -3017,9 +3017,9 @@
         "slide2_sort": "Orden",
         "slide2_filter": "Filtro",
         "slide2_collapse": "Contraer",
-        "slide3_title": "Busca con ⌘K",
+        "slide3_title": "Busca con ⌘K / Ctrl+K",
         "slide3_placeholder": "Buscar viaje, patente o conductor…",
-        "slide3_desc": "Presiona ⌘K en cualquier momento para ir directo a la búsqueda.",
+        "slide3_desc": "Presiona ⌘K / Ctrl+K en cualquier momento para ir directo a la búsqueda.",
         "slide4_title": "Tu Vista, Recordada",
         "slide4_desc": "Densidad, orden, filtros y columnas contraídas persisten al recargar."
       },

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -3008,6 +3008,21 @@
       "license_plate_and_date_range": "patente y rango de fechas."
     },
     "slider": {
+      "kanban": {
+        "slide1_title": "Tablero Kanban Renovado",
+        "slide1_subtitle": "Columnas más limpias, controles más rápidos.",
+        "slide2_title": "Acciones por Columna",
+        "slide2_lane": "Iniciar viaje",
+        "slide2_density": "Densidad",
+        "slide2_sort": "Orden",
+        "slide2_filter": "Filtro",
+        "slide2_collapse": "Contraer",
+        "slide3_title": "Busca con ⌘K",
+        "slide3_placeholder": "Buscar viaje, patente o conductor…",
+        "slide3_desc": "Presiona ⌘K en cualquier momento para ir directo a la búsqueda.",
+        "slide4_title": "Tu Vista, Recordada",
+        "slide4_desc": "Densidad, orden, filtros y columnas contraídas persisten al recargar."
+      },
       "new_features_appeared": "Hay nuevas funcionalidades.",
       "test_pulse_historic_feature": "¡Prueba el nuevo Histórico de pulsos!",
       "description": "Filtra pulsos por patente y rango de fechas para obtener un reporte descargable basado en posiciones pasadas de los vehículos.",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -54,6 +54,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Opciones de columna",
+          "density": "Densidad",
+          "densityInherit": "Predeterminado",
+          "densityCompact": "Compacta",
+          "densityExpanded": "Expandida",
+          "sort": "Ordenar por",
+          "sortNone": "Orden predeterminado",
+          "sortPriority": "Prioridad",
+          "sortEta": "Fecha de salida",
+          "sortCode": "Código de servicio",
+          "filter": "Filtrar",
+          "filterNone": "Mostrar todo",
+          "filterUrgent": "Solo urgentes",
+          "filterActionable": "Solo accionables",
+          "collapse": "Contraer columna",
+          "expand": "Expandir columna"
+        },
         "transportValidation": "Validación de Conductor / transporte",
         "transportValidationCompact": "Validación transporte",
         "missionControlTripInit": "Iniciar viaje",
@@ -170,6 +188,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Opciones de columna",
+          "density": "Densidad",
+          "densityInherit": "Predeterminado",
+          "densityCompact": "Compacta",
+          "densityExpanded": "Expandida",
+          "sort": "Ordenar por",
+          "sortNone": "Orden predeterminado",
+          "sortPriority": "Prioridad",
+          "sortEta": "Fecha de salida",
+          "sortCode": "Código de servicio",
+          "filter": "Filtrar",
+          "filterNone": "Mostrar todo",
+          "filterUrgent": "Solo urgentes",
+          "filterActionable": "Solo accionables",
+          "collapse": "Contraer columna",
+          "expand": "Expandir columna"
+        },
         "consolidateLoad": "Consolidar Carga",
         "separateDocuments": "Separar Documentos",
         "planService": "Planificar Servicio",
@@ -503,6 +539,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Opciones de columna",
+          "density": "Densidad",
+          "densityInherit": "Predeterminado",
+          "densityCompact": "Compacta",
+          "densityExpanded": "Expandida",
+          "sort": "Ordenar por",
+          "sortNone": "Orden predeterminado",
+          "sortPriority": "Prioridad",
+          "sortEta": "Fecha de salida",
+          "sortCode": "Código de servicio",
+          "filter": "Filtrar",
+          "filterNone": "Mostrar todo",
+          "filterUrgent": "Solo urgentes",
+          "filterActionable": "Solo accionables",
+          "collapse": "Contraer columna",
+          "expand": "Expandir columna"
+        },
         "transportValidation": "Validación de Conductor / transporte",
         "transportValidationCompact": "Validación transporte",
         "missionControlTripInit": "Iniciar viaje",
@@ -651,6 +705,24 @@
         "activeCount": "{count} visibles"
       },
       "kanban": {
+        "lane": {
+          "menuLabel": "Opciones de columna",
+          "density": "Densidad",
+          "densityInherit": "Predeterminado",
+          "densityCompact": "Compacta",
+          "densityExpanded": "Expandida",
+          "sort": "Ordenar por",
+          "sortNone": "Orden predeterminado",
+          "sortPriority": "Prioridad",
+          "sortEta": "Fecha de salida",
+          "sortCode": "Código de servicio",
+          "filter": "Filtrar",
+          "filterNone": "Mostrar todo",
+          "filterUrgent": "Solo urgentes",
+          "filterActionable": "Solo accionables",
+          "collapse": "Contraer columna",
+          "expand": "Expandir columna"
+        },
         "confirmDelivery": "Confirmar Entrega",
         "confirmDeliveryCompact": "Confirmar Entrega",
         "receiveDelivery": "Confirmar Recepción",


### PR DESCRIPTION
Closes #553

## Summary

Surgical adaptation of the Mintral design kit (`ui_kits/mintral-app` + `components-kanban.html`) to the shipping kanban module (`features/shipping`). Brings the design's visual clarity and ergonomics while respecting our constraints: columns are **workflow-bound stages** (not user-creatable), tasks are **pooled** (no single assignee), and there's no add-trip / card-CRUD path.

## What's included

- **Separated lane panels** — board (`gray-50`) < lane (`gray-100`) < white card tone order, borderless, matching the design.
- **Per-lane `⋯` actions menu** (view-only): density (compact/expanded per lane), sort (priority / departure date / service code), filter (urgent / actionable), collapse lane. **Persisted** to localStorage (`kanbanLaneViewState`).
- **Board expand/compact toggle persisted** to localStorage (`kanbanCompactView`).
- **Page header → design `Topbar`**: bottom border, 60px height, 24px padding, amber "N visibles" pill (11px).
- **⌘K / Ctrl+K search** focus + hint chip, wired to the existing `SearchBar`.
- **Pooled-task group avatar** (initials + hashed color) replacing the dead per-user member avatars.
- Spacing/sizes aligned to the design (lane padding 12px, header→card 10px, expanded card gap 8px, count pill, title tracking).
- A11y/polish: pointer cursors on the actions button and collapsed strip; dark-mode checkmark contrast 6.11:1.

## What's intentionally skipped

- "Add trip" button + card CRUD modals (no backend path) — removed dead code.
- Design sidebar (our collapsed icon-rail is kept).
- Profile/settings relocation (global navbar left as-is).
- Drag-and-drop (workflow-bound; stays disabled).

## ⚠️ Backend dependency

`candidateGroup` is mapped defensively in `data.service.ts` from likely raw fields (`mintral_candidateGroup` / `bpm_groupAssignee` / `bpm_pooledActors`) and renders nothing until the proxy surfaces the task's candidate group. The card degrades gracefully until then. Tracked via `TODO(backend)`.

## Verification

- `tsc --noEmit` clean; shipping unit tests pass (incl. new `group-avatar` tests).
- Verified live on `/app/es/shipping` in light + dark mode (lanes, `⋯` menu, ⌘K, persistence across reload, header border/sizing, contrast).
- Merged latest `trunk` (clean, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut (⌘K / Ctrl+K) to focus search with a visible hint
  * Group avatars on task cards to indicate ownership
  * Per-lane controls: collapse, density, sorting and filtering
  * Persisted per-lane settings and compact/expanded view across sessions
  * Kanban feature slider announcing lane actions and quick search

* **UI Updates**
  * Task counter now a compact pill-style badge
  * Kanban layout and lane management visuals refined

* **Tests**
  * Added unit tests for group avatar rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->