### PR TITLE
feat(quarkus): SSE relay for /runs/{id}/stream through the harness proxy (#582)

### DIFF
--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -8,7 +8,6 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.http.HttpClient;
-import io.vertx.mutiny.core.http.HttpClientResponse;
 import io.vertx.mutiny.core.http.HttpServerResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -3,6 +3,13 @@ package com.microboxlabs.miot.core.api;
 import com.microboxlabs.miot.core.auth.OrganizationContext;
 import com.microboxlabs.miot.core.auth.TenantContext;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.http.HttpClient;
+import io.vertx.mutiny.core.http.HttpClientResponse;
+import io.vertx.mutiny.core.http.HttpServerResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -15,6 +22,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -42,14 +50,29 @@ public class HarnessProxyResource {
     private final HarnessClient harness;
     private final TenantContext tenantContext;
     private final OrganizationContext organizationContext;
+    private final HttpClient httpClient;
+    private final String harnessBaseUrl;
 
     @Inject
     public HarnessProxyResource(@RestClient HarnessClient harness,
                                 TenantContext tenantContext,
-                                OrganizationContext organizationContext) {
+                                OrganizationContext organizationContext,
+                                Vertx vertx,
+                                @ConfigProperty(name = "miot.harness.base-url")
+                                String harnessBaseUrl) {
         this.harness = harness;
         this.tenantContext = tenantContext;
         this.organizationContext = organizationContext;
+        // Dedicated streaming client for the SSE relay: the JSON rest-client
+        // buffers full responses, which never completes for an open event
+        // stream. A raw Vert.x client lets us pipe harness frames straight
+        // through (id:/event:/data: preserved) without SSE re-encoding.
+        this.httpClient = vertx.createHttpClient();
+        this.harnessBaseUrl = stripTrailingSlash(harnessBaseUrl);
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
     @POST
@@ -81,6 +104,69 @@ public class HarnessProxyResource {
         String userEmail = organizationContext.getUserEmail();
         String authMode = userEmail != null ? "web" : "m2m";
         return passThrough(harness.getRun(runId, authorization, tenantClientId, userEmail, authMode));
+    }
+
+    /**
+     * SSE relay (Q3) for the harness {@code GET /runs/{runId}/stream}.
+     * Streams the harness event stream straight to the browser, preserving
+     * the {@code id:}/{@code event:}/{@code data:} framing byte-for-byte —
+     * a raw passthrough rather than a {@code @RestStreamElementType}
+     * producer, which would re-wrap each chunk and drop the id/event lines.
+     * Auth + org membership are inherited from the path prefix exactly like
+     * the other routes, so a non-member never reaches this method.
+     */
+    @GET
+    @Path("/runs/{runId}/stream")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Uni<Void> streamRun(@PathParam("slug") String slug,
+                               @PathParam("runId") String runId,
+                               @HeaderParam("Authorization") String authorization,
+                               @HeaderParam("Last-Event-ID") String lastEventId,
+                               RoutingContext routingContext) {
+        String tenantClientId = tenantContext.getClientId();
+        String userEmail = organizationContext.getUserEmail();
+        String authMode = userEmail != null ? "web" : "m2m";
+
+        RequestOptions options = new RequestOptions()
+                .setMethod(HttpMethod.GET)
+                .setAbsoluteURI(harnessBaseUrl + "/runs/" + runId + "/stream");
+
+        return httpClient.request(options)
+                .flatMap(req -> {
+                    if (authorization != null) {
+                        req.putHeader("Authorization", authorization);
+                    }
+                    if (tenantClientId != null) {
+                        req.putHeader("X-Miot-Tenant-Client-Id", tenantClientId);
+                    }
+                    if (userEmail != null) {
+                        req.putHeader("X-Miot-User-Email", userEmail);
+                    }
+                    req.putHeader("X-Miot-Auth-Mode", authMode);
+                    if (lastEventId != null) {
+                        req.putHeader("Last-Event-ID", lastEventId);
+                    }
+                    return req.send();
+                })
+                // Take sole ownership of the Vert.x response and pipe the
+                // harness body straight through: status + framing headers
+                // copied from upstream, then pipeTo streams every chunk
+                // byte-for-byte (id:/event:/data: preserved) and ends the
+                // response when the harness closes the stream. A single owner
+                // here avoids the chunk corruption that arises from mixing a
+                // framework streaming writer with manual response writes.
+                .flatMap(resp -> {
+                    HttpServerResponse out =
+                            HttpServerResponse.newInstance(routingContext.response());
+                    out.setStatusCode(resp.statusCode());
+                    String contentType = resp.headers().get("Content-Type");
+                    out.putHeader("Content-Type",
+                            contentType != null ? contentType : MediaType.SERVER_SENT_EVENTS);
+                    out.putHeader("Cache-Control", "no-cache");
+                    out.putHeader("X-Accel-Buffering", "no");
+                    out.setChunked(true);
+                    return resp.pipeTo(out);
+                });
     }
 
     private Uni<Response> forward(String authorization,

--- a/quarkus-srv/miot-core/src/main/resources/application.properties
+++ b/quarkus-srv/miot-core/src/main/resources/application.properties
@@ -5,3 +5,9 @@
 # dev or staging. Test-mode overrides live in HarnessProxyTestProfile
 # (points at the WireMock instance the test resource lifecycle starts).
 quarkus.rest-client."harness".url=${MIOT_HARNESS_BASE_URL:http://miot-harness:8000}
+
+# Same harness base URL for the SSE relay's raw Vert.x streaming client
+# (HarnessProxyResource#streamRun). The JSON rest-client buffers full
+# responses, so the open-ended event stream needs its own client; it reads
+# this plain key (the quoted rest-client key above is awkward to inject).
+miot.harness.base-url=${MIOT_HARNESS_BASE_URL:http://miot-harness:8000}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceStreamTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceStreamTest.java
@@ -1,0 +1,157 @@
+package com.microboxlabs.miot.core.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile.WireMockLifecycle;
+import com.microboxlabs.miot.core.auth.StubAlfrescoMembershipClient;
+import com.microboxlabs.miot.core.auth.TestTokenFactory;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code HarnessProxyResource#streamRun} (Q3, #582) relays the
+ * harness SSE stream byte-for-byte, behind the same
+ * {@code DualJwtAuthMechanism} + {@code OrganizationRequestFilter} chain
+ * the other proxy routes use, and forwards the caller's identity +
+ * {@code Last-Event-ID} to the harness.
+ */
+@QuarkusTest
+@TestProfile(HarnessProxyTestProfile.class)
+class HarnessProxyResourceStreamTest {
+
+    private static final String ORG_SLUG = "harness-stream-test-org";
+    private static final String ORG_GROUP = "GROUP_harness_stream_test";
+    private static final String ORG_TENANT = "harness-stream-tenant";
+    private static final String NON_MEMBER = "intruder@test.example";
+    private static final String RUN_ID_OK = "run_stream_ok";
+    private static final String RUN_ID_MISSING = "run_stream_missing";
+    private static final String LAST_EVENT_ID = "evt-5";
+
+    // The exact frames the harness emits: id:/event:/data:, double-newline
+    // separated. The relay must pass these through unchanged.
+    private static final String SSE_BODY =
+            "id: 1\nevent: step_started\ndata: {\"step\":\"plan\"}\n\n"
+                    + "id: 2\nevent: step_completed\ndata: {\"answer\":\"42\"}\n\n";
+
+    @Inject
+    AgroalDataSource ds;
+
+    @BeforeEach
+    void seedOrgAndStubs() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "INSERT INTO miot_core.organizations "
+                        + "(slug, name, alfresco_group_id, tenant_client_id, active) "
+                        + "VALUES (?, ?, ?, ?, true)")) {
+            st.setString(1, ORG_SLUG);
+            st.setString(2, "Harness Stream Test Org");
+            st.setString(3, ORG_GROUP);
+            st.setString(4, ORG_TENANT);
+            st.executeUpdate();
+        }
+        WireMockLifecycle.server().resetAll();
+        WireMockLifecycle.server().stubFor(
+                WireMock.get(WireMock.urlEqualTo("/runs/" + RUN_ID_OK + "/stream"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "text/event-stream")
+                                .withBody(SSE_BODY)));
+        WireMockLifecycle.server().stubFor(
+                WireMock.get(WireMock.urlEqualTo("/runs/" + RUN_ID_MISSING + "/stream"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"detail\":\"Run not found\"}")));
+    }
+
+    @AfterEach
+    void cleanupOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "DELETE FROM miot_core.organizations WHERE slug = ?")) {
+            st.setString(1, ORG_SLUG);
+            st.executeUpdate();
+        }
+    }
+
+    @Test
+    void memberStreamRelaysEventStreamUnchanged() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        Response resp = given()
+                .header("Authorization", "Bearer " + token)
+                .header("Accept", "text/event-stream")
+                .header("Last-Event-ID", LAST_EVENT_ID)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK + "/stream");
+
+        assertThat(resp.statusCode(), is(200));
+        assertThat(resp.getContentType(), containsString("text/event-stream"));
+        String body = resp.body().asString();
+        // Frames passed through intact.
+        assertThat(body, containsString("id: 1"));
+        assertThat(body, containsString("event: step_started"));
+        assertThat(body, containsString("data: {\"answer\":\"42\"}"));
+        // Guard against SSE re-wrapping: a framework that re-encoded each
+        // chunk as its own event would produce "data: id: 1", destroying the
+        // original framing. Assert that did NOT happen.
+        assertThat(body, not(containsString("data: id:")));
+
+        // Identity + resume cursor forwarded to the harness.
+        WireMockLifecycle.server().verify(WireMock.getRequestedFor(
+                WireMock.urlEqualTo("/runs/" + RUN_ID_OK + "/stream"))
+                .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT))
+                .withHeader("X-Miot-User-Email",
+                        WireMock.equalTo(StubAlfrescoMembershipClient.MEMBER_EMAIL))
+                .withHeader("X-Miot-Auth-Mode", WireMock.equalTo("web"))
+                .withHeader("Last-Event-ID", WireMock.equalTo(LAST_EVENT_ID)));
+    }
+
+    @Test
+    void memberStreamMissingRunPasses404Through() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .header("Accept", "text/event-stream")
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_MISSING + "/stream")
+                .statusCode();
+        assertThat("upstream 404 must pass through the relay", status, is(404));
+    }
+
+    @Test
+    void nonMemberHits403WithoutCallingUpstream() {
+        String token = TestTokenFactory.signWebToken(NON_MEMBER);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .header("Accept", "text/event-stream")
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK + "/stream")
+                .statusCode();
+        assertThat(status, is(403));
+        WireMockLifecycle.server().verify(0,
+                WireMock.getRequestedFor(
+                        WireMock.urlEqualTo("/runs/" + RUN_ID_OK + "/stream")));
+    }
+
+    @Test
+    void noTokenHits401() {
+        int status = given()
+                .header("Accept", "text/event-stream")
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/runs/" + RUN_ID_OK + "/stream")
+                .statusCode();
+        assertThat(status, is(401));
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
@@ -100,9 +100,12 @@ public class HarnessProxyTestProfile implements QuarkusTestProfile {
         public Map<String, String> start() {
             server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
             server.start();
+            String url = "http://localhost:" + server.port();
+            // Both the JSON rest-client (POST/GET routes) and the SSE relay's
+            // raw Vert.x streaming client must point at the same WireMock.
             return Map.of(
-                    "quarkus.rest-client.\"harness\".url",
-                    "http://localhost:" + server.port());
+                    "quarkus.rest-client.\"harness\".url", url,
+                    "miot.harness.base-url", url);
         }
 
         @Override


### PR DESCRIPTION
## What
Implements the Q3 SSE relay deferred from #522: a new authenticated Quarkus route
`GET /api/v1/orgs/{slug}/harness/runs/{runId}/stream` that relays the miot-harness
SSE stream to the browser. The harness already emits SSE; this is the proxy side.

## How
- **Raw byte passthrough** via a dedicated Vert.x streaming HTTP client. The JSON
  rest-client buffers full responses (never completes for an open stream), so the
  relay pipes the harness body straight through with `pipeTo`, preserving the
  `id:`/`event:`/`data:` framing byte-for-byte (no `@RestStreamElementType`
  re-wrapping).
- **Single response owner**: copies the harness status + `Content-Type`, adds
  `Cache-Control: no-cache` + `X-Accel-Buffering: no`, returns `Uni<Void>`. Mixing
  a framework streaming writer with manual response writes corrupts chunked
  encoding, so the relay owns the response end-to-end.
- **Auth inherited** from the `/api/v1/orgs/{slug}` path prefix (DualJwtAuthMechanism
  + OrganizationRequestFilter) — a non-member never reaches the method.
- Forwards `Authorization`, `X-Miot-Tenant-Client-Id`, `X-Miot-User-Email`,
  `X-Miot-Auth-Mode`, `Last-Event-ID`.

## Tests
`HarnessProxyResourceStreamTest` (hermetic — WireMock + DevServices Postgres +
forged tokens, no real Auth0):
- member stream relays frames unchanged (asserts no SSE re-wrap) + identity &
  `Last-Event-ID` forwarded to the harness
- harness 404 → 404 passthrough
- non-member → 403 with **zero** upstream calls
- missing token → 401

Full `miot-core` suite green (29 tests).

## Scope / follow-ups
Part of #582 (does not fully close it). Remaining: real-Auth0 docker-compose
full-chain smoke (`<5s` first byte) + the decision-doc checkbox — deferred pending
Auth0 test credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Server-Sent Events streaming for harness run events, delivering real-time run updates to the browser while preserving original event framing and status codes.

* **Chores**
  * New configuration option to specify the harness base URL for streaming clients (overridable via environment).

* **Tests**
  * Added end-to-end tests covering streaming behavior, auth/authorization checks, and error pass-through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->