### PR TITLE
feat(app): redirect bare root to /app basePath in local dev

### DIFF
--- a/turbo-repo/apps/app/next.config.mjs
+++ b/turbo-repo/apps/app/next.config.mjs
@@ -9,6 +9,21 @@ const nextConfig = {
   // Required for npm workspace monorepo: trace dependencies from monorepo root
   outputFileTracingRoot: path.join(import.meta.dirname, "../../"),
   basePath: "/app",
+  // Dev-only: redirect the bare root to the app's basePath so opening
+  // http://localhost:3050/ lands on /app instead of a 404. In production the
+  // front load balancer already handles this, so we skip it there.
+  // basePath: false keeps source/destination from being prefixed with /app.
+  async redirects() {
+    if (process.env.NODE_ENV !== "development") return [];
+    return [
+      {
+        source: "/",
+        destination: "/app",
+        basePath: false,
+        permanent: false,
+      },
+    ];
+  },
   // Enable source maps for production/staging debugging
   productionBrowserSourceMaps: true,
   images: {


### PR DESCRIPTION
## Summary

`apps/app` is configured with `basePath: "/app"`, so every route lives under `/app`. After `turbo run dev -F @modulariot/app`, Next prints `http://localhost:3050` and opening the bare root (`/`) serves nothing → 404. This adds a **dev-only** redirect so `/` lands on `/app`.

## Changes

- `turbo-repo/apps/app/next.config.mjs`: add `async redirects()` returning `/` → `/app`.
  - `basePath: false` so source/destination aren't auto-prefixed with `/app`.
  - `permanent: false` (307) to avoid browser caching the redirect.
  - Gated on `process.env.NODE_ENV === "development"` → only active under `next dev`.

## Why dev-only

In production the front load balancer already handles the root redirect, so `redirects()` returns `[]` there and the build is unchanged.

## Notes

Config `redirects` run before the locale middleware in `src/proxy.ts`, so `/` → `/app` fires first and the existing middleware then resolves the locale/landing route as usual.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)