### PR TITLE
fix(app): accept PROOF_OF_LOAD_RECEIPT in delivery document validation

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-actions/use-document-validation.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-actions/use-document-validation.ts
@@ -68,9 +68,17 @@ export function useDocumentValidation(
 
   const entries: NodeEntry[] = data?.data?.list?.entries || [];
 
-  const hasPOD = entries.some(
-    (file) =>
-      file.entry.properties?.["mintral:contentType"] === "PROOF_OF_DELIVERY"
+  // A delivery document can arrive classified either as PROOF_OF_DELIVERY or
+  // PROOF_OF_LOAD_RECEIPT, so both satisfy the document gate.
+  const ACCEPTED_POD_CONTENT_TYPES = [
+    "PROOF_OF_DELIVERY",
+    "PROOF_OF_LOAD_RECEIPT",
+  ];
+
+  const hasPOD = entries.some((file) =>
+    ACCEPTED_POD_CONTENT_TYPES.includes(
+      file.entry.properties?.["mintral:contentType"] ?? ""
+    )
   );
 
   const hasPOLF = false;

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-actions/use-document-validation.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-actions/use-document-validation.ts
@@ -33,6 +33,13 @@ const TASK_TYPES_REQUIRING_VALIDATION = [
   TYPE_WFDELIVERY_RECEIVE_DELIVERY_TASK,
 ] as const;
 
+// A delivery document can arrive classified either as PROOF_OF_DELIVERY or
+// PROOF_OF_LOAD_RECEIPT, so both satisfy the document gate.
+const ACCEPTED_POD_CONTENT_TYPES = new Set([
+  "PROOF_OF_DELIVERY",
+  "PROOF_OF_LOAD_RECEIPT",
+]);
+
 function requiresValidation(taskType: TaskType): boolean {
   return (TASK_TYPES_REQUIRING_VALIDATION as readonly string[]).includes(
     taskType
@@ -68,15 +75,8 @@ export function useDocumentValidation(
 
   const entries: NodeEntry[] = data?.data?.list?.entries || [];
 
-  // A delivery document can arrive classified either as PROOF_OF_DELIVERY or
-  // PROOF_OF_LOAD_RECEIPT, so both satisfy the document gate.
-  const ACCEPTED_POD_CONTENT_TYPES = [
-    "PROOF_OF_DELIVERY",
-    "PROOF_OF_LOAD_RECEIPT",
-  ];
-
   const hasPOD = entries.some((file) =>
-    ACCEPTED_POD_CONTENT_TYPES.includes(
+    ACCEPTED_POD_CONTENT_TYPES.has(
       file.entry.properties?.["mintral:contentType"] ?? ""
     )
   );


### PR DESCRIPTION
Closes #592

## Context
A client reported they **cannot continue a delivery workflow even when the delivery document is present**. The driver task card showed the "Proof of delivery" validation as a red error and the **Continue button disappeared**.

The driver delivery gate (`useDocumentValidation`) only treated a file whose Alfresco property `mintral:contentType === "PROOF_OF_DELIVERY"` as satisfying the document requirement. Delivery documents can also arrive classified as **`PROOF_OF_LOAD_RECEIPT`** (which the backend's Alerce image check already accepts), so a valid document went unrecognized and the gate stayed closed.

## Change
Broaden the `hasPOD` check in `apps/app/src/features/task-forms/components/task-actions/use-document-validation.ts` to accept either `PROOF_OF_DELIVERY` **or** `PROOF_OF_LOAD_RECEIPT`.

Because `hasPOD` is the single source of truth feeding `isValid`, the fix flows automatically to:
- the **Continue button gate** (`task-actions.tsx`) — button reappears when a POLR is present, and
- the **"Proof of delivery" status row** (`validations.tsx`) — turns green (kept as one combined row).

## Known limitation (intentionally out of scope)
The **ecm-coordinator** backend (`OnCompleteDeliveryTask.isPodContentType`) still validates `PROOF_OF_DELIVERY` **only** on task completion. For a package that has a POLR but no true POD, the UI now allows Continue, but completing *Recibir Entrega / Viaje Finalizado / Notificar Arribo / Notificar Entrega* can still return `422 error.delivery.pod_required`. A matching backend OR-change would be a separate PR in that repo.

## Verification
- `tsc --noEmit` (check-types) passes clean.
- No existing tests reference this hook or the content-type values.
- Manual: open a `confirmDeliveryTask` / `receiveDeliveryTask` whose package has a `PROOF_OF_LOAD_RECEIPT` → row is green and Continue is shown; a package with neither still shows red + hidden Continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proof of Load Receipt documents are now accepted for delivery document validation, in addition to Proof of Delivery documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->