### PR TITLE
ci: split app nightly from release train

### DIFF
--- a/.github/prompts/app-release-notes.prompt.yml
+++ b/.github/prompts/app-release-notes.prompt.yml
@@ -85,4 +85,9 @@ messages:
       - Do not invent issue numbers, implementation details, metrics, or statuses.
       - Avoid saying an item is shipped unless the issue state is closed. If open, phrase as
         planned/prepared work in the release scope.
+      - MDX safety: never output raw angle-bracket identifiers such as
+        <AccreditationBadge>, <Component>, or <tag> in prose. MDX parses these
+        as JSX and the build will fail. When mentioning component names,
+        render only the identifier as inline code, for example
+        `AccreditationBadge`, or escape angle brackets as `&lt;...&gt;`.
       - Keep the note polished but compact.

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -29,31 +29,34 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 env:
   NODE_VERSION: "22"
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
   IMAGE_NAME: miot-app
-  NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}
-  NEXT_PUBLIC_MAPBOX_API_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_API_KEY }}
-  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-  NEXT_PUBLIC_AUTENTIA_PATH: ${{ secrets.NEXT_PUBLIC_AUTENTIA_PATH }}
 
 jobs:
   build:
     name: Build and publish nightly app image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}
+      NEXT_PUBLIC_MAPBOX_API_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_API_KEY }}
+      NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
+      NEXT_PUBLIC_AUTENTIA_PATH: ${{ secrets.NEXT_PUBLIC_AUTENTIA_PATH }}
     outputs:
       image: ${{ steps.image.outputs.image }}
       short_sha: ${{ steps.vars.outputs.short_sha }}
       nightly_date: ${{ steps.vars.outputs.nightly_date }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -82,10 +85,10 @@ jobs:
           cp turbo-repo/docker/nextjs.standalone.Dockerfile /tmp/build-app/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -93,7 +96,7 @@ jobs:
 
       - name: Build and push Docker image
         id: docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: /tmp/build-app/
           file: /tmp/build-app/nextjs.standalone.Dockerfile
@@ -129,10 +132,12 @@ jobs:
     name: Deploy development environments
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     environment:
       name: app-nightly-development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Deploy nightly image
         env:

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -1,0 +1,152 @@
+name: App Nightly
+
+on:
+  push:
+    branches:
+      - trunk
+      - main
+    paths:
+      - 'turbo-repo/apps/app/**'
+      - 'turbo-repo/packages/ui/**'
+      - 'turbo-repo/packages/db/**'
+      - 'turbo-repo/packages/typescript-config/**'
+      - 'turbo-repo/package-lock.json'
+      - 'turbo-repo/docker/**'
+      - 'ops/deploy-app-nightly.sh'
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      deploy_environments:
+        description: "Comma-separated development environment names consumed by deploy hook."
+        required: false
+        default: "development"
+        type: string
+
+concurrency:
+  group: app-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  NODE_VERSION: "22"
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_OWNER: microboxlabs
+  IMAGE_NAME: miot-app
+  NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}
+  NEXT_PUBLIC_MAPBOX_API_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_API_KEY }}
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
+  NEXT_PUBLIC_AUTENTIA_PATH: ${{ secrets.NEXT_PUBLIC_AUTENTIA_PATH }}
+
+jobs:
+  build:
+    name: Build and publish nightly app image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      short_sha: ${{ steps.vars.outputs.short_sha }}
+      nightly_date: ${{ steps.vars.outputs.nightly_date }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: turbo-repo/package-lock.json
+
+      - name: Resolve image metadata
+        id: vars
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "nightly_date=$(date -u +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: turbo-repo
+
+      - name: Build app
+        run: npx turbo run build --filter=@modulariot/app
+        working-directory: turbo-repo
+
+      - name: Prepare Docker context
+        run: |
+          mkdir -p /tmp/build-app/.next
+          cp -r turbo-repo/apps/app/.next/standalone /tmp/build-app/.next/standalone
+          cp -r turbo-repo/apps/app/.next/static /tmp/build-app/.next/static
+          cp -r turbo-repo/apps/app/public /tmp/build-app/public
+          cp turbo-repo/docker/nextjs.standalone.Dockerfile /tmp/build-app/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/build-app/
+          file: /tmp/build-app/nextjs.standalone.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:nightly
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:nightly-${{ steps.vars.outputs.nightly_date }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.description=ModularIoT app nightly build
+            org.opencontainers.image.vendor=MicroboxLabs
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          build-args: |
+            APP_NAME=app
+          provenance: true
+          sbom: true
+
+      - name: Resolve immutable image reference
+        id: image
+        run: echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Nightly summary
+        run: |
+          echo "# App Nightly" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: \`${{ steps.image.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Tags: \`nightly\`, \`nightly-${{ steps.vars.outputs.nightly_date }}\`, \`sha-${{ steps.vars.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+  deploy:
+    name: Deploy development environments
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: app-nightly-development
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy nightly image
+        env:
+          IMAGE_REF: ${{ needs.build.outputs.image }}
+          IMAGE_TAG: nightly
+          GIT_SHA: ${{ github.sha }}
+          SHORT_SHA: ${{ needs.build.outputs.short_sha }}
+          NIGHTLY_DATE: ${{ needs.build.outputs.nightly_date }}
+          DEPLOY_ENVIRONMENTS: ${{ inputs.deploy_environments || 'development' }}
+        run: |
+          if [[ -x "./ops/deploy-app-nightly.sh" ]]; then
+            ./ops/deploy-app-nightly.sh
+          else
+            echo "No ./ops/deploy-app-nightly.sh hook found."
+            echo "Create it to deploy IMAGE_REF=$IMAGE_REF to: $DEPLOY_ENVIRONMENTS."
+            exit 1
+          fi

--- a/.github/workflows/app-preview.yml
+++ b/.github/workflows/app-preview.yml
@@ -143,7 +143,7 @@ jobs:
           EOF
           )"
 
-          comment_id="$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+          comment_id="$(gh api --paginate "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
             --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -1)"
 
           if [[ -n "$comment_id" ]]; then

--- a/.github/workflows/app-preview.yml
+++ b/.github/workflows/app-preview.yml
@@ -57,7 +57,11 @@ jobs:
 
       - name: Resolve image metadata
         id: vars
-        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          sha="${PR_HEAD_SHA:-$GITHUB_SHA}"
+          echo "short_sha=${sha::7}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/app-preview.yml
+++ b/.github/workflows/app-preview.yml
@@ -1,0 +1,152 @@
+name: App Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - trunk
+      - main
+    paths:
+      - 'turbo-repo/apps/app/**'
+      - 'turbo-repo/packages/ui/**'
+      - 'turbo-repo/packages/db/**'
+      - 'turbo-repo/packages/typescript-config/**'
+      - 'turbo-repo/package-lock.json'
+      - 'turbo-repo/docker/**'
+
+concurrency:
+  group: app-preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: "22"
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_OWNER: microboxlabs
+  IMAGE_NAME: miot-app
+  NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}
+  NEXT_PUBLIC_MAPBOX_API_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_API_KEY }}
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
+  NEXT_PUBLIC_AUTENTIA_PATH: ${{ secrets.NEXT_PUBLIC_AUTENTIA_PATH }}
+
+jobs:
+  build:
+    name: Build and publish PR preview image
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      short_sha: ${{ steps.vars.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: turbo-repo/package-lock.json
+
+      - name: Resolve image metadata
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: turbo-repo
+
+      - name: Build app
+        run: npx turbo run build --filter=@modulariot/app
+        working-directory: turbo-repo
+
+      - name: Prepare Docker context
+        run: |
+          mkdir -p /tmp/build-app/.next
+          cp -r turbo-repo/apps/app/.next/standalone /tmp/build-app/.next/standalone
+          cp -r turbo-repo/apps/app/.next/static /tmp/build-app/.next/static
+          cp -r turbo-repo/apps/app/public /tmp/build-app/public
+          cp turbo-repo/docker/nextjs.standalone.Dockerfile /tmp/build-app/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/build-app/
+          file: /tmp/build-app/nextjs.standalone.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-sha-${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.description=ModularIoT app PR preview build
+            org.opencontainers.image.vendor=MicroboxLabs
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          build-args: |
+            APP_NAME=app
+          provenance: true
+          sbom: true
+
+      - name: Resolve immutable image reference
+        id: image
+        run: echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Preview summary
+        run: |
+          echo "# App Preview" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- PR: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: \`${{ steps.image.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Tags: \`pr-${{ github.event.pull_request.number }}\`, \`pr-${{ github.event.pull_request.number }}-sha-${{ steps.vars.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upsert PR preview comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IMAGE_REF: ${{ steps.image.outputs.image }}
+          SHORT_SHA: ${{ steps.vars.outputs.short_sha }}
+        run: |
+          marker="<!-- app-preview-image -->"
+          body="$(cat <<EOF
+          $marker
+          ## App preview image
+
+          The latest app preview image for this PR is ready.
+
+          - Immutable image: \`$IMAGE_REF\`
+          - Moving tag: \`${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:pr-$PR_NUMBER\`
+          - SHA tag: \`${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:pr-$PR_NUMBER-sha-$SHORT_SHA\`
+          EOF
+          )"
+
+          comment_id="$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -1)"
+
+          if [[ -n "$comment_id" ]]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/$comment_id" \
+              -f body="$body" >/dev/null
+          else
+            gh pr comment "$PR_NUMBER" --body "$body"
+          fi

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -50,6 +50,7 @@ jobs:
       app_version: ${{ steps.version.outputs.app_version }}
       tag: ${{ steps.version.outputs.tag }}
       branch: ${{ steps.branch.outputs.branch }}
+      pr_number: ${{ steps.pr.outputs.number }}
       pr_url: ${{ steps.pr.outputs.url }}
     steps:
       - uses: actions/checkout@v4
@@ -170,6 +171,8 @@ jobs:
             --head "${{ steps.branch.outputs.branch }}" \
             --title "chore(app): prepare v${{ steps.version.outputs.app_version }} release" \
             --body "Prepares app release ${{ steps.version.outputs.tag }} with release notes v${{ inputs.release_notes_version }}.\n\nApprove and merge this PR, then approve the protected release job to tag, build, and deploy.")"
+          number="${url##*/}"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
   approve:
@@ -188,16 +191,35 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, approve]
     outputs:
-      sha: ${{ steps.trunk.outputs.sha }}
+      sha: ${{ steps.release_pr.outputs.sha }}
     steps:
+      - name: Wait for release PR merge
+        id: release_pr
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          for attempt in {1..60}; do
+            merged_at="$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt')"
+            merge_sha="$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid // ""')"
+
+            if [[ "$merged_at" != "null" && -n "$merge_sha" ]]; then
+              echo "Release PR #$PR_NUMBER merged at $merged_at ($merge_sha)."
+              echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "Release PR #$PR_NUMBER is not merged yet. Waiting before tagging... ($attempt/60)"
+            sleep 60
+          done
+
+          echo "::error::Release PR #$PR_NUMBER was approved but is still not merged. Merge it before the release train can tag trunk."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
-          ref: trunk
+          ref: ${{ steps.release_pr.outputs.sha }}
           fetch-depth: 0
-
-      - name: Resolve trunk
-        id: trunk
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Verify release prep landed on trunk
         run: |

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -349,3 +349,21 @@ jobs:
             echo "Create it to update environment variables and deploy IMAGE_REF=$IMAGE_REF to: $DEPLOY_ENVIRONMENTS."
             exit 1
           fi
+
+  close-milestones:
+    name: Close release milestones
+    runs-on: ubuntu-latest
+    needs: [prepare, tag, deploy]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+
+      - name: Close private and OSS milestones
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          GH_PROJECT_OWNER: microboxlabs
+        run: |
+          ./turbo-repo/generative_ai/tools/sh/close-release-milestones.sh \
+            --release "${{ inputs.private_milestone }}" \
+            --oss "${{ inputs.oss_milestone }}"

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -200,8 +200,15 @@ jobs:
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
         run: |
           for attempt in {1..60}; do
-            merged_at="$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt')"
-            merge_sha="$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid // ""')"
+            pr="$(gh pr view "$PR_NUMBER" --json mergedAt,mergeCommit,state)"
+            merged_at="$(echo "$pr" | jq -r '.mergedAt')"
+            merge_sha="$(echo "$pr" | jq -r '.mergeCommit.oid // ""')"
+            state="$(echo "$pr" | jq -r '.state')"
+
+            if [[ "$state" == "CLOSED" && ( "$merged_at" == "null" || -z "$merge_sha" ) ]]; then
+              echo "::error::Release PR #$PR_NUMBER was closed without being merged. Re-run the release train to create a new release PR."
+              exit 1
+            fi
 
             if [[ "$merged_at" != "null" && -n "$merge_sha" ]]; then
               echo "Release PR #$PR_NUMBER merged at $merged_at ($merge_sha)."
@@ -313,7 +320,7 @@ jobs:
           tags: |
             ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.app_version }}
             ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:app-v${{ needs.prepare.outputs.app_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
           build-args: |
             APP_NAME=app
           provenance: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install, lint, build, changes]
     if: always()
+    permissions: {}
     steps:
       - name: Create summary
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,35 +1,14 @@
 # =============================================================================
-# Build and Publish - ModularIoT Monorepo
+# CI - ModularIoT Monorepo
 # =============================================================================
-# This workflow builds and publishes Docker images for multiple applications
-# in the monorepo.
-#
-# Docker Images published to:
-#   - GitHub Container Registry (GHCR) - Primary registry
-#   - Docker Hub - Secondary mirror (non-PR builds only)
-#
-# Applications built:
-#   - docs: Documentation site (miot-docs)
-#   - app: Main application (miot-app)
-#   - web: Marketing website (miot-web)
-#
-# Tagging Strategy:
-#   - PRs:        ghcr.io/microboxlabs/<image>:pr-<number>
-#   - trunk:      ghcr.io/microboxlabs/<image>:latest
-#   - Tags:       ghcr.io/microboxlabs/<image>:<version>
-#
-# Required Secrets:
-#   Docker Hub:
-#     - DOCKERHUB_USERNAME: Docker Hub username
-#     - DOCKERHUB_TOKEN: Docker Hub access token
-#
-# Required Variables:
-#   - NEXT_PUBLIC_INGEST_URL: Ingest URL for the app
+# This workflow validates Turbo repo changes on pull requests, trunk/main pushes,
+# and manual dispatches. Release tagging, image publishing, and deployment are
+# handled by app-release-train.yml.
 # =============================================================================
 
-name: Build and Publish
+name: CI
 
-run-name: ${{ github.actor }} is building ${{ github.repository }} 🚀
+run-name: ${{ github.actor }} is validating ${{ github.repository }}
 
 on:
   push:
@@ -38,8 +17,6 @@ on:
     branches:
       - trunk
       - main
-    tags:
-      - "v*"
   pull_request:
     paths:
       - 'turbo-repo/**'
@@ -48,25 +25,20 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  # Registry configuration
-  GHCR_REGISTRY: ghcr.io
-  DOCKERHUB_REGISTRY: docker.io
-  # Organization/owner for images
-  IMAGE_OWNER: microboxlabs
-  # Build configuration
   NODE_VERSION: "22"
-  # Application environment
   NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}
   NEXT_PUBLIC_MAPBOX_API_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_API_KEY }}
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
   NEXT_PUBLIC_AUTENTIA_PATH: ${{ secrets.NEXT_PUBLIC_AUTENTIA_PATH }}
 
-
-
 jobs:
   # ===========================================================================
-  # Changed paths - Detect which areas of the monorepo changed
+  # Changed paths - Detect whether app build inputs changed
   # ===========================================================================
   changes:
     name: Detect Changes
@@ -78,6 +50,7 @@ jobs:
       apps: ${{ steps.filter.outputs.apps }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -98,14 +71,8 @@ jobs:
     name: Install Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     permissions:
       contents: read
-
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      is-release: ${{ steps.version.outputs.is-release }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -116,21 +83,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
           cache-dependency-path: turbo-repo/package-lock.json
-
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "is-release=true" >> $GITHUB_OUTPUT
-            echo "📦 Release version: $VERSION"
-          else
-            VERSION="0.0.0-$(echo $GITHUB_SHA | cut -c1-7)"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "is-release=false" >> $GITHUB_OUTPUT
-            echo "📦 Development version: $VERSION"
-          fi
 
       - name: Cache node_modules
         id: cache-modules
@@ -155,10 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     timeout-minutes: 10
-
     permissions:
       contents: read
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -188,18 +138,16 @@ jobs:
         working-directory: turbo-repo
 
   # ===========================================================================
-  # Build - Turbo build all Next.js apps and upload standalone artifacts
+  # Build - Validate the Next.js apps that participate in release/deploy flows
   # ===========================================================================
   build:
     name: Build Apps
     runs-on: ubuntu-latest
     needs: [install, changes]
-    if: needs.changes.outputs.apps == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.apps == 'true'
     timeout-minutes: 15
-
     permissions:
       contents: read
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -222,237 +170,24 @@ jobs:
         run: npx turbo run build --filter=@modulariot/docs --filter=@modulariot/app --filter=@modulariot/web
         working-directory: turbo-repo
 
-      - name: Stage docs artifacts
-        run: |
-          mkdir -p /tmp/build-docs/.next
-          cp -r turbo-repo/apps/docs/.next/standalone /tmp/build-docs/.next/standalone
-          cp -r turbo-repo/apps/docs/.next/static /tmp/build-docs/.next/static
-          cp -r turbo-repo/apps/docs/public /tmp/build-docs/public
-
-      - name: Stage app artifacts
-        run: |
-          mkdir -p /tmp/build-app/.next
-          cp -r turbo-repo/apps/app/.next/standalone /tmp/build-app/.next/standalone
-          cp -r turbo-repo/apps/app/.next/static /tmp/build-app/.next/static
-          cp -r turbo-repo/apps/app/public /tmp/build-app/public
-
-      - name: Stage web artifacts
-        run: |
-          mkdir -p /tmp/build-web/.next
-          cp -r turbo-repo/apps/web/.next/standalone /tmp/build-web/.next/standalone
-          cp -r turbo-repo/apps/web/.next/static /tmp/build-web/.next/static
-          cp -r turbo-repo/apps/web/public /tmp/build-web/public
-
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-docs
-          path: /tmp/build-docs/
-          include-hidden-files: true
-          retention-days: 1
-
-      - name: Upload app artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-app
-          path: /tmp/build-app/
-          include-hidden-files: true
-          retention-days: 1
-
-      - name: Upload web artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-web
-          path: /tmp/build-web/
-          include-hidden-files: true
-          retention-days: 1
-
-  # ===========================================================================
-  # Publish Docker Images - Package pre-built standalone output
-  # ===========================================================================
-  publish-docker:
-    name: Publish ${{ matrix.app }} Image
-    runs-on: ubuntu-latest
-    needs: [lint, build, changes]
-    if: needs.changes.outputs.apps == 'true'
-    timeout-minutes: 15
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - app: docs
-            image-name: miot-docs
-          - app: app
-            image-name: miot-app
-          - app: web
-            image-name: miot-web
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-      security-events: write
-
-    outputs:
-      image-tags: ${{ steps.meta.outputs.tags }}
-      image-digest: ${{ steps.build-push.outputs.digest }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: turbo-repo/docker
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-${{ matrix.app }}
-          path: build-context/
-
-      - name: Copy Dockerfile into build context
-        run: cp turbo-repo/docker/nextjs.standalone.Dockerfile build-context/
-
-      # =========================================================================
-      # Docker Build Setup
-      # =========================================================================
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # =========================================================================
-      # Registry Authentication
-      # =========================================================================
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKERHUB_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # =========================================================================
-      # Image Metadata and Tags
-      # =========================================================================
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image-name }}
-            ${{ github.event_name != 'pull_request' && format('{0}/{1}/{2}', env.DOCKERHUB_REGISTRY, env.IMAGE_OWNER, matrix.image-name) || '' }}
-          tags: |
-            type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=sha,prefix=sha-,format=short
-          labels: |
-            org.opencontainers.image.title=${{ matrix.image-name }}
-            org.opencontainers.image.description=ModularIoT ${{ matrix.app }} application
-            org.opencontainers.image.vendor=MicroboxLabs
-            org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
-
-      # =========================================================================
-      # Build and Push - Package pre-built standalone output
-      # =========================================================================
-      - name: Build and push Docker image
-        id: build-push
-        uses: docker/build-push-action@v6
-        with:
-          context: build-context/
-          file: build-context/nextjs.standalone.Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            APP_NAME=${{ matrix.app }}
-          provenance: true
-          sbom: true
-
-      # =========================================================================
-      # Post-build Information
-      # =========================================================================
-      - name: Output image information
-        run: |
-          echo "## 🐳 Docker Image Published: ${{ matrix.image-name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Image Tags" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Image Digest" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.build-push.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Pull Commands" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "# From GitHub Container Registry (primary)" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image-name }}:sha-${GITHUB_SHA::7}" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "# From Docker Hub (mirror)" >> $GITHUB_STEP_SUMMARY
-            echo "docker pull ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image-name }}:sha-${GITHUB_SHA::7}" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      # =========================================================================
-      # Security Scan
-      # =========================================================================
-      - name: Run Trivy vulnerability scanner
-        if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
-        with:
-          image-ref: "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image-name }}@${{ steps.build-push.outputs.digest }}"
-          format: "sarif"
-          output: "trivy-results-${{ matrix.app }}.sarif"
-        continue-on-error: true
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results-${{ matrix.app }}.sarif"
-          category: "${{ matrix.app }}-security"
-        continue-on-error: true
-
   # ===========================================================================
   # Summary Job - Aggregate results
   # ===========================================================================
   summary:
-    name: Build Summary
+    name: CI Summary
     runs-on: ubuntu-latest
-    needs: [install, lint, build, publish-docker, changes]
+    needs: [install, lint, build, changes]
     if: always()
-
     steps:
       - name: Create summary
         run: |
-          echo "# 📊 Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "# CI Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Install | ${{ needs.install.result == 'success' && '✅ Cached' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Lint & Types | ${{ needs.lint.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build Apps | ${{ needs.build.result == 'success' && '✅ Built' || needs.build.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker Publish | ${{ needs.publish-docker.result == 'success' && '✅ Published' || needs.publish-docker.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Install | ${{ needs.install.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Lint & Types | ${{ needs.lint.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build Apps | ${{ needs.build.result == 'success' && 'Built' || needs.build.result == 'skipped' && 'Skipped' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Version Information" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** ${{ needs.install.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release:** ${{ needs.install.outputs.is-release }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** \`${GITHUB_SHA::7}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: \`${GITHUB_SHA::7}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Release publishing: handled by \`app-release-train.yml\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "22"
   NEXT_PUBLIC_INGEST_URL: ${{ vars.NEXT_PUBLIC_INGEST_URL }}

--- a/ops/deploy-app-nightly.example.sh
+++ b/ops/deploy-app-nightly.example.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copy this file to ops/deploy-app-nightly.sh and replace the echo blocks with
+# the real development environment deployment commands.
+#
+# Required environment:
+#   IMAGE_REF           Immutable image digest, for example ghcr.io/...@sha256:...
+#   IMAGE_TAG           Moving tag, normally nightly
+#   GIT_SHA             Source commit SHA
+#   SHORT_SHA           Short source commit SHA
+#   NIGHTLY_DATE        UTC build date in YYYYMMDD format
+#   DEPLOY_ENVIRONMENTS Comma-separated environment names, for example dev,qa
+
+: "${IMAGE_REF:?IMAGE_REF is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+: "${GIT_SHA:?GIT_SHA is required}"
+: "${SHORT_SHA:?SHORT_SHA is required}"
+: "${NIGHTLY_DATE:?NIGHTLY_DATE is required}"
+: "${DEPLOY_ENVIRONMENTS:?DEPLOY_ENVIRONMENTS is required}"
+
+IFS=, read -ra environments <<< "$DEPLOY_ENVIRONMENTS"
+
+for environment in "${environments[@]}"; do
+  environment="$(echo "$environment" | xargs)"
+  [[ -z "$environment" ]] && continue
+
+  echo "Deploying $IMAGE_TAG ($IMAGE_REF) to $environment"
+
+  # Replace this section with the real deployment mechanism. Common examples:
+  # - update the app image reference in Helm/Kubernetes
+  # - update APP_VERSION / RELEASE_VERSION / BUILD_SHA in the target environment
+  # - restart or roll out the workload
+  #
+  # kubectl --context "$environment" \
+  #   set image deployment/miot-app miot-app="$IMAGE_REF" \
+  #   --namespace modulariot
+  #
+  # kubectl --context "$environment" \
+  #   set env deployment/miot-app \
+  #   APP_VERSION="$IMAGE_TAG" \
+  #   RELEASE_VERSION="$IMAGE_TAG" \
+  #   BUILD_SHA="$GIT_SHA" \
+  #   NIGHTLY_DATE="$NIGHTLY_DATE" \
+  #   --namespace modulariot
+  #
+  # kubectl --context "$environment" \
+  #   rollout status deployment/miot-app \
+  #   --namespace modulariot
+done

--- a/turbo-repo/generative_ai/tools/sh/close-release-milestones.sh
+++ b/turbo-repo/generative_ai/tools/sh/close-release-milestones.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Close matching release milestones across all repositories in a GitHub org.
+#
+# Requirements: gh (GitHub CLI, authenticated), jq
+#
+# Usage:
+#   ./close-release-milestones.sh --release 1.31.2 --oss MIOT-0.5.5
+#
+# Options:
+#   --org ORG         GitHub org (default: GH_PROJECT_OWNER env, or microboxlabs)
+#   --release NAME    Private release milestone title (e.g. 1.31.2) [required]
+#   --oss NAME        OSS milestone title (e.g. MIOT-0.5.5)         [optional]
+#   -h                Show this help
+
+set -euo pipefail
+
+ORG="${GH_PROJECT_OWNER:-microboxlabs}"
+RELEASE_MILESTONE=""
+OSS_MILESTONE=""
+
+usage() {
+  echo "Usage: $0 --release VERSION [--oss OSS_MILESTONE] [--org ORG] [-h]"
+  echo "  --release NAME    Private release milestone title (e.g. 1.31.2) [required]"
+  echo "  --oss NAME        OSS milestone title (e.g. MIOT-0.5.5)         [optional]"
+  echo "  --org ORG         GitHub org (default: ${ORG})"
+  echo "  -h                This help"
+  return 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release) RELEASE_MILESTONE="$2"; shift 2 ;;
+    --oss)     OSS_MILESTONE="$2";     shift 2 ;;
+    --org)     ORG="$2";               shift 2 ;;
+    -h) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$RELEASE_MILESTONE" ]]; then
+  echo "Error: --release is required." >&2
+  usage; exit 1
+fi
+
+for cmd in gh jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is required but not installed." >&2
+    exit 1
+  fi
+done
+
+MILESTONE_ENTRIES=("${RELEASE_MILESTONE}:private")
+[[ -n "$OSS_MILESTONE" ]] && MILESTONE_ENTRIES+=("${OSS_MILESTONE}:oss")
+
+echo "Fetching repos for org: ${ORG}..." >&2
+REPOS=()
+api_page=1
+while true; do
+  PAGE=$(gh api "orgs/${ORG}/repos?per_page=100&page=${api_page}&type=all" \
+    --jq '.[].full_name' 2>/dev/null || echo "")
+  [[ -z "$PAGE" ]] && break
+  while IFS= read -r repo; do REPOS+=("$repo"); done <<< "$PAGE"
+  page_count=$(echo "$PAGE" | wc -l | tr -d ' ')
+  [[ "$page_count" -lt 100 ]] && break
+  api_page=$((api_page + 1))
+done
+
+echo "  -> ${#REPOS[@]} repos" >&2
+
+closed_count=0
+already_closed_count=0
+missing_count=0
+
+for repo in "${REPOS[@]}"; do
+  milestones_json="$(gh api "repos/${repo}/milestones?state=all&per_page=100" 2>/dev/null || echo "[]")"
+
+  for entry in "${MILESTONE_ENTRIES[@]}"; do
+    milestone_title="${entry%%:*}"
+    milestone_source="${entry##*:}"
+
+    milestone="$(echo "$milestones_json" | jq -c --arg title "$milestone_title" '.[] | select(.title == $title)' | head -1)"
+
+    if [[ -z "$milestone" ]]; then
+      missing_count=$((missing_count + 1))
+      continue
+    fi
+
+    milestone_number="$(echo "$milestone" | jq -r '.number')"
+    milestone_state="$(echo "$milestone" | jq -r '.state')"
+
+    if [[ "$milestone_state" == "closed" ]]; then
+      echo "Already closed: [$milestone_source] $repo milestone '$milestone_title' (#$milestone_number)" >&2
+      already_closed_count=$((already_closed_count + 1))
+      continue
+    fi
+
+    echo "Closing: [$milestone_source] $repo milestone '$milestone_title' (#$milestone_number)" >&2
+    gh api \
+      --method PATCH \
+      "repos/${repo}/milestones/${milestone_number}" \
+      -f state=closed >/dev/null
+    closed_count=$((closed_count + 1))
+  done
+done
+
+echo "" >&2
+echo "Milestones closed: ${closed_count}" >&2
+echo "Already closed: ${already_closed_count}" >&2
+echo "Missing repo/milestone pairs skipped: ${missing_count}" >&2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR preview images published for pull requests with immutable and moving tags, plus summary comments.
  * Nightly images built and published automatically with multi-tagging (nightly/date/sha) and immutable digests; optional nightly deploy trigger.

* **Chores**
  * Release process now waits for release PR merge and tags images by merge commit SHA.
  * CI workflow refocused and environment config centralized.
  * Added example deployment helper and a milestone-closing utility script.
  * Prompt rule added to prevent MDX JSX parsing issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microboxlabs/modulariot/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->