### PR TITLE
Deleted seelctor dropdown validation for type

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/viewer-toolbar.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/viewer-toolbar.tsx
@@ -110,16 +110,14 @@ export default function ViewerToolbar({
       </Button>
 
       {/* Category selector — left of review actions */}
-      {isReviewable && (
-        <SelectorDropdown
-          categories={categories}
-          baseCategory={currentCategory}
-          selectCategory={onCategoryChange}
-          dictionary={dictionary}
-          fitWidth
-          triggerClassName="h-7 sm:h-9 !py-0 !px-2 text-xs sm:text-sm"
-        />
-      )}
+      <SelectorDropdown
+        categories={categories}
+        baseCategory={currentCategory}
+        selectCategory={onCategoryChange}
+        dictionary={dictionary}
+        fitWidth
+        triggerClassName="h-7 sm:h-9 !py-0 !px-2 text-xs sm:text-sm"
+      />
 
       {/* Review actions */}
       {isReviewable && status !== "approved" && (


### PR DESCRIPTION
Fixed verification needed for type selector on document view (the validation was incorrectly added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The category selector in the multimedia viewer is now consistently displayed in all scenarios, improving accessibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->