### PR TITLE
fix(app): contain kanban header z-index to stop mobile overlaps

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -210,7 +210,7 @@ export default function PageContent({
         </div>
       </div>
       <div
-        className={`h-screen w-full overflow-auto ${
+        className={`isolate h-screen w-full overflow-auto ${
           activeView === "kanban" ? "bg-gray-50 dark:bg-gray-900" : ""
         }`}
       >

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -151,7 +151,15 @@ export function LaneColumn({
         compact ? "w-44" : "w-[280px]"
       }`}
     >
-      <div className="sticky top-0 z-20 mb-2.5 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 dark:bg-gray-800">
+      {/*
+        The sticky header is a z-20 stacking context, which traps the lane menu
+        (a DOM descendant) at z-20 — so a later column's header paints over an
+        open menu. Flowbite renders the menu inline (no portal) and exposes no
+        open-state callback, so we detect "menu open" via the floating
+        role="menu" element it mounts only while open, and lift this header
+        above its z-20 siblings for the duration.
+      */}
+      <div className="sticky top-0 z-20 mb-2.5 flex min-h-[2.5rem] items-center justify-between gap-2 bg-gray-100 has-[[role=menu]]:z-30 dark:bg-gray-800">
         <span className="line-clamp-2 min-w-0 flex-1 text-xs font-semibold uppercase leading-tight tracking-wide text-gray-700 dark:text-gray-300">
           {title}
         </span>


### PR DESCRIPTION
## What

Fixes two mobile stacking-order regressions on the shipping Kanban board, both rooted in the `z-index` added to the lane header when the per-lane actions menu landed (#553 / PR #554).

| Before | Fix |
| --- | --- |
| Column titles paint over the open mobile navigation drawer | Board scroll container is now an isolated stacking context, so the header's `z-index` no longer leaks into the root context and the whole board sits below the drawer |
| An open lane `…` menu is painted under the headers of columns further right | While a menu is open, its header is lifted above `z-20` siblings |

## Root cause

`LaneColumn`'s header is `sticky top-0 z-20`. None of its ancestors (the column, the `overflow-auto` board scroll container) established a stacking context, so that `z-20` competed in the **root** stacking context — tying the mobile sidebar `<nav>` (`z-20`) and beating its backdrop (`z-10`).

The header is itself a stacking context (positioned + `z-index`), and the lane menu is a **DOM descendant** of it. Flowbite (`^0.12.10`) renders the menu **inline (no portal)** and exposes **no open-state callback**, so the menu's `z-50` is trapped inside the header's `z-20` layer and cannot rise above a sibling column's header (also `z-20`, later in the DOM).

## Changes

- **`content.tsx`** — add `isolate` to the board scroll container. The header keeps `z-20` *relative to its own cards* (the reason it was added), but the board now participates in the root context as a single `z-auto` element, below the drawer/backdrop. Isolating at the container (not per-column) keeps the menu's `z-50` above **all** sibling columns.
- **`lane-column.tsx`** — `has-[[role=menu]]:z-30` on the header. Flowbite mounts a `role="menu"` element (a stable ARIA contract) as a header descendant only while the menu is open, so `:has([role=menu])` is a precise open-state signal. Lifting the header to `z-30` carries the trapped menu above the `z-20` siblings. A code comment documents why this indirection is needed.

The two changes compose: the `z-30` open-header still lives inside the isolated board, so it remains under the mobile drawer.

## Testing

Verified manually on a mobile viewport:

- [x] Open the navigation drawer over the Kanban board — column titles sit **under** the drawer.
- [x] Scroll a column vertically — its sticky header still covers its own cards.
- [x] Open a lane `…` menu on a left/middle column — it now sits above neighboring columns' headers and cards (tested scrolled too).

## Notes

The defect-2 fix keys off Flowbite's internal `role="menu"`. Flowbite is pinned at `^0.12.10` and `role="menu"` is an accessibility requirement unlikely to change; if a future Flowbite bump reintroduces the overlap, the `has-[[role=menu]]` selector in `lane-column.tsx` is the place to check (the inline comment explains the constraint).

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
