### PR TITLE
feat(calendar): 3-state accreditation badge for planning resources

### DIFF
--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -475,9 +475,9 @@ export async function fetchTruckCatalogByIdOrPlate(
 /**
  * Row shape returned by `ams.fn_rd_accredited_resources`. One row per
  * resource (driver / truck / trailer / carrier) known to the tenant for the
- * given (rut_mandante, delegacion) pair. The `is_acredited` column flags
- * whether that resource actually holds an ACCREDITED record — the function
- * also returns NOT ACCREDITED rows so the UI can surface both states.
+ * given (rut_mandante, delegacion) pair. The `is_acredited` column flags the
+ * resource's accreditation state — `ACCREDITED`, `NOT_ACCREDITED` or
+ * `SUPER_ACCREDITED` — so the UI can surface all three.
  *
  * `trip_count` / `last_trip` are derived from `public.historical_trip`,
  * `symptoms` is a JSON rollup of `public.symptoms` over the last 90 days
@@ -500,7 +500,7 @@ export interface PgrestAccreditedResourceRow {
   external_id: string | null;
   faena: string | null;
   rut_mandante: string | null;
-  is_acredited: "ACREDITED" | "NOT ACREDITED";
+  is_acredited: "ACCREDITED" | "NOT_ACCREDITED" | "SUPER_ACCREDITED";
   trip_count: number | null;
   last_trip: string | null;
   /**

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { HiCheck, HiStar } from "react-icons/hi";
+import { twMerge } from "tailwind-merge";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+
+/**
+ * UI-facing accreditation level for a resource (carrier / driver / truck /
+ * trailer). Mirrors the three states the upstream `is_acredited` column emits
+ * — `ACCREDITED`, `NOT_ACCREDITED`, `SUPER_ACCREDITED` — but normalized to a
+ * closed, lowercase union so the badge/label lookups can be exhaustive maps.
+ */
+export type AccreditationLevel =
+  | "accredited"
+  | "notAccredited"
+  | "superAccredited";
+
+const RAW_TO_LEVEL: Record<string, AccreditationLevel> = {
+  ACCREDITED: "accredited",
+  NOT_ACCREDITED: "notAccredited",
+  SUPER_ACCREDITED: "superAccredited",
+};
+
+/**
+ * Map the raw upstream `is_acredited` string onto an {@link AccreditationLevel}.
+ * Any value the contract doesn't recognize (including null/empty) collapses to
+ * `notAccredited` so an unexpected upstream code never renders the resource as
+ * accredited by accident.
+ */
+export function toAccreditationLevel(
+  raw: string | null | undefined
+): AccreditationLevel {
+  if (!raw) return "notAccredited";
+  return RAW_TO_LEVEL[raw] ?? "notAccredited";
+}
+
+const LABEL_KEY: Record<AccreditationLevel, string> = {
+  accredited: "pages.planning.sidebar.assignment.enabled",
+  notAccredited: "pages.planning.sidebar.assignment.notEnabled",
+  superAccredited: "pages.planning.sidebar.assignment.superAccredited",
+};
+
+/** Translated label for an accreditation level (used by the searchable field). */
+export function accreditationLabel(
+  level: AccreditationLevel,
+  dict: I18nRecord
+): string {
+  return tr(LABEL_KEY[level], dict);
+}
+
+// Color scheme (with dark-mode contrast):
+//   accredited      → neutral / "normal" gray (the baseline state)
+//   notAccredited   → amber (caution)
+//   superAccredited → green (the standout positive state)
+const BADGE_TONE: Record<AccreditationLevel, string> = {
+  accredited:
+    "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+  notAccredited:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  superAccredited:
+    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+};
+
+// Inner icon-circle tint, paired with BADGE_TONE. `notAccredited` renders no
+// circle so it stays visually quieter than the other two.
+const DOT_TONE: Record<AccreditationLevel, string> = {
+  accredited: "bg-gray-200 dark:bg-gray-600",
+  notAccredited: "",
+  superAccredited: "bg-green-200 dark:bg-green-800/50",
+};
+
+interface AccreditationBadgeProps {
+  readonly level: AccreditationLevel;
+  readonly dict: I18nRecord;
+  /** Extra classes merged onto the badge wrapper (e.g. layout tweaks). */
+  readonly className?: string;
+}
+
+/**
+ * Colored accreditation chip shown on every resource card. `accredited` and
+ * `superAccredited` carry a leading icon-in-circle (check / star); the quieter
+ * `notAccredited` state is text-only, matching the original "No Acreditado"
+ * badge.
+ */
+export function AccreditationBadge({
+  level,
+  dict,
+  className,
+}: AccreditationBadgeProps) {
+  const base =
+    "text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1";
+  const label = accreditationLabel(level, dict);
+
+  if (level === "notAccredited") {
+    return (
+      <span className={twMerge(base, BADGE_TONE[level], className)}>
+        {label}
+      </span>
+    );
+  }
+
+  const Icon = level === "superAccredited" ? HiStar : HiCheck;
+
+  return (
+    <span className={twMerge(base, BADGE_TONE[level], className)}>
+      <span
+        className={twMerge(
+          "flex items-center justify-center w-3.5 h-3.5 rounded-full",
+          DOT_TONE[level]
+        )}
+      >
+        <Icon className="w-2.5 h-2.5" />
+      </span>
+      {label}
+    </span>
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -11,6 +11,10 @@ import {
   useAccreditedResources,
   type AccreditedResource,
 } from "@/features/calendar/services/accredited-resources.service";
+import {
+  toAccreditationLevel,
+  type AccreditationLevel,
+} from "./accreditation";
 import { DriverSearchDropdown } from "./driver-search-dropdown";
 import {
   CarrierSearchDropdown,
@@ -35,7 +39,7 @@ export interface DriverOption {
    * (driver Alerce contract — `conductor` field — still expects RUT today).
    */
   externalId: string | null;
-  estado: "habilitado" | "no habilitado";
+  acreditacion: AccreditationLevel;
   viajesPrevios: number;
   ultimoViaje: string;
   excesoVelocidad: number;
@@ -183,10 +187,10 @@ function formatLastTrip(raw: string | null | undefined): string {
 
 /**
  * Map an `ams.fn_rd_accredited_resources` CARRIER row to the shape expected by
- * `CarrierSearchDropdown`. The upstream function returns both accredited
- * and non-accredited carriers; `is_acredited` drives the UI badge. Both states
- * are surfaced and selectable — the planner sees accreditation as context, not
- * as a hard block.
+ * `CarrierSearchDropdown`. The upstream function returns carriers in every
+ * accreditation state; `is_acredited` drives the UI badge. All states are
+ * surfaced and selectable — the planner sees accreditation as context, not as
+ * a hard block.
  */
 function carrierRowToOption(row: AccreditedResource): CarrierOption {
   const rut = row.identifier ?? "";
@@ -195,7 +199,7 @@ function carrierRowToOption(row: AccreditedResource): CarrierOption {
     name: row.resource_name ?? rut,
     rut,
     externalId: row.external_id,
-    estado: row.is_acredited === "ACREDITED" ? "habilitado" : "no habilitado",
+    acreditacion: toAccreditationLevel(row.is_acredited),
   };
 }
 
@@ -207,8 +211,8 @@ function carrierRowToOption(row: AccreditedResource): CarrierOption {
  * map preview can drop a pin. `gpsIntegrado` is driven by `integration`
  * (independent of whether a recent position is on file); `estadoGps`
  * reflects coordinate availability — `online` only when we have something
- * to plot. `estado` piggybacks on `is_acredited` (ACREDITED → `disponible`,
- * NOT ACREDITED → `ocupado`) to reuse the existing UI badge.
+ * to plot. `acreditacion` carries the upstream `is_acredited` state through
+ * to the shared accreditation badge.
  */
 function truckRowToOption(row: AccreditedResource): TruckOption {
   const plate = row.identifier ?? "";
@@ -222,7 +226,7 @@ function truckRowToOption(row: AccreditedResource): TruckOption {
     externalId: row.external_id,
     marca: row.resource_name ?? "",
     tipo: "truck",
-    estado: row.is_acredited === "ACREDITED" ? "disponible" : "ocupado",
+    acreditacion: toAccreditationLevel(row.is_acredited),
     gpsIntegrado: row.integration === "INTEGRATED",
     estadoGps: hasPosition ? "online" : "offline",
     viajesPrevios: row.trip_count ?? 0,
@@ -236,7 +240,7 @@ function truckRowToOption(row: AccreditedResource): TruckOption {
 
 /**
  * Map an `ams.fn_rd_accredited_resources` TRAILER row onto the existing
- * `TrailerOption` shape. Mirrors `truckRowToOption`: `estado` rides on
+ * `TrailerOption` shape. Mirrors `truckRowToOption`: `acreditacion` rides on
  * `is_acredited`, GPS defaults to "no signal", and `problemasReportados`
  * surfaces lost-signal counts from the symptoms bag. The numeric fleet
  * fields (`capacidadKg`, `kilometraje`) and `ultimoMantenimiento` are not
@@ -252,7 +256,7 @@ function trailerRowToOption(row: AccreditedResource): TrailerOption {
     plate,
     externalId: row.external_id,
     tipo: TRAILER_TIPO_FALLBACK,
-    estado: row.is_acredited === "ACREDITED" ? "disponible" : "ocupado",
+    acreditacion: toAccreditationLevel(row.is_acredited),
     gpsIntegrado: false,
     estadoGps: "offline",
     capacidadKg: 0,
@@ -277,7 +281,7 @@ function driverRowToOption(row: AccreditedResource): DriverOption {
     name: row.resource_name ?? rut,
     rut,
     externalId: row.external_id,
-    estado: row.is_acredited === "ACREDITED" ? "habilitado" : "no habilitado",
+    acreditacion: toAccreditationLevel(row.is_acredited),
     viajesPrevios: row.trip_count ?? 0,
     ultimoViaje: formatLastTrip(row.last_trip),
     excesoVelocidad: symptoms[SYMPTOM_SPEED_LIMIT] ?? 0,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/carrier-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/carrier-search-dropdown.tsx
@@ -11,6 +11,11 @@ import { twMerge } from "tailwind-merge";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
+  AccreditationBadge,
+  accreditationLabel,
+  type AccreditationLevel,
+} from "./accreditation";
+import {
   BaseSearchDropdown,
   type FieldConfig,
   type CardRenderProps,
@@ -31,10 +36,10 @@ export interface CarrierOption {
    * second lookup. `null` when the upstream row has no code on file.
    */
   externalId: string | null;
-  estado: "habilitado" | "no habilitado";
+  acreditacion: AccreditationLevel;
 }
 
-type CarrierMatchType = "name" | "rut" | "estado";
+type CarrierMatchType = "name" | "rut" | "acreditacion";
 
 interface CarrierSearchDropdownProps {
   readonly label: string;
@@ -83,11 +88,8 @@ const CARRIER_FIELDS: readonly FieldConfig<
     getIcon: () => <HiIdentification className={ICON_CLASS} />,
   },
   {
-    field: "estado",
-    getValue: (carrier, dict) =>
-      carrier.estado === "habilitado"
-        ? tr("pages.planning.sidebar.assignment.enabled", dict)
-        : tr("pages.planning.sidebar.assignment.notEnabled", dict),
+    field: "acreditacion",
+    getValue: (carrier, dict) => accreditationLabel(carrier.acreditacion, dict),
     getLabel: (dict) =>
       tr(
         "pages.planning.sidebar.assignment.carrierSearchFields.status",
@@ -109,8 +111,6 @@ function CarrierCard({
   onClick,
   onMouseEnter,
 }: CardRenderProps<CarrierOption>) {
-  const isEnabled = carrier.estado === "habilitado";
-
   return (
     <button
       type="button"
@@ -136,18 +136,7 @@ function CarrierCard({
         <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
           {carrier.rut}
         </span>
-        {isEnabled ? (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
-            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-              <HiCheck className="w-2.5 h-2.5" />
-            </span>
-            {tr("pages.planning.sidebar.assignment.enabled", dict)}
-          </span>
-        ) : (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
-          </span>
-        )}
+        <AccreditationBadge level={carrier.acreditacion} dict={dict} />
       </div>
     </button>
   );
@@ -161,8 +150,6 @@ function renderSelectedCarrierButton(
   carrier: CarrierOption,
   dict: I18nRecord
 ) {
-  const isEnabled = carrier.estado === "habilitado";
-
   return (
     <div className="flex items-center gap-2">
       <div className="flex-1 min-w-0">
@@ -178,18 +165,7 @@ function renderSelectedCarrierButton(
           <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
             {carrier.rut}
           </span>
-          {isEnabled ? (
-            <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 shrink-0">
-              <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-                <HiCheck className="w-2.5 h-2.5" />
-              </span>
-              {tr("pages.planning.sidebar.assignment.enabled", dict)}
-            </span>
-          ) : (
-            <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 shrink-0">
-              {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
-            </span>
-          )}
+          <AccreditationBadge level={carrier.acreditacion} dict={dict} />
         </div>
       </div>
       <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/driver-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/driver-search-dropdown.tsx
@@ -11,6 +11,7 @@ import { twMerge } from "tailwind-merge";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import type { DriverOption } from "./assignment-form";
+import { AccreditationBadge, accreditationLabel } from "./accreditation";
 import {
   BaseSearchDropdown,
   type FieldConfig,
@@ -24,7 +25,7 @@ import {
 type DriverMatchType =
   | "name"
   | "rut"
-  | "estado"
+  | "acreditacion"
   | "viajesPrevios"
   | "ultimoViaje";
 
@@ -69,11 +70,8 @@ const DRIVER_FIELDS: readonly FieldConfig<DriverOption, DriverMatchType>[] =
       getIcon: () => <HiIdentification className={ICON_CLASS} />,
     },
     {
-      field: "estado",
-      getValue: (driver, dict) =>
-        driver.estado === "habilitado"
-          ? tr("pages.planning.sidebar.assignment.enabled", dict)
-          : tr("pages.planning.sidebar.assignment.notEnabled", dict),
+      field: "acreditacion",
+      getValue: (driver, dict) => accreditationLabel(driver.acreditacion, dict),
       getLabel: (dict) =>
         tr("pages.planning.sidebar.assignment.searchFields.status", dict),
       getIcon: () => <HiCheck className={ICON_CLASS} />,
@@ -106,8 +104,6 @@ function DriverCard({
   onClick,
   onMouseEnter,
 }: CardRenderProps<DriverOption>) {
-  const isEnabled = driver.estado === "habilitado";
-
   return (
     <button
       type="button"
@@ -133,18 +129,7 @@ function DriverCard({
         <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
           {driver.rut}
         </span>
-        {isEnabled ? (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
-            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-              <HiCheck className="w-2.5 h-2.5" />
-            </span>
-            {tr("pages.planning.sidebar.assignment.enabled", dict)}
-          </span>
-        ) : (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
-          </span>
-        )}
+        <AccreditationBadge level={driver.acreditacion} dict={dict} />
       </div>
 
       {/* Stats Column */}
@@ -195,8 +180,6 @@ function DriverCard({
 // ============================================================================
 
 function renderSelectedDriverButton(driver: DriverOption, dict: I18nRecord) {
-  const isEnabled = driver.estado === "habilitado";
-
   return (
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-1.5 min-w-0">
@@ -209,18 +192,7 @@ function renderSelectedDriverButton(driver: DriverOption, dict: I18nRecord) {
         <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
           {driver.rut}
         </span>
-        {isEnabled ? (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 shrink-0">
-            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-              <HiCheck className="w-2.5 h-2.5" />
-            </span>
-            {tr("pages.planning.sidebar.assignment.enabled", dict)}
-          </span>
-        ) : (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 shrink-0">
-            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
-          </span>
-        )}
+        <AccreditationBadge level={driver.acreditacion} dict={dict} />
       </div>
     </div>
   );

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/trailer-search-dropdown.tsx
@@ -11,6 +11,11 @@ import {
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
+  AccreditationBadge,
+  accreditationLabel,
+  type AccreditationLevel,
+} from "./accreditation";
+import {
   BaseSearchDropdown,
   type FieldConfig,
   type CardRenderProps,
@@ -71,7 +76,7 @@ export interface TrailerOption {
    */
   externalId: string | null;
   tipo: RemolqueTipo;
-  estado: "disponible" | "ocupado";
+  acreditacion: AccreditationLevel;
   gpsIntegrado: boolean;
   estadoGps: "online" | "offline";
   capacidadKg: number;
@@ -83,7 +88,7 @@ export interface TrailerOption {
 type TrailerMatchType =
   | "plate"
   | "tipo"
-  | "estado"
+  | "acreditacion"
   | "gpsIntegrado"
   | "capacidadKg"
   | "kilometraje";
@@ -134,11 +139,8 @@ const TRAILER_FIELDS: readonly FieldConfig<
     getIcon: () => <HiTruck className={ICON_CLASS} />,
   },
   {
-    field: "estado",
-    getValue: (trailer, dict) =>
-      trailer.estado === "disponible"
-        ? tr("pages.planning.sidebar.assignment.available", dict)
-        : tr("pages.planning.sidebar.assignment.busy", dict),
+    field: "acreditacion",
+    getValue: (trailer, dict) => accreditationLabel(trailer.acreditacion, dict),
     getLabel: (dict) =>
       tr("pages.planning.sidebar.assignment.trailerSearchFields.status", dict),
     getIcon: () => <HiStatusOnline className={ICON_CLASS} />,
@@ -201,18 +203,21 @@ function TrailerCard({
       onClick={onClick}
       onMouseEnter={onMouseEnter}
     >
-      {/* Header: Plate + Type + GPS Status */}
+      {/* Header: Plate + Type + accreditation badge + GPS Status */}
       <div className="flex items-start justify-between gap-2 mb-2">
         <VehicleHeader
           plate={trailer.plate}
           subtitle={subtitle}
           isSelected={isSelected}
         />
-        <GpsStatusColumn
-          isGpsIntegrado={isGpsIntegrado}
-          isOnline={isOnline}
-          dict={dict}
-        />
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <AccreditationBadge level={trailer.acreditacion} dict={dict} />
+          <GpsStatusColumn
+            isGpsIntegrado={isGpsIntegrado}
+            isOnline={isOnline}
+            dict={dict}
+          />
+        </div>
       </div>
 
       {/* Stats Column */}
@@ -258,11 +263,12 @@ function renderSelectedTrailerButton(
 
   return (
     <div className="flex flex-col">
-      {/* Header with plate, type, GPS status, and chevron */}
+      {/* Header with plate, type, accreditation badge, GPS status, chevron */}
       <div className="flex items-start justify-between gap-2 mb-1.5">
         <VehicleHeader plate={trailer.plate} subtitle={subtitle} isSelected />
         <div className="flex flex-col items-end gap-1 shrink-0">
           <div className="flex items-center gap-1.5">
+            <AccreditationBadge level={trailer.acreditacion} dict={dict} />
             <GpsBadge isGpsIntegrado={isGpsIntegrado} dict={dict} />
             <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
           </div>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/truck-search-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/truck-search-dropdown.tsx
@@ -14,6 +14,11 @@ import { twMerge } from "tailwind-merge";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
+  AccreditationBadge,
+  accreditationLabel,
+  type AccreditationLevel,
+} from "./accreditation";
+import {
   BaseSearchDropdown,
   type FieldConfig,
   type CardRenderProps,
@@ -39,7 +44,7 @@ export interface TruckOption {
   externalId: string | null;
   marca: string;
   tipo: "truck" | "furgon" | "trucketa";
-  estado: "disponible" | "ocupado";
+  acreditacion: AccreditationLevel;
   gpsIntegrado: boolean;
   estadoGps: "online" | "offline";
   viajesPrevios: number;
@@ -54,7 +59,7 @@ type TruckMatchType =
   | "plate"
   | "marca"
   | "tipo"
-  | "estado"
+  | "acreditacion"
   | "gpsIntegrado"
   | "viajesPrevios";
 
@@ -105,11 +110,8 @@ const TRUCK_FIELDS: readonly FieldConfig<TruckOption, TruckMatchType>[] = [
     getIcon: () => <HiTruck className={ICON_CLASS} />,
   },
   {
-    field: "estado",
-    getValue: (truck, dict) =>
-      truck.estado === "disponible"
-        ? tr("pages.planning.sidebar.assignment.available", dict)
-        : tr("pages.planning.sidebar.assignment.busy", dict),
+    field: "acreditacion",
+    getValue: (truck, dict) => accreditationLabel(truck.acreditacion, dict),
     getLabel: (dict) =>
       tr("pages.planning.sidebar.assignment.truckSearchFields.status", dict),
     getIcon: () => <HiStatusOnline className={ICON_CLASS} />,
@@ -298,7 +300,6 @@ function TruckCard({
   onClick,
   onMouseEnter,
 }: CardRenderProps<TruckOption>) {
-  const isAvailable = truck.estado === "disponible";
   const truckTypeLabel = tr(
     `pages.planning.sidebar.assignment.truckType.${truck.tipo}`,
     dict
@@ -319,18 +320,7 @@ function TruckCard({
           subtitle={subtitle}
           isSelected={isSelected}
         />
-        {isAvailable ? (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
-            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-green-200 dark:bg-green-800/50">
-              <HiCheck className="w-2.5 h-2.5" />
-            </span>
-            {tr("pages.planning.sidebar.assignment.enabled", dict)}
-          </span>
-        ) : (
-          <span className="text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-            {tr("pages.planning.sidebar.assignment.notEnabled", dict)}
-          </span>
-        )}
+        <AccreditationBadge level={truck.acreditacion} dict={dict} />
       </div>
 
       {/* 5-row stats block, always visible (mockup). */}
@@ -356,7 +346,10 @@ function renderSelectedTruckButton(truck: TruckOption, dict: I18nRecord) {
     <div className="flex flex-col">
       <div className="flex items-start justify-between gap-2 mb-1.5">
         <VehicleHeader plate={truck.plate} subtitle={subtitle} isSelected />
-        <HiChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
+        <div className="flex items-center gap-1.5 shrink-0">
+          <AccreditationBadge level={truck.acreditacion} dict={dict} />
+          <HiChevronDown className="w-4 h-4 text-gray-500" />
+        </div>
       </div>
       <div className="flex flex-col gap-0.5 text-[11px] pt-1 border-t border-gray-100 dark:border-gray-700">
         <TruckStatsRows truck={truck} dict={dict} />

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -24,7 +24,13 @@ export interface AccreditedResource {
   external_id: string | null;
   faena: string | null;
   rut_mandante: string | null;
-  is_acredited: "ACREDITED" | "NOT ACREDITED";
+  /**
+   * Accreditation state for the resource. Upstream emits three values:
+   * `ACCREDITED`, `NOT_ACCREDITED` and `SUPER_ACCREDITED` (the last one flags
+   * a resource accredited beyond the baseline). Normalized for the UI via
+   * `toAccreditationLevel`.
+   */
+  is_acredited: "ACCREDITED" | "NOT_ACCREDITED" | "SUPER_ACCREDITED";
   trip_count: number | null;
   last_trip: string | null;
   /** GPS integration flag (TRUCK rows). Independent of whether a position is on file. */

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -420,6 +420,7 @@
           "status": "Status",
           "enabled": "Accredited",
           "notEnabled": "Not Accredited",
+          "superAccredited": "Super Accredited",
           "previousTrips": "Previous trips",
           "lastTrip": "Last trip",
           "speedExcess": "Speed excess",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -420,6 +420,7 @@
           "status": "Estado",
           "enabled": "Acreditado",
           "notEnabled": "No Acreditado",
+          "superAccredited": "Súper Acreditado",
           "previousTrips": "Viajes previos",
           "lastTrip": "Último viaje",
           "speedExcess": "Exceso velocidad",


### PR DESCRIPTION
## Summary

The upstream `is_acredited` field for planning resources changed from a 2-state value (`ACREDITED` / `NOT ACREDITED`, old spelling) to a **3-state** value with new spelling: `ACCREDITED`, `NOT_ACCREDITED`, `SUPER_ACCREDITED`.

The existing frontend compared against the old spelling in the carrier/driver/truck/trailer option mappers (`row.is_acredited === "ACREDITED"`), which would silently break against the new values — every resource would render as "not accredited" — and collapsed the result into a 2-state badge with no place for the new `SUPER_ACCREDITED` state.

## Changes

- **New shared `accreditation.tsx` module** — single source of truth:
  - `AccreditationLevel` union (`accredited` / `notAccredited` / `superAccredited`)
  - `toAccreditationLevel()` normalizer — unknown/null collapses to `notAccredited` so a bad upstream code never renders as accredited by accident
  - `accreditationLabel()` for the searchable status field
  - `<AccreditationBadge>` component
- Updated row types in `accredited-resources.service.ts` and `pgrest-client.ts` to the 3-state union.
- Reworked carrier/driver/truck/trailer option mappers + dropdowns to carry `acreditacion` (replacing the old `estado` field) and render the badge in both list cards and selected-button views.
- i18n: added `superAccredited` → "Súper Acreditado" (es) / "Super Accredited" (en).

## Colors (dark-mode safe)

| State | Treatment |
|---|---|
| `ACCREDITED` | neutral gray (baseline), check icon |
| `NOT_ACCREDITED` | amber / yellow, text-only |
| `SUPER_ACCREDITED` | green, star icon |

## Note

Trucks and trailers previously reused this badge as their "Disponible/Ocupado" status, but that was always derived from accreditation, so it now shows the accreditation badge directly. There is no separate availability data from the backend today.

## Verification

- `npm run check-types` ✅
- `eslint` on all touched files ✅

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
