### PR TITLE
fix: attach-based debug config for apps/app server-side breakpoints

### DIFF
--- a/turbo-repo/.vscode/launch.json
+++ b/turbo-repo/.vscode/launch.json
@@ -2,11 +2,26 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "App: debug server-side",
-      "type": "node-terminal",
-      "request": "launch",
-      "command": "npx turbo run dev --filter=@modulariot/app",
-      "cwd": "${workspaceFolder}"
+      // ── Server-side debugging (API routes, server components) ─────────────
+      // 1) Run the dev server in a terminal (plain Turbopack is fine — this only
+      //    adds the Node inspector on :9229):
+      //        cd apps/app && npm run dev -- --inspect
+      // 2) Select this config and press F5 to attach.
+      //
+      // Why ATTACH and not a `node-terminal` launch: js-debug's terminal
+      // auto-attach never adopts Next's server worker (the process that runs
+      // route handlers), so breakpoints stay unbound. Attaching to :9229
+      // directly hits that worker — the same thing chrome://inspect does.
+      "name": "App: attach to server (:9229)",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "cwd": "${workspaceFolder}/apps/app",
+      // Loosen js-debug's source-map location filter so route maps resolve
+      // regardless of the bundler's generated-URL scheme.
+      "resolveSourceMapLocations": null,
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**"]
     },
     {
       "name": "App: debug client-side",
@@ -14,18 +29,6 @@
       "request": "launch",
       "url": "http://localhost:3050/app",
       "webRoot": "${workspaceFolder}/apps/app"
-    },
-    {
-      "name": "App: debug full stack",
-      "type": "node-terminal",
-      "request": "launch",
-      "command": "npx turbo run dev --filter=@modulariot/app",
-      "cwd": "${workspaceFolder}",
-      "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
-      }
     }
   ]
 }


### PR DESCRIPTION
## What
Fixes server-side breakpoints not binding in `apps/app` (Next 16 App Router) under VS Code / Cursor.

## Why
The previous `node-terminal` launch config's auto-attach never adopted Next's **server worker** process (where route handlers run) — a js-debug trace confirmed the parent terminal session attaches but no debuggee child ever does, so breakpoints had nothing to bind to.

## Change
`turbo-repo/.vscode/launch.json`:
- **Server-side**: an **attach** config to `:9229` (`type: node`, `request: attach`) — the same mechanism `chrome://inspect` uses, which always worked.
- `resolveSourceMapLocations: null` so dev-server source maps aren't filtered out.
- Removed the broken `node-terminal` launch and the misleading `--webpack` requirement.

## How to use
```
cd apps/app && npm run dev -- --inspect      # plain Turbopack is fine
```
then Run & Debug → **"App: attach to server (:9229)"** → F5.

## Verified
- Breakpoint at `route.ts:30` binds and pauses.
- Plain Turbopack binds via attach — `--webpack` not needed (confirmed by inspecting the on-disk source map + DevTools Protocol).
- Works on Node 24; no Node downgrade required.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code debug configuration to use Node inspector attach mode for server-side debugging.
  * Removed redundant full-stack debug configuration entry.
  * Streamlined available debug options in development environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->