### PR TITLE
refactor(harness)!: datasource-agnostic core — Nexo becomes the first DataSourceProvider

### DIFF
--- a/miot-harness/.env.example
+++ b/miot-harness/.env.example
@@ -37,57 +37,69 @@ MIOT_HARNESS_DEFAULT_TENANT_ID=demo-tenant
 MIOT_HARNESS_DEFAULT_USER_ID=demo-user
 
 # -----------------------------------------------------------------------------
-# Nexo data integration (Coordinador / Mintral)
+# Datasource connection / domain overrides (provider-agnostic)
 # -----------------------------------------------------------------------------
+# Selects the DataSourceProvider from datasource/registry.py.
+MIOT_HARNESS_DATASOURCE_KIND=nexo
+
 # Standard Postgres connection string (DSN) for the Coordinador database:
 #   postgresql://user:password@host:port/database
 # This is the sole source of Nexo DB credentials. The harness expects a
 # read-only `harness` PG role to exist in the target DB. Leave commented
 # to disable the Nexo integration — the harness still serves non-Nexo
 # runs with mocked tools.
-# MIOT_HARNESS_NEXO_DSN=postgresql://user:password@host:6432/citus
+# MIOT_HARNESS_DATASOURCE_DSN=postgresql://user:password@host:6432/citus
 
 # Surfaces in Postgres `pg_stat_activity.application_name` so DBAs can
 # attribute connections to the harness without log correlation.
-MIOT_HARNESS_NEXO_APPLICATION_NAME=miot-harness
+MIOT_HARNESS_DATASOURCE_APPLICATION_NAME=miot-harness
 
 # Hard tenant lock applied to every coordinador_* tool call. Must match
-# MIOT_HARNESS_DEFAULT_TENANT_ID for end-to-end runs.
-MIOT_HARNESS_NEXO_TENANT_LOCK=mintral
+# MIOT_HARNESS_DEFAULT_TENANT_ID for end-to-end runs. Leave unset to use
+# the provider profile's default lock.
+MIOT_HARNESS_DATASOURCE_TENANT_LOCK=mintral
 
 # Postgres schema where `fn_dx_*` functions live. Validated against
 # `^[a-z_][a-z0-9_]*$` at boot — invalid names disable Nexo fail-closed.
+# Provider-private (Nexo-specific Postgres concept), so it keeps the
+# MIOT_HARNESS_NEXO_* prefix.
 MIOT_HARNESS_NEXO_SEARCH_PATH=nexo
+
+# EXPLAIN plan-cost refuse gate for the composable Nexo primitives.
+# Provider-private (PostgreSQL plan-cost units). Default 10000.
+# MIOT_HARNESS_NEXO_EXPLAIN_COST_THRESHOLD=10000
 
 # Snapshot freshness gates in minutes. Boot probes `fn_dx_centro_control`
 # and disables Nexo if the data is older than the *refuse* threshold.
-# `warn` is informational; `refuse` is a hard gate.
-MIOT_HARNESS_NEXO_FRESHNESS_WARN_MINUTES=30
-MIOT_HARNESS_NEXO_FRESHNESS_REFUSE_MINUTES=240
+# `warn` is informational; `refuse` is a hard gate. Leave unset to use
+# the provider profile's defaults.
+MIOT_HARNESS_DATASOURCE_FRESHNESS_WARN_MINUTES=30
+MIOT_HARNESS_DATASOURCE_FRESHNESS_REFUSE_MINUTES=240
 
-# Max LangGraph turns per Nexo run. Cap exists so a misbehaving plan can't
+# -----------------------------------------------------------------------------
+# Agent / graph settings
+# -----------------------------------------------------------------------------
+# Max LangGraph turns per run. Cap exists so a misbehaving plan can't
 # loop indefinitely; surfaces as a planning failure if reached.
-MIOT_HARNESS_NEXO_MAX_TURNS=8
+MIOT_HARNESS_AGENTS_MAX_TURNS=8
 
 # Wires the critic node into the conversational graph. Off by default
 # because it doubles model spend per run.
-MIOT_HARNESS_NEXO_CRITIC_ENABLED=false
+MIOT_HARNESS_AGENTS_CRITIC_ENABLED=false
 
-# -----------------------------------------------------------------------------
-# Multi-agent model assignment (per plan §"Cost-control rules")
-# -----------------------------------------------------------------------------
+# Multi-agent model assignment (per plan §"Cost-control rules").
 # `rule` = deterministic keyword routing (cheap, recommended for prod).
 # `llm` = supervisor delegates to a small model for routing decisions.
-MIOT_HARNESS_NEXO_SUPERVISOR_MODE=rule
+MIOT_HARNESS_AGENTS_SUPERVISOR_MODE=rule
 
 # Per-agent model. Haiku for high-throughput cheap tiers, Sonnet for
 # reasoning. See `agents/chat_models.py` for the prefix → provider map
 # (claude-* → Anthropic, gpt-*/o1-*/o3-* → OpenAI).
-MIOT_HARNESS_NEXO_FILTER_EXPERT_MODEL=claude-haiku-4-5
-MIOT_HARNESS_NEXO_ANALYST_MODEL=claude-sonnet-4-6
-MIOT_HARNESS_NEXO_SYNTHESIZER_MODEL=claude-sonnet-4-6
-MIOT_HARNESS_NEXO_CRITIC_MODEL=claude-sonnet-4-6
-MIOT_HARNESS_NEXO_SUMMARIZER_MODEL=claude-haiku-4-5
+MIOT_HARNESS_AGENTS_FILTER_EXPERT_MODEL=claude-haiku-4-5
+MIOT_HARNESS_AGENTS_ANALYST_MODEL=claude-sonnet-4-6
+MIOT_HARNESS_AGENTS_SYNTHESIZER_MODEL=claude-sonnet-4-6
+MIOT_HARNESS_AGENTS_CRITIC_MODEL=claude-sonnet-4-6
+MIOT_HARNESS_AGENTS_SUMMARIZER_MODEL=claude-haiku-4-5
 
 # -----------------------------------------------------------------------------
 # Phase E: LLM intent router + composable primitives (plan 13)

--- a/miot-harness/README.md
+++ b/miot-harness/README.md
@@ -119,18 +119,49 @@ probes don't auth). Only `POST /runs`, `POST /runs:start`,
 - Deep Agents integration lives behind an adapter so the MIOT runtime can keep
   its own tool, permission, and audit contracts.
 
+## Datasource
+
+The harness core is datasource-agnostic. A `DataSourceProvider` owns the
+connection lifecycle and registers tools, and a declarative
+`DataSourceProfile` supplies every domain-specific name, prompt keyword,
+and threshold the core reads (display name, tool prefix, primer, router
+keywords, tenant lock, freshness SLA). The core never hardcodes which
+system the tools come from — see `src/miot_harness/datasource/`.
+
+`MIOT_HARNESS_DATASOURCE_KIND` selects the provider at boot from the
+named registry (`datasource/registry.py`). The first (and default)
+provider is **nexo** (Citus/Postgres, Coordinador schema), which lives
+entirely under `src/miot_harness/integrations/nexo/` — the only package
+allowed to say "Nexo", "Coordinador", or "mintral".
+
+| Env var                              | Default        | Purpose                                                             |
+|--------------------------------------|----------------|--------------------------------------------------------------------|
+| `MIOT_HARNESS_DATASOURCE_KIND`       | `nexo`         | Registry key selecting the `DataSourceProvider`.                   |
+| `MIOT_HARNESS_DATASOURCE_DSN`        | _(unset)_      | Datasource connection string; unset → datasource disabled at boot. |
+| `MIOT_HARNESS_DATASOURCE_APPLICATION_NAME` | `miot-harness` | Surfaces in `pg_stat_activity.application_name`.             |
+| `MIOT_HARNESS_DATASOURCE_TENANT_LOCK`| _(profile)_    | Override the profile's tenant lock; unset → profile default.       |
+| `MIOT_HARNESS_DATASOURCE_FRESHNESS_WARN_MINUTES`   | _(profile)_ | Override snapshot-age warn threshold.                        |
+| `MIOT_HARNESS_DATASOURCE_FRESHNESS_REFUSE_MINUTES` | _(profile)_ | Override snapshot-age refuse threshold.                     |
+| `MIOT_HARNESS_AGENTS_*`              | per-agent      | Per-agent model assignment (filter expert / analyst / etc.).       |
+
+Provider-private knobs keep the `MIOT_HARNESS_NEXO_*` prefix because they
+are genuinely Nexo's (Postgres concepts) — currently
+`MIOT_HARNESS_NEXO_SEARCH_PATH` (schema) and the EXPLAIN cost ceiling.
+
 ## Run Modes
 
 `POST /runs` accepts an optional `mode` field on the request body
 (`Literal["auto", "canned", "meta", "agentic"]`, default `"auto"`).
-Mode picks *which dispatch path* the supervisor takes. The four values:
+Mode picks *which dispatch path* the supervisor takes. The four values
+(route names are the `HarnessRoute` enum; "off-lock" = a tenant other
+than the datasource's `tenant_lock`):
 
-| `mode`     | Route          | DB touch | Non-Mintral?     | LLM calls / run | Best for                                              |
+| `mode`     | Route          | DB touch | Off-lock tenant? | LLM calls / run | Best for                                              |
 |------------|----------------|----------|------------------|-----------------|-------------------------------------------------------|
 | `auto`     | (LLM-decided)  | depends  | depends on route | depends         | default — the intent router picks one of the below.   |
-| `canned`   | `NEXO_QUERY`   | ✅ yes   | ❌ refused       | ~4-5            | "what's the data right now?" — curated `fn_dx_*`.     |
-| `meta`     | `NEXO_META`    | ❌ no    | ✅ allowed       | 1               | "what data exists / how is X calculated?" — no SQL.   |
-| `agentic`  | `NEXO_AGENTIC` | ✅ yes   | ❌ refused       | variable        | free-form exploration via composable primitives.      |
+| `canned`   | `DATA_QUERY`   | ✅ yes   | ❌ refused       | ~4-5            | "what's the data right now?" — curated functions.     |
+| `meta`     | `DATA_META`    | ❌ no    | ✅ allowed       | 1               | "what data exists / how is X calculated?" — no SQL.   |
+| `agentic`  | `DATA_AGENTIC` | ✅ yes   | ❌ refused       | variable        | free-form exploration via composable primitives.      |
 
 The explicit modes (`canned` / `meta` / `agentic`) bypass the LLM
 intent router entirely. They're useful for ops (deterministic
@@ -140,14 +171,14 @@ per run than `canned`).
 
 ### `canned` — answer FROM the data
 
-Routes through the plan-12 `nexo_graph`: `filter_expert` picks one
-curated `fn_dx_*` Postgres function from the registered catalog, the
-harness runs that SQL against the tunneled Coordinador DB,
-`domain_analyst` inspects freshness, `synthesizer` writes the answer,
-`critic` reviews it (when enabled). Refused at the tenant gate for
-non-Mintral tenants because it reads confidential data.
+Routes through the data graph (`runtime/data_graph.py`): `filter_expert`
+picks one curated tool from the registered catalog, the harness runs it
+against the live datasource, `domain_analyst` inspects freshness,
+`synthesizer` writes the answer, `critic` reviews it (when enabled).
+Refused at the tenant gate for off-lock tenants because it reads
+confidential data.
 
-Examples that route here:
+Examples (with the default **nexo** provider) that route here:
 - *"estado del coordinador hoy"* → `coordinador_centro_control`
 - *"cola crítica para hoy"* → `coordinador_cola_critica`
 - *"servicios con ETA en riesgo"* → `coordinador_eta_riesgo_hoy`
@@ -156,10 +187,10 @@ Examples that route here:
 
 Calls `agents/meta_agent.py:meta_agent_node` **directly** — no
 LangGraph, one async LLM call (Haiku tier). The system prompt is the
-Coordinador primer plus the catalog of `fn_dx_*` descriptions; the
-function signature has no `pool` / `registry` / `tools` parameter, so
-"no SQL" is a structural guarantee — not a comment. Allowed for any
-tenant (meta info is non-confidential); emits a
+active datasource's primer plus the catalog of curated-function
+descriptions; the function signature has no `pool` / `registry` /
+`tools` parameter, so "no SQL" is a structural guarantee — not a
+comment. Allowed for any tenant (meta info is non-confidential); emits a
 `tenant.bypass: meta_route` audit attribute when an off-lock tenant
 uses it.
 
@@ -171,12 +202,13 @@ Examples that route here:
 ### `agentic` — explore the data with composable primitives
 
 Routes through `runtime/agentic_graph.py`. Instead of being constrained
-to one curated `fn_dx_*`, the planner can string together
-`nexo_describe` / `nexo_select` / `nexo_grep` / `nexo_explain` calls
-within the sqlglot safety gate (positive function allowlist, LATERAL
-rejection, mutation rejection, EXPLAIN cost ceiling). Critic is ON
-by default in this mode because the agent has more freedom to invent
-joins. Same tenant gate as `canned` — refused for non-Mintral. See
+to one curated function, the planner can string together the
+datasource's composable primitives (for **nexo**: `nexo_describe` /
+`nexo_select` / `nexo_grep` / `nexo_explain`) within the provider's
+safety gate (positive function allowlist, LATERAL rejection, mutation
+rejection, EXPLAIN cost ceiling). Critic is ON by default in this mode
+because the agent has more freedom to invent joins. Same tenant gate as
+`canned` — refused for off-lock tenants. See
 `integrations/nexo/primitives.py`.
 
 ### Cost separation in Langfuse

--- a/miot-harness/docker-compose.yml
+++ b/miot-harness/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "8000:8000"
     volumes:
       - harness-workspace:/app/.miot-workspace
-    # Resolves `host.docker.internal` on Linux so MIOT_HARNESS_NEXO_DSN
+    # Resolves `host.docker.internal` on Linux so MIOT_HARNESS_DATASOURCE_DSN
     # pointing at host.docker.internal:6434 (a host-side kubectl
     # port-forward) works without --network host. macOS / Windows
     # Docker Desktop already provide this name automatically; the
@@ -84,7 +84,7 @@ services:
             port-forward svc/prod-mintral-pgbouncer 6434:6432 \
             -n <namespace>
 
-        Then point MIOT_HARNESS_NEXO_DSN at host.docker.internal:6434
+        Then point MIOT_HARNESS_DATASOURCE_DSN at host.docker.internal:6434
         (or use --network host on Linux) so the harness container
         reaches the tunnel.
         ===============================================================

--- a/miot-harness/docs/dispatch-modes.md
+++ b/miot-harness/docs/dispatch-modes.md
@@ -12,13 +12,14 @@ Sources of truth:
 - `miot-harness/src/miot_harness/runtime/router.py` — `HarnessRoute` enum and
   the keyword router used by `auto`.
 - `miot-harness/src/miot_harness/runtime/supervisor.py` — dispatch in
-  `HarnessSupervisor.run()` (`_run_nexo` / `_run_nexo_meta` / `_run_nexo_agentic`).
+  `HarnessSupervisor.run()` (`_run_data_query` / `_run_data_meta` /
+  `_run_data_agentic`).
 
 ## `auto` — let the harness pick
 
 - **What it does:** runs the LLM intent router if injected, else the keyword
-  router (`IntentRouter`). The router returns one of `NEXO_QUERY`,
-  `NEXO_META`, `NEXO_AGENTIC`, `STORYTELLING_RUN`, `DIRECT`, or `OTHER`.
+  router (`IntentRouter`). The router returns one of `DATA_QUERY`,
+  `DATA_META`, `DATA_AGENTIC`, `STORYTELLING_RUN`, `DIRECT`, or `OTHER`.
 - **When to use:** day-to-day chat. You don't know — or don't care — which
   path is appropriate.
 - **Example questions:**
@@ -26,14 +27,15 @@ Sources of truth:
   - "How does `fn_dx_cola_critica` work?" → routes to meta.
   - "Hi, what can you do?" → routes to direct.
 
-## `canned` — `NEXO_QUERY` → `nexo_graph`
+## `canned` — `DATA_QUERY` → data graph
 
-- **What it does:** dispatches directly to the curated `nexo_graph`, which
-  invokes the `fn_dx_*` Coordinador analytical functions. Deterministic SQL,
-  real data, tenant-gated.
-- **Tenant rule:** data-touching, gated by `tenant_lock` (defaults to
-  `mintral`). The mode itself isn't refused at validation, but the underlying
-  tools enforce the tenant lock.
+- **What it does:** dispatches directly to the curated data graph
+  (`runtime/data_graph.py`), which invokes the datasource's curated analytical
+  functions (for **nexo**: the `fn_dx_*` Coordinador functions). Deterministic
+  SQL, real data, tenant-gated.
+- **Tenant rule:** data-touching, gated by `tenant_lock` (the datasource
+  profile's default; `mintral` for nexo). The mode itself isn't refused at
+  validation, but the underlying tools enforce the tenant lock.
 - **When to use:** you know the answer lives in a curated analytical function
   and you want to skip the router.
 - **Example questions:**
@@ -42,11 +44,11 @@ Sources of truth:
   - "Resumen del dimensionamiento de hoy."
   - "Auditoría POD de la última hora."
 
-## `meta` — `NEXO_META` → `meta_agent_node`
+## `meta` — `DATA_META` → `meta_agent_node`
 
-- **What it does:** answers from the **cached `pg_proc` catalog + Coordinador
-  primer text**. No SQL, no tool invocation, no data access — pure
-  schema/introspection.
+- **What it does:** answers from the **cached catalog + the active datasource's
+  primer text** (for **nexo**: the `pg_proc` catalog + Coordinador primer). No
+  SQL, no tool invocation, no data access — pure schema/introspection.
 - **Tenant rule:** allowed for **any tenant** — meta-info is non-confidential
   per the plan's tenant-gate decision.
 - **When to use:** "what does this function do / what's in the catalog /
@@ -57,15 +59,15 @@ Sources of truth:
   - "Which function should I use to look up a POD audit?"
   - "Describe the inputs and outputs of `fn_dx_cola_critica`."
 
-## `agentic` — `NEXO_AGENTIC` → `agentic_graph`
+## `agentic` — `DATA_AGENTIC` → `agentic_graph`
 
 - **What it does:** planner Sonnet + **composable primitives** for open-ended
   exploration. Turn cap is 12 (vs 8 in `canned`), critic is ON by default.
-- **Tenant rule:** **Mintral-only**. `resolve_mode()` raises
-  `ModeAccessDenied` at request-validation time for any other tenant; the
-  supervisor records a `mode_access_denied` answer and emits
-  `answer.completed`. The `miot-chat` TUI header bar warns in yellow if you
-  set `mode=agentic` on a non-`mintral` tenant.
+- **Tenant rule:** **locked-tenant-only** (the datasource's `tenant_lock`;
+  `mintral` for nexo). `resolve_mode()` raises `ModeAccessDenied` at
+  request-validation time for any off-lock tenant; the supervisor records a
+  `mode_access_denied` answer and emits `answer.completed`. The `miot-chat` TUI
+  header bar warns in yellow if you set `mode=agentic` on an off-lock tenant.
 - **When to use:** multi-step exploration where no single canned function
   answers the question — combine primitives, hypothesize, iterate.
 - **Example questions:**
@@ -79,9 +81,9 @@ Sources of truth:
 | Mode      | Route          | Backend            | SQL?       | Tenant gate     | Best for                          |
 |-----------|----------------|--------------------|------------|-----------------|-----------------------------------|
 | `auto`    | router-decided | any                | maybe      | inherits route  | normal use                        |
-| `canned`  | `NEXO_QUERY`   | `nexo_graph`       | yes, curated | mintral-only* | known operational questions       |
-| `meta`    | `NEXO_META`    | `meta_agent_node`  | **no**     | any tenant      | schema, primer, "how does X work" |
-| `agentic` | `NEXO_AGENTIC` | `agentic_graph`    | yes, via primitives | **mintral-only** (rejected at validation) | exploratory analysis |
+| `canned`  | `DATA_QUERY`   | data graph         | yes, curated | locked-tenant-only* | known operational questions   |
+| `meta`    | `DATA_META`    | `meta_agent_node`  | **no**     | any tenant      | schema, primer, "how does X work" |
+| `agentic` | `DATA_AGENTIC` | `agentic_graph`    | yes, via primitives | **locked-tenant-only** (rejected at validation) | exploratory analysis |
 
 \* `canned` data access is enforced inside the tools via `tenant_lock`; the
 mode itself is not rejected by `resolve_mode()`.

--- a/miot-harness/docs/plans/2026-06-05-harness-datasource-refactor.md
+++ b/miot-harness/docs/plans/2026-06-05-harness-datasource-refactor.md
@@ -1,0 +1,1131 @@
+# Harness Datasource Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the harness core datasource-agnostic: "Nexo", "Coordinador", and "mintral" live only inside `integrations/nexo/`, behind a `DataSourceProvider` interface selected by `MIOT_HARNESS_DATASOURCE_KIND`.
+
+**Architecture:** A new `datasource/` package defines `DataSourceProvider` (lifecycle) + `DataSourceProfile` (declarative domain values: names, prompts, keywords, thresholds) + a named registry. `integrations/nexo/` becomes the first provider. Core (runtime/agents/api/observability/evals) reads only the profile. Runtime output (tool names, SSE source strings, refusal copy, span names) stays byte-identical because the nexo profile carries today's exact values; the wire-visible breaks are route strings (`nexo_query`→`data_query`), artifact type (`nexo_plan`→`data_plan`), `/health` block key, and the env-var rename.
+
+**Tech Stack:** Python 3.11, pydantic / pydantic-settings, LangGraph, FastAPI, asyncpg, pytest, uv.
+
+**Spec:** `miot-harness/docs/specs/2026-06-05-harness-datasource-refactor-design.md`
+
+**Working directory:** all commands run from `miot-harness/` in the `based/harness-nexo-refactor` worktree.
+
+**Per-task gates (run after EVERY task unless the task says otherwise):**
+```bash
+uv run pytest -q          # all green
+uv run ruff check src tests
+uv run mypy
+```
+
+---
+
+## Stage 1 — The seam (commit: `feat(harness): add DataSourceProvider seam with nexo as first provider`)
+
+### Task 1: `DataSourceProfile`, `BootResult`, `DataSourceProvider`
+
+**Files:**
+- Create: `src/miot_harness/datasource/__init__.py` (empty)
+- Create: `src/miot_harness/datasource/provider.py`
+- Test: `tests/datasource/test_provider.py` (create `tests/datasource/__init__.py` empty)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/datasource/test_provider.py
+"""DataSourceProvider seam: profile shape and provider contract."""
+
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+
+
+def make_profile(**overrides) -> DataSourceProfile:
+    base = dict(
+        name="fake",
+        display_name="FakeSource",
+        source_label="FakeSource · fake (test)",
+        tool_prefix="fake_",
+        primer="FakeSource answers questions about test fixtures.",
+        router_keywords=frozenset({"fakesource", "fixture"}),
+        tenant_lock="acme",
+        tenant_refusal_template=(
+            "{display_name} is {lock}-only. I can't answer for other tenants."
+        ),
+        freshness_warn_minutes=30,
+        freshness_refuse_minutes=240,
+    )
+    base.update(overrides)
+    return DataSourceProfile(**base)
+
+
+def test_profile_is_frozen() -> None:
+    profile = make_profile()
+    import pytest
+
+    with pytest.raises(Exception):  # dataclasses.FrozenInstanceError
+        profile.name = "other"  # type: ignore[misc]
+
+
+def test_refusal_template_formats() -> None:
+    profile = make_profile()
+    msg = profile.tenant_refusal_template.format(
+        display_name=profile.display_name, lock=profile.tenant_lock
+    )
+    assert msg == "FakeSource is acme-only. I can't answer for other tenants."
+
+
+def test_boot_result_defaults() -> None:
+    r = BootResult(enabled=False, registered=[])
+    assert r.reason is None
+    assert r.snapshot_age_minutes is None
+
+
+def test_provider_is_abstract() -> None:
+    import pytest
+
+    with pytest.raises(TypeError):
+        DataSourceProvider()  # type: ignore[abstract]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/datasource/test_provider.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'miot_harness.datasource'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/miot_harness/datasource/provider.py
+"""The datasource seam.
+
+The harness core is datasource-agnostic: it orchestrates agents over a
+tool registry, but never names the system the tools come from (a DB, a
+filesystem, a cloud API, an MCP server). Everything domain-specific is
+supplied by a DataSourceProvider:
+
+- lifecycle (`boot` / `close`): connect, discover capabilities,
+  register tools into the shared ToolRegistry;
+- a declarative `DataSourceProfile`: every name, prompt, keyword and
+  threshold the core needs to speak about the datasource without
+  hardcoding it.
+
+Each profile field maps 1:1 to a former hardcode (see
+docs/specs/2026-06-05-harness-datasource-refactor-design.md).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from miot_harness.config import HarnessSettings
+    from miot_harness.tools.registry import ToolRegistry
+
+
+@dataclass(frozen=True)
+class DataSourceProfile:
+    """Declarative domain values the core reads instead of hardcoding.
+
+    - name:            machine id ("nexo") — /health block, graph label,
+                       OTel span prefix.
+    - display_name:    human name ("Coordinador") — agent prompt templating.
+    - source_label:    provenance string shown on SSE tool events and
+                       evidence rows.
+    - tool_prefix:     prefix of tools this datasource registers
+                       ("coordinador_") — used by the filter expert to
+                       scope tool selection.
+    - primer:          grounding text injected into analyst / synthesizer /
+                       meta-agent system prompts.
+    - router_keywords: lowercase literals that route a message to the
+                       data pipeline (keyword router).
+    - tenant_lock:     default tenant the datasource is locked to, or
+                       None for no lock. Env-overridable via
+                       `datasource_tenant_lock`.
+    - tenant_refusal_template: str.format template with {display_name}
+                       and {lock} placeholders — the exact user-visible
+                       refusal copy.
+    - freshness_warn_minutes / freshness_refuse_minutes: snapshot-age
+                       SLA defaults. Env-overridable.
+    """
+
+    name: str
+    display_name: str
+    source_label: str
+    tool_prefix: str
+    primer: str
+    router_keywords: frozenset[str]
+    tenant_lock: str | None
+    tenant_refusal_template: str
+    freshness_warn_minutes: int
+    freshness_refuse_minutes: int
+
+
+@dataclass(frozen=True)
+class BootResult:
+    """Outcome of DataSourceProvider.boot — same shape for every provider."""
+
+    enabled: bool
+    registered: list[str]
+    reason: str | None = None
+    snapshot_age_minutes: float | None = None
+
+
+class DataSourceProvider(ABC):
+    """Lifecycle owner for one datasource.
+
+    Implementations own their connection handles (pool, client, MCP
+    session); the harness only calls boot() once from the lifespan and
+    close() on shutdown. boot() must not raise for operational failures
+    — return BootResult(enabled=False, reason=...) so the harness keeps
+    serving non-data routes.
+    """
+
+    profile: DataSourceProfile
+
+    @abstractmethod
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult: ...
+
+    @abstractmethod
+    async def close(self) -> None: ...
+```
+
+Also create the two empty `__init__.py` files:
+
+```bash
+touch src/miot_harness/datasource/__init__.py tests/datasource/__init__.py
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/datasource/test_provider.py -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Run gates** (`uv run pytest -q && uv run ruff check src tests && uv run mypy`)
+
+### Task 2: Named registry
+
+**Files:**
+- Create: `src/miot_harness/datasource/registry.py`
+- Test: `tests/datasource/test_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/datasource/test_registry.py
+import pytest
+
+from miot_harness.datasource.registry import available_kinds, resolve
+
+
+def test_nexo_is_registered() -> None:
+    assert "nexo" in available_kinds()
+
+
+def test_resolve_nexo_returns_provider_with_profile() -> None:
+    provider = resolve("nexo")
+    assert provider.profile.name == "nexo"
+    assert provider.profile.display_name == "Coordinador"
+    assert provider.profile.tool_prefix == "coordinador_"
+    assert provider.profile.tenant_lock == "mintral"
+
+
+def test_resolve_unknown_kind_fails_fast_listing_kinds() -> None:
+    with pytest.raises(ValueError) as exc:
+        resolve("definitely-not-a-datasource")
+    assert "nexo" in str(exc.value)  # lists available kinds
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/datasource/test_registry.py -v`
+Expected: FAIL — `ModuleNotFoundError` (registry.py missing; NexoProvider not yet written — Task 3 makes the second test pass, write both before running full green)
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/miot_harness/datasource/registry.py
+"""Named datasource registry.
+
+`MIOT_HARNESS_DATASOURCE_KIND` selects the provider at boot. This
+registry is the future plugin hook: entry-point-discovered or
+MCP-backed providers register here the same way the in-repo one does.
+
+Imports are deferred into the factory functions so importing the
+registry never drags in provider dependencies (asyncpg etc.).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from miot_harness.datasource.provider import DataSourceProvider
+
+
+def _make_nexo() -> DataSourceProvider:
+    from miot_harness.integrations.nexo.provider import NexoProvider
+
+    return NexoProvider()
+
+
+_REGISTRY: dict[str, Callable[[], DataSourceProvider]] = {
+    "nexo": _make_nexo,
+}
+
+
+def available_kinds() -> tuple[str, ...]:
+    return tuple(sorted(_REGISTRY))
+
+
+def resolve(kind: str) -> DataSourceProvider:
+    """Instantiate the provider for `kind`.
+
+    Raises ValueError listing available kinds — called from the
+    lifespan so a typo in MIOT_HARNESS_DATASOURCE_KIND fails the boot,
+    not the first request (same fail-fast pattern as
+    validate_auth_config).
+    """
+    factory = _REGISTRY.get(kind)
+    if factory is None:
+        raise ValueError(
+            f"Unknown datasource kind {kind!r}. Available: "
+            + ", ".join(available_kinds())
+        )
+    return factory()
+```
+
+- [ ] **Step 4: Continue to Task 3 (registry tests need NexoProvider), then run both test files**
+
+### Task 3: `NexoProvider` + `NEXO_PROFILE`
+
+**Files:**
+- Create: `src/miot_harness/integrations/nexo/provider.py`
+- Test: `tests/integrations/nexo/test_provider.py` (create `tests/integrations/__init__.py` and `tests/integrations/nexo/__init__.py`, both empty)
+
+The profile values below are **today's exact strings** — copied from `tool_factory.py` (source label, refusal copy), `primer.py`, `router.py` (`_NEXO_LITERAL_TOKENS`), and `config.py` defaults. Do not normalize or "improve" any of them.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integrations/nexo/test_provider.py
+"""NexoProvider: profile carries today's exact runtime strings, and
+boot() degrades to disabled when no DSN is configured."""
+
+import pytest
+
+from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE, NexoProvider
+from miot_harness.tools.registry import ToolRegistry
+
+
+def test_profile_values_match_legacy_hardcodes() -> None:
+    p = NEXO_PROFILE
+    assert p.name == "nexo"
+    assert p.display_name == "Coordinador"
+    assert p.source_label == "Coordinador · nexo (Citus DB)"
+    assert p.tool_prefix == "coordinador_"
+    assert "coordinador" in p.router_keywords
+    assert "mintral" in p.router_keywords
+    assert p.tenant_lock == "mintral"
+    assert (
+        p.tenant_refusal_template.format(
+            display_name=p.display_name, lock=p.tenant_lock
+        )
+        == "Coordinador is mintral-only. I can't answer for other tenants."
+    )
+    assert p.freshness_warn_minutes == 30
+    assert p.freshness_refuse_minutes == 240
+
+
+@pytest.mark.asyncio
+async def test_boot_without_dsn_returns_disabled() -> None:
+    provider = NexoProvider()
+    settings = HarnessSettings(nexo_dsn=None)
+    result = await provider.boot(ToolRegistry(), settings)
+    assert result.enabled is False
+    assert result.registered == []
+    assert result.reason is not None
+    await provider.close()  # no-op when never connected; must not raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/integrations/nexo/test_provider.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... integrations.nexo.provider`
+
+- [ ] **Step 3: Write the implementation**
+
+Note: in Stage 1 the provider still reads the OLD settings names (`nexo_dsn`, `nexo_application_name`) so the suite stays green; Task 14 (settings break) switches them.
+
+```python
+# src/miot_harness/integrations/nexo/provider.py
+"""Nexo: the first DataSourceProvider (Citus/Postgres, Coordinador schema).
+
+This package is the ONLY place in the harness allowed to say
+"Nexo", "Coordinador", or "mintral".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+from miot_harness.integrations.nexo.boot import load_nexo_tools
+from miot_harness.integrations.nexo.pool import create_nexo_pool
+from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+NEXO_PROFILE = DataSourceProfile(
+    name="nexo",
+    display_name="Coordinador",
+    source_label="Coordinador · nexo (Citus DB)",
+    tool_prefix="coordinador_",
+    primer=COORDINADOR_PRIMER,
+    router_keywords=frozenset(
+        {
+            "coordinador",
+            "mintral",
+            "centro de control",
+            "cola crítica",
+            "cola critica",
+            "dimensionamiento",
+            "torre de control",
+            "auditoría pod",
+            "auditoria pod",
+            "fn_dx",
+        }
+    ),
+    tenant_lock="mintral",
+    tenant_refusal_template=(
+        "{display_name} is {lock}-only. I can't answer for other tenants."
+    ),
+    freshness_warn_minutes=30,
+    freshness_refuse_minutes=240,
+)
+
+
+class NexoProvider(DataSourceProvider):
+    profile = NEXO_PROFILE
+
+    def __init__(self) -> None:
+        self._pool: asyncpg.Pool | None = None
+
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult:
+        dsn = settings.nexo_dsn  # Task 14 renames to datasource_dsn
+        if dsn is None:
+            return BootResult(
+                enabled=False,
+                registered=[],
+                reason="MIOT_HARNESS_NEXO_DSN is not set",
+            )
+        try:
+            self._pool = await create_nexo_pool(
+                dsn, application_name=settings.nexo_application_name
+            )
+        except Exception as exc:  # noqa: BLE001 — boot must not die
+            logger.critical("Nexo: pool creation failed (%s)", exc)
+            return BootResult(
+                enabled=False, registered=[], reason=f"pool creation failed: {exc}"
+            )
+        legacy = await load_nexo_tools(registry, settings=settings, pool=self._pool)
+        return BootResult(
+            enabled=legacy.enabled,
+            registered=list(legacy.registered),
+            reason=legacy.reason,
+            snapshot_age_minutes=legacy.snapshot_age_minutes,
+        )
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            try:
+                await self._pool.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Nexo: pool close raised %s", exc)
+            self._pool = None
+```
+
+- [ ] **Step 4: Run all three new test files**
+
+Run: `uv run pytest tests/datasource/ tests/integrations/ -v`
+Expected: all PASS (registry tests from Task 2 now pass too)
+
+- [ ] **Step 5: Run gates**
+
+### Task 4: `FakeProvider` test fixture (the de-facto second provider)
+
+**Files:**
+- Create: `tests/fixtures/fake_provider.py` (create `tests/fixtures/__init__.py` empty)
+- Test: `tests/datasource/test_fake_provider.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/datasource/test_fake_provider.py
+import pytest
+
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE, FakeProvider
+from miot_harness.config import HarnessSettings
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_boots_and_registers_tools() -> None:
+    provider = FakeProvider()
+    registry = ToolRegistry()
+    result = await provider.boot(registry, HarnessSettings())
+    assert result.enabled is True
+    assert result.registered == ["fake_lookup"]
+    assert "fake_lookup" in registry.names()
+    assert provider.profile is FAKE_PROFILE
+    await provider.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/datasource/test_fake_provider.py -v`
+Expected: FAIL — `ModuleNotFoundError: tests.fixtures.fake_provider`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# tests/fixtures/fake_provider.py
+"""A minimal second DataSourceProvider.
+
+Exists to prove the seam: core runtime/agent tests run against this
+provider so they cannot accidentally depend on Nexo/Coordinador/Mintral
+specifics. Mirrors the eval-stub tool shape used by run_golden.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.permissions import PermissionResult
+from miot_harness.runtime.tool import HarnessTool
+from miot_harness.tools.registry import ToolRegistry
+
+FAKE_PROFILE = DataSourceProfile(
+    name="fake",
+    display_name="FakeSource",
+    source_label="FakeSource · fake (test)",
+    tool_prefix="fake_",
+    primer="FakeSource is a synthetic datasource used in harness tests.",
+    router_keywords=frozenset({"fakesource", "fixture"}),
+    tenant_lock="acme",
+    tenant_refusal_template=(
+        "{display_name} is {lock}-only. I can't answer for other tenants."
+    ),
+    freshness_warn_minutes=30,
+    freshness_refuse_minutes=240,
+)
+
+
+class _In(BaseModel):
+    pass
+
+
+class _Out(BaseModel):
+    rows: list[dict[str, Any]] = []
+    refreshed_at: datetime | None = None
+    source: str = FAKE_PROFILE.source_label
+
+
+async def _check(ctx: HarnessContext, inp: BaseModel) -> PermissionResult:
+    if ctx.tenant_id != FAKE_PROFILE.tenant_lock:
+        return PermissionResult.deny("FakeSource is acme-only")
+    return PermissionResult.allow()
+
+
+async def _call(
+    ctx: HarnessContext, inp: BaseModel, progress: Callable[..., None]
+) -> _Out:
+    now = datetime.now(UTC)
+    return _Out(rows=[{"value": 42, "refreshed_at": now}], refreshed_at=now)
+
+
+class FakeProvider(DataSourceProvider):
+    profile = FAKE_PROFILE
+
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult:
+        registry.register(
+            HarnessTool(
+                name="fake_lookup",
+                description="[Layer L1] fake test tool",
+                input_model=_In,
+                output_model=_Out,
+                check_permission=_check,
+                call=_call,
+            )
+        )
+        return BootResult(enabled=True, registered=["fake_lookup"])
+
+    async def close(self) -> None:
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/datasource/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run gates**
+
+### Task 5: server lifespan boots via the registry
+
+**Files:**
+- Modify: `src/miot_harness/api/server.py` (lifespan only — find the `if settings.nexo_dsn is None:` block and the `pool = await create_nexo_pool(...)` / `load_nexo_tools(...)` calls)
+- Test: existing `tests/api/` suite is the safety net (lifespan behavior unchanged)
+
+- [ ] **Step 1: Replace direct nexo calls with provider calls**
+
+In `_make_lifespan`, replace:
+
+```python
+# OLD (delete):
+if settings.nexo_dsn is None:
+    logger.info("Nexo: disabled (MIOT_HARNESS_NEXO_DSN is not set)")
+    ...
+pool = await create_nexo_pool(settings.nexo_dsn)
+result = await load_nexo_tools(harness.tools, settings=settings, pool=pool)
+```
+
+with:
+
+```python
+# NEW:
+from miot_harness.datasource.registry import resolve  # top-of-file import
+
+provider = resolve(settings.datasource_kind)  # Stage 1: hardcode "nexo" until Task 14 adds the setting
+app.state.datasource_provider = provider
+result = await provider.boot(harness.tools, settings)
+```
+
+Stage-1 transitional note: until Task 14 adds `datasource_kind`, call `resolve("nexo")`. Keep `app.state.nexo_*` names for now (renamed in Task 12). The `finally:` block replaces `await pool.close()` with `await provider.close()`. Remove the now-unused `create_nexo_pool` / `load_nexo_tools` imports from server.py.
+
+- [ ] **Step 2: Run the API suite**
+
+Run: `uv run pytest tests/api -q`
+Expected: all PASS (no behavior change — provider wraps the same calls)
+
+- [ ] **Step 3: Run gates**
+
+- [ ] **Step 4: Commit Stage 1**
+
+```bash
+git add -A miot-harness
+git commit -m "feat(harness): add DataSourceProvider seam with nexo as first provider"
+```
+
+---
+
+## Stage 2 — Core consumes the profile (commit: `refactor(harness): core reads DataSourceProfile instead of hardcoded domain values`)
+
+Plumbing rule for every task in this stage: the profile travels **explicitly** — `HarnessSupervisor` gains a `profile: DataSourceProfile | None` attribute (set by the lifespan from `provider.profile`; `None` keeps legacy defaults during the transition), and `build_nexo_graph(...)`/`build_agentic_graph(...)` gain a required `profile` keyword that they close over into their nodes. No global/ambient profile.
+
+### Task 6: keyword router takes profile keywords
+
+**Files:**
+- Modify: `src/miot_harness/runtime/router.py` (`_NEXO_LITERAL_TOKENS` and `IntentRouter`)
+- Modify test: `tests/test_router.py` (or wherever `IntentRouter()` is constructed — `grep -rln "IntentRouter(" tests/ src/`)
+
+- [ ] **Step 1: Write the failing test** (add to the existing router test file)
+
+```python
+def test_router_accepts_custom_keywords() -> None:
+    from miot_harness.runtime.router import IntentRouter
+
+    router = IntentRouter(data_keywords=frozenset({"fakesource"}))
+    result = router.route("estado de fakesource?")
+    assert result.route.value == "nexo_query"  # renamed to data_query in Task 11
+```
+
+- [ ] **Step 2: Run to verify it fails** (`TypeError: unexpected keyword argument`)
+
+- [ ] **Step 3: Implement** — `IntentRouter.__init__(self, data_keywords: frozenset[str] | None = None)`; default `None` keeps the current `_NEXO_LITERAL_TOKENS` tuple (renamed `_DEFAULT_DATA_TOKENS`) so existing construction sites behave identically. `route()` checks `self._data_keywords`. Construction sites that have a profile (server lifespan, supervisor LLM-router fallback) pass `profile.router_keywords`.
+
+- [ ] **Step 4: Run gates**
+
+### Task 7: tenancy gate takes lock + refusal from profile
+
+**Files:**
+- Modify: `src/miot_harness/runtime/tenancy.py`
+- Modify: callers — `src/miot_harness/runtime/nexo_graph.py` and `src/miot_harness/runtime/agentic_graph.py` (pass their `profile` through to the gate)
+- Test: `tests/runtime/test_tenancy_gate.py` (existing file — extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_gate_uses_profile_lock_and_template() -> None:
+    from tests.fixtures.fake_provider import FAKE_PROFILE
+    decision = tenancy_gate_decision(
+        ctx=make_ctx(tenant_id="intruder"),
+        route=HarnessRoute.NEXO_QUERY,
+        settings=HarnessSettings(),
+        profile=FAKE_PROFILE,
+    )
+    assert decision.allowed is False
+    assert decision.refusal_message == (
+        "FakeSource is acme-only. I can't answer for other tenants."
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+- [ ] **Step 3: Implement** — add `profile: DataSourceProfile | None = None` keyword. Lock resolution: `lock = settings.nexo_tenant_lock if profile is None else (settings override or profile.tenant_lock)` — in Stage 2 keep it simple: `lock = profile.tenant_lock if profile is not None else settings.nexo_tenant_lock`; Task 14 adds the env override. Refusal message: `profile.tenant_refusal_template.format(display_name=profile.display_name, lock=lock)` when profile present; the legacy f-string otherwise. Existing tests (no profile arg) stay green.
+
+- [ ] **Step 4: Run gates**
+
+### Task 8: agents read profile (prompts, primer, prefix, source, freshness)
+
+**Files:**
+- Modify: `src/miot_harness/agents/filter_expert.py` — system prompt `"You are the Filter Expert for Coordinador (Mintral fleet operations)"` → templated with `profile.display_name`; the two `name.startswith("coordinador_")` checks → `name.startswith(profile.tool_prefix)`
+- Modify: `src/miot_harness/agents/domain_analyst.py` — prompt `"You are the Coordinador Domain Analyst"` → templated; `COORDINADOR_PRIMER` import → `profile.primer`
+- Modify: `src/miot_harness/agents/synthesizer.py` — same pattern; the tenant-refusal helper uses `profile.tenant_refusal_template`; keep ALL Spanish user-facing copy byte-identical
+- Modify: `src/miot_harness/agents/critic.py` — prompt templated
+- Modify: `src/miot_harness/agents/freshness_judge.py` — thresholds from `profile.freshness_*_minutes` (Stage 2: profile wins when present, settings otherwise); `"Coordinador snapshot is stale"` → `f"{profile.display_name} snapshot is stale"`
+- Modify: `src/miot_harness/agents/data_fetcher.py` — `source="Coordinador · nexo (Citus DB)"` → `source=profile.source_label`
+- Modify: `src/miot_harness/runtime/nexo_graph.py` — `build_nexo_graph(..., profile: DataSourceProfile)` required kwarg, passed into every node builder
+- Modify: `src/miot_harness/runtime/agentic_graph.py` — same; system prompt `"You are the Coordinador agentic synthesizer for Mintral fleet operations"` → templated with display_name; `COORDINADOR_PRIMER` import → `profile.primer`
+- Modify: call sites of `build_nexo_graph` / `build_agentic_graph`: `src/miot_harness/api/server.py` (pass `provider.profile`), `src/miot_harness/evals/run_golden.py` (pass `NEXO_PROFILE` for now — Task 16 generalizes)
+- Tests: existing agent tests pin behavior; add one seam test:
+
+- [ ] **Step 1: Write the failing seam test**
+
+```python
+# tests/test_graph_profile_seam.py
+"""Building the data graph with the FakeProvider profile must produce
+FakeSource-flavored agents — proof no Coordinador string is reachable
+from core code."""
+
+from miot_harness.config import HarnessSettings
+from miot_harness.runtime.nexo_graph import build_nexo_graph  # data_graph after Task 11
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+def test_graph_builds_with_fake_profile() -> None:
+    graph = build_nexo_graph(
+        registry=ToolRegistry(),
+        settings=HarnessSettings(),
+        models={},          # match existing no-model test pattern in tests/
+        profile=FAKE_PROFILE,
+    )
+    assert graph is not None
+```
+
+(Adjust the `models={}` line to whatever minimal-models pattern the existing graph tests use — see `grep -rn "build_nexo_graph(" tests/` and copy the cheapest construction.)
+
+- [ ] **Step 2: Run to verify it fails** (`TypeError: unexpected keyword 'profile'`)
+
+- [ ] **Step 3: Implement file by file, running the file's tests after each** — e.g. after filter_expert: `uv run pytest tests/test_filter_expert.py -q`. The prompt templating pattern, applied uniformly:
+
+```python
+# OLD
+SYSTEM_PROMPT = """You are the Filter Expert for Coordinador (Mintral fleet operations).
+..."""
+
+# NEW
+SYSTEM_PROMPT_TEMPLATE = """You are the Filter Expert for {display_name}.
+..."""
+# at node-build time:
+system_prompt = SYSTEM_PROMPT_TEMPLATE.format(display_name=profile.display_name)
+```
+
+Where a prompt previously interleaved primer text via `COORDINADOR_PRIMER`, substitute `profile.primer` at the same position. **Never reword the surrounding prompt text** — diff should show only the name/primer substitutions.
+
+- [ ] **Step 4: Verify byte-identical output for nexo**: run the fake-mode evals — `uv run miot-harness-evals --mode fake` → Expected: `25/25 ran cleanly`.
+
+- [ ] **Step 5: Run gates**
+
+### Task 9: supervisor + telemetry take the profile
+
+**Files:**
+- Modify: `src/miot_harness/runtime/supervisor.py` — add `self.profile: DataSourceProfile | None = None`; the disabled message `"Coordinador integration is currently disabled"` → `f"{display_name} integration is currently disabled"` with `display_name = self.profile.display_name if self.profile else "Coordinador"`; `tenant_lock` constructor default stays until Task 14
+- Modify: `src/miot_harness/observability/callbacks.py` — `NexoTelemetryCallback` gains `span_prefix: str = "nexo"` constructor arg; `f"nexo.{agent}"` → `f"{self._span_prefix}.{agent}"` (class renamed in Task 11)
+- Modify: `src/miot_harness/api/server.py` lifespan — `harness.profile = provider.profile`; telemetry callback constructed with `span_prefix=provider.profile.name`
+- Test: extend `tests/runtime/test_supervisor_event_bus.py`-adjacent suite or the existing supervisor tests with:
+
+```python
+def test_disabled_message_uses_profile_display_name() -> None:
+    sup = make_supervisor()              # existing helper pattern in the test file
+    sup.profile = FAKE_PROFILE
+    # drive the disabled path the same way the existing
+    # "nexo disabled" test does and assert the message contains "FakeSource"
+```
+
+- [ ] **Steps: test-fail-implement-pass, then gates** (same cadence as above)
+
+- [ ] **Commit Stage 2**
+
+```bash
+git add -A miot-harness
+git commit -m "refactor(harness): core reads DataSourceProfile instead of hardcoded domain values"
+```
+
+---
+
+## Stage 3 — Renames (commit: `refactor(harness): rename nexo core symbols and wire strings to datasource-generic terms`)
+
+### Task 10: state types (`plan.py`)
+
+**Files:**
+- Modify: `src/miot_harness/runtime/plan.py` + every importer (`grep -rln "NexoState\|NexoPlan\|NexoStep\|NexoEvidence" src/ tests/`)
+
+- [ ] **Step 1: Mechanical rename, exact table:**
+
+| Old | New |
+|---|---|
+| `NexoStep` | `DataStep` |
+| `NexoPlan` | `DataPlan` |
+| `NexoEvidence` | `DataEvidence` |
+| `NexoState` | `DataState` |
+
+```bash
+grep -rl "NexoStep\|NexoPlan\|NexoEvidence\|NexoState" src/ tests/ \
+  | xargs sed -i '' -e 's/NexoStep/DataStep/g; s/NexoPlan/DataPlan/g; s/NexoEvidence/DataEvidence/g; s/NexoState/DataState/g'
+```
+
+- [ ] **Step 2: Run gates** (pytest + ruff + mypy — mypy catches any missed import)
+
+### Task 11: modules, routes, supervisor methods, telemetry class
+
+- [ ] **Step 1: module + builder renames**
+
+```bash
+git mv src/miot_harness/runtime/nexo_graph.py src/miot_harness/runtime/data_graph.py
+grep -rl "nexo_graph\|build_nexo_graph" src/ tests/ \
+  | xargs sed -i '' -e 's/build_nexo_graph/build_data_graph/g; s/runtime\.nexo_graph/runtime.data_graph/g; s/runtime\/nexo_graph/runtime\/data_graph/g'
+```
+
+- [ ] **Step 2: route enum + wire values** (in `router.py`, then all references)
+
+```python
+class HarnessRoute(StrEnum):
+    DIRECT = "direct"
+    STORYTELLING_RUN = "storytelling_run"
+    DATA_QUERY = "data_query"        # was NEXO_QUERY = "nexo_query"
+    DATA_META = "data_meta"          # was NEXO_META = "nexo_meta"
+    DATA_AGENTIC = "data_agentic"    # was NEXO_AGENTIC = "nexo_agentic"
+    OTHER = "other"
+```
+
+```bash
+grep -rl "NEXO_QUERY\|NEXO_META\|NEXO_AGENTIC" src/ tests/ \
+  | xargs sed -i '' -e 's/NEXO_QUERY/DATA_QUERY/g; s/NEXO_META/DATA_META/g; s/NEXO_AGENTIC/DATA_AGENTIC/g'
+grep -rl '"nexo_query"\|"nexo_meta"\|"nexo_agentic"\|"nexo_plan"' src/ tests/ \
+  | xargs sed -i '' -e 's/"nexo_query"/"data_query"/g; s/"nexo_meta"/"data_meta"/g; s/"nexo_agentic"/"data_agentic"/g; s/"nexo_plan"/"data_plan"/g'
+```
+
+Also check the **LLM intent-router prompt** (`runtime/intent_router.py`): its route vocabulary must emit the new strings; reword its routing-rule examples from "Coordinador/Mintral" to profile-agnostic phrasing parameterized with `profile.display_name` + `profile.router_keywords` (this is the one prompt where wording legitimately changes — it names routes, and the route names changed).
+
+- [ ] **Step 3: supervisor internals**
+
+| Old | New |
+|---|---|
+| `_run_nexo` | `_run_data_query` |
+| `_run_nexo_agentic` | `_run_data_agentic` |
+| `_run_nexo_meta` | `_run_data_meta` |
+| `self.nexo_graph` | `self.data_graph` |
+
+```bash
+grep -rl "_run_nexo\|nexo_graph" src/ tests/ \
+  | xargs sed -i '' -e 's/_run_nexo_agentic/_run_data_agentic/g; s/_run_nexo_meta/_run_data_meta/g; s/_run_nexo\b/_run_data_query/g; s/\.nexo_graph/.data_graph/g'
+```
+
+(Then `grep -rn "nexo_graph" src/ tests/` and fix any leftover by hand — sed word-boundary on macOS is fragile; verify with the grep.)
+
+- [ ] **Step 4: telemetry class** — `NexoTelemetryCallback` → `AgentTelemetryCallback` (constructor already takes `span_prefix` from Task 9; nexo deployments keep emitting `nexo.*` spans because the lifespan passes `profile.name`):
+
+```bash
+grep -rl "NexoTelemetryCallback" src/ tests/ | xargs sed -i '' 's/NexoTelemetryCallback/AgentTelemetryCallback/g'
+```
+
+- [ ] **Step 5: rename test files** whose names say nexo but test core behavior:
+
+```bash
+git mv tests/test_supervisor_nexo_branch.py tests/test_supervisor_data_branch.py
+```
+
+(Inspect remaining `tests/test_*nexo*` files: those exercising the provider move under `tests/integrations/nexo/` with `git mv`; those exercising core get renamed like above. List them with `ls tests/ | grep -i nexo` and decide per file by what they import.)
+
+- [ ] **Step 6: Run gates + fake evals (25/25)**
+
+### Task 12: API surface — `/health` block + `app.state`
+
+**Files:**
+- Modify: `src/miot_harness/api/server.py`
+- Modify: `tests/api/` health tests; `evals/deploy/02-image-boots.sh` (greps the health payload)
+
+- [ ] **Step 1: Update the failing tests first** (health tests asserting `body["nexo"]`):
+
+```python
+assert body["datasource"] == {
+    "name": "nexo",
+    "enabled": False,
+    "tools": [],
+    "snapshot_age_minutes": None,
+}
+```
+
+- [ ] **Step 2: Implement** — `app.state.nexo_enabled/nexo_pool/nexo_registered/nexo_snapshot_age_minutes` → `app.state.datasource_enabled/datasource_registered/datasource_snapshot_age_minutes` (the pool no longer lives on app.state — the provider owns it). `/health` and `/health/ready` emit:
+
+```python
+"datasource": {
+    "name": provider.profile.name,
+    "enabled": app.state.datasource_enabled,
+    "tools": list(app.state.datasource_registered),
+    "snapshot_age_minutes": app.state.datasource_snapshot_age_minutes,
+},
+```
+
+`/health/ready` keeps the same readiness semantics: `required = settings.datasource_dsn is not None` (still `nexo_dsn` until Task 14), `ready = (not required) or enabled`. Update `evals/deploy/02-image-boots.sh` to grep `"datasource"` instead of `"nexo"`.
+
+- [ ] **Step 3: Run gates**
+
+### Task 13: cross-package client + chat fixtures
+
+**Files:**
+- Modify: `../turbo-repo/packages/miot-harness-client/src/types.ts:53,59` — route-string unions gain the new values; `graph: "nexo" | "agentic" | "meta"` is **unchanged**
+- Modify: `../turbo-repo/packages/miot-chat/src/tui/__tests__/components/App.smoke.test.tsx` — `"nexo_meta"` → `"data_meta"`, `"nexo_query"` → `"data_query"` in fixtures
+
+- [ ] **Step 1: Apply both edits**, exact type change in types.ts: any union containing `"nexo_query" | "nexo_meta" | "nexo_agentic"` route literals becomes `"data_query" | "data_meta" | "data_agentic"`.
+
+- [ ] **Step 2: Run the JS tests**
+
+```bash
+cd ../turbo-repo && npx turbo run test --filter=@microboxlabs/miot-chat --filter=@microboxlabs/miot-harness-client
+```
+Expected: PASS. (Package docs/changelog sync happens at release time via the doc-sync-package flow — out of this plan's scope.)
+
+- [ ] **Step 3: Commit Stage 3**
+
+```bash
+git add -A miot-harness ../turbo-repo/packages/miot-harness-client ../turbo-repo/packages/miot-chat
+git commit -m "refactor(harness): rename nexo core symbols and wire strings to datasource-generic terms"
+```
+
+---
+
+## Stage 4 — Settings break (commit: `refactor(harness)!: rename MIOT_HARNESS_NEXO_* env vars to DATASOURCE_*/AGENTS_*`)
+
+### Task 14: config.py regroup
+
+**Files:**
+- Modify: `src/miot_harness/config.py`
+- Create: `src/miot_harness/integrations/nexo/settings.py`
+- Modify: every reader (`grep -rn "nexo_" src/ tests/ --include="*.py" -l` after Stage 3 — should be config readers only)
+- Test: `tests/test_config.py` (extend existing or create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py (add)
+def test_datasource_and_agents_settings_env_names(monkeypatch) -> None:
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_KIND", "nexo")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@h:5432/db")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_MAX_TURNS", "5")
+    s = HarnessSettings()
+    assert s.datasource_kind == "nexo"
+    assert s.datasource_dsn == "postgresql://u:p@h:5432/db"
+    assert s.agents_max_turns == 5
+    assert not hasattr(s, "nexo_dsn")  # clean break — old name is gone
+
+
+def test_nexo_provider_private_settings(monkeypatch) -> None:
+    from miot_harness.integrations.nexo.settings import NexoSettings
+
+    monkeypatch.setenv("MIOT_HARNESS_NEXO_SEARCH_PATH", "custom_schema")
+    ns = NexoSettings()
+    assert ns.nexo_search_path == "custom_schema"
+    assert ns.nexo_explain_cost_threshold == 10000.0
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+- [ ] **Step 3: Implement.** Exact rename table in `HarnessSettings`:
+
+| Old field | New field | Default |
+|---|---|---|
+| — | `datasource_kind: str` | `"nexo"` |
+| `nexo_dsn` | `datasource_dsn: str \| None` | `None` |
+| `nexo_application_name` | `datasource_application_name: str` | `"miot-harness"` |
+| `nexo_tenant_lock` | `datasource_tenant_lock: str \| None` | `None` (None → profile default) |
+| `nexo_freshness_warn_minutes` | `datasource_freshness_warn_minutes: int \| None` | `None` (None → profile default) |
+| `nexo_freshness_refuse_minutes` | `datasource_freshness_refuse_minutes: int \| None` | `None` (None → profile default) |
+| `nexo_max_turns` | `agents_max_turns: int` | `8` |
+| `nexo_critic_enabled` | `agents_critic_enabled: bool` | `False` |
+| `nexo_supervisor_mode` | `agents_supervisor_mode: Literal["rule", "llm"]` | `"rule"` |
+| `nexo_filter_expert_model` | `agents_filter_expert_model: str` | `"claude-haiku-4-5"` |
+| `nexo_analyst_model` | `agents_analyst_model: str` | `"claude-sonnet-4-6"` |
+| `nexo_synthesizer_model` | `agents_synthesizer_model: str` | `"claude-sonnet-4-6"` |
+| `nexo_critic_model` | `agents_critic_model: str` | `"claude-sonnet-4-6"` |
+| `nexo_summarizer_model` | `agents_summarizer_model: str` | `"claude-haiku-4-5"` |
+| `nexo_synthesizer_stream` | `agents_synthesizer_stream: bool` | `True` |
+| `nexo_synthesizer_thinking_budget` | `agents_synthesizer_thinking_budget: int (ge=0)` | `4096` |
+| `nexo_search_path` | → moves to `NexoSettings.nexo_search_path` | `"nexo"` |
+| `nexo_explain_cost_threshold` | → moves to `NexoSettings.nexo_explain_cost_threshold` | `10000.0 (gt=0)` |
+
+Preserve every existing docstring/comment, adjusting only the names. New provider-private file:
+
+```python
+# src/miot_harness/integrations/nexo/settings.py
+"""Nexo-private settings.
+
+These are Postgres concepts (schema search path, EXPLAIN plan cost),
+honestly Nexo's — they keep the MIOT_HARNESS_NEXO_* prefix and live
+here so HarnessSettings never mentions the provider. Loaded by
+NexoProvider/boot at boot time, never by core code.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class NexoSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="MIOT_HARNESS_",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    nexo_search_path: str = "nexo"
+    # PostgreSQL plan-cost units; EXPLAIN total cost > this → refuse.
+    nexo_explain_cost_threshold: float = Field(default=10000.0, gt=0.0)
+```
+
+Effective-value resolution (where Stage 2 left "profile wins"):
+
+```python
+# tenancy.py / freshness_judge.py pattern:
+lock = settings.datasource_tenant_lock or profile.tenant_lock
+warn = settings.datasource_freshness_warn_minutes or profile.freshness_warn_minutes
+refuse = settings.datasource_freshness_refuse_minutes or profile.freshness_refuse_minutes
+```
+
+Then run `grep -rn "\.nexo_" src/ tests/` and update every reader to the new names (`boot.py`/`primitives.py` read `NexoSettings` for the two private knobs; `NexoProvider.boot` switches to `settings.datasource_dsn`/`datasource_application_name`; server lifespan switches `resolve("nexo")` → `resolve(settings.datasource_kind)` and readiness `required = settings.datasource_dsn is not None`).
+
+- [ ] **Step 4: Run gates**
+
+### Task 15: deploy/config files + docs sweep for env names
+
+**Files:**
+- Modify: `docker-compose.yml`, `.env.example`, `README.md`, `docs/dispatch-modes.md`, `evals/deploy/*.sh`, `evals/README.md` — every `MIOT_HARNESS_NEXO_*` reference
+
+- [ ] **Step 1: Mechanical sweep**
+
+```bash
+grep -rln "MIOT_HARNESS_NEXO_" --exclude-dir=.venv --exclude-dir=node_modules . | grep -v "integrations/nexo\|uv.lock"
+```
+
+For each hit apply the Task 14 table (`MIOT_HARNESS_NEXO_DSN` → `MIOT_HARNESS_DATASOURCE_DSN`, `MIOT_HARNESS_NEXO_MAX_TURNS` → `MIOT_HARNESS_AGENTS_MAX_TURNS`, etc.). `MIOT_HARNESS_NEXO_SEARCH_PATH` / `_EXPLAIN_COST_THRESHOLD` stay (provider-private). Add `MIOT_HARNESS_DATASOURCE_KIND=nexo` to `.env.example` with a comment.
+
+- [ ] **Step 2: Run gates + fake evals**
+
+- [ ] **Step 3: Commit Stage 4**
+
+```bash
+git add -A miot-harness
+git commit -m "refactor(harness)!: rename MIOT_HARNESS_NEXO_* env vars to DATASOURCE_*/AGENTS_*
+
+BREAKING CHANGE: deployments must rename env vars per the table in
+docs/specs/2026-06-05-harness-datasource-refactor-design.md. The two
+Postgres-specific knobs (MIOT_HARNESS_NEXO_SEARCH_PATH,
+MIOT_HARNESS_NEXO_EXPLAIN_COST_THRESHOLD) are unchanged."
+```
+
+---
+
+## Stage 5 — Evals + final sweep (commit: `refactor(evals): de-hardcode golden runner; enforce datasource-clean core`)
+
+### Task 16: run_golden.py de-hardcoding
+
+**Files:**
+- Modify: `src/miot_harness/evals/run_golden.py`
+- Test: `tests/test_run_golden.py` (existing — extend)
+
+- [ ] **Step 1: Changes, each grounded in a current hardcode:**
+  1. `_build_fake_registry`: drop the `if not tool_name.startswith("coordinador_"): continue` filter — build a stub for every name in `expected_tools` verbatim; the always-registered fallback name comes from a module constant `DEFAULT_FALLBACK_TOOL = NEXO_PROFILE.tool_prefix + "centro_control"`.
+  2. Stub `_Out.source` default and `_check` refusal: import `NEXO_PROFILE` (the provider under test) — `source=NEXO_PROFILE.source_label`, tenant compare against `NEXO_PROFILE.tenant_lock`.
+  3. Refusal detection in `_score`: `answer_is_refusal` substrings derive from the profile: `f"{NEXO_PROFILE.tenant_lock}-only" in answer or "no puedo responder" in answer` (the Spanish phrase is synthesizer copy, not a domain name — keep it).
+  4. Real mode (`_build_real_setup`): replace `create_nexo_pool` + `load_nexo_tools` direct calls with `registry.resolve(settings.datasource_kind)` + `provider.boot(...)`; the refusal errors keep their current texts but reference the new env names (`MIOT_HARNESS_DATASOURCE_DSN`).
+  5. `build_data_graph(..., profile=provider.profile)` in both fake and real paths (fake path uses `NEXO_PROFILE` — the dataset is the nexo provider's).
+  6. CLI `--yaml` default becomes `f"evals/golden/{settings.datasource_kind}/examples.yaml"` resolved at parse time with a plain `"evals/golden/nexo/examples.yaml"` fallback comment.
+
+- [ ] **Step 2: Run** `uv run pytest tests/test_run_golden.py -q` then `uv run miot-harness-evals --mode fake` → `25/25 ran cleanly`, and `MIOT_HARNESS_DATASOURCE_DSN="" uv run miot-harness-evals --mode real` → refuses, exit 1.
+
+### Task 17: final grep gate + docs sweep
+
+- [ ] **Step 1: The gate that proves the goal**
+
+```bash
+grep -rin "nexo\|coordinador\|mintral" src/miot_harness --exclude-dir=integrations
+```
+Expected: **zero matches**. Every hit is a missed reference — fix it (typically: comments, docstrings, log strings missed by the symbol renames).
+
+- [ ] **Step 2: Same sweep over tests** (allowed only under `tests/integrations/nexo/` and imports of `NEXO_PROFILE`/`tests.fixtures`):
+
+```bash
+grep -rln "nexo\|coordinador\|mintral" -i tests/ | grep -v "tests/integrations/nexo"
+```
+Inspect each remaining file: legitimate hits are only `from miot_harness.integrations.nexo.provider import NEXO_PROFILE` in eval-related tests. Fix the rest (switch to FakeProvider).
+
+- [ ] **Step 3: README sweep** — `miot-harness/README.md` + `evals/README.md`: describe the datasource seam (one short section: kind selection, profile, where nexo lives), update env-var tables.
+
+- [ ] **Step 4: Full final verification**
+
+```bash
+uv run pytest -q                      # all green
+uv run ruff check src tests          # clean
+uv run mypy                          # clean
+uv run miot-harness-evals --mode fake   # 25/25
+cd ../turbo-repo && npx turbo run test --filter=@microboxlabs/miot-chat --filter=@microboxlabs/miot-harness-client
+```
+
+- [ ] **Step 5: Commit Stage 5**
+
+```bash
+git add -A miot-harness
+git commit -m "refactor(evals): de-hardcode golden runner; enforce datasource-clean core"
+```
+
+---
+
+## Out of scope (tracked in spec)
+
+- Entry-point/pip plugin discovery; MCP-backed provider (the registry + `boot()` are the hooks).
+- Real-mode baseline re-validation (needs tunnel + API key).
+- Renaming golden dataset content; any prompt-semantics change beyond name/primer substitution (except the intent-router prompt, whose route vocabulary necessarily changed — Task 11 Step 2).

--- a/miot-harness/docs/specs/2026-06-05-harness-datasource-refactor-design.md
+++ b/miot-harness/docs/specs/2026-06-05-harness-datasource-refactor-design.md
@@ -37,7 +37,7 @@ server. Core code must not name any specific connection system.
 
 ## Architecture
 
-```
+```text
 src/miot_harness/
 ├── datasource/
 │   ├── provider.py      # DataSourceProvider ABC + DataSourceProfile + BootResult

--- a/miot-harness/docs/specs/2026-06-05-harness-datasource-refactor-design.md
+++ b/miot-harness/docs/specs/2026-06-05-harness-datasource-refactor-design.md
@@ -1,0 +1,178 @@
+# Harness datasource refactor — design
+
+**Branch**: `based/harness-nexo-refactor`
+**Date**: 2026-06-05
+**Status**: approved (brainstorming with odtorres)
+
+## Problem
+
+The harness hardcodes the names of one specific deployment everywhere:
+
+- **Nexo** (a Citus/Postgres DB): 330 occurrences across 32 Python files,
+  16 `MIOT_HARNESS_NEXO_*` env vars, `runtime/nexo_graph.py`, the `/health`
+  response, OTel span names.
+- **Coordinador** (the product/schema): the `coordinador_*` tool prefix,
+  `COORDINADOR_PRIMER`, and agent system prompts.
+- **mintral** (a customer tenant): the tenant-lock default, refusal copy,
+  router keywords, test fixtures.
+
+The harness is meant to be environment-independent: the datasource could be
+a DB, a filesystem, a cloud API — and in the future a skill/plugin or an MCP
+server. Core code must not name any specific connection system.
+
+## Decisions (from brainstorming)
+
+1. **Depth**: abstraction + rename. A real provider interface; Nexo becomes
+   the first implementation. Not a full plugin system yet.
+2. **Scope**: all of it — Coordinador and mintral move behind the seam too.
+3. **Compatibility**: clean break on env vars and the `/health` payload.
+   docker-compose, `.env.example`, deploy scripts, and docs update in the
+   same PR. No aliases.
+4. **Generic term**: `datasource` (`DataSourceProvider`,
+   `MIOT_HARNESS_DATASOURCE_*`, `/health` `"datasource"` block).
+5. **Loading**: named in-repo registry selected by
+   `MIOT_HARNESS_DATASOURCE_KIND=nexo`. The registry is the future
+   plugin/MCP hook; no entry-point machinery yet.
+6. **Delivery**: one PR with staged commits, each leaving the suite green.
+
+## Architecture
+
+```
+src/miot_harness/
+├── datasource/
+│   ├── provider.py      # DataSourceProvider ABC + DataSourceProfile + BootResult
+│   └── registry.py      # {"nexo": NexoProvider}; resolve(kind) -> provider
+├── integrations/
+│   └── nexo/            # the ONLY place that says Postgres/Coordinador/Mintral
+│       ├── provider.py  # NexoProvider(boot, close, profile=NEXO_PROFILE)
+│       ├── settings.py  # NexoSettings (provider-private env vars)
+│       └── pool.py / introspect.py / tool_factory.py / primer.py / primitives.py
+│                        # unchanged logic, now private to the package
+└── runtime/, agents/, api/, observability/
+                         # generic terms only; read DataSourceProfile
+```
+
+Boot flow: `server.py` lifespan → `registry.resolve(settings.datasource_kind)`
+→ `provider.boot(tool_registry, settings)` → core builds the data graph with
+`provider.profile` plumbed down. Core never imports `integrations.nexo`.
+
+## The interface
+
+```python
+class DataSourceProvider(ABC):
+    profile: DataSourceProfile
+    async def boot(self, registry: ToolRegistry, settings: HarnessSettings) -> BootResult: ...
+    async def close(self) -> None: ...
+
+@dataclass(frozen=True)
+class DataSourceProfile:
+    name: str                       # "nexo" — /health, graph label, span prefix
+    display_name: str               # "Coordinador" — agent prompt templating
+    source_label: str               # "Coordinador · nexo (Citus DB)" — SSE/evidence source
+    tool_prefix: str                # "coordinador_" — filter_expert tool filtering
+    primer: str                     # COORDINADOR_PRIMER — agent grounding text
+    router_keywords: frozenset[str] # keyword-router literals
+    tenant_lock: str | None         # "mintral" — default; env-overridable
+    tenant_refusal_template: str    # exact current refusal copy, templated
+    freshness_warn_minutes: int     # 30 — default; env-overridable
+    freshness_refuse_minutes: int   # 240 — default; env-overridable
+```
+
+`BootResult` = today's `NexoBootResult` renamed (`enabled`, `registered`,
+`reason`, `snapshot_age_minutes`).
+
+Every profile field maps 1:1 to a hardcode found in the coupling audit;
+nothing speculative. **Runtime output stays byte-identical** for: tool names
+(`coordinador_*`), SSE `source` strings, refusal copy, OTel span names
+(`nexo.*` via `span_prefix=profile.name`), node-lifecycle `graph` label
+(`"nexo"`). What changes is who supplies the words.
+
+## Settings (clean break)
+
+| Group | New | Old |
+|---|---|---|
+| Core datasource | `datasource_kind` (new, default `"nexo"`) | — |
+| | `datasource_dsn` | `nexo_dsn` |
+| | `datasource_application_name` | `nexo_application_name` |
+| | `datasource_tenant_lock` (overrides profile) | `nexo_tenant_lock` |
+| | `datasource_freshness_warn_minutes` / `_refuse_minutes` (override profile) | `nexo_freshness_*` |
+| Agent/graph | `agents_filter_expert_model`, `agents_analyst_model`, `agents_synthesizer_model`, `agents_critic_model`, `agents_summarizer_model`, `agents_supervisor_mode`, `agents_max_turns`, `agents_critic_enabled`, `agents_synthesizer_stream`, `agents_synthesizer_thinking_budget` | `nexo_*` equivalents |
+| Provider-private (`integrations/nexo/settings.py`) | `MIOT_HARNESS_NEXO_SEARCH_PATH`, `MIOT_HARNESS_NEXO_EXPLAIN_COST_THRESHOLD` | unchanged — Postgres concepts, honestly Nexo's |
+
+Tenant lock and freshness windows become profile defaults overridable by
+env, so removing the env var does not change behavior.
+
+## Renames
+
+Core code (no behavior change):
+
+| Old | New |
+|---|---|
+| `runtime/nexo_graph.py` / `build_nexo_graph` | `runtime/data_graph.py` / `build_data_graph` |
+| `NexoState` / `NexoPlan` / `NexoStep` / `NexoEvidence` | `DataState` / `DataPlan` / `DataStep` / `DataEvidence` |
+| `HarnessRoute.NEXO_QUERY / NEXO_META / NEXO_AGENTIC` | `DATA_QUERY / DATA_META / DATA_AGENTIC` |
+| `supervisor._run_nexo*` / `supervisor.nexo_graph` | `_run_data*` / `data_graph` |
+| `NexoTelemetryCallback` | `AgentTelemetryCallback(span_prefix=profile.name)` |
+| `load_nexo_tools` / `create_nexo_pool` / `NexoBootResult` | private to provider / `BootResult` |
+
+Wire contract (visible, clean break):
+
+| Surface | Old | New |
+|---|---|---|
+| `route.selected` data | `"nexo_query"` / `"nexo_meta"` / `"nexo_agentic"` | `"data_query"` / `"data_meta"` / `"data_agentic"` |
+| Artifact type | `"nexo_plan"` | `"data_plan"` |
+| `/health`, `/health/ready` | `"nexo": {...}` | `"datasource": {"name": "nexo", "enabled": ..., "tools": ..., "snapshot_age_minutes": ...}` |
+| Node-lifecycle `graph` label | `"nexo"` | unchanged (it is `profile.name`) |
+| OTel spans, tool names, `source` strings, refusal copy | | unchanged (profile-supplied) |
+
+Cross-package: `turbo-repo/packages/miot-harness-client/src/types.ts` route
+strings and `miot-chat` test fixtures update in the same PR
+(`graph: "nexo"` stays valid). Client docs/changelog sync via the
+doc-sync-package flow before any release tag.
+
+## Evals and tests
+
+- `evals/golden/nexo/examples.yaml` stays — it is the nexo provider's golden
+  dataset. Convention: `evals/golden/<datasource-kind>/`.
+- `run_golden.py` de-hardcoded: fake registry builds stubs from each entry's
+  `expected_tools` verbatim; stub `source` and refusal-detection substrings
+  come from the imported provider profile; real mode boots via the registry.
+- Tests: nexo-specific fixtures move under `tests/integrations/nexo/`;
+  core runtime/agent tests use a `FakeProvider` with a synthetic profile —
+  the de-facto second provider that proves the seam.
+  `test_supervisor_nexo_branch.py` → `test_supervisor_data_branch.py`.
+- Gates per commit: full pytest, `ruff check`, `mypy`, fake-mode evals
+  25/25, and the grep gate:
+  `grep -ri "nexo\|coordinador\|mintral" src/ --exclude-dir=integrations`
+  must return zero matches at the final commit.
+
+## Error handling
+
+- Unknown `MIOT_HARNESS_DATASOURCE_KIND` → boot fails fast listing available
+  kinds (same pattern as `validate_auth_config`).
+- No DSN / boot failure → `BootResult(enabled=False, reason=...)`; harness
+  serves non-data routes exactly as today; disabled-copy comes from the
+  profile so user-visible text is unchanged.
+- Env overrides unset → profile defaults apply (mintral lock, 30/240
+  freshness windows): zero behavior change for existing deploys that only
+  set `MIOT_HARNESS_NEXO_DSN` → they must rename it to
+  `MIOT_HARNESS_DATASOURCE_DSN` (the one mandatory ops change).
+
+## Delivery — one PR, staged commits
+
+1. **Seam**: `datasource/` package + `NexoProvider` wrapping existing
+   modules + `FakeProvider` fixture. Nothing else moves; suite green.
+2. **Core consumes profile**: agents/router/tenancy/graph/observability
+   read the profile; prompts templated by `display_name`/`primer`.
+3. **Renames**: modules, types, routes, supervisor methods, wire strings;
+   client TS types + chat test fixtures.
+4. **Settings break**: config regroup; compose/.env/deploy scripts/docs.
+5. **Evals**: run_golden de-hardcoding; README/docs sweep; final grep gate.
+
+## Out of scope
+
+- Entry-point / pip-installable plugin discovery (future; the registry is
+  the hook).
+- MCP-backed provider implementation (future; `boot()` is where it plugs).
+- Renaming the golden dataset content or re-validating real-mode baselines.
+- Any change to agent pipeline behavior, prompt semantics, or scoring.

--- a/miot-harness/evals/README.md
+++ b/miot-harness/evals/README.md
@@ -2,24 +2,25 @@
 
 ## What an "eval" is
 
-The harness runs an AI agent ("Nexo") that answers operational questions by calling tools and reading data. An eval suite is the agent's test
-harness — it feeds the agent a set of known questions and checks whether it behaved correctly (picked the right tool, cited fresh data, refused
-when it should, didn't make things up). Think of it as a report card for the AI, run automatically so you catch quality regressions before
-users do.
+The harness runs an AI agent over a configured **datasource** that answers operational questions by calling tools and reading data. An eval
+suite is the agent's test harness — it feeds the agent a set of known questions and checks whether it behaved correctly (picked the right
+tool, cited fresh data, refused when it should, didn't make things up). Think of it as a report card for the AI, run automatically so you
+catch quality regressions before users do. The golden dataset shipped here targets the default **nexo** provider.
 
 Two independent suites live under `evals/`. They share a directory but never
 share a runner; their exit codes mean different things.
 
 | Suite | What it measures | Entry point |
 |---|---|---|
-| **Golden** (this dir + `src/miot_harness/evals/run_golden.py`) | Agent quality on the Nexo conversational graph — tool routing, freshness, refusals, KPI grounding, step economy. | `miot-harness-evals` |
+| **Golden** (this dir + `src/miot_harness/evals/run_golden.py`) | Agent quality on the datasource conversational graph — tool routing, freshness, refusals, KPI grounding, step economy. | `miot-harness-evals` |
 | **Judge** (`judge_prompt.md`) | Advisory Tier-3 LLM-judge rubric scored 1–5 per axis on a real trajectory. | prompt, run out-of-band |
 | **Deploy** (`deploy/`) | Operational checks that the harness packages and runs as a container. | `deploy/run-all.sh` (see `deploy/README.md`) |
 
 ## Golden suite
 
-`miot-harness-evals` reads `evals/golden/nexo/examples.yaml` and runs each entry
-through the Nexo graph in one of three modes:
+`miot-harness-evals` reads `evals/golden/<datasource-kind>/examples.yaml`
+(default `evals/golden/nexo/examples.yaml`, override with `--yaml`) and runs
+each entry through the datasource graph in one of three modes:
 
 ```bash
 # YAML schema validation only — no graph runs, no LLMs.
@@ -28,11 +29,15 @@ uv run miot-harness-evals --mode static
 # Scripted FakeListChatModel run — deterministic; the default.
 uv run miot-harness-evals --mode fake
 
-# Live Anthropic + live Nexo DB (NotImplementedError today; needs env vars).
+# Live Anthropic + live datasource. Needs MIOT_HARNESS_DATASOURCE_DSN and
+# ANTHROPIC_API_KEY; refuses (exit 1) when either is missing. The provider is
+# selected by MIOT_HARNESS_DATASOURCE_KIND via the registry path.
 uv run miot-harness-evals --mode real
 ```
 
-Results are written to `evals/results/<commit-sha>.json`.
+Results are written to `evals/results/<commit-sha>.json` (fake/static) or
+`evals/results/<commit-sha>-real.json` (real, so it never clobbers the
+canonical fake baseline).
 
 ### Scored axes (deterministic)
 
@@ -50,7 +55,9 @@ scripted model cannot make that judgment; those are validated in real mode.
 ### Dataset contract (fake mode)
 
 Fake mode is intentionally deterministic so it catches routing/structural
-regressions without spending tokens. When authoring `examples.yaml`:
+regressions without spending tokens. The values below (`coordinador_*` tool
+names, the `mintral` tenant lock) are the **nexo** profile's, since the
+shipped dataset targets the nexo provider. When authoring `examples.yaml`:
 
 - The scripted synthesizer always emits
   `"Resultado al snapshot <ts>: 2 servicios críticos, 3 ETA en riesgo."`, so
@@ -60,9 +67,11 @@ regressions without spending tokens. When authoring `examples.yaml`:
   document the *real-mode* envelope; in fake mode keep `min ≤ 1 ≤ max` for a
   green baseline. The `max` cap is the part that catches over-engineering once
   real mode lands.
-- `expected_tools` must be `coordinador_*` names (the fake registry only stubs
-  those). Adversarial cases use `[]`; a non-`mintral` `tenant_id` exercises the
-  tenant gate and produces the canonical `"…is mintral-only…"` refusal.
+- `expected_tools` may be any tool names — the fake registry now stubs every
+  name in `expected_tools` verbatim (plus a `<prefix>centro_control` fallback).
+  For the nexo dataset these are `coordinador_*` names. Adversarial cases use
+  `[]`; an off-lock `tenant_id` (≠ `mintral` for nexo) exercises the tenant gate
+  and produces the canonical `"…is mintral-only…"` refusal.
 - `category: adversarial` requires `expected_refusal: true` (enforced by
   `validate_entries`).
 - Every `expected_refusal: true` case must declare `refusal_mechanism:

--- a/miot-harness/evals/deploy/02-image-boots.sh
+++ b/miot-harness/evals/deploy/02-image-boots.sh
@@ -2,7 +2,7 @@
 # 02-image-boots.sh — Category A.2
 # Asserts: a freshly-started container responds 200 on /health within
 # BOOT_TIMEOUT_S, and the response payload has the deploy-readable
-# shape ({status, env, nexo:{enabled, tools[], snapshot_age_minutes}}).
+# shape ({status, env, datasource:{name, enabled, tools[], snapshot_age_minutes}}).
 #
 # Race-condition note: `docker run -d` returns BEFORE uvicorn binds the
 # port. We poll `curl` in a bounded loop instead of `sleep N + curl` so
@@ -62,7 +62,7 @@ fi
 
 # Shape check: tolerate missing jq by using grep fallbacks. We don't
 # parse fully — just confirm the deploy-readable keys are present.
-required_keys=("status" "env" "enabled" "tools" "snapshot_age_minutes")
+required_keys=("status" "env" "datasource" "name" "enabled" "tools" "snapshot_age_minutes")
 for key in "${required_keys[@]}"; do
   if ! echo "$RESPONSE" | grep -q "\"$key\""; then
     fail "/health payload missing key \"$key\" — got: $RESPONSE"

--- a/miot-harness/scripts/smoke_auth_e2e.py
+++ b/miot-harness/scripts/smoke_auth_e2e.py
@@ -151,7 +151,7 @@ def main() -> None:
                 "MIOT_HARNESS_WORKSPACE_DIR": workdir,
             }
         )
-        os.environ.pop("MIOT_HARNESS_NEXO_DSN", None)
+        os.environ.pop("MIOT_HARNESS_DATASOURCE_DSN", None)
         _seed_record(workdir)
 
         from miot_harness.api.server import create_app

--- a/miot-harness/src/miot_harness/agents/critic.py
+++ b/miot-harness/src/miot_harness/agents/critic.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 # {display_name} → profile.display_name; {tenant_display} → the tenant the
-# datasource is locked to (profile.tenant_lock, capitalized). Render
-# byte-identically to the former hardcodes for NEXO ("Coordinador", "Mintral").
+# datasource is locked to (profile.tenant_lock, capitalized). Both come
+# straight from the active datasource profile.
 _CRITIC_SYSTEM_TEMPLATE = """\
 You are the {display_name} critic. Inspect the proposed answer against the
 collected evidence. Output ONLY a JSON object:

--- a/miot-harness/src/miot_harness/agents/critic.py
+++ b/miot-harness/src/miot_harness/agents/critic.py
@@ -18,19 +18,23 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
 
 logger = logging.getLogger(__name__)
 
 
-_CRITIC_SYSTEM = """\
-You are the Coordinador critic. Inspect the proposed answer against the
+# {display_name} → profile.display_name; {tenant_display} → the tenant the
+# datasource is locked to (profile.tenant_lock, capitalized). Render
+# byte-identically to the former hardcodes for NEXO ("Coordinador", "Mintral").
+_CRITIC_SYSTEM_TEMPLATE = """\
+You are the {display_name} critic. Inspect the proposed answer against the
 collected evidence. Output ONLY a JSON object:
-{"verdict": "pass" | "fail", "concerns": "..."}
+{{"verdict": "pass" | "fail", "concerns": "..."}}
 Fail if the answer:
 - invents numbers not in the evidence,
 - omits refreshed_at when the evidence has it,
 - claims data is fresh when is_stale=true,
-- answers a non-Mintral question with anything other than "Mintral-only".
+- answers a non-{tenant_display} question with anything other than "{tenant_display}-only".
 """
 
 
@@ -39,6 +43,7 @@ async def critic_node(
     *,
     settings: HarnessSettings,
     model: BaseChatModel,
+    profile: DataSourceProfile,
 ) -> dict[str, Any]:
     if not settings.nexo_critic_enabled:
         return {}
@@ -54,9 +59,13 @@ async def critic_node(
     )[:2000]
     human = f"User question: {user_message}\n\nProposed answer:\n{answer}\n\nEvidence:\n{rendered}"
 
+    system = _CRITIC_SYSTEM_TEMPLATE.format(
+        display_name=profile.display_name,
+        tenant_display=(profile.tenant_lock or profile.display_name).capitalize(),
+    )
     response = await model.ainvoke(
         [
-            SystemMessage(content=_CRITIC_SYSTEM),
+            SystemMessage(content=system),
             HumanMessage(content=human),
         ]
     )

--- a/miot-harness/src/miot_harness/agents/critic.py
+++ b/miot-harness/src/miot_harness/agents/critic.py
@@ -1,6 +1,6 @@
 """Critic agent (Sonnet tier; wired but off by default).
 
-When `settings.nexo_critic_enabled` is False, the node is a no-op.
+When `settings.agents_critic_enabled` is False, the node is a no-op.
 When enabled, it asks the model whether the synthesizer's answer
 adequately cites refreshed_at, flags stale data, and avoids
 hallucination. v1 surfaces concerns into state but does not loop
@@ -45,7 +45,7 @@ async def critic_node(
     model: BaseChatModel,
     profile: DataSourceProfile,
 ) -> dict[str, Any]:
-    if not settings.nexo_critic_enabled:
+    if not settings.agents_critic_enabled:
         return {}
 
     answer = state.get("answer", "")

--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -1,7 +1,7 @@
 """Data Fetcher (deterministic; no LLM).
 
-Reads the next pending NexoStep, invokes the corresponding tool via
-ToolRegistry, wraps the typed output as NexoEvidence, and returns a
+Reads the next pending DataStep, invokes the corresponding tool via
+ToolRegistry, wraps the typed output as DataEvidence, and returns a
 state delta. Failures (raised exceptions, permission denials) are
 caught and surface as `state["failure"]` so the supervisor can route
 the synthesizer for graceful refusal — no double-fetching.
@@ -17,7 +17,7 @@ from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 from miot_harness.runtime.tool import Progress
 from miot_harness.tools.registry import ToolRegistry
 
@@ -56,7 +56,7 @@ def _evidence_from_output(
     *,
     warn_minutes: int,
     source_label: str,
-) -> NexoEvidence:
+) -> DataEvidence:
     if hasattr(output, "model_dump"):
         dump = output.model_dump()
     elif isinstance(output, dict):
@@ -90,7 +90,7 @@ def _evidence_from_output(
         # Tool returned data but no refreshed_at — treat as unverified
         is_stale = True
 
-    return NexoEvidence(
+    return DataEvidence(
         step_id=step_id,
         tool=tool,
         source=str(dump.get("source", source_label)),
@@ -146,7 +146,7 @@ async def data_fetcher_node(
         source_label=profile.source_label,
     )
     return {
-        "evidence": [evidence],  # appended by NexoState's operator.add reducer
+        "evidence": [evidence],  # appended by DataState's operator.add reducer
         "pending_step_index": pending + 1,
         "next_action": "judge_freshness",
     }

--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -93,7 +93,9 @@ def _evidence_from_output(
     return DataEvidence(
         step_id=step_id,
         tool=tool,
-        source=str(dump.get("source", source_label)),
+        # `or` (not a .get default) so a payload carrying source=None or ""
+        # falls back to the profile label instead of stringifying to "None".
+        source=str(dump.get("source") or source_label),
         refreshed_at=refreshed_at if isinstance(refreshed_at, datetime) else None,
         output=dump,
         sample_size=sample_size,

--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -142,7 +142,13 @@ async def data_fetcher_node(
         step.id,
         step.tool,
         output,
-        warn_minutes=settings.nexo_freshness_warn_minutes,
+        # Effective threshold: env override wins (including an explicit 0),
+        # else the profile default. Mirrors freshness_judge's resolution.
+        warn_minutes=(
+            settings.datasource_freshness_warn_minutes
+            if settings.datasource_freshness_warn_minutes is not None
+            else profile.freshness_warn_minutes
+        ),
         source_label=profile.source_label,
     )
     return {

--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoEvidence
@@ -54,6 +55,7 @@ def _evidence_from_output(
     output: Any,
     *,
     warn_minutes: int,
+    source_label: str,
 ) -> NexoEvidence:
     if hasattr(output, "model_dump"):
         dump = output.model_dump()
@@ -91,7 +93,7 @@ def _evidence_from_output(
     return NexoEvidence(
         step_id=step_id,
         tool=tool,
-        source=str(dump.get("source", "Coordinador · nexo (Citus DB)")),
+        source=str(dump.get("source", source_label)),
         refreshed_at=refreshed_at if isinstance(refreshed_at, datetime) else None,
         output=dump,
         sample_size=sample_size,
@@ -105,6 +107,7 @@ async def data_fetcher_node(
     registry: ToolRegistry,
     settings: HarnessSettings,
     progress: Progress,
+    profile: DataSourceProfile,
 ) -> dict[str, Any]:
     plan = state.get("plan")
     pending = int(state.get("pending_step_index", 0))
@@ -140,6 +143,7 @@ async def data_fetcher_node(
         step.tool,
         output,
         warn_minutes=settings.nexo_freshness_warn_minutes,
+        source_label=profile.source_label,
     )
     return {
         "evidence": [evidence],  # appended by NexoState's operator.add reducer

--- a/miot-harness/src/miot_harness/agents/domain_analyst.py
+++ b/miot-harness/src/miot_harness/agents/domain_analyst.py
@@ -42,8 +42,8 @@ def _strip_fences(text: str) -> str:
 
 # {display_name} → profile.display_name; {tenant_display} → the tenant the
 # datasource is locked to (profile.tenant_lock, capitalized); {prefix_label}
-# → profile.tool_prefix + "*". Render byte-identically to the former
-# hardcodes for NEXO_PROFILE ("Coordinador", "Mintral", "coordinador_*").
+# → profile.tool_prefix + "*". All come straight from the active datasource
+# profile.
 _ANALYST_SYSTEM_TEMPLATE = """\
 You are the {display_name} Domain Analyst. Your job is to decide whether the
 collected evidence is enough to answer the user's question.

--- a/miot-harness/src/miot_harness/agents/domain_analyst.py
+++ b/miot-harness/src/miot_harness/agents/domain_analyst.py
@@ -25,7 +25,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from miot_harness.datasource.provider import DataSourceProfile
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ Output ONLY a JSON object:
 """
 
 
-def _render_evidence(evidence: list[NexoEvidence]) -> str:
+def _render_evidence(evidence: list[DataEvidence]) -> str:
     if not evidence:
         return "(no evidence collected yet)"
     lines: list[str] = []
@@ -82,7 +82,7 @@ async def domain_analyst_node(
     model: BaseChatModel,
     profile: DataSourceProfile,
 ) -> dict[str, Any]:
-    evidence: list[NexoEvidence] = list(state.get("evidence", []))
+    evidence: list[DataEvidence] = list(state.get("evidence", []))
     if not evidence:
         # Nothing to analyze — bounce back to filter_expert via supervisor
         return {"next_action": "need_more_tools"}

--- a/miot-harness/src/miot_harness/agents/domain_analyst.py
+++ b/miot-harness/src/miot_harness/agents/domain_analyst.py
@@ -24,7 +24,7 @@ from typing import Any
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.plan import NexoEvidence
 
 logger = logging.getLogger(__name__)
@@ -40,8 +40,12 @@ def _strip_fences(text: str) -> str:
     return text
 
 
+# {display_name} → profile.display_name; {tenant_display} → the tenant the
+# datasource is locked to (profile.tenant_lock, capitalized); {prefix_label}
+# → profile.tool_prefix + "*". Render byte-identically to the former
+# hardcodes for NEXO_PROFILE ("Coordinador", "Mintral", "coordinador_*").
 _ANALYST_SYSTEM_TEMPLATE = """\
-You are the Coordinador Domain Analyst. Your job is to decide whether the
+You are the {display_name} Domain Analyst. Your job is to decide whether the
 collected evidence is enough to answer the user's question.
 
 You DO NOT write the final answer. The synthesizer does that.
@@ -53,8 +57,8 @@ Output ONLY a JSON object:
 {{"verdict": "ready" | "need_more", "reasoning": "..."}}
 
 - "ready" means the evidence is sufficient to answer (or to refuse
-  gracefully if the question is out of scope or non-Mintral).
-- "need_more" means another coordinador_* tool call would help.
+  gracefully if the question is out of scope or non-{tenant_display}).
+- "need_more" means another {prefix_label} tool call would help.
 """
 
 
@@ -76,6 +80,7 @@ async def domain_analyst_node(
     state: dict[str, Any],
     *,
     model: BaseChatModel,
+    profile: DataSourceProfile,
 ) -> dict[str, Any]:
     evidence: list[NexoEvidence] = list(state.get("evidence", []))
     if not evidence:
@@ -83,7 +88,12 @@ async def domain_analyst_node(
         return {"next_action": "need_more_tools"}
 
     user_message = state.get("user_message", "")
-    system = _ANALYST_SYSTEM_TEMPLATE.format(primer=COORDINADOR_PRIMER)
+    system = _ANALYST_SYSTEM_TEMPLATE.format(
+        display_name=profile.display_name,
+        tenant_display=(profile.tenant_lock or profile.display_name).capitalize(),
+        prefix_label=f"{profile.tool_prefix}*",
+        primer=profile.primer,
+    )
     rendered = _render_evidence(evidence)
     human = f"User question:\n{user_message}\n\nEvidence collected so far:\n{rendered}"
 

--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -9,7 +9,7 @@ when the analyst signals "need_more_tools" repeatedly.
 
 One LLM call per turn. Given the user message and a catalog of
 coordinador_* tools (with @meta / Layer hints), emits a single
-NexoStep representing the next tool call. The supervisor then routes
+DataStep representing the next tool call. The supervisor then routes
 to data_fetcher; on return, freshness_judge + domain_analyst decide
 whether to ask for another step.
 
@@ -33,7 +33,7 @@ from pydantic import ValidationError
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoPlan, NexoStep
+from miot_harness.runtime.plan import DataPlan, DataStep
 from miot_harness.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -95,14 +95,14 @@ def build_tool_catalog(registry: ToolRegistry, *, profile: DataSourceProfile) ->
     )
 
 
-def _parse_step(text: str) -> NexoStep | None:
+def _parse_step(text: str) -> DataStep | None:
     cleaned = _strip_fences(text)
     try:
         payload = json.loads(cleaned)
     except json.JSONDecodeError:
         return None
     try:
-        return NexoStep(
+        return DataStep(
             intent=payload.get("intent", ""),
             tool=payload.get("tool", ""),
             args=payload.get("args", {}) or {},
@@ -173,14 +173,14 @@ async def filter_expert_node(
     plan = state.get("plan")
     try:
         if plan is None:
-            new_plan = NexoPlan(steps=[step])
+            new_plan = DataPlan(steps=[step])
         else:
-            new_plan = NexoPlan(
+            new_plan = DataPlan(
                 steps=[*plan.steps, step],
                 final_format=plan.final_format,
             )
     except ValidationError as exc:
-        # NexoPlan caps steps at max_length=4 (review item N13).
+        # DataPlan caps steps at max_length=4 (review item N13).
         logger.warning("filter_expert: plan capped at max steps; routing to synth (%s)", exc)
         return {
             "failure": "plan reached max step cap; synthesizing with current evidence",

--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -100,6 +100,10 @@ def _parse_step(text: str) -> DataStep | None:
         payload = json.loads(cleaned)
     except json.JSONDecodeError:
         return None
+    if not isinstance(payload, dict):
+        # Valid JSON but not an object (e.g. "[]" or "42") — same
+        # malformed-step fallback as undecodable text.
+        return None
     try:
         return DataStep(
             intent=payload.get("intent", ""),

--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -7,8 +7,8 @@ when the analyst signals "need_more_tools" repeatedly.
 
 
 
-One LLM call per turn. Given the user message and a catalog of
-coordinador_* tools (with @meta / Layer hints), emits a single
+One LLM call per turn. Given the user message and a catalog of the
+datasource's tools (with @meta / Layer hints), emits a single
 DataStep representing the next tool call. The supervisor then routes
 to data_fetcher; on return, freshness_judge + domain_analyst decide
 whether to ask for another step.
@@ -54,8 +54,7 @@ def _strip_fences(text: str) -> str:
 # datasource is locked to (profile.tenant_lock, capitalized), {tool_prefix}
 # → profile.tool_prefix, {prefix_label} → the prefix with its trailing
 # underscore turned into a "*" glob the way the prompt names the naming
-# convention. For NEXO_PROFILE these render byte-identically to the former
-# hardcodes ("Coordinador", "Mintral", "coordinador_", "coordinador_*").
+# convention. All come straight from the active datasource profile.
 _FILTER_EXPERT_SYSTEM_TEMPLATE = """\
 You are the Filter Expert for {display_name} ({tenant_display} fleet operations).
 You pick the SINGLE next {prefix_label} tool call to advance the user's
@@ -127,7 +126,7 @@ async def filter_expert_node(
     about that" can be resolved against context (plan 13 §E5 hydration).
     """
     catalog = build_tool_catalog(registry, profile=profile)
-    # "coordinador_" → "coordinador_*" for the naming-convention phrasing.
+    # e.g. "<prefix>_" → "<prefix>_*" for the naming-convention phrasing.
     prefix_label = f"{profile.tool_prefix}*"
     system = _FILTER_EXPERT_SYSTEM_TEMPLATE.format(
         display_name=profile.display_name,

--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -30,6 +30,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from pydantic import ValidationError
 
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoPlan, NexoStep
@@ -49,9 +50,15 @@ def _strip_fences(text: str) -> str:
     return text
 
 
+# {display_name} → profile.display_name, {tenant_display} → the tenant the
+# datasource is locked to (profile.tenant_lock, capitalized), {tool_prefix}
+# → profile.tool_prefix, {prefix_label} → the prefix with its trailing
+# underscore turned into a "*" glob the way the prompt names the naming
+# convention. For NEXO_PROFILE these render byte-identically to the former
+# hardcodes ("Coordinador", "Mintral", "coordinador_", "coordinador_*").
 _FILTER_EXPERT_SYSTEM_TEMPLATE = """\
-You are the Filter Expert for Coordinador (Mintral fleet operations).
-You pick the SINGLE next coordinador_* tool call to advance the user's
+You are the Filter Expert for {display_name} ({tenant_display} fleet operations).
+You pick the SINGLE next {prefix_label} tool call to advance the user's
 question. You DO NOT answer the question yourself.
 
 Routing hints:
@@ -61,7 +68,7 @@ Routing hints:
 - VT tools support shift-handoff narratives.
 
 Output ONLY a JSON object with this exact shape:
-{{"intent": "...", "tool": "coordinador_xxx", "args": {{}}, "rationale": "..."}}
+{{"intent": "...", "tool": "{tool_prefix}xxx", "args": {{}}, "rationale": "..."}}
 - intent: one short phrase describing what you're trying to learn.
 - tool: must be the exact name of one of the tools in the catalog.
 - args: a JSON object of p_* parameter overrides; empty {{}} is fine
@@ -73,15 +80,19 @@ Available tools:
 """
 
 
-def build_tool_catalog(registry: ToolRegistry) -> str:
+def build_tool_catalog(registry: ToolRegistry, *, profile: DataSourceProfile) -> str:
     lines: list[str] = []
     for name in registry.names():
-        if not name.startswith("coordinador_"):
+        if not name.startswith(profile.tool_prefix):
             continue
         tool = registry.get(name)
         first_line = (tool.description or "").splitlines()[0].strip()
         lines.append(f"- {name}: {first_line}")
-    return "\n".join(lines) if lines else "(no coordinador tools registered)"
+    return (
+        "\n".join(lines)
+        if lines
+        else f"(no {profile.display_name.lower()} tools registered)"
+    )
 
 
 def _parse_step(text: str) -> NexoStep | None:
@@ -106,6 +117,7 @@ async def filter_expert_node(
     *,
     registry: ToolRegistry,
     model: BaseChatModel,
+    profile: DataSourceProfile,
 ) -> dict[str, Any]:
     """LangGraph node: returns a state delta dict.
 
@@ -114,8 +126,16 @@ async def filter_expert_node(
     prompt and the current user message so references like "tell me more
     about that" can be resolved against context (plan 13 §E5 hydration).
     """
-    catalog = build_tool_catalog(registry)
-    system = _FILTER_EXPERT_SYSTEM_TEMPLATE.format(catalog=catalog)
+    catalog = build_tool_catalog(registry, profile=profile)
+    # "coordinador_" → "coordinador_*" for the naming-convention phrasing.
+    prefix_label = f"{profile.tool_prefix}*"
+    system = _FILTER_EXPERT_SYSTEM_TEMPLATE.format(
+        display_name=profile.display_name,
+        tenant_display=(profile.tenant_lock or profile.display_name).capitalize(),
+        tool_prefix=profile.tool_prefix,
+        prefix_label=prefix_label,
+        catalog=catalog,
+    )
 
     user_message = state.get("user_message", "")
     prior_messages = state.get("prior_messages") or []
@@ -136,8 +156,8 @@ async def filter_expert_node(
             "next_action": None,
         }
 
-    if not step.tool.startswith("coordinador_"):
-        logger.error("filter_expert: model picked non-Nexo tool %r", step.tool)
+    if not step.tool.startswith(profile.tool_prefix):
+        logger.error("filter_expert: model picked out-of-scope datasource tool %r", step.tool)
         return {
             "failure": f"filter_expert picked out-of-scope tool: {step.tool}",
             "next_action": None,

--- a/miot-harness/src/miot_harness/agents/freshness_judge.py
+++ b/miot-harness/src/miot_harness/agents/freshness_judge.py
@@ -36,12 +36,19 @@ def freshness_judge_node(
     progress: Progress,
     profile: DataSourceProfile,
 ) -> dict[str, Any]:
-    # Thresholds come from the profile now. The env-override layering (where
-    # settings.nexo_freshness_* could differ) arrives in the settings stage;
-    # today the settings defaults (30 / 240) equal the NEXO profile values,
-    # so behavior is identical.
-    warn = profile.freshness_warn_minutes
-    refuse = profile.freshness_refuse_minutes
+    # Effective thresholds: env override wins (including an explicit 0),
+    # else the profile default. This is the single resolution point that
+    # data_fetcher mirrors when it stamps is_stale.
+    warn = (
+        settings.datasource_freshness_warn_minutes
+        if settings.datasource_freshness_warn_minutes is not None
+        else profile.freshness_warn_minutes
+    )
+    refuse = (
+        settings.datasource_freshness_refuse_minutes
+        if settings.datasource_freshness_refuse_minutes is not None
+        else profile.freshness_refuse_minutes
+    )
 
     evidence: list[DataEvidence] = list(state.get("evidence", []))
     if not evidence:

--- a/miot-harness/src/miot_harness/agents/freshness_judge.py
+++ b/miot-harness/src/miot_harness/agents/freshness_judge.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoEvidence
@@ -33,7 +34,15 @@ def freshness_judge_node(
     *,
     settings: HarnessSettings,
     progress: Progress,
+    profile: DataSourceProfile,
 ) -> dict[str, Any]:
+    # Thresholds come from the profile now. The env-override layering (where
+    # settings.nexo_freshness_* could differ) arrives in the settings stage;
+    # today the settings defaults (30 / 240) equal the NEXO profile values,
+    # so behavior is identical.
+    warn = profile.freshness_warn_minutes
+    refuse = profile.freshness_refuse_minutes
+
     evidence: list[NexoEvidence] = list(state.get("evidence", []))
     if not evidence:
         return {"next_action": "analyze", "freshness": FRESHNESS_FRESH}
@@ -47,9 +56,9 @@ def freshness_judge_node(
         verdict = FRESHNESS_WARN
     else:
         age_minutes = (datetime.now(UTC) - last.refreshed_at).total_seconds() / 60
-        if age_minutes <= settings.nexo_freshness_warn_minutes:
+        if age_minutes <= warn:
             verdict = FRESHNESS_FRESH
-        elif age_minutes <= settings.nexo_freshness_refuse_minutes:
+        elif age_minutes <= refuse:
             verdict = FRESHNESS_WARN
         else:
             verdict = FRESHNESS_REFUSE
@@ -83,8 +92,8 @@ def freshness_judge_node(
             "freshness": verdict,
             "next_action": "ready_to_synthesize",
             "failure": (
-                f"Coordinador snapshot is stale (age {age_minutes:.0f}min > "
-                f"refuse threshold {settings.nexo_freshness_refuse_minutes}min)."
+                f"{profile.display_name} snapshot is stale (age {age_minutes:.0f}min > "
+                f"refuse threshold {refuse}min)."
             ),
         }
 

--- a/miot-harness/src/miot_harness/agents/freshness_judge.py
+++ b/miot-harness/src/miot_harness/agents/freshness_judge.py
@@ -21,7 +21,7 @@ from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 from miot_harness.runtime.tool import Progress
 
 FRESHNESS_FRESH = "fresh"
@@ -43,7 +43,7 @@ def freshness_judge_node(
     warn = profile.freshness_warn_minutes
     refuse = profile.freshness_refuse_minutes
 
-    evidence: list[NexoEvidence] = list(state.get("evidence", []))
+    evidence: list[DataEvidence] = list(state.get("evidence", []))
     if not evidence:
         return {"next_action": "analyze", "freshness": FRESHNESS_FRESH}
 
@@ -81,7 +81,7 @@ def freshness_judge_node(
             )
         )
 
-    # NOTE: is_stale is set by data_fetcher when it constructs NexoEvidence
+    # NOTE: is_stale is set by data_fetcher when it constructs DataEvidence
     # (using the same warn_minutes threshold). The judge classifies + emits
     # but does not mutate evidence, because the LangGraph reducer is
     # operator.add — returning an "evidence" key here would APPEND to the

--- a/miot-harness/src/miot_harness/agents/meta_agent.py
+++ b/miot-harness/src/miot_harness/agents/meta_agent.py
@@ -6,7 +6,7 @@ the structural guarantee lives in the function signature (no
 ``registry`` / ``tools`` / ``pool`` parameter; nothing to call).
 
 Cheap path for "what data do you have?", "what does fn_dx_eta_hoy
-return?", "how is es_critico calculated?". Falls through to NEXO_QUERY
+return?", "how is es_critico calculated?". Falls through to DATA_QUERY
 upstream if the intent router confused a data question with a meta one.
 """
 

--- a/miot-harness/src/miot_harness/agents/meta_agent.py
+++ b/miot-harness/src/miot_harness/agents/meta_agent.py
@@ -1,12 +1,12 @@
 """Meta-question agent (Haiku tier).
 
-Answers schema/primer/introspection questions from a cached pg_proc
-catalog + the Coordinador primer text. No SQL, no tool invocation —
+Answers schema/primer/introspection questions from a cached catalog +
+the active datasource's primer text. No SQL, no tool invocation —
 the structural guarantee lives in the function signature (no
 ``registry`` / ``tools`` / ``pool`` parameter; nothing to call).
 
-Cheap path for "what data do you have?", "what does fn_dx_eta_hoy
-return?", "how is es_critico calculated?". Falls through to DATA_QUERY
+Cheap path for "what data do you have?", "what does function X
+return?", "how is metric Y calculated?". Falls through to DATA_QUERY
 upstream if the intent router confused a data question with a meta one.
 """
 
@@ -28,10 +28,10 @@ function does* — never the data itself. You have NO database access
 and NO tools. If the question requires querying data, say so and stop:
 the user can re-ask in agentic or canned mode.
 
-# Coordinador primer
+# Datasource primer
 {primer}
 
-# Curated catalog (each row is one `fn_dx_*` function)
+# Curated catalog (each row is one curated function)
 {catalog}
 
 Be concise. Cite function names by their exact identifier. If the

--- a/miot-harness/src/miot_harness/agents/supervisor.py
+++ b/miot-harness/src/miot_harness/agents/supervisor.py
@@ -1,4 +1,4 @@
-"""Rule-based supervisor for the Nexo conversational graph.
+"""Rule-based supervisor for the datasource conversational graph.
 
 v1 ships without an LLM in this seat — `next_agent(state)` is a small
 state machine that reads from the state set by the previous node and

--- a/miot-harness/src/miot_harness/agents/supervisor.py
+++ b/miot-harness/src/miot_harness/agents/supervisor.py
@@ -5,13 +5,13 @@ state machine that reads from the state set by the previous node and
 returns the next node name. Nodes set `state.next_action` to suggest
 where to go next; the supervisor enforces invariants on top:
 
-  - turn cap (`settings.nexo_max_turns`) → force synthesizer
+  - turn cap (`settings.agents_max_turns`) → force synthesizer
   - failure flag → synthesizer (it renders a graceful refusal)
   - answer set → END
   - long transcript → summarizer (>10 messages)
 
 The intent is to keep cost predictable in v1 while leaving the seat
-open for an LLM-based supervisor (`nexo_supervisor_mode='llm'`) once
+open for an LLM-based supervisor (`agents_supervisor_mode='llm'`) once
 we have observed traffic.
 """
 
@@ -36,7 +36,7 @@ def next_agent(state: dict[str, Any], settings: HarnessSettings) -> str:
         return "synthesizer"
 
     turn_count = int(state.get("turn_count", 0))
-    if turn_count >= settings.nexo_max_turns:
+    if turn_count >= settings.agents_max_turns:
         return "synthesizer"
 
     messages = state.get("messages") or []

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -4,10 +4,10 @@ Produces the final user-facing answer. Three modes:
 
   1. Failure mode: state['failure'] is set → render a graceful
      refusal locally (no LLM call). Cheaper, deterministic.
-  2. Tenant refusal: ctx.tenant_id != 'mintral' AND no evidence →
-     render the canonical "Coordinador is Mintral-only" line.
-     Defense-in-depth; tenant_gate_node should have caught this
-     earlier in the graph.
+  2. Tenant refusal: ctx.tenant_id is off the datasource lock AND no
+     evidence → render the canonical "<datasource> is <tenant>-only" line
+     from the profile template. Defense-in-depth; tenant_gate_node should
+     have caught this earlier in the graph.
   3. Normal: format primer + evidence, ask the model for prose
      that cites refreshed_at and flags stale data.
 
@@ -37,16 +37,15 @@ logger = logging.getLogger(__name__)
 
 def _tenant_refusal(profile: DataSourceProfile, tenant_lock: str) -> str:
     # Render the canonical refusal from the profile template. The lock is
-    # capitalized so it reads "Mintral-only" (matches the former local copy
-    # "Coordinador is Mintral-only."); display_name comes straight from the
-    # profile. Renders byte-identically to the former hardcode for NEXO.
+    # capitalized (e.g. "<Tenant>-only"); display_name comes straight from
+    # the profile.
     label = tenant_lock.capitalize() if tenant_lock else "the locked tenant"
     return profile.tenant_refusal_template.format(
         display_name=profile.display_name, lock=label
     )
 
 
-# {display_name} → profile.display_name; byte-identical to "Coordinador" for NEXO.
+# {display_name} → profile.display_name (the active datasource's human name).
 _SYNTH_SYSTEM_TEMPLATE = """\
 You are the {display_name} synthesizer. Write the final answer for the user
 in the same language as their question. Be concise (≤200 words).
@@ -64,8 +63,7 @@ Rules:
 
 def _snapshot_stale_prefix(profile: DataSourceProfile) -> str:
     # Must match the prefix freshness_judge emits: f"{display_name} snapshot
-    # is stale". For NEXO display_name == "Coordinador" so this renders the
-    # former hardcode "Coordinador snapshot is stale" byte-identically.
+    # is stale" — display_name is the active datasource's human name.
     return f"{profile.display_name} snapshot is stale"
 
 

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -26,7 +26,7 @@ from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from miot_harness.agents.llm_streaming import stream_llm_with_thinking
 from miot_harness.config import HarnessSettings
-from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoEvidence
@@ -35,13 +35,20 @@ from miot_harness.runtime.tool import Progress
 logger = logging.getLogger(__name__)
 
 
-def _tenant_refusal(tenant_lock: str) -> str:
+def _tenant_refusal(profile: DataSourceProfile, tenant_lock: str) -> str:
+    # Render the canonical refusal from the profile template. The lock is
+    # capitalized so it reads "Mintral-only" (matches the former local copy
+    # "Coordinador is Mintral-only."); display_name comes straight from the
+    # profile. Renders byte-identically to the former hardcode for NEXO.
     label = tenant_lock.capitalize() if tenant_lock else "the locked tenant"
-    return f"Coordinador is {label}-only. I can't answer for other tenants."
+    return profile.tenant_refusal_template.format(
+        display_name=profile.display_name, lock=label
+    )
 
 
+# {display_name} → profile.display_name; byte-identical to "Coordinador" for NEXO.
 _SYNTH_SYSTEM_TEMPLATE = """\
-You are the Coordinador synthesizer. Write the final answer for the user
+You are the {display_name} synthesizer. Write the final answer for the user
 in the same language as their question. Be concise (≤200 words).
 
 {primer}
@@ -55,11 +62,17 @@ Rules:
 """
 
 
-_SNAPSHOT_STALE_PREFIX = "Coordinador snapshot is stale"
+def _snapshot_stale_prefix(profile: DataSourceProfile) -> str:
+    # Must match the prefix freshness_judge emits: f"{display_name} snapshot
+    # is stale". For NEXO display_name == "Coordinador" so this renders the
+    # former hardcode "Coordinador snapshot is stale" byte-identically.
+    return f"{profile.display_name} snapshot is stale"
+
+
 _SNAPSHOT_AGE_RE = re.compile(r"\(age\s*(\d+)\s*min")
 
 
-def _render_failure(reason: str) -> str:
+def _render_failure(reason: str, *, snapshot_stale_prefix: str) -> str:
     """Render a graceful refusal for the user (Spanish, user-facing).
 
     The previous copy unconditionally suggested waiting for a fresh
@@ -76,7 +89,7 @@ def _render_failure(reason: str) -> str:
       malformed step") is intentionally hidden — it leaks pipeline
       structure with no user value.
     """
-    if reason.startswith(_SNAPSHOT_STALE_PREFIX):
+    if reason.startswith(snapshot_stale_prefix):
         m = _SNAPSHOT_AGE_RE.search(reason)
         if m:
             age = m.group(1)
@@ -126,6 +139,7 @@ async def synthesizer_node(
     *,
     model: BaseChatModel,
     progress: Progress,
+    profile: DataSourceProfile,
     settings: HarnessSettings | None = None,
 ) -> dict[str, Any]:
     ctx: HarnessContext = state["ctx"]
@@ -134,17 +148,21 @@ async def synthesizer_node(
     tenant_lock = settings.nexo_tenant_lock if settings is not None else "mintral"
 
     if failure:
-        answer = _render_failure(failure)
+        answer = _render_failure(
+            failure, snapshot_stale_prefix=_snapshot_stale_prefix(profile)
+        )
         _emit(progress, ctx.run_id, answer)
         return {"answer": answer}
 
     if ctx.tenant_id != tenant_lock and not evidence:
-        refusal = _tenant_refusal(tenant_lock)
+        refusal = _tenant_refusal(profile, tenant_lock)
         _emit(progress, ctx.run_id, refusal)
         return {"answer": refusal}
 
     user_message = state.get("user_message", "")
-    system = _SYNTH_SYSTEM_TEMPLATE.format(primer=COORDINADOR_PRIMER)
+    system = _SYNTH_SYSTEM_TEMPLATE.format(
+        display_name=profile.display_name, primer=profile.primer
+    )
     rendered = _render_evidence_for_synth(evidence)
     human = f"User question:\n{user_message}\n\nEvidence:\n{rendered}\n\nWrite the answer."
 

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -29,7 +29,7 @@ from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 from miot_harness.runtime.tool import Progress
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ def _render_failure(reason: str, *, snapshot_stale_prefix: str) -> str:
     )
 
 
-def _render_evidence_for_synth(evidence: list[NexoEvidence]) -> str:
+def _render_evidence_for_synth(evidence: list[DataEvidence]) -> str:
     if not evidence:
         return "(sin evidencia)"
     lines: list[str] = []
@@ -144,7 +144,7 @@ async def synthesizer_node(
 ) -> dict[str, Any]:
     ctx: HarnessContext = state["ctx"]
     failure = state.get("failure")
-    evidence: list[NexoEvidence] = list(state.get("evidence", []))
+    evidence: list[DataEvidence] = list(state.get("evidence", []))
     tenant_lock = settings.nexo_tenant_lock if settings is not None else "mintral"
 
     if failure:

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -145,7 +145,10 @@ async def synthesizer_node(
     ctx: HarnessContext = state["ctx"]
     failure = state.get("failure")
     evidence: list[DataEvidence] = list(state.get("evidence", []))
-    tenant_lock = settings.nexo_tenant_lock if settings is not None else "mintral"
+    # Effective lock: env override wins, else the profile's lock.
+    tenant_lock = (
+        settings.datasource_tenant_lock if settings is not None else None
+    ) or profile.tenant_lock
 
     if failure:
         answer = _render_failure(
@@ -154,7 +157,7 @@ async def synthesizer_node(
         _emit(progress, ctx.run_id, answer)
         return {"answer": answer}
 
-    if ctx.tenant_id != tenant_lock and not evidence:
+    if tenant_lock is not None and ctx.tenant_id != tenant_lock and not evidence:
         refusal = _tenant_refusal(profile, tenant_lock)
         _emit(progress, ctx.run_id, refusal)
         return {"answer": refusal}
@@ -175,7 +178,7 @@ async def synthesizer_node(
     messages.extend(prior_messages)
     messages.append(HumanMessage(content=human))
 
-    stream_enabled = bool(settings and settings.nexo_synthesizer_stream)
+    stream_enabled = bool(settings and settings.agents_synthesizer_stream)
     if stream_enabled:
         answer = await stream_llm_with_thinking(
             model=model,

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -232,13 +232,31 @@ def _make_lifespan(
                 # Tools registered fine but the supervisor can't reach
                 # them without the graph — clear the public state so
                 # /health reports the disabled-and-empty truth, not a
-                # tool list that is unreachable. The provider is closed by
-                # the outer `finally` below; we just drop the public
-                # references here.
+                # tool list that is unreachable. Every graph/meta entry
+                # point is cleared (the failure may have struck after
+                # some were already wired — a live agentic_graph behind
+                # a disabled /health would silently keep serving), and
+                # the provider is closed NOW so its pool doesn't stay
+                # allocated for an app that can't use it (close() is
+                # idempotent; the outer `finally` re-close is a no-op).
+                # harness.router (keyword routing) is intentionally
+                # kept: it powers the disabled-path "integration
+                # disabled" answer.
                 app.state.datasource_enabled = False
                 app.state.datasource_registered = []
                 app.state.datasource_snapshot_age_minutes = None
                 harness.data_graph = None
+                harness.agentic_graph = None
+                harness.meta_model = None
+                harness.meta_primer = ""  # meta path gates on meta_model
+                harness.meta_catalog = []
+                harness.llm_router = None
+                try:
+                    await provider.close()
+                except Exception as close_exc:  # noqa: BLE001
+                    logger.warning(
+                        "Datasource: provider close raised %s", close_exc
+                    )
 
         try:
             yield

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -29,10 +29,10 @@ from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
 from miot_harness.observability.otel import configure_tracing, shutdown_tracing
 from miot_harness.runtime.agentic_graph import build_agentic_graph
 from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.factory import build_harness
 from miot_harness.runtime.intent_router import LLMIntentRouter
-from miot_harness.runtime.nexo_graph import build_nexo_graph
 from miot_harness.runtime.router import IntentRouter
 from miot_harness.runtime.run_store import HarnessRunRecord
 from miot_harness.runtime.supervisor import HarnessSupervisor
@@ -55,9 +55,9 @@ def _make_lifespan(
 ) -> Callable[[FastAPI], AbstractAsyncContextManager[None]]:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        app.state.nexo_enabled = False
-        app.state.nexo_registered = []
-        app.state.nexo_snapshot_age_minutes = None
+        app.state.datasource_enabled = False
+        app.state.datasource_registered = []
+        app.state.datasource_snapshot_age_minutes = None
         app.state.datasource_provider = None
         # Streaming state: harness ref for endpoint access (tests inject
         # controlled graphs by mutating this), event bus the SSE handler
@@ -96,7 +96,7 @@ def _make_lifespan(
                 )
 
         # Telemetry: configure_tracing installs the global TracerProvider so
-        # NexoTelemetryCallback's spans (per-agent) and Traceloop's
+        # AgentTelemetryCallback's spans (per-agent) and Traceloop's
         # auto-instrumented child spans (per LLM SDK call) flow to the same
         # collector. No-op when MIOT_HARNESS_OTEL_ENABLED is false.
         tracer_provider = configure_tracing(
@@ -127,9 +127,9 @@ def _make_lifespan(
         app.state.datasource_provider = provider
         harness.profile = provider.profile
         result = await provider.boot(harness.tools, settings)
-        app.state.nexo_enabled = result.enabled
-        app.state.nexo_registered = list(result.registered)
-        app.state.nexo_snapshot_age_minutes = result.snapshot_age_minutes
+        app.state.datasource_enabled = result.enabled
+        app.state.datasource_registered = list(result.registered)
+        app.state.datasource_snapshot_age_minutes = result.snapshot_age_minutes
         if not result.enabled:
             logger.info(
                 "Datasource %s: disabled (%s)", provider.profile.name, result.reason
@@ -154,7 +154,7 @@ def _make_lifespan(
                     "critic": get_chat_model(settings.nexo_critic_model),
                     "summarizer": get_chat_model(settings.nexo_summarizer_model),
                 }
-                harness.nexo_graph = build_nexo_graph(
+                harness.data_graph = build_data_graph(
                     registry=harness.tools,
                     settings=settings,
                     models=models,
@@ -195,6 +195,7 @@ def _make_lifespan(
                     get_chat_model(settings.intent_router_model),
                     confidence_threshold=settings.intent_router_confidence_threshold,
                     keyword_fallback=IntentRouter(data_keywords=provider.profile.router_keywords),
+                    profile=provider.profile,
                 )
                 logger.info(
                     "Nexo: Phase E wired (LLM router=%s, agentic_graph, meta_agent)",
@@ -212,10 +213,10 @@ def _make_lifespan(
                 # tool list that is unreachable. The provider is closed by
                 # the outer `finally` below; we just drop the public
                 # references here.
-                app.state.nexo_enabled = False
-                app.state.nexo_registered = []
-                app.state.nexo_snapshot_age_minutes = None
-                harness.nexo_graph = None
+                app.state.datasource_enabled = False
+                app.state.datasource_registered = []
+                app.state.datasource_snapshot_age_minutes = None
+                harness.data_graph = None
 
         try:
             yield
@@ -400,13 +401,16 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     async def health() -> dict[str, object]:
+        provider = getattr(app.state, "datasource_provider", None)
+        ds_name = provider.profile.name if provider is not None else "nexo"
         return {
             "status": "ok",
             "env": settings.env,
-            "nexo": {
-                "enabled": app.state.nexo_enabled,
-                "tools": list(app.state.nexo_registered),
-                "snapshot_age_minutes": app.state.nexo_snapshot_age_minutes,
+            "datasource": {
+                "name": ds_name,
+                "enabled": app.state.datasource_enabled,
+                "tools": list(app.state.datasource_registered),
+                "snapshot_age_minutes": app.state.datasource_snapshot_age_minutes,
             },
         }
 
@@ -417,19 +421,22 @@ def create_app() -> FastAPI:
         # the lifespan logs critical and continues serving, but the pod
         # should not receive traffic until tools register and the snapshot
         # passes the refuse-gate.
-        nexo_required = settings.nexo_dsn is not None
-        nexo_enabled = bool(app.state.nexo_enabled)
-        ready = (not nexo_required) or nexo_enabled
+        required = settings.nexo_dsn is not None
+        enabled = bool(app.state.datasource_enabled)
+        ready = (not required) or enabled
         if not ready:
             response.status_code = 503
+        provider = getattr(app.state, "datasource_provider", None)
+        ds_name = provider.profile.name if provider is not None else "nexo"
         return {
             "status": "ready" if ready else "not_ready",
             "env": settings.env,
-            "nexo": {
-                "required": nexo_required,
-                "enabled": nexo_enabled,
-                "tools": list(app.state.nexo_registered),
-                "snapshot_age_minutes": app.state.nexo_snapshot_age_minutes,
+            "datasource": {
+                "name": ds_name,
+                "required": required,
+                "enabled": enabled,
+                "tools": list(app.state.datasource_registered),
+                "snapshot_age_minutes": app.state.datasource_snapshot_age_minutes,
             },
         }
 
@@ -441,7 +448,7 @@ def create_app() -> FastAPI:
         auth: Mapping[str, Any] = Depends(require_auth),
     ) -> HarnessRunRecord:
         # Read harness from app.state so tests that inject a controlled
-        # graph (via app.state.harness.nexo_graph = ...) see their patch.
+        # graph (via app.state.harness.data_graph = ...) see their patch.
         # Explicit annotation narrows `app.state` (Any) for mypy.
         harness: HarnessSupervisor = app.state.harness
         request = _resolve_request_identity(http_request, request)

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -24,8 +24,7 @@ from miot_harness.api.identity import (
     verify_signed_identity,
 )
 from miot_harness.config import HarnessSettings, get_settings
-from miot_harness.integrations.nexo.boot import load_nexo_tools
-from miot_harness.integrations.nexo.pool import create_nexo_pool
+from miot_harness.datasource.registry import resolve as resolve_datasource
 from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
 from miot_harness.observability.otel import configure_tracing, shutdown_tracing
 from miot_harness.runtime.agentic_graph import build_agentic_graph
@@ -57,9 +56,9 @@ def _make_lifespan(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.nexo_enabled = False
-        app.state.nexo_pool = None
         app.state.nexo_registered = []
         app.state.nexo_snapshot_age_minutes = None
+        app.state.datasource_provider = None
         # Streaming state: harness ref for endpoint access (tests inject
         # controlled graphs by mutating this), event bus the SSE handler
         # subscribes to, and the in-flight task table the stream uses to
@@ -124,118 +123,103 @@ def _make_lifespan(
             )
         app.state.tracer_provider = tracer_provider
 
-        if settings.nexo_dsn is None:
-            logger.info("Nexo: disabled (MIOT_HARNESS_NEXO_DSN is not set)")
-            try:
-                yield
-            finally:
-                try:
-                    shutdown_tracing(tracer_provider)
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("OTel: shutdown_tracing raised %s", exc)
-            return
-
-        pool = None
-        try:
-            logger.info("Nexo: connecting via MIOT_HARNESS_NEXO_DSN")
-            pool = await create_nexo_pool(settings.nexo_dsn)
-            result = await load_nexo_tools(harness.tools, settings=settings, pool=pool)
-            app.state.nexo_enabled = result.enabled
-            app.state.nexo_registered = list(result.registered)
-            app.state.nexo_snapshot_age_minutes = result.snapshot_age_minutes
-            if result.enabled:
-                app.state.nexo_pool = pool
-                logger.info("Nexo: %d tools registered", len(result.registered))
-                # Build the conversational graph and inject into the
-                # supervisor. Per-agent models come from settings.
-                try:
-                    synth_thinking_budget = (
-                        settings.nexo_synthesizer_thinking_budget
-                        if settings.nexo_synthesizer_stream
-                        else None
-                    )
-                    models = {
-                        "filter_expert": get_chat_model(settings.nexo_filter_expert_model),
-                        "domain_analyst": get_chat_model(settings.nexo_analyst_model),
-                        "synthesizer": get_chat_model(
-                            settings.nexo_synthesizer_model,
-                            thinking_budget_tokens=synth_thinking_budget,
-                        ),
-                        "critic": get_chat_model(settings.nexo_critic_model),
-                        "summarizer": get_chat_model(settings.nexo_summarizer_model),
-                    }
-                    harness.nexo_graph = build_nexo_graph(
-                        registry=harness.tools, settings=settings, models=models
-                    )
-
-                    # Phase E wiring: tenant_lock + agentic_graph + meta
-                    # agent + LLM intent router. All optional on the
-                    # supervisor — falling back to keyword routing if any
-                    # of these aren't injected.
-                    harness.tenant_lock = settings.nexo_tenant_lock
-                    harness.agentic_graph = build_agentic_graph(
-                        settings=settings,
-                        models={
-                            **models,
-                            # Agentic graph uses the analyst model as its
-                            # planner; same model pool, same callbacks.
-                            "planner": get_chat_model(settings.nexo_analyst_model),
-                        },
-                        provenance_log=None,  # wired in F-phase when executor lands
-                    )
-                    harness.meta_model = get_chat_model(
-                        settings.intent_router_model,
-                        thinking_budget_tokens=synth_thinking_budget,
-                    )
-                    harness.meta_primer = COORDINADOR_PRIMER
-                    harness.meta_catalog = [
-                        MetaAgentCatalogEntry(
-                            name=name,
-                            layer="L*",
-                            title=name,
-                            body=f"Auto-registered curated function `{name}`.",
-                        )
-                        for name in result.registered
-                    ]
-                    harness.llm_router = LLMIntentRouter(
-                        get_chat_model(settings.intent_router_model),
-                        confidence_threshold=settings.intent_router_confidence_threshold,
-                        keyword_fallback=IntentRouter(),
-                    )
-                    logger.info(
-                        "Nexo: Phase E wired (LLM router=%s, agentic_graph, meta_agent)",
-                        settings.intent_router_model,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    logger.critical(
-                        "Nexo: failed to build chat models / graph (%s); "
-                        "falling back to Nexo disabled",
-                        exc,
-                    )
-                    # Tools registered fine but the supervisor can't reach
-                    # them without the graph — clear the public state so
-                    # /health reports the disabled-and-empty truth, not a
-                    # tool list that is unreachable. The pool is closed by
-                    # the outer `finally` below; we just drop the public
-                    # reference here.
-                    app.state.nexo_enabled = False
-                    app.state.nexo_pool = None
-                    app.state.nexo_registered = []
-                    app.state.nexo_snapshot_age_minutes = None
-                    harness.nexo_graph = None
-        except Exception as exc:  # noqa: BLE001 — boot must not die
-            logger.critical(
-                "Nexo: lifespan boot failed (%s); harness continues with Nexo disabled", exc
+        provider = resolve_datasource("nexo")  # TODO(stage-4): settings.datasource_kind
+        app.state.datasource_provider = provider
+        result = await provider.boot(harness.tools, settings)
+        app.state.nexo_enabled = result.enabled
+        app.state.nexo_registered = list(result.registered)
+        app.state.nexo_snapshot_age_minutes = result.snapshot_age_minutes
+        if not result.enabled:
+            logger.info(
+                "Datasource %s: disabled (%s)", provider.profile.name, result.reason
             )
+        else:
+            logger.info("Nexo: %d tools registered", len(result.registered))
+            # Build the conversational graph and inject into the
+            # supervisor. Per-agent models come from settings.
+            try:
+                synth_thinking_budget = (
+                    settings.nexo_synthesizer_thinking_budget
+                    if settings.nexo_synthesizer_stream
+                    else None
+                )
+                models = {
+                    "filter_expert": get_chat_model(settings.nexo_filter_expert_model),
+                    "domain_analyst": get_chat_model(settings.nexo_analyst_model),
+                    "synthesizer": get_chat_model(
+                        settings.nexo_synthesizer_model,
+                        thinking_budget_tokens=synth_thinking_budget,
+                    ),
+                    "critic": get_chat_model(settings.nexo_critic_model),
+                    "summarizer": get_chat_model(settings.nexo_summarizer_model),
+                }
+                harness.nexo_graph = build_nexo_graph(
+                    registry=harness.tools, settings=settings, models=models
+                )
+
+                # Phase E wiring: tenant_lock + agentic_graph + meta
+                # agent + LLM intent router. All optional on the
+                # supervisor — falling back to keyword routing if any
+                # of these aren't injected.
+                harness.tenant_lock = settings.nexo_tenant_lock
+                harness.agentic_graph = build_agentic_graph(
+                    settings=settings,
+                    models={
+                        **models,
+                        # Agentic graph uses the analyst model as its
+                        # planner; same model pool, same callbacks.
+                        "planner": get_chat_model(settings.nexo_analyst_model),
+                    },
+                    provenance_log=None,  # wired in F-phase when executor lands
+                )
+                harness.meta_model = get_chat_model(
+                    settings.intent_router_model,
+                    thinking_budget_tokens=synth_thinking_budget,
+                )
+                harness.meta_primer = COORDINADOR_PRIMER
+                harness.meta_catalog = [
+                    MetaAgentCatalogEntry(
+                        name=name,
+                        layer="L*",
+                        title=name,
+                        body=f"Auto-registered curated function `{name}`.",
+                    )
+                    for name in result.registered
+                ]
+                harness.llm_router = LLMIntentRouter(
+                    get_chat_model(settings.intent_router_model),
+                    confidence_threshold=settings.intent_router_confidence_threshold,
+                    keyword_fallback=IntentRouter(),
+                )
+                logger.info(
+                    "Nexo: Phase E wired (LLM router=%s, agentic_graph, meta_agent)",
+                    settings.intent_router_model,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.critical(
+                    "Nexo: failed to build chat models / graph (%s); "
+                    "falling back to Nexo disabled",
+                    exc,
+                )
+                # Tools registered fine but the supervisor can't reach
+                # them without the graph — clear the public state so
+                # /health reports the disabled-and-empty truth, not a
+                # tool list that is unreachable. The provider is closed by
+                # the outer `finally` below; we just drop the public
+                # references here.
+                app.state.nexo_enabled = False
+                app.state.nexo_registered = []
+                app.state.nexo_snapshot_age_minutes = None
+                harness.nexo_graph = None
 
         try:
             yield
         finally:
-            if pool is not None:
+            if provider is not None:
                 try:
-                    await pool.close()
+                    await provider.close()
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("Nexo: pool close raised %s", exc)
+                    logger.warning("Nexo: provider close raised %s", exc)
             try:
                 shutdown_tracing(tracer_provider)
             except Exception as exc:  # noqa: BLE001

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -125,6 +125,7 @@ def _make_lifespan(
 
         provider = resolve_datasource("nexo")  # TODO(stage-4): settings.datasource_kind
         app.state.datasource_provider = provider
+        harness.profile = provider.profile
         result = await provider.boot(harness.tools, settings)
         app.state.nexo_enabled = result.enabled
         app.state.nexo_registered = list(result.registered)
@@ -154,7 +155,10 @@ def _make_lifespan(
                     "summarizer": get_chat_model(settings.nexo_summarizer_model),
                 }
                 harness.nexo_graph = build_nexo_graph(
-                    registry=harness.tools, settings=settings, models=models
+                    registry=harness.tools,
+                    settings=settings,
+                    models=models,
+                    profile=provider.profile,
                 )
 
                 # Phase E wiring: tenant_lock + agentic_graph + meta
@@ -171,6 +175,7 @@ def _make_lifespan(
                         "planner": get_chat_model(settings.nexo_analyst_model),
                     },
                     provenance_log=None,  # wired in F-phase when executor lands
+                    profile=provider.profile,
                 )
                 harness.meta_model = get_chat_model(
                     settings.intent_router_model,
@@ -189,7 +194,7 @@ def _make_lifespan(
                 harness.llm_router = LLMIntentRouter(
                     get_chat_model(settings.intent_router_model),
                     confidence_threshold=settings.intent_router_confidence_threshold,
-                    keyword_fallback=IntentRouter(),
+                    keyword_fallback=IntentRouter(data_keywords=provider.profile.router_keywords),
                 )
                 logger.info(
                     "Nexo: Phase E wired (LLM router=%s, agentic_graph, meta_agent)",

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -25,7 +25,6 @@ from miot_harness.api.identity import (
 )
 from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.datasource.registry import resolve as resolve_datasource
-from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
 from miot_harness.observability.otel import configure_tracing, shutdown_tracing
 from miot_harness.runtime.agentic_graph import build_agentic_graph
 from miot_harness.runtime.context import UserRequest
@@ -112,8 +111,8 @@ def _make_lifespan(
                 disable_batch=False,
                 telemetry_enabled=False,  # do not phone home; we self-host
             )
-            # HTTP request spans parent the per-run `nexo.run` span so the
-            # full request → graph → LLM tree shows up in Langfuse.
+            # HTTP request spans parent the per-run `<datasource>.run` span so
+            # the full request → graph → LLM tree shows up in Langfuse.
             FastAPIInstrumentor.instrument_app(app, tracer_provider=tracer_provider)
             logger.info(
                 "OTel: tracing enabled (service=%s, env=%s, endpoint=%s)",
@@ -126,6 +125,21 @@ def _make_lifespan(
         provider = resolve_datasource(settings.datasource_kind)
         app.state.datasource_provider = provider
         harness.profile = provider.profile
+        # The base keyword router ships with no vocabulary; the profile
+        # supplies it. Wired BEFORE boot so that a disabled datasource
+        # still routes its keywords to the data path (where the
+        # "integration disabled" answer lives) instead of DIRECT/OTHER.
+        harness.router = IntentRouter(
+            data_keywords=provider.profile.router_keywords
+        )
+        # Tenant lock likewise resolves regardless of boot outcome so
+        # mode gating (mode_resolver) keeps refusing off-lock tenants
+        # even while the datasource is disabled.
+        resolved_lock = (
+            settings.datasource_tenant_lock or provider.profile.tenant_lock
+        )
+        if resolved_lock is not None:
+            harness.tenant_lock = resolved_lock
         result = await provider.boot(harness.tools, settings)
         app.state.datasource_enabled = result.enabled
         app.state.datasource_registered = list(result.registered)
@@ -135,7 +149,11 @@ def _make_lifespan(
                 "Datasource %s: disabled (%s)", provider.profile.name, result.reason
             )
         else:
-            logger.info("Nexo: %d tools registered", len(result.registered))
+            logger.info(
+                "Datasource %s: %d tools registered",
+                provider.profile.name,
+                len(result.registered),
+            )
             # Build the conversational graph and inject into the
             # supervisor. Per-agent models come from settings.
             try:
@@ -161,15 +179,12 @@ def _make_lifespan(
                     profile=provider.profile,
                 )
 
-                # Phase E wiring: tenant_lock + agentic_graph + meta
-                # agent + LLM intent router. All optional on the
-                # supervisor — falling back to keyword routing if any
-                # of these aren't injected.
-                resolved_lock = (
-                    settings.datasource_tenant_lock or provider.profile.tenant_lock
-                )
-                if resolved_lock is not None:
-                    harness.tenant_lock = resolved_lock
+                # Phase E wiring: agentic_graph + meta agent + LLM
+                # intent router. All optional on the supervisor —
+                # falling back to keyword routing if any of these
+                # aren't injected. (tenant_lock + keyword router are
+                # wired above, before boot, so the disabled path keeps
+                # routing and mode gating intact.)
                 harness.agentic_graph = build_agentic_graph(
                     settings=settings,
                     models={
@@ -185,7 +200,7 @@ def _make_lifespan(
                     settings.intent_router_model,
                     thinking_budget_tokens=synth_thinking_budget,
                 )
-                harness.meta_primer = COORDINADOR_PRIMER
+                harness.meta_primer = provider.profile.primer
                 harness.meta_catalog = [
                     MetaAgentCatalogEntry(
                         name=name,
@@ -202,13 +217,16 @@ def _make_lifespan(
                     profile=provider.profile,
                 )
                 logger.info(
-                    "Nexo: Phase E wired (LLM router=%s, agentic_graph, meta_agent)",
+                    "Datasource %s: Phase E wired "
+                    "(LLM router=%s, agentic_graph, meta_agent)",
+                    provider.profile.name,
                     settings.intent_router_model,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.critical(
-                    "Nexo: failed to build chat models / graph (%s); "
-                    "falling back to Nexo disabled",
+                    "Datasource %s: failed to build chat models / graph (%s); "
+                    "falling back to datasource disabled",
+                    provider.profile.name,
                     exc,
                 )
                 # Tools registered fine but the supervisor can't reach
@@ -229,7 +247,7 @@ def _make_lifespan(
                 try:
                     await provider.close()
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("Nexo: provider close raised %s", exc)
+                    logger.warning("Datasource: provider close raised %s", exc)
             try:
                 shutdown_tracing(tracer_provider)
             except Exception as exc:  # noqa: BLE001
@@ -406,7 +424,9 @@ def create_app() -> FastAPI:
     @app.get("/health")
     async def health() -> dict[str, object]:
         provider = getattr(app.state, "datasource_provider", None)
-        ds_name = provider.profile.name if provider is not None else "nexo"
+        ds_name = (
+            provider.profile.name if provider is not None else settings.datasource_kind
+        )
         return {
             "status": "ok",
             "env": settings.env,
@@ -420,8 +440,8 @@ def create_app() -> FastAPI:
 
     @app.get("/health/ready")
     async def health_ready(response: Response) -> dict[str, object]:
-        # Readiness contract (kubelet readinessProbe target): Nexo is
-        # "required" iff a DSN is configured. When required-but-not-enabled
+        # Readiness contract (kubelet readinessProbe target): the datasource
+        # is "required" iff a DSN is configured. When required-but-not-enabled
         # the lifespan logs critical and continues serving, but the pod
         # should not receive traffic until tools register and the snapshot
         # passes the refuse-gate.
@@ -431,7 +451,9 @@ def create_app() -> FastAPI:
         if not ready:
             response.status_code = 503
         provider = getattr(app.state, "datasource_provider", None)
-        ds_name = provider.profile.name if provider is not None else "nexo"
+        ds_name = (
+            provider.profile.name if provider is not None else settings.datasource_kind
+        )
         return {
             "status": "ready" if ready else "not_ready",
             "env": settings.env,
@@ -647,8 +669,8 @@ def _enforce_debug_allowlist(request: UserRequest, settings: HarnessSettings) ->
     """Refuse debug=true for tenants that aren't on the allow-list.
 
     Debug-flagged runs surface full tool inputs and truncated outputs over
-    the SSE stream. On coordinador-touching routes that exposes real
-    Mintral fleet data, so the gate is secure-by-default: with no
+    the SSE stream. On data-touching routes that exposes real tenant
+    data, so the gate is secure-by-default: with no
     `MIOT_HARNESS_ALLOW_DEBUG_TENANTS` configured, no tenant can opt in.
     """
     if not request.debug:

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -123,7 +123,7 @@ def _make_lifespan(
             )
         app.state.tracer_provider = tracer_provider
 
-        provider = resolve_datasource("nexo")  # TODO(stage-4): settings.datasource_kind
+        provider = resolve_datasource(settings.datasource_kind)
         app.state.datasource_provider = provider
         harness.profile = provider.profile
         result = await provider.boot(harness.tools, settings)
@@ -140,19 +140,19 @@ def _make_lifespan(
             # supervisor. Per-agent models come from settings.
             try:
                 synth_thinking_budget = (
-                    settings.nexo_synthesizer_thinking_budget
-                    if settings.nexo_synthesizer_stream
+                    settings.agents_synthesizer_thinking_budget
+                    if settings.agents_synthesizer_stream
                     else None
                 )
                 models = {
-                    "filter_expert": get_chat_model(settings.nexo_filter_expert_model),
-                    "domain_analyst": get_chat_model(settings.nexo_analyst_model),
+                    "filter_expert": get_chat_model(settings.agents_filter_expert_model),
+                    "domain_analyst": get_chat_model(settings.agents_analyst_model),
                     "synthesizer": get_chat_model(
-                        settings.nexo_synthesizer_model,
+                        settings.agents_synthesizer_model,
                         thinking_budget_tokens=synth_thinking_budget,
                     ),
-                    "critic": get_chat_model(settings.nexo_critic_model),
-                    "summarizer": get_chat_model(settings.nexo_summarizer_model),
+                    "critic": get_chat_model(settings.agents_critic_model),
+                    "summarizer": get_chat_model(settings.agents_summarizer_model),
                 }
                 harness.data_graph = build_data_graph(
                     registry=harness.tools,
@@ -165,14 +165,18 @@ def _make_lifespan(
                 # agent + LLM intent router. All optional on the
                 # supervisor — falling back to keyword routing if any
                 # of these aren't injected.
-                harness.tenant_lock = settings.nexo_tenant_lock
+                resolved_lock = (
+                    settings.datasource_tenant_lock or provider.profile.tenant_lock
+                )
+                if resolved_lock is not None:
+                    harness.tenant_lock = resolved_lock
                 harness.agentic_graph = build_agentic_graph(
                     settings=settings,
                     models={
                         **models,
                         # Agentic graph uses the analyst model as its
                         # planner; same model pool, same callbacks.
-                        "planner": get_chat_model(settings.nexo_analyst_model),
+                        "planner": get_chat_model(settings.agents_analyst_model),
                     },
                     provenance_log=None,  # wired in F-phase when executor lands
                     profile=provider.profile,
@@ -421,7 +425,7 @@ def create_app() -> FastAPI:
         # the lifespan logs critical and continues serving, but the pod
         # should not receive traffic until tools register and the snapshot
         # passes the refuse-gate.
-        required = settings.nexo_dsn is not None
+        required = settings.datasource_dsn is not None
         enabled = bool(app.state.datasource_enabled)
         ready = (not required) or enabled
         if not ready:

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -26,8 +26,9 @@ class HarnessSettings(BaseSettings):
     datasource_kind: str = "nexo"
     # Standard Postgres connection string, e.g.
     # `postgresql://user:password@host:port/database`. This is the sole
-    # source of Nexo DB credentials — when unset, Nexo is disabled at boot
-    # and the harness still serves non-Nexo runs with mocked tools.
+    # source of the datasource's DB credentials — when unset, the datasource
+    # is disabled at boot and the harness still serves non-data runs with
+    # mocked tools.
     datasource_dsn: str | None = None
     # Surfaces in Postgres `pg_stat_activity.application_name` so DBAs
     # can attribute connections to the harness without log correlation.
@@ -108,9 +109,9 @@ class HarnessSettings(BaseSettings):
 
     # Tenants permitted to request `debug=true` runs. Debug runs surface
     # full tool inputs and truncated tool outputs over SSE, which on a
-    # coordinador-touching path means real Mintral fleet data. None / empty
+    # data-touching path means real tenant data. None / empty
     # (default) blocks debug for ALL tenants — debug requests get a 403.
-    # Comma-separated env var: `MIOT_HARNESS_ALLOW_DEBUG_TENANTS=mintral-dev,mintral-stg`.
+    # Comma-separated env var: `MIOT_HARNESS_ALLOW_DEBUG_TENANTS=acme-dev,acme-stg`.
     # Kept as a raw string so pydantic-settings doesn't try to parse it
     # as JSON; `debug_tenant_allowed()` below does the split.
     allow_debug_tenants: str | None = None

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -21,21 +21,26 @@ class HarnessSettings(BaseSettings):
     default_tenant_id: str = "demo-tenant"
     default_user_id: str = "demo-user"
 
-    # Nexo data integration (Coordinador / Mintral)
+    # Datasource connection / domain overrides (provider-agnostic).
+    # Selects the DataSourceProvider from datasource/registry.py.
+    datasource_kind: str = "nexo"
     # Standard Postgres connection string, e.g.
     # `postgresql://user:password@host:port/database`. This is the sole
     # source of Nexo DB credentials — when unset, Nexo is disabled at boot
     # and the harness still serves non-Nexo runs with mocked tools.
-    nexo_dsn: str | None = None
+    datasource_dsn: str | None = None
     # Surfaces in Postgres `pg_stat_activity.application_name` so DBAs
     # can attribute connections to the harness without log correlation.
-    nexo_application_name: str = "miot-harness"
-    nexo_tenant_lock: str = "mintral"
-    nexo_search_path: str = "nexo"
-    nexo_freshness_warn_minutes: int = 30
-    nexo_freshness_refuse_minutes: int = 240
-    nexo_max_turns: int = 8
-    nexo_critic_enabled: bool = False
+    datasource_application_name: str = "miot-harness"
+    # None → profile default (the provider's DataSourceProfile.tenant_lock).
+    datasource_tenant_lock: str | None = None
+    # None → profile default. An explicit 0 is honored ("anything older
+    # than now is stale"); negatives are rejected at boot.
+    datasource_freshness_warn_minutes: int | None = Field(default=None, ge=0)
+    # None → profile default.
+    datasource_freshness_refuse_minutes: int | None = Field(default=None, ge=0)
+    agents_max_turns: int = 8
+    agents_critic_enabled: bool = False
 
     # Phase E (plan 13): LLM intent router. Default model is Haiku tier
     # for cost — the router is invoked on every "auto" request. Below
@@ -47,13 +52,6 @@ class HarnessSettings(BaseSettings):
     # entirely (>1) or disables the keyword fallback (<0). Either way
     # produces silent misrouting, so reject at startup.
     intent_router_confidence_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
-
-    # Composable Nexo primitives (E3). EXPLAIN total cost > this → refuse.
-    # PostgreSQL plan-cost units. Default 10000 is roughly "10s of seq scans
-    # on a million-row table" — generous enough for analyst exploration,
-    # tight enough to refuse an unindexed cross-join. Must be strictly
-    # positive; 0 or negative would refuse every query.
-    nexo_explain_cost_threshold: float = Field(default=10000.0, gt=0.0)
 
     # Phase E5 hydration cap. When a `/runs` request carries
     # `conversation_id`, the supervisor reads prior turns from
@@ -85,28 +83,28 @@ class HarnessSettings(BaseSettings):
     langfuse_host: str = "http://localhost:3000"
 
     # Multi-agent model assignment (per plan 12 §"Cost-control rules")
-    nexo_supervisor_mode: Literal["rule", "llm"] = "rule"
-    nexo_filter_expert_model: str = "claude-haiku-4-5"
-    nexo_analyst_model: str = "claude-sonnet-4-6"
-    nexo_synthesizer_model: str = "claude-sonnet-4-6"
-    nexo_critic_model: str = "claude-sonnet-4-6"
-    nexo_summarizer_model: str = "claude-haiku-4-5"
+    agents_supervisor_mode: Literal["rule", "llm"] = "rule"
+    agents_filter_expert_model: str = "claude-haiku-4-5"
+    agents_analyst_model: str = "claude-sonnet-4-6"
+    agents_synthesizer_model: str = "claude-sonnet-4-6"
+    agents_critic_model: str = "claude-sonnet-4-6"
+    agents_summarizer_model: str = "claude-haiku-4-5"
 
     # Synthesizer streaming (plan: SSE rich events). When enabled, the
     # synthesizer's LLM call runs as a streaming `astream_events` loop
     # and emits `thinking.delta` / `thinking.completed` SSE events so
     # CLI clients see Claude's reasoning unfold in real time. Set to
-    # False (or `MIOT_HARNESS_NEXO_SYNTHESIZER_STREAM=0` at runtime)
+    # False (or `MIOT_HARNESS_AGENTS_SYNTHESIZER_STREAM=0` at runtime)
     # to fall back to the legacy `.ainvoke()` path with no thinking
     # visibility — the production kill switch.
-    nexo_synthesizer_stream: bool = True
+    agents_synthesizer_stream: bool = True
     # Extended-thinking budget for the synthesizer. 0 disables thinking
     # (the model still streams text). 4096 is a moderate default;
     # increase up to ~16K for harder reasoning, but note the latency
     # cost (8–15s extra at Sonnet 4.6 typical speed). Anthropic
     # constraint: max_tokens must exceed budget_tokens — the chat-model
     # factory bumps max_tokens automatically.
-    nexo_synthesizer_thinking_budget: int = Field(default=4096, ge=0)
+    agents_synthesizer_thinking_budget: int = Field(default=4096, ge=0)
 
     # Tenants permitted to request `debug=true` runs. Debug runs surface
     # full tool inputs and truncated tool outputs over SSE, which on a

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -34,7 +34,12 @@ class HarnessSettings(BaseSettings):
     # can attribute connections to the harness without log correlation.
     datasource_application_name: str = "miot-harness"
     # None → profile default (the provider's DataSourceProfile.tenant_lock).
-    datasource_tenant_lock: str | None = None
+    # `min_length=1` rejects the empty string at boot (same rationale as
+    # `identity_signing_key`): "" is ambiguous — truthiness resolution
+    # would silently fall back to the profile lock, while a strict
+    # is-not-None reading would make it an unmatchable lock refusing
+    # every tenant. Refusing to start beats either silent behavior.
+    datasource_tenant_lock: str | None = Field(default=None, min_length=1)
     # None → profile default. An explicit 0 is honored ("anything older
     # than now is stale"); negatives are rejected at boot.
     datasource_freshness_warn_minutes: int | None = Field(default=None, ge=0)

--- a/miot-harness/src/miot_harness/datasource/provider.py
+++ b/miot-harness/src/miot_harness/datasource/provider.py
@@ -30,14 +30,14 @@ if TYPE_CHECKING:
 class DataSourceProfile:
     """Declarative domain values the core reads instead of hardcoding.
 
-    - name:            machine id ("nexo") — /health block, graph label,
-                       OTel span prefix.
-    - display_name:    human name ("Coordinador") — agent prompt templating.
+    - name:            machine id (lowercase slug) — /health block, graph
+                       label, OTel span prefix.
+    - display_name:    human-facing name — agent prompt templating.
     - source_label:    provenance string shown on SSE tool events and
                        evidence rows.
-    - tool_prefix:     prefix of tools this datasource registers
-                       ("coordinador_") — used by the filter expert to
-                       scope tool selection.
+    - tool_prefix:     prefix of tools this datasource registers (e.g.
+                       "<slug>_") — used by the filter expert to scope tool
+                       selection.
     - primer:          grounding text injected into analyst / synthesizer /
                        meta-agent system prompts.
     - router_keywords: lowercase literals that route a message to the
@@ -72,7 +72,7 @@ class BootResult:
     registered: tuple[str, ...]
     reason: str | None = None
     # float is intentional: sub-minute precision from timestamp arithmetic
-    # (parity with the legacy NexoBootResult).
+    # (sub-minute precision is required by the freshness SLA checks).
     snapshot_age_minutes: float | None = None
 
 

--- a/miot-harness/src/miot_harness/datasource/provider.py
+++ b/miot-harness/src/miot_harness/datasource/provider.py
@@ -1,0 +1,105 @@
+"""The datasource seam.
+
+The harness core is datasource-agnostic: it orchestrates agents over a
+tool registry, but never names the system the tools come from (a DB, a
+filesystem, a cloud API, an MCP server). Everything domain-specific is
+supplied by a DataSourceProvider:
+
+- lifecycle (`boot` / `close`): connect, discover capabilities,
+  register tools into the shared ToolRegistry;
+- a declarative `DataSourceProfile`: every name, prompt, keyword and
+  threshold the core needs to speak about the datasource without
+  hardcoding it.
+
+Each profile field maps 1:1 to a former hardcode (see
+docs/specs/2026-06-05-harness-datasource-refactor-design.md).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from miot_harness.config import HarnessSettings
+    from miot_harness.tools.registry import ToolRegistry
+
+
+@dataclass(frozen=True)
+class DataSourceProfile:
+    """Declarative domain values the core reads instead of hardcoding.
+
+    - name:            machine id ("nexo") — /health block, graph label,
+                       OTel span prefix.
+    - display_name:    human name ("Coordinador") — agent prompt templating.
+    - source_label:    provenance string shown on SSE tool events and
+                       evidence rows.
+    - tool_prefix:     prefix of tools this datasource registers
+                       ("coordinador_") — used by the filter expert to
+                       scope tool selection.
+    - primer:          grounding text injected into analyst / synthesizer /
+                       meta-agent system prompts.
+    - router_keywords: lowercase literals that route a message to the
+                       data pipeline (keyword router).
+    - tenant_lock:     default tenant the datasource is locked to, or
+                       None for no lock. Env-overridable via
+                       `datasource_tenant_lock`.
+    - tenant_refusal_template: str.format template with {display_name}
+                       and {lock} placeholders — the exact user-visible
+                       refusal copy.
+    - freshness_warn_minutes / freshness_refuse_minutes: snapshot-age
+                       SLA defaults. Env-overridable.
+    """
+
+    name: str
+    display_name: str
+    source_label: str
+    tool_prefix: str
+    primer: str
+    router_keywords: frozenset[str]
+    tenant_lock: str | None
+    tenant_refusal_template: str
+    freshness_warn_minutes: int
+    freshness_refuse_minutes: int
+
+
+@dataclass(frozen=True)
+class BootResult:
+    """Outcome of DataSourceProvider.boot — same shape for every provider."""
+
+    enabled: bool
+    registered: tuple[str, ...]
+    reason: str | None = None
+    # float is intentional: sub-minute precision from timestamp arithmetic
+    # (parity with the legacy NexoBootResult).
+    snapshot_age_minutes: float | None = None
+
+
+class DataSourceProvider(ABC):
+    """Lifecycle owner for one datasource.
+
+    Implementations own their connection handles (pool, client, MCP
+    session); the harness only calls boot() once from the lifespan and
+    close() on shutdown. boot() must not raise for operational failures
+    — return BootResult(enabled=False, reason=...) so the harness keeps
+    serving non-data routes.
+    """
+
+    @property
+    @abstractmethod
+    def profile(self) -> DataSourceProfile:
+        """Return the datasource profile for this provider.
+
+        Subclasses may satisfy this with a plain class attribute
+        (``profile = MY_PROFILE``) — Python honours it as the property value.
+        """
+        ...
+
+    @abstractmethod
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult: ...
+
+    @abstractmethod
+    async def close(self) -> None: ...

--- a/miot-harness/src/miot_harness/datasource/registry.py
+++ b/miot-harness/src/miot_harness/datasource/registry.py
@@ -1,0 +1,47 @@
+"""Named datasource registry.
+
+`MIOT_HARNESS_DATASOURCE_KIND` selects the provider at boot. This
+registry is the future plugin hook: entry-point-discovered or
+MCP-backed providers register here the same way the in-repo one does.
+
+Imports are deferred into the factory functions so importing the
+registry never drags in provider dependencies (asyncpg etc.).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from miot_harness.datasource.provider import DataSourceProvider
+
+
+def _make_nexo() -> DataSourceProvider:
+    from miot_harness.integrations.nexo.provider import NexoProvider
+
+    return NexoProvider()
+
+
+_REGISTRY: dict[str, Callable[[], DataSourceProvider]] = {
+    "nexo": _make_nexo,
+}
+
+
+def available_kinds() -> tuple[str, ...]:
+    return tuple(sorted(_REGISTRY))
+
+
+def resolve(kind: str) -> DataSourceProvider:
+    """Instantiate the provider for `kind`.
+
+    Raises ValueError listing available kinds — called from the
+    lifespan so a typo in MIOT_HARNESS_DATASOURCE_KIND fails the boot,
+    not the first request (same fail-fast pattern as
+    validate_auth_config).
+    """
+    factory = _REGISTRY.get(kind)
+    if factory is None:
+        raise ValueError(
+            f"Unknown datasource kind {kind!r}. Available: "
+            + ", ".join(available_kinds())
+        )
+    return factory()

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -46,12 +46,8 @@ from langchain_core.language_models import FakeListChatModel
 from pydantic import BaseModel
 
 from miot_harness.config import HarnessSettings, get_settings
-
-# NOTE: the golden dataset under evals/golden/nexo IS the nexo provider's own
-# dataset, so importing the provider-under-test (NEXO_PROFILE) here is correct:
-# the eval fixture and the profile it asserts against must come from the same
-# source. This is the single deliberate provider import in the eval runner.
-from miot_harness.integrations.nexo.provider import NEXO_PROFILE
+from miot_harness.datasource.provider import DataSourceProfile
+from miot_harness.datasource.registry import resolve as resolve_datasource
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.permissions import PermissionResult
@@ -60,11 +56,21 @@ from miot_harness.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-# The always-registered fallback tool for refusal cases (empty
-# expected_tools): the centro_control coordinator under the profile's
-# tool prefix. Sourced from NEXO_PROFILE because the golden dataset is
-# the nexo provider's own.
-DEFAULT_FALLBACK_TOOL = NEXO_PROFILE.tool_prefix + "centro_control"
+def _active_profile() -> DataSourceProfile:
+    """Profile of the datasource under test, per MIOT_HARNESS_DATASOURCE_KIND.
+
+    The golden dataset, the fake stubs, and the refusal scoring must all
+    derive from the SAME provider — resolving it here keeps the runner
+    datasource-agnostic (registry resolution instantiates the provider
+    without connecting to anything).
+    """
+    return resolve_datasource(get_settings().datasource_kind).profile
+
+
+def default_fallback_tool(profile: DataSourceProfile) -> str:
+    """The always-registered fallback tool for refusal cases (empty
+    expected_tools): centro_control under the profile's tool prefix."""
+    return profile.tool_prefix + "centro_control"
 
 
 _REQUIRED_FIELDS = (
@@ -119,7 +125,9 @@ def validate_entries(entries: list[dict[str, Any]]) -> list[str]:
     return errors
 
 
-def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
+def _build_fake_registry(
+    entry: dict[str, Any], profile: DataSourceProfile
+) -> ToolRegistry:
     """Build a stub registry with one tool per entry's expected_tools."""
 
     class _In(BaseModel):
@@ -128,11 +136,11 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
     class _Out(BaseModel):
         rows: list[dict[str, Any]] = []
         refreshed_at: datetime | None = None
-        source: str = NEXO_PROFILE.source_label
+        source: str = profile.source_label
 
     async def _check(ctx: HarnessContext, inp: BaseModel) -> PermissionResult:
-        if ctx.tenant_id != NEXO_PROFILE.tenant_lock:
-            return PermissionResult.deny(f"{NEXO_PROFILE.tenant_lock}-only")
+        if ctx.tenant_id != profile.tenant_lock:
+            return PermissionResult.deny(f"{profile.tenant_lock}-only")
         return PermissionResult.allow()
 
     refreshed = datetime.now(UTC)
@@ -161,13 +169,14 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
         registry.register(_stub(tool_name))
     # Always register the fallback tool so empty expected_tools (refusal
     # cases) still resolve.
-    if DEFAULT_FALLBACK_TOOL not in registry.names():
-        registry.register(_stub(DEFAULT_FALLBACK_TOOL))
+    fallback = default_fallback_tool(profile)
+    if fallback not in registry.names():
+        registry.register(_stub(fallback))
     return registry
 
 
-def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
-    expected = entry.get("expected_tools") or [DEFAULT_FALLBACK_TOOL]
+def _fake_models(entry: dict[str, Any], profile: DataSourceProfile) -> dict[str, Any]:
+    expected = entry.get("expected_tools") or [default_fallback_tool(profile)]
     chosen = expected[0]
     return {
         "filter_expert": FakeListChatModel(
@@ -202,12 +211,13 @@ def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
 
 async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     settings = HarnessSettings()
-    registry = _build_fake_registry(entry)
+    profile = _active_profile()
+    registry = _build_fake_registry(entry, profile)
     graph = build_data_graph(
         registry=registry,
         settings=settings,
-        models=_fake_models(entry),
-        profile=NEXO_PROFILE,
+        models=_fake_models(entry, profile),
+        profile=profile,
     )
     ctx = HarnessContext(thread_id="t", tenant_id=entry["tenant_id"], user_id="u")
 
@@ -220,10 +230,16 @@ async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     t0 = time.perf_counter()
     final = await graph.ainvoke(initial)
     latency_ms = (time.perf_counter() - t0) * 1000
-    return _score(entry, final, latency_ms)
+    return _score(entry, final, latency_ms, profile=profile)
 
 
-def _score(entry: dict[str, Any], final: dict[str, Any], latency_ms: float) -> EvalScore:
+def _score(
+    entry: dict[str, Any],
+    final: dict[str, Any],
+    latency_ms: float,
+    *,
+    profile: DataSourceProfile,
+) -> EvalScore:
     """Deterministic scoring shared by fake and real modes — identical rules
     applied to the same final-state shape."""
     plan = final.get("plan")
@@ -237,7 +253,7 @@ def _score(entry: dict[str, Any], final: dict[str, Any], latency_ms: float) -> E
     # responder" is the synthesizer's literal copy, not a domain name, so it
     # stays hardcoded.
     answer_is_refusal = (
-        f"{NEXO_PROFILE.tenant_lock}-only" in answer or "no puedo responder" in answer
+        f"{profile.tenant_lock}-only" in answer or "no puedo responder" in answer
     )
 
     if not refusal_expected:
@@ -316,7 +332,6 @@ async def _build_real_setup(
     if not settings.anthropic_api_key:
         raise RuntimeError("real mode requires ANTHROPIC_API_KEY")
 
-    from miot_harness.datasource.registry import resolve as resolve_datasource
     from miot_harness.tools.registry import build_default_registry
 
     registry = build_default_registry()
@@ -351,7 +366,7 @@ async def _run_one_real(
     t0 = time.perf_counter()
     final = await graph.ainvoke(initial)
     latency_ms = (time.perf_counter() - t0) * 1000
-    return _score(entry, final, latency_ms)
+    return _score(entry, final, latency_ms, profile=provider.profile)
 
 
 def _commit_sha() -> str:

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -48,7 +48,7 @@ from pydantic import BaseModel
 from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.permissions import PermissionResult
 from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
@@ -200,7 +200,7 @@ def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
 async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     settings = HarnessSettings()
     registry = _build_fake_registry(entry)
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry,
         settings=settings,
         models=_fake_models(entry),

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -46,6 +46,7 @@ from langchain_core.language_models import FakeListChatModel
 from pydantic import BaseModel
 
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.nexo_graph import build_nexo_graph
 from miot_harness.runtime.permissions import PermissionResult
@@ -199,7 +200,12 @@ def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
 async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     settings = HarnessSettings()
     registry = _build_fake_registry(entry)
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_fake_models(entry))
+    graph = build_nexo_graph(
+        registry=registry,
+        settings=settings,
+        models=_fake_models(entry),
+        profile=NEXO_PROFILE,
+    )
     ctx = HarnessContext(thread_id="t", tenant_id=entry["tenant_id"], user_id="u")
 
     initial: dict[str, Any] = {

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -329,8 +329,20 @@ async def _build_real_setup(
         raise RuntimeError(
             "real mode requires MIOT_HARNESS_DATASOURCE_DSN (datasource credentials)"
         )
-    if not settings.anthropic_api_key:
-        raise RuntimeError("real mode requires ANTHROPIC_API_KEY")
+    # Only required when the configured model mix actually uses Anthropic —
+    # mirrors get_chat_model's "claude-*" provider dispatch.
+    agent_models = (
+        settings.agents_filter_expert_model,
+        settings.agents_analyst_model,
+        settings.agents_synthesizer_model,
+        settings.agents_critic_model,
+        settings.agents_summarizer_model,
+    )
+    if any(m.startswith("claude-") for m in agent_models) and not settings.anthropic_api_key:
+        raise RuntimeError(
+            "real mode requires ANTHROPIC_API_KEY (the configured agent "
+            "models include claude-*)"
+        )
 
     from miot_harness.tools.registry import build_default_registry
 

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -1,13 +1,13 @@
-"""Golden eval runner for the Nexo conversational graph.
+"""Golden eval runner for the datasource conversational graph.
 
-Reads `evals/golden/nexo/examples.yaml`, runs each entry through the
-graph in one of three modes:
+Reads `evals/golden/<datasource_kind>/examples.yaml`, runs each entry
+through the graph in one of three modes:
 
   static — validate YAML schema only (no graph runs, no LLMs).
   fake   — use FakeListChatModel scripted to emit each entry's first
            expected_tool; stub registry returns canned data. Default;
            catches routing / structural regressions deterministically.
-  real   — use real Anthropic + the live Nexo DB. Requires env vars.
+  real   — use real Anthropic + the live datasource. Requires env vars.
 
 For each entry, scores deterministic axes:
   - tool_selection      did the chosen tool intersect expected_tools?
@@ -45,7 +45,12 @@ import yaml
 from langchain_core.language_models import FakeListChatModel
 from pydantic import BaseModel
 
-from miot_harness.config import HarnessSettings
+from miot_harness.config import HarnessSettings, get_settings
+
+# NOTE: the golden dataset under evals/golden/nexo IS the nexo provider's own
+# dataset, so importing the provider-under-test (NEXO_PROFILE) here is correct:
+# the eval fixture and the profile it asserts against must come from the same
+# source. This is the single deliberate provider import in the eval runner.
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.data_graph import build_data_graph
@@ -54,6 +59,12 @@ from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+# The always-registered fallback tool for refusal cases (empty
+# expected_tools): the centro_control coordinator under the profile's
+# tool prefix. Sourced from NEXO_PROFILE because the golden dataset is
+# the nexo provider's own.
+DEFAULT_FALLBACK_TOOL = NEXO_PROFILE.tool_prefix + "centro_control"
 
 
 _REQUIRED_FIELDS = (
@@ -117,11 +128,11 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
     class _Out(BaseModel):
         rows: list[dict[str, Any]] = []
         refreshed_at: datetime | None = None
-        source: str = "Coordinador · nexo (Citus DB)"
+        source: str = NEXO_PROFILE.source_label
 
     async def _check(ctx: HarnessContext, inp: BaseModel) -> PermissionResult:
-        if ctx.tenant_id != "mintral":
-            return PermissionResult.deny("Mintral-only")
+        if ctx.tenant_id != NEXO_PROFILE.tenant_lock:
+            return PermissionResult.deny(f"{NEXO_PROFILE.tenant_lock}-only")
         return PermissionResult.allow()
 
     refreshed = datetime.now(UTC)
@@ -132,39 +143,31 @@ def _build_fake_registry(entry: dict[str, Any]) -> ToolRegistry:
             refreshed_at=refreshed,
         )
 
+    def _stub(tool_name: str) -> HarnessTool[_In, _Out]:
+        return HarnessTool(
+            name=tool_name,
+            description="[Layer L1] eval-stub",
+            input_model=_In,
+            output_model=_Out,
+            check_permission=_check,
+            call=_call,
+        )
+
     registry = ToolRegistry()
     expected = entry.get("expected_tools") or []
+    # Build a stub for EVERY expected tool name verbatim — no prefix filter,
+    # so the registry mirrors whatever the dataset asks for.
     for tool_name in expected:
-        if not tool_name.startswith("coordinador_"):
-            continue
-        registry.register(
-            HarnessTool(
-                name=tool_name,
-                description="[Layer L1] eval-stub",
-                input_model=_In,
-                output_model=_Out,
-                check_permission=_check,
-                call=_call,
-            )
-        )
-    # Always register a centro_control fallback so empty expected_tools (refusal cases)
-    # still resolve.
-    if "coordinador_centro_control" not in registry.names() and not expected:
-        registry.register(
-            HarnessTool(
-                name="coordinador_centro_control",
-                description="[Layer L1] eval-stub",
-                input_model=_In,
-                output_model=_Out,
-                check_permission=_check,
-                call=_call,
-            )
-        )
+        registry.register(_stub(tool_name))
+    # Always register the fallback tool so empty expected_tools (refusal
+    # cases) still resolve.
+    if DEFAULT_FALLBACK_TOOL not in registry.names():
+        registry.register(_stub(DEFAULT_FALLBACK_TOOL))
     return registry
 
 
 def _fake_models(entry: dict[str, Any]) -> dict[str, Any]:
-    expected = entry.get("expected_tools") or ["coordinador_centro_control"]
+    expected = entry.get("expected_tools") or [DEFAULT_FALLBACK_TOOL]
     chosen = expected[0]
     return {
         "filter_expert": FakeListChatModel(
@@ -217,8 +220,12 @@ async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     t0 = time.perf_counter()
     final = await graph.ainvoke(initial)
     latency_ms = (time.perf_counter() - t0) * 1000
+    return _score(entry, final, latency_ms)
 
-    # Score
+
+def _score(entry: dict[str, Any], final: dict[str, Any], latency_ms: float) -> EvalScore:
+    """Deterministic scoring shared by fake and real modes — identical rules
+    applied to the same final-state shape."""
     plan = final.get("plan")
     plan_tools = [s.tool for s in plan.steps] if plan is not None else []
     answer = (final.get("answer") or "").lower()
@@ -226,7 +233,12 @@ async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     forbidden = set(entry.get("forbidden_tools") or [])
 
     refusal_expected = bool(entry.get("expected_refusal"))
-    answer_is_refusal = "mintral-only" in answer or "no puedo responder" in answer
+    # "<lock>-only" is the tenant-gate refusal (profile-derived); "no puedo
+    # responder" is the synthesizer's literal copy, not a domain name, so it
+    # stays hardcoded.
+    answer_is_refusal = (
+        f"{NEXO_PROFILE.tenant_lock}-only" in answer or "no puedo responder" in answer
+    )
 
     if not refusal_expected:
         refusal_score: bool | None = None
@@ -266,6 +278,82 @@ async def _run_one_fake(entry: dict[str, Any]) -> EvalScore:
     )
 
 
+def _real_models(settings: HarnessSettings) -> dict[str, Any]:
+    """Per-agent live chat models for real mode (built once per suite)."""
+    from miot_harness.agents.chat_models import get_chat_model
+
+    synth_budget = (
+        settings.agents_synthesizer_thinking_budget
+        if settings.agents_synthesizer_stream
+        else None
+    )
+    return {
+        "filter_expert": get_chat_model(settings.agents_filter_expert_model),
+        "domain_analyst": get_chat_model(settings.agents_analyst_model),
+        "synthesizer": get_chat_model(
+            settings.agents_synthesizer_model, thinking_budget_tokens=synth_budget
+        ),
+        "critic": get_chat_model(settings.agents_critic_model),
+        "summarizer": get_chat_model(settings.agents_summarizer_model),
+    }
+
+
+async def _build_real_setup(
+    settings: HarnessSettings,
+) -> tuple[ToolRegistry, Any, dict[str, Any]]:
+    """Boot the configured datasource provider and build live models.
+
+    Returns (registry, provider, models). The connection pool is owned by
+    the provider now (not returned directly) — the caller closes it via
+    `await provider.close()`.
+    """
+    # Fail-fast on missing credentials with a clear message rather than
+    # discovering the misconfiguration mid-suite or auth-failing per case.
+    if not settings.datasource_dsn:
+        raise RuntimeError(
+            "real mode requires MIOT_HARNESS_DATASOURCE_DSN (datasource credentials)"
+        )
+    if not settings.anthropic_api_key:
+        raise RuntimeError("real mode requires ANTHROPIC_API_KEY")
+
+    from miot_harness.datasource.registry import resolve as resolve_datasource
+    from miot_harness.tools.registry import build_default_registry
+
+    registry = build_default_registry()
+    provider = resolve_datasource(settings.datasource_kind)
+    boot = await provider.boot(registry, settings)
+    if not boot.enabled:
+        await provider.close()
+        raise RuntimeError(f"Datasource boot failed: {boot.reason}")
+    return registry, provider, _real_models(settings)
+
+
+async def _run_one_real(
+    entry: dict[str, Any],
+    registry: ToolRegistry,
+    provider: Any,
+    models: dict[str, Any],
+    settings: HarnessSettings,
+) -> EvalScore:
+    graph = build_data_graph(
+        registry=registry,
+        settings=settings,
+        models=models,
+        profile=provider.profile,
+    )
+    ctx = HarnessContext(thread_id="t", tenant_id=entry["tenant_id"], user_id="u")
+    initial: dict[str, Any] = {
+        "user_message": entry["question"],
+        "ctx": ctx,
+        "evidence": [],
+        "turn_count": 0,
+    }
+    t0 = time.perf_counter()
+    final = await graph.ainvoke(initial)
+    latency_ms = (time.perf_counter() - t0) * 1000
+    return _score(entry, final, latency_ms)
+
+
 def _commit_sha() -> str:
     try:
         return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
@@ -296,34 +384,51 @@ async def run_golden(
     if mode == "static":
         return {"mode": "static", "valid": True, "errors": [], "scored": []}
 
-    if mode != "fake":
-        raise NotImplementedError(f"mode {mode!r} not yet supported (fake|static only).")
+    if mode not in ("fake", "real"):
+        raise NotImplementedError(f"mode {mode!r} not yet supported (static|fake|real).")
+
+    settings = HarnessSettings()
+
+    def _error_score(entry: dict[str, Any], exc: Exception) -> EvalScore:
+        logger.exception("eval entry %s raised", entry.get("id"))
+        return EvalScore(
+            id=entry.get("id", "?"),
+            category=entry.get("category", ""),
+            tool_selection=False,
+            filter_sanity=False,
+            freshness_citation=False,
+            refusal=False,
+            no_hallucination=False,
+            step_economy=False,
+            latency_ms=None,
+            notes=f"runner_error: {exc}",
+        )
 
     scored: list[EvalScore] = []
-    for entry in entries:
+    if mode == "fake":
+        for entry in entries:
+            try:
+                scored.append(await _run_one_fake(entry))
+            except Exception as exc:  # noqa: BLE001
+                scored.append(_error_score(entry, exc))
+    else:  # real — build the live setup once, then run each entry against it
+        registry, provider, models = await _build_real_setup(settings)
         try:
-            scored.append(await _run_one_fake(entry))
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("eval entry %s raised", entry.get("id"))
-            scored.append(
-                EvalScore(
-                    id=entry.get("id", "?"),
-                    category=entry.get("category", ""),
-                    tool_selection=False,
-                    filter_sanity=False,
-                    freshness_citation=False,
-                    refusal=False,
-                    no_hallucination=False,
-                    step_economy=False,
-                    latency_ms=None,
-                    notes=f"runner_error: {exc}",
-                )
-            )
+            for entry in entries:
+                try:
+                    scored.append(
+                        await _run_one_real(entry, registry, provider, models, settings)
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    scored.append(_error_score(entry, exc))
+        finally:
+            await provider.close()
 
     out_dir.mkdir(parents=True, exist_ok=True)
     sha = _commit_sha()
-    out_path = out_dir / f"{sha}.json"
-    settings = HarnessSettings()
+    # Real-mode results land at `<sha>-real.json` so they don't clobber the
+    # canonical fake-mode baseline at `<sha>.json`.
+    out_path = out_dir / (f"{sha}-real.json" if mode == "real" else f"{sha}.json")
     payload = {
         "mode": mode,
         "valid": True,
@@ -358,8 +463,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="miot-harness-evals", description=__doc__)
     parser.add_argument(
         "--yaml",
-        default="evals/golden/nexo/examples.yaml",
-        help="Path to the golden eval YAML.",
+        default=None,
+        help=(
+            "Path to the golden eval YAML. Defaults to "
+            "evals/golden/<MIOT_HARNESS_DATASOURCE_KIND>/examples.yaml."
+        ),
     )
     parser.add_argument(
         "--out-dir",
@@ -373,17 +481,25 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "static = YAML validation only; "
             "fake = scripted FakeListChatModel run; "
-            "real = live LLM (TODO)."
+            "real = live LLM + datasource."
         ),
     )
     args = parser.parse_args(argv)
 
-    yaml_path = Path(args.yaml)
+    yaml_path = Path(
+        args.yaml or f"evals/golden/{get_settings().datasource_kind}/examples.yaml"
+    )
     if not yaml_path.is_file():
         print(f"Golden YAML not found: {yaml_path}", file=sys.stderr)
         return 2
 
-    payload = asyncio.run(run_golden(yaml_path, Path(args.out_dir), mode=args.mode))
+    try:
+        payload = asyncio.run(run_golden(yaml_path, Path(args.out_dir), mode=args.mode))
+    except RuntimeError as exc:
+        # Real-mode setup refuses (missing credentials / boot failed) — clean
+        # exit 1 with the reason on stderr instead of a traceback.
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 1
     if not payload["valid"]:
         for err in payload["errors"]:
             print(f"INVALID: {err}", file=sys.stderr)
@@ -396,7 +512,8 @@ def main(argv: list[str] | None = None) -> int:
             if not str(s.get("notes", "")).startswith("runner_error")
         )
         total = len(payload["scored"])
-        out_path = Path(args.out_dir) / (payload.get("commit", "baseline") + ".json")
+        suffix = "-real.json" if args.mode == "real" else ".json"
+        out_path = Path(args.out_dir) / (payload.get("commit", "baseline") + suffix)
         print(f"Wrote {out_path}: {ok}/{total} ran cleanly (no runner errors)")
     else:
         print(f"Validated {len(yaml.safe_load(yaml_path.read_text()))} entries")

--- a/miot-harness/src/miot_harness/evals/run_golden.py
+++ b/miot-harness/src/miot_harness/evals/run_golden.py
@@ -336,11 +336,11 @@ async def run_golden(
             "cpu_count": os.cpu_count(),
             "deterministic": mode == "fake",
             "models": {
-                "filter_expert": settings.nexo_filter_expert_model,
-                "analyst": settings.nexo_analyst_model,
-                "synthesizer": settings.nexo_synthesizer_model,
-                "critic": settings.nexo_critic_model,
-                "summarizer": settings.nexo_summarizer_model,
+                "filter_expert": settings.agents_filter_expert_model,
+                "analyst": settings.agents_analyst_model,
+                "synthesizer": settings.agents_synthesizer_model,
+                "critic": settings.agents_critic_model,
+                "summarizer": settings.agents_summarizer_model,
                 "intent_router": settings.intent_router_model,
             },
             "note": (

--- a/miot-harness/src/miot_harness/integrations/nexo/boot.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/boot.py
@@ -5,7 +5,7 @@ Steps:
   1. ACL check — embedded equivalent of `check-harness-role.sql`
      `fn_refresh_direct_leak` MUST be 0; any leak disables Nexo.
   2. Connectivity + freshness — call `nexo.fn_dx_centro_control` and
-     verify `refreshed_at_servicios` is within `nexo_freshness_refuse_minutes`.
+     verify `refreshed_at_servicios` is within the effective refuse threshold.
   3. Introspect — `pg_proc` query → list[FunctionDescriptor].
   4. Build + register — one `coordinador_*` tool per surviving descriptor.
 
@@ -24,7 +24,6 @@ from typing import Any
 
 import asyncpg
 
-from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.introspect import introspect_nexo_functions
 from miot_harness.integrations.nexo.tool_factory import build_nexo_tool
 from miot_harness.tools.registry import ToolRegistry
@@ -60,9 +59,18 @@ SELECT * FROM {schema}.fn_dx_centro_control() LIMIT 1
 async def load_nexo_tools(
     registry: ToolRegistry,
     *,
-    settings: HarnessSettings,
+    schema: str,
+    tenant_lock: str,
+    refuse_minutes: int,
     pool: asyncpg.Pool | None,
 ) -> NexoBootResult:
+    """Boot the Nexo tools.
+
+    The provider-private knobs are passed in already resolved:
+    ``schema`` from :class:`NexoSettings`, and ``tenant_lock`` /
+    ``refuse_minutes`` as the effective values (env override over the
+    NEXO profile default), resolved once in :meth:`NexoProvider.boot`.
+    """
     if pool is None:
         logger.warning("Nexo: disabled (no asyncpg pool — tunnel may be down)")
         return NexoBootResult(
@@ -71,7 +79,6 @@ async def load_nexo_tools(
             reason="No asyncpg pool provided; tunnel/connection unavailable.",
         )
 
-    schema = settings.nexo_search_path
     if not _SCHEMA_NAME_RE.match(schema):
         logger.critical(
             "Nexo: refusing to boot with invalid schema name %r (must match [a-z_][a-z0-9_]*)",
@@ -122,19 +129,19 @@ async def load_nexo_tools(
             logger.warning("Nexo: centro_control probe returned no refreshed_at; continuing")
         else:
             age_minutes = (datetime.now(UTC) - refreshed_at).total_seconds() / 60
-            if age_minutes > settings.nexo_freshness_refuse_minutes:
+            if age_minutes > refuse_minutes:
                 logger.critical(
                     "Nexo: centro_control snapshot is %.0f min old "
                     "(refuse threshold %d). Disabling.",
                     age_minutes,
-                    settings.nexo_freshness_refuse_minutes,
+                    refuse_minutes,
                 )
                 return NexoBootResult(
                     enabled=False,
                     registered=[],
                     reason=(
                         f"Snapshot stale: refreshed_at age {age_minutes:.0f}min "
-                        f"> refuse threshold {settings.nexo_freshness_refuse_minutes}min."
+                        f"> refuse threshold {refuse_minutes}min."
                     ),
                     snapshot_age_minutes=age_minutes,
                 )
@@ -166,7 +173,7 @@ async def load_nexo_tools(
             tool = build_nexo_tool(
                 descriptor,
                 pool=pool,
-                tenant_lock=settings.nexo_tenant_lock,
+                tenant_lock=tenant_lock,
                 schema=schema,
             )
             registry.register(tool)

--- a/miot-harness/src/miot_harness/integrations/nexo/pool.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/pool.py
@@ -44,7 +44,7 @@ async def create_nexo_pool(
 
     `dsn` is a standard Postgres connection string
     (`postgresql://user:password@host:port/database`), sourced from the
-    `MIOT_HARNESS_NEXO_DSN` setting.
+    `MIOT_HARNESS_DATASOURCE_DSN` setting.
 
     Does NOT pass `server_settings` (PgBouncer rejects unknown startup
     parameters in transaction-pooling mode). Read-only enforcement is

--- a/miot-harness/src/miot_harness/integrations/nexo/provider.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/provider.py
@@ -1,0 +1,95 @@
+"""Nexo: the first DataSourceProvider (Citus/Postgres, Coordinador schema).
+
+This package is the ONLY place in the harness allowed to say
+"Nexo", "Coordinador", or "mintral".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+from miot_harness.integrations.nexo.boot import load_nexo_tools
+from miot_harness.integrations.nexo.pool import create_nexo_pool
+from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+NEXO_PROFILE = DataSourceProfile(
+    name="nexo",
+    display_name="Coordinador",
+    source_label="Coordinador · nexo (Citus DB)",
+    tool_prefix="coordinador_",
+    primer=COORDINADOR_PRIMER,
+    router_keywords=frozenset(
+        {
+            "coordinador",
+            "mintral",
+            "centro de control",
+            "cola crítica",
+            "cola critica",
+            "dimensionamiento",
+            "torre de control",
+            "auditoría pod",
+            "auditoria pod",
+            "fn_dx",
+        }
+    ),
+    tenant_lock="mintral",
+    tenant_refusal_template=(
+        "{display_name} is {lock}-only. I can't answer for other tenants."
+    ),
+    freshness_warn_minutes=30,
+    freshness_refuse_minutes=240,
+)
+
+
+class NexoProvider(DataSourceProvider):
+    profile = NEXO_PROFILE
+
+    def __init__(self) -> None:
+        self._pool: asyncpg.Pool | None = None
+
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult:
+        dsn = settings.nexo_dsn  # renamed to datasource_dsn in a later task
+        if dsn is None:
+            return BootResult(
+                enabled=False,
+                registered=(),
+                reason="MIOT_HARNESS_NEXO_DSN is not set",
+            )
+        try:
+            self._pool = await create_nexo_pool(
+                dsn, application_name=settings.nexo_application_name
+            )
+            legacy = await load_nexo_tools(registry, settings=settings, pool=self._pool)
+        except Exception as exc:  # noqa: BLE001 — boot must not die (base-class contract)
+            logger.critical("Nexo: boot failed (%s)", exc)
+            await self.close()
+            return BootResult(
+                enabled=False, registered=(), reason=f"boot failed: {exc}"
+            )
+        return BootResult(
+            enabled=legacy.enabled,
+            registered=tuple(legacy.registered),
+            reason=legacy.reason,
+            snapshot_age_minutes=legacy.snapshot_age_minutes,
+        )
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            try:
+                await self._pool.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Nexo: pool close raised %s", exc)
+            self._pool = None

--- a/miot-harness/src/miot_harness/integrations/nexo/provider.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/provider.py
@@ -19,6 +19,7 @@ from miot_harness.datasource.provider import (
 from miot_harness.integrations.nexo.boot import load_nexo_tools
 from miot_harness.integrations.nexo.pool import create_nexo_pool
 from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.integrations.nexo.settings import NexoSettings
 from miot_harness.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -61,18 +62,36 @@ class NexoProvider(DataSourceProvider):
     async def boot(
         self, registry: ToolRegistry, settings: HarnessSettings
     ) -> BootResult:
-        dsn = settings.nexo_dsn  # renamed to datasource_dsn in a later task
+        dsn = settings.datasource_dsn
         if dsn is None:
             return BootResult(
                 enabled=False,
                 registered=(),
-                reason="MIOT_HARNESS_NEXO_DSN is not set",
+                reason="MIOT_HARNESS_DATASOURCE_DSN is not set",
             )
+        # Resolve provider-private + effective knobs once. The schema /
+        # EXPLAIN cost knobs are honestly Nexo's (Postgres concepts), so
+        # they live in NexoSettings with the MIOT_HARNESS_NEXO_* prefix.
+        # tenant_lock / freshness are env overrides over the NEXO profile.
+        nexo_settings = NexoSettings()
+        tenant_lock = settings.datasource_tenant_lock or self.profile.tenant_lock
+        assert tenant_lock is not None  # NEXO_PROFILE.tenant_lock is "mintral"
+        refuse_minutes = (
+            settings.datasource_freshness_refuse_minutes
+            if settings.datasource_freshness_refuse_minutes is not None
+            else self.profile.freshness_refuse_minutes
+        )
         try:
             self._pool = await create_nexo_pool(
-                dsn, application_name=settings.nexo_application_name
+                dsn, application_name=settings.datasource_application_name
             )
-            legacy = await load_nexo_tools(registry, settings=settings, pool=self._pool)
+            legacy = await load_nexo_tools(
+                registry,
+                schema=nexo_settings.nexo_search_path,
+                tenant_lock=tenant_lock,
+                refuse_minutes=refuse_minutes,
+                pool=self._pool,
+            )
         except Exception as exc:  # noqa: BLE001 — boot must not die (base-class contract)
             logger.critical("Nexo: boot failed (%s)", exc)
             await self.close()

--- a/miot-harness/src/miot_harness/integrations/nexo/settings.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/settings.py
@@ -1,0 +1,29 @@
+"""Nexo-private settings.
+
+These are Postgres concepts (schema search path, EXPLAIN plan cost),
+honestly Nexo's — they keep the MIOT_HARNESS_NEXO_* prefix and live
+here so HarnessSettings never mentions the provider. Loaded by the
+NexoProvider boot path, never by core code.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class NexoSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="MIOT_HARNESS_",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    nexo_search_path: str = "nexo"
+    # Composable Nexo primitives (E3). EXPLAIN total cost > this → refuse.
+    # PostgreSQL plan-cost units. Default 10000 is roughly "10s of seq scans
+    # on a million-row table" — generous enough for analyst exploration,
+    # tight enough to refuse an unindexed cross-join. Must be strictly
+    # positive; 0 or negative would refuse every query.
+    nexo_explain_cost_threshold: float = Field(default=10000.0, gt=0.0)

--- a/miot-harness/src/miot_harness/observability/callbacks.py
+++ b/miot-harness/src/miot_harness/observability/callbacks.py
@@ -117,7 +117,7 @@ class AgentTelemetryCallback(BaseCallbackHandler):
         tags: Sequence[str] | None = None,
         environment: str | None = None,
         progress: Progress | None = None,
-        span_prefix: str = "nexo",
+        span_prefix: str = "datasource",
     ) -> None:
         self._agent_name = agent_name
         self._run_id = run_id

--- a/miot-harness/src/miot_harness/observability/callbacks.py
+++ b/miot-harness/src/miot_harness/observability/callbacks.py
@@ -1,6 +1,6 @@
 """LangChain callback that emits per-agent OTel GenAI spans for each LLM call.
 
-Bound to each LangGraph node in ``runtime/nexo_graph.py`` (A3) via the
+Bound to each LangGraph node in ``runtime/data_graph.py`` (A3) via the
 ``callbacks`` field of ``RunnableConfig``. One callback instance per node
 invocation; the instance tracks per-run-id span handles so concurrent LLM
 calls under the same node do not cross-talk.
@@ -102,7 +102,7 @@ def _extract_usage(response: LLMResult) -> TokenUsage:
     )
 
 
-class NexoTelemetryCallback(BaseCallbackHandler):
+class AgentTelemetryCallback(BaseCallbackHandler):
     """Emits one OTel span per LLM call, attributed to the owning agent."""
 
     def __init__(

--- a/miot-harness/src/miot_harness/observability/callbacks.py
+++ b/miot-harness/src/miot_harness/observability/callbacks.py
@@ -117,6 +117,7 @@ class NexoTelemetryCallback(BaseCallbackHandler):
         tags: Sequence[str] | None = None,
         environment: str | None = None,
         progress: Progress | None = None,
+        span_prefix: str = "nexo",
     ) -> None:
         self._agent_name = agent_name
         self._run_id = run_id
@@ -126,6 +127,7 @@ class NexoTelemetryCallback(BaseCallbackHandler):
         self._session_id = session_id
         self._tags = list(tags) if tags else None
         self._environment = environment
+        self._span_prefix = span_prefix
         self._tracer = trace.get_tracer(_TRACER_NAME)
         self._open_spans: dict[UUID, _CallState] = {}
         # Optional SSE event sink. When set, the callback also publishes
@@ -145,10 +147,10 @@ class NexoTelemetryCallback(BaseCallbackHandler):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        span = self._tracer.start_span(f"nexo.{self._agent_name}")
+        span = self._tracer.start_span(f"{self._span_prefix}.{self._agent_name}")
         provider = _provider_from_serialized(serialized)
         model = _model_from_serialized(serialized)
-        span.set_attribute("gen_ai.operation.name", f"nexo.{self._agent_name}")
+        span.set_attribute("gen_ai.operation.name", f"{self._span_prefix}.{self._agent_name}")
         span.set_attribute("gen_ai.system", provider)
         if model:
             span.set_attribute("gen_ai.request.model", model)

--- a/miot-harness/src/miot_harness/observability/provenance.py
+++ b/miot-harness/src/miot_harness/observability/provenance.py
@@ -1,10 +1,11 @@
-"""Provenance log for composable Nexo primitive calls (plan 13, E4).
+"""Provenance log for composable datasource primitive calls (plan 13, E4).
 
-Every call to `nexo_select` / `nexo_grep` / `nexo_explain` writes one
-JSONL line under `evals/provenance/YYYY-MM-DD.jsonl`. The weekly
-`scripts/provenance-curate.py` pass reads these to surface candidates:
+Every call to a datasource's composable primitives (e.g. select / grep /
+explain) writes one JSONL line under `evals/provenance/YYYY-MM-DD.jsonl`.
+The weekly `scripts/provenance-curate.py` pass reads these to surface
+candidates:
 
-- Repeated `(table, where_pattern)` combos → new curated `fn_dx_*` candidate.
+- Repeated `(table, where_pattern)` combos → new curated function candidate.
 - Cross-tenant volume → multi-tenant indexing candidate.
 - Plan-cost outliers → index or denial candidate.
 

--- a/miot-harness/src/miot_harness/observability/spans.py
+++ b/miot-harness/src/miot_harness/observability/spans.py
@@ -3,7 +3,7 @@
 The supervisor opens a ``nexo.run`` root span around the whole graph
 invocation (see ``runtime/supervisor.py``). LangGraph node bodies do not
 wrap themselves in ``agent_span`` — instead, the per-agent
-``NexoTelemetryCallback`` emits one ``nexo.<agent>`` span per LLM call
+``AgentTelemetryCallback`` emits one ``nexo.<agent>`` span per LLM call
 (in ``observability/callbacks.py``). Both layers share the
 ``modular.run_id`` attribute so Langfuse can regroup spans even when
 LangGraph's parallel branches break OTel context propagation.

--- a/miot-harness/src/miot_harness/observability/spans.py
+++ b/miot-harness/src/miot_harness/observability/spans.py
@@ -1,10 +1,11 @@
 """Run-level span context manager.
 
-The supervisor opens a ``nexo.run`` root span around the whole graph
-invocation (see ``runtime/supervisor.py``). LangGraph node bodies do not
-wrap themselves in ``agent_span`` — instead, the per-agent
-``AgentTelemetryCallback`` emits one ``nexo.<agent>`` span per LLM call
-(in ``observability/callbacks.py``). Both layers share the
+The supervisor opens a ``<datasource>.run`` root span around the whole
+graph invocation (see ``runtime/supervisor.py``). LangGraph node bodies
+do not wrap themselves in ``agent_span`` — instead, the per-agent
+``AgentTelemetryCallback`` emits one ``<datasource>.<agent>`` span per LLM
+call (in ``observability/callbacks.py``). The span prefix is the active
+datasource profile name. Both layers share the
 ``modular.run_id`` attribute so Langfuse can regroup spans even when
 LangGraph's parallel branches break OTel context propagation.
 
@@ -40,11 +41,11 @@ def agent_span(
     session_id: str | None = None,
     tags: Sequence[str] | None = None,
     environment: str | None = None,
-    span_prefix: str = "nexo",
+    span_prefix: str = "datasource",
 ) -> Iterator[Span]:
     """Open a ``<span_prefix>.<name>`` span carrying the run/tenant/mode attribution.
 
-    ``span_prefix`` defaults to ``"nexo"`` so existing callers are unchanged.
+    ``span_prefix`` defaults to ``"datasource"`` as a neutral fallback.
     Pass ``profile.name`` when a profile is in scope to make telemetry
     datasource-agnostic.
 

--- a/miot-harness/src/miot_harness/observability/spans.py
+++ b/miot-harness/src/miot_harness/observability/spans.py
@@ -40,8 +40,13 @@ def agent_span(
     session_id: str | None = None,
     tags: Sequence[str] | None = None,
     environment: str | None = None,
+    span_prefix: str = "nexo",
 ) -> Iterator[Span]:
-    """Open a ``nexo.<name>`` span carrying the run/tenant/mode attribution.
+    """Open a ``<span_prefix>.<name>`` span carrying the run/tenant/mode attribution.
+
+    ``span_prefix`` defaults to ``"nexo"`` so existing callers are unchanged.
+    Pass ``profile.name`` when a profile is in scope to make telemetry
+    datasource-agnostic.
 
     Optional ``user_id`` / ``session_id`` / ``tags`` / ``environment``
     arguments populate Langfuse's first-class trace fields (E10).
@@ -54,7 +59,7 @@ def agent_span(
     # AttributeValue is `str | bool | int | float | Sequence[...]` — a
     # bare `object` value type is too loose for that contract.
     attributes: dict[str, str] = {
-        "gen_ai.operation.name": f"nexo.{name}",
+        "gen_ai.operation.name": f"{span_prefix}.{name}",
         "modular.run_id": run_id,
     }
     if tenant_id is not None:
@@ -73,5 +78,5 @@ def agent_span(
         # the Langfuse ingest, so we serialise as JSON for portability.
         attributes["langfuse.tags"] = json.dumps(list(tags))
 
-    with tracer.start_as_current_span(f"nexo.{name}", attributes=attributes) as span:
+    with tracer.start_as_current_span(f"{span_prefix}.{name}", attributes=attributes) as span:
         yield span

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -135,7 +135,7 @@ def build_agentic_graph(
         messages.extend(prior_messages)
         messages.append(HumanMessage(content=snapshot.get("user_message", "")))
 
-        if settings.nexo_synthesizer_stream:
+        if settings.agents_synthesizer_stream:
             events: list[HarnessEvent] = []
             answer = await stream_llm_with_thinking(
                 model=model,

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -1,4 +1,4 @@
-"""Agentic graph (plan 13, E6) — looser variant of `nexo_graph` for free
+"""Agentic graph (plan 13, E6) — looser variant of `data_graph` for free
 exploration of the datasource via the composable primitives.
 
 Differences from the plan-execute graph:
@@ -32,7 +32,7 @@ from miot_harness.observability.provenance import ProvenanceLog
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.node_lifecycle import wrap_node_with_lifecycle
-from miot_harness.runtime.plan import NexoState
+from miot_harness.runtime.plan import DataState
 from miot_harness.runtime.router import HarnessRoute
 from miot_harness.runtime.tenancy import tenancy_gate_decision
 
@@ -84,18 +84,18 @@ def build_agentic_graph(
     Pass None for tests that don't need provenance recording.
     """
 
-    graph = StateGraph(NexoState)
+    graph = StateGraph(DataState)
 
-    async def tenancy_gate(state: NexoState) -> dict[str, Any]:
+    async def tenancy_gate(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         decision = tenancy_gate_decision(
-            ctx=ctx, route=HarnessRoute.NEXO_AGENTIC, settings=settings, profile=profile
+            ctx=ctx, route=HarnessRoute.DATA_AGENTIC, settings=settings, profile=profile
         )
         if not decision.allowed:
             return {"answer": decision.refusal_message}
         return {}
 
-    async def planner(state: NexoState) -> dict[str, Any]:
+    async def planner(state: DataState) -> dict[str, Any]:
         # Stub planner: bumps turn count, exits if at cap. The real
         # planner (live LLM call) constructs a plan with curated tools
         # and/or composable primitives. Tests assert wiring; F3 covers
@@ -113,7 +113,7 @@ def build_agentic_graph(
             return {"failure": "agentic turn cap exceeded"}
         return {"turn_count": turn_count + 1}
 
-    async def synthesizer(state: NexoState) -> dict[str, Any]:
+    async def synthesizer(state: DataState) -> dict[str, Any]:
         # Fire the synthesizer model with: SystemMessage(primer + rules)
         # + prior_messages (E5 hydration) + current user HumanMessage.
         # The SystemMessage is load-bearing in stub state — without it,
@@ -160,12 +160,12 @@ def build_agentic_graph(
         text = response.content if hasattr(response, "content") else str(response)
         return {"answer": text if isinstance(text, str) else str(text)}
 
-    async def critic(state: NexoState) -> dict[str, Any]:
+    async def critic(state: DataState) -> dict[str, Any]:
         # Critic ON by default in agentic mode (plan 12 §line 245). For
         # the wiring tests we approve and pass through.
         return {}
 
-    async def summarizer(state: NexoState) -> dict[str, Any]:
+    async def summarizer(state: DataState) -> dict[str, Any]:
         return {}
 
     graph.add_node(
@@ -179,7 +179,7 @@ def build_agentic_graph(
 
     graph.set_entry_point("tenancy_gate")
 
-    def route_from_gate(state: NexoState) -> str:
+    def route_from_gate(state: DataState) -> str:
         if cast(dict[str, Any], state).get("answer"):
             return END
         return "planner"

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -46,9 +46,8 @@ _AGENTIC_TURN_CAP = 12
 # apology mode. The primer + the "prior turns are authoritative" rule
 # below stops that.
 # {display_name} → profile.display_name; {tenant_display} → the tenant the
-# datasource is locked to (profile.tenant_lock, capitalized). For NEXO_PROFILE
-# these render byte-identically to the former hardcodes ("Coordinador",
-# "Mintral").
+# datasource is locked to (profile.tenant_lock, capitalized). Both come
+# straight from the active datasource profile.
 _AGENTIC_SYNTH_SYSTEM_TEMPLATE = """\
 You are the {display_name} agentic synthesizer for {tenant_display} fleet operations.
 Answer the user's question in the same language they used. Be concise

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -1,11 +1,11 @@
 """Agentic graph (plan 13, E6) — looser variant of `nexo_graph` for free
-exploration of Coordinador data via the composable primitives.
+exploration of the datasource via the composable primitives.
 
 Differences from the plan-execute graph:
 - Turn cap is 12 (vs 8) — exploration is the whole point.
 - Critic is ON by default. Composable primitives have more freedom, so
   the critic seat catches hallucinated joins or out-of-bounds reads.
-- `tenancy_gate_node` refuses non-Mintral tenants BEFORE any LLM call.
+- `tenancy_gate_node` refuses off-lock datasource tenants BEFORE any LLM call.
 
 Nodes wired in this iteration: ``tenancy_gate``, ``planner`` (stub —
 turn counter only), ``synthesizer``, ``critic`` (stub — pass-through),
@@ -27,7 +27,7 @@ from langgraph.graph import END, StateGraph
 
 from miot_harness.agents.llm_streaming import stream_llm_with_thinking
 from miot_harness.config import HarnessSettings
-from miot_harness.integrations.nexo.primer import COORDINADOR_PRIMER
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.provenance import ProvenanceLog
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
@@ -45,8 +45,12 @@ _AGENTIC_TURN_CAP = 12
 # turns' data came from and defaults to "I must have hallucinated it"
 # apology mode. The primer + the "prior turns are authoritative" rule
 # below stops that.
+# {display_name} → profile.display_name; {tenant_display} → the tenant the
+# datasource is locked to (profile.tenant_lock, capitalized). For NEXO_PROFILE
+# these render byte-identically to the former hardcodes ("Coordinador",
+# "Mintral").
 _AGENTIC_SYNTH_SYSTEM_TEMPLATE = """\
-You are the Coordinador agentic synthesizer for Mintral fleet operations.
+You are the {display_name} agentic synthesizer for {tenant_display} fleet operations.
 Answer the user's question in the same language they used. Be concise
 (≤200 words).
 
@@ -54,11 +58,11 @@ Answer the user's question in the same language they used. Be concise
 
 Conversational rules:
 - Prior assistant turns in this conversation were produced by real
-  curated Coordinador tools. Treat their numbers, tables, and claims
+  curated {display_name} tools. Treat their numbers, tables, and claims
   as authoritative evidence — do NOT claim you fabricated them.
 - If the user asks for *new* data that would require running fresh
   tools, acknowledge the request and suggest they rephrase as a direct
-  Coordinador question (the agentic data executor is not yet wired in
+  {display_name} question (the agentic data executor is not yet wired in
   this build).
 - Do not invent rows, numbers, or service names that aren't in the
   conversation.
@@ -71,6 +75,7 @@ def build_agentic_graph(
     settings: HarnessSettings,
     models: dict[str, BaseChatModel],
     provenance_log: ProvenanceLog | None,
+    profile: DataSourceProfile,
 ) -> Any:
     """Compile and return the LangGraph agentic StateGraph.
 
@@ -84,7 +89,7 @@ def build_agentic_graph(
     async def tenancy_gate(state: NexoState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         decision = tenancy_gate_decision(
-            ctx=ctx, route=HarnessRoute.NEXO_AGENTIC, settings=settings
+            ctx=ctx, route=HarnessRoute.NEXO_AGENTIC, settings=settings, profile=profile
         )
         if not decision.allowed:
             return {"answer": decision.refusal_message}
@@ -113,14 +118,18 @@ def build_agentic_graph(
         # + prior_messages (E5 hydration) + current user HumanMessage.
         # The SystemMessage is load-bearing in stub state — without it,
         # the LLM has no grounding for prior turn data and apologizes
-        # for "fabricating" real Coordinador output (see template above).
+        # for "fabricating" real datasource output (see template above).
         snapshot = cast(dict[str, Any], state)
         if snapshot.get("failure"):
             return {"answer": "(no answer — see failure)"}
         model = models["synthesizer"]
         ctx: HarnessContext = snapshot["ctx"]
 
-        system = _AGENTIC_SYNTH_SYSTEM_TEMPLATE.format(primer=COORDINADOR_PRIMER)
+        system = _AGENTIC_SYNTH_SYSTEM_TEMPLATE.format(
+            display_name=profile.display_name,
+            tenant_display=(profile.tenant_lock or profile.display_name).capitalize(),
+            primer=profile.primer,
+        )
         prior_messages = snapshot.get("prior_messages") or []
         messages: list[BaseMessage] = [SystemMessage(content=system)]
         messages.extend(prior_messages)

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -31,7 +31,7 @@ class HarnessContext(BaseModel):
     # Used as the Langfuse `session_id` (falls back to `thread_id`).
     conversation_id: str | None = None
     # When true, the SSE stream carries full tool inputs and truncated
-    # tool outputs (~2KB cap). Off by default; coordinador outputs
+    # tool outputs (~2KB cap). Off by default; datasource tool outputs
     # contain customer/fleet data that should not leak to unauthenticated
     # stream consumers.
     debug: bool = False

--- a/miot-harness/src/miot_harness/runtime/conversation.py
+++ b/miot-harness/src/miot_harness/runtime/conversation.py
@@ -109,7 +109,7 @@ def to_messages(
 ) -> list[BaseMessage]:
     """Project history into a LangChain message list, trimmed to a token budget.
 
-    Used by the supervisor to hydrate `NexoState.prior_messages` before graph
+    Used by the supervisor to hydrate `DataState.prior_messages` before graph
     dispatch. Each `ConversationTurn(user_message, assistant_answer)` expands
     to a `[HumanMessage, AIMessage]` pair (chronological order); we then
     delegate to `langchain_core.messages.trim_messages` with

--- a/miot-harness/src/miot_harness/runtime/data_graph.py
+++ b/miot-harness/src/miot_harness/runtime/data_graph.py
@@ -41,11 +41,11 @@ from miot_harness.agents.supervisor import next_agent
 from miot_harness.agents.synthesizer import synthesizer_node
 from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
-from miot_harness.observability.callbacks import NexoTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.node_lifecycle import GraphLabel, wrap_node_with_lifecycle
-from miot_harness.runtime.plan import NexoState
+from miot_harness.runtime.plan import DataState
 from miot_harness.runtime.router import HarnessRoute
 from miot_harness.runtime.tenancy import tenancy_gate_decision
 from miot_harness.tools.registry import ToolRegistry
@@ -81,7 +81,7 @@ def instrument_model(
     # set so one-shot requests still group under a session key.
     session_id = ctx.conversation_id or ctx.thread_id
     tags = [f"tenant:{ctx.tenant_id}", f"mode:{ctx.mode}", f"agent:{agent_name}"]
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name=agent_name,
         run_id=ctx.run_id,
         tenant_id=ctx.tenant_id,
@@ -97,7 +97,7 @@ def instrument_model(
 
 def _make_event_buffer() -> tuple[list[HarnessEvent], Any]:
     """Return (buffer, append) — nodes push events into the buffer, then
-    return them in their state delta as `_events`. NexoState declares
+    return them in their state delta as `_events`. DataState declares
     `_events` with a list/operator.add reducer so events accumulate in
     order across supersteps without relying on in-place mutation
     of state (which is not part of the LangGraph contract).
@@ -118,7 +118,7 @@ async def _tenant_gate_node(
     """
     ctx: HarnessContext = state["ctx"]
     decision = tenancy_gate_decision(
-        ctx=ctx, route=HarnessRoute.NEXO_QUERY, settings=settings, profile=profile
+        ctx=ctx, route=HarnessRoute.DATA_QUERY, settings=settings, profile=profile
     )
     if not decision.allowed:
         # Skip every LLM call; supervisor sees `answer` set and ends.
@@ -141,14 +141,14 @@ _ROUTE_MAP = {
 }
 
 
-def build_nexo_graph(
+def build_data_graph(
     *,
     registry: ToolRegistry,
     settings: HarnessSettings,
     models: dict[str, BaseChatModel],
     profile: DataSourceProfile,
 ) -> Any:
-    graph = StateGraph(NexoState)
+    graph = StateGraph(DataState)
     # Graph label for node-lifecycle spans. For NEXO_PROFILE this is "nexo",
     # byte-identical to the former literal on the wire. GraphLabel is a
     # constrained Literal today; widening it to accept any profile.name is a
@@ -161,7 +161,7 @@ def build_nexo_graph(
             delta["_events"] = [*existing, *events]
         return delta
 
-    async def _filter_expert(state: NexoState) -> dict[str, Any]:
+    async def _filter_expert(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
         delta = await filter_expert_node(
@@ -175,7 +175,7 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    async def _data_fetcher(state: NexoState) -> dict[str, Any]:
+    async def _data_fetcher(state: DataState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
         delta = await data_fetcher_node(
             cast(dict[str, Any], state),
@@ -186,14 +186,14 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    def _freshness_judge(state: NexoState) -> dict[str, Any]:
+    def _freshness_judge(state: DataState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
         delta = freshness_judge_node(
             cast(dict[str, Any], state), settings=settings, progress=progress, profile=profile
         )
         return _merge_events(delta, buf)
 
-    async def _domain_analyst(state: NexoState) -> dict[str, Any]:
+    async def _domain_analyst(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
         delta = await domain_analyst_node(
@@ -206,7 +206,7 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    async def _synthesizer(state: NexoState) -> dict[str, Any]:
+    async def _synthesizer(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
         delta = await synthesizer_node(
@@ -221,7 +221,7 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    async def _critic(state: NexoState) -> dict[str, Any]:
+    async def _critic(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
         delta = await critic_node(
@@ -235,7 +235,7 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    async def _summarizer(state: NexoState) -> dict[str, Any]:
+    async def _summarizer(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
         delta = await summarizer_node(
@@ -247,7 +247,7 @@ def build_nexo_graph(
         )
         return _merge_events(delta, buf)
 
-    async def _tenant_gate(state: NexoState) -> dict[str, Any]:
+    async def _tenant_gate(state: DataState) -> dict[str, Any]:
         return await _tenant_gate_node(
             cast(dict[str, Any], state), settings=settings, profile=profile
         )
@@ -280,7 +280,7 @@ def build_nexo_graph(
 
     graph.set_entry_point("tenant_gate")
 
-    def route(state: NexoState) -> str:
+    def route(state: DataState) -> str:
         return _route(cast(dict[str, Any], state), settings)
 
     # Most nodes route via the supervisor; synthesizer always flows

--- a/miot-harness/src/miot_harness/runtime/data_graph.py
+++ b/miot-harness/src/miot_harness/runtime/data_graph.py
@@ -1,4 +1,4 @@
-"""LangGraph wiring for the Nexo conversational graph (staged Option C).
+"""LangGraph wiring for the datasource conversational graph (staged Option C).
 
 Node layout::
 
@@ -57,7 +57,7 @@ def instrument_model(
     ctx: HarnessContext,
     *,
     progress: Any = None,
-    span_prefix: str = "nexo",
+    span_prefix: str = "datasource",
 ) -> Any:
     """Wrap a chat model with a per-agent telemetry callback for this run.
 
@@ -66,8 +66,8 @@ def instrument_model(
     ``modular.*`` attrs we group by, AND the ``langfuse.*`` attrs the
     Langfuse UI promotes to first-class filter columns (E10).
 
-    ``span_prefix`` defaults to ``"nexo"`` so existing callers are unchanged.
-    Pass ``profile.name`` when a profile is in scope.
+    ``span_prefix`` defaults to ``"datasource"`` as a neutral fallback; pass
+    ``profile.name`` when a profile is in scope (every in-tree caller does).
 
     When `progress` is set, the callback ALSO emits a `usage.recorded`
     HarnessEvent per LLM call so SSE consumers (curl, miot-chat) see
@@ -149,11 +149,10 @@ def build_data_graph(
     profile: DataSourceProfile,
 ) -> Any:
     graph = StateGraph(DataState)
-    # Graph label for node-lifecycle spans. For NEXO_PROFILE this is "nexo",
-    # byte-identical to the former literal on the wire. GraphLabel is a
-    # constrained Literal today; widening it to accept any profile.name is a
-    # later-stage telemetry change, so we cast at this boundary for now.
-    graph_label = cast(GraphLabel, profile.name)
+    # Graph label for node-lifecycle spans: the datasource profile name.
+    # GraphLabel is a plain `str` alias so any profile.name flows through
+    # directly.
+    graph_label: GraphLabel = profile.name
 
     def _merge_events(delta: dict[str, Any], events: list[HarnessEvent]) -> dict[str, Any]:
         if events:

--- a/miot-harness/src/miot_harness/runtime/factory.py
+++ b/miot-harness/src/miot_harness/runtime/factory.py
@@ -14,11 +14,11 @@ from miot_harness.tools.registry import build_default_registry
 def build_harness(workspace_dir: Path) -> HarnessSupervisor:
     """Build the base supervisor with the always-on dependencies.
 
-    Phase-E modules that require LIVE Nexo boot — `LLMIntentRouter`,
+    Phase-E modules that require a LIVE datasource boot — `LLMIntentRouter`,
     `agentic_graph`, `meta_model`, `meta_catalog`, and `tenant_lock` —
-    are wired by the FastAPI lifespan (`api/server.py`) once the Nexo
+    are wired by the FastAPI lifespan (`api/server.py`) once the datasource
     integration is up; they remain `None` here so unit tests and
-    Nexo-disabled deploys keep working.
+    datasource-disabled deploys keep working.
 
     `conversation_store` is always-on because it's pure memory.
     `conversation_token_budget` reads from settings so operators can tune

--- a/miot-harness/src/miot_harness/runtime/intent_router.py
+++ b/miot-harness/src/miot_harness/runtime/intent_router.py
@@ -29,9 +29,9 @@ logger = logging.getLogger(__name__)
 
 
 # Defaults used when no profile is threaded in (legacy / unit-test paths).
-# They preserve the historical Coordinador routing semantics.
+# Generic, datasource-agnostic placeholders; a real profile overrides both.
 _DEFAULT_DISPLAY_NAME = "the data source"
-_DEFAULT_KEYWORD_EXAMPLES = "centro de control, ETA en riesgo, cola crítica"
+_DEFAULT_KEYWORD_EXAMPLES = "operational status, KPIs, fleet metrics"
 
 _SYSTEM_PROMPT_TEMPLATE = """You are the intent router for the ModularIoT harness.
 
@@ -66,8 +66,7 @@ def _render_system_prompt(profile: DataSourceProfile | None) -> str:
 
     The route vocabulary is profile-agnostic; only the example wording is
     parameterized via the profile's `display_name` and `router_keywords`
-    so the prompt names the active datasource (e.g. "Coordinador") instead
-    of hardcoding it.
+    so the prompt names the active datasource instead of hardcoding it.
     """
 
     if profile is None:

--- a/miot-harness/src/miot_harness/runtime/intent_router.py
+++ b/miot-harness/src/miot_harness/runtime/intent_router.py
@@ -1,7 +1,7 @@
 """LLM-driven intent router (plan 13, E1).
 
 Classifies a free-form user message into one of six routes:
-NEXO_QUERY, NEXO_META, NEXO_AGENTIC, STORYTELLING_RUN, DIRECT, OTHER.
+DATA_QUERY, DATA_META, DATA_AGENTIC, STORYTELLING_RUN, DIRECT, OTHER.
 
 When the LLM's reported confidence is below the configured threshold, we
 fall back to the keyword router (`runtime/router.IntentRouter`) — this is
@@ -22,25 +22,31 @@ from dataclasses import dataclass
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.router import HarnessRoute, IntentRouter, RouteResult
 
 logger = logging.getLogger(__name__)
 
 
-_SYSTEM_PROMPT = """You are the intent router for the ModularIoT harness.
+# Defaults used when no profile is threaded in (legacy / unit-test paths).
+# They preserve the historical Coordinador routing semantics.
+_DEFAULT_DISPLAY_NAME = "the data source"
+_DEFAULT_KEYWORD_EXAMPLES = "centro de control, ETA en riesgo, cola crítica"
+
+_SYSTEM_PROMPT_TEMPLATE = """You are the intent router for the ModularIoT harness.
 
 Classify the user's message into EXACTLY ONE of these routes:
 
-- NEXO_QUERY: A canned data question about Coordinador/Mintral that maps
-  cleanly to a curated `fn_dx_*` function. Examples: "estado del centro
-  de control", "ETA en riesgo hoy", "cola crítica del turno".
-- NEXO_META: A schema/primer/introspection question that needs no SQL.
-  Examples: "what data do you have?", "how is es_critico calculated?",
-  "what does fn_dx_centro_control return?".
-- NEXO_AGENTIC: A free-form exploration of Coordinador data that may
-  need composable primitives (nexo_describe/select/grep) — the canned
-  catalog doesn't cover it. Examples: "show me services where
-  delta_eta_horas > 6", "tell me more about that", multi-turn drilldowns.
+- DATA_QUERY: A canned data question about {display_name} that maps
+  cleanly to a curated data function. Examples are phrased around its
+  vocabulary: {keyword_examples}.
+- DATA_META: A schema/primer/introspection question that needs no SQL.
+  Examples: "what data do you have?", "how is this field calculated?",
+  "what does this function return?".
+- DATA_AGENTIC: A free-form exploration of {display_name} data that may
+  need composable primitives (describe/select/grep) — the canned
+  catalog doesn't cover it. Examples: "show me rows where some_metric
+  > 6", "tell me more about that", multi-turn drilldowns.
 - STORYTELLING_RUN: User wants a written narrative or dashboard draft.
   Examples: "write a story about", "draft a status update".
 - DIRECT: Greetings, small talk, simple chat where no data or narrative
@@ -48,11 +54,35 @@ Classify the user's message into EXACTLY ONE of these routes:
 - OTHER: Anything else (out-of-scope, abusive, malformed).
 
 Reply with a single JSON object, no prose:
-{"route": "<ROUTE_NAME>", "confidence": <0..1>, "reasoning": "<one short sentence>"}
+{{"route": "<ROUTE_NAME>", "confidence": <0..1>, "reasoning": "<one short sentence>"}}
 
 `confidence` is your subjective certainty in the label, calibrated honestly
 — if the message could plausibly be two routes, drop confidence below 0.7.
 """
+
+
+def _render_system_prompt(profile: DataSourceProfile | None) -> str:
+    """Render the router prompt for a given datasource profile.
+
+    The route vocabulary is profile-agnostic; only the example wording is
+    parameterized via the profile's `display_name` and `router_keywords`
+    so the prompt names the active datasource (e.g. "Coordinador") instead
+    of hardcoding it.
+    """
+
+    if profile is None:
+        display_name = _DEFAULT_DISPLAY_NAME
+        keyword_examples = _DEFAULT_KEYWORD_EXAMPLES
+    else:
+        display_name = profile.display_name
+        # Sorted for deterministic rendering; the full keyword set keeps
+        # distinctive literals (e.g. tenant names) visible to the LLM.
+        keyword_examples = ", ".join(sorted(profile.router_keywords)) or (
+            _DEFAULT_KEYWORD_EXAMPLES
+        )
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        display_name=display_name, keyword_examples=keyword_examples
+    )
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
@@ -111,16 +141,18 @@ class LLMIntentRouter:
         *,
         confidence_threshold: float = 0.7,
         keyword_fallback: IntentRouter | None = None,
+        profile: DataSourceProfile | None = None,
     ) -> None:
         self._model = model
         self._threshold = confidence_threshold
         self._fallback = keyword_fallback or IntentRouter()
+        self._system_prompt = _render_system_prompt(profile)
 
     async def route(self, message: str) -> RouteResult:
         try:
             response = await self._model.ainvoke(
                 [
-                    SystemMessage(content=_SYSTEM_PROMPT),
+                    SystemMessage(content=self._system_prompt),
                     HumanMessage(content=message),
                 ]
             )

--- a/miot-harness/src/miot_harness/runtime/mode_resolver.py
+++ b/miot-harness/src/miot_harness/runtime/mode_resolver.py
@@ -22,9 +22,9 @@ class ModeAccessDenied(PermissionError):
 
 
 _EXPLICIT_MODE_ROUTES: dict[str, HarnessRoute] = {
-    "canned": HarnessRoute.NEXO_QUERY,
-    "meta": HarnessRoute.NEXO_META,
-    "agentic": HarnessRoute.NEXO_AGENTIC,
+    "canned": HarnessRoute.DATA_QUERY,
+    "meta": HarnessRoute.DATA_META,
+    "agentic": HarnessRoute.DATA_AGENTIC,
 }
 
 

--- a/miot-harness/src/miot_harness/runtime/mode_resolver.py
+++ b/miot-harness/src/miot_harness/runtime/mode_resolver.py
@@ -3,7 +3,7 @@
 When `request.mode == "auto"` the LLM intent router decides. When it's
 one of `canned` / `meta` / `agentic`, we skip the router entirely and
 dispatch directly. Validation rejects data-touching modes (`canned`,
-`agentic`) for non-Mintral tenants at request-validation time so
+`agentic`) for off-lock tenants at request-validation time so
 unauthorized callers never reach an LLM, graph node, or a tool call
 that would emit billable telemetry. `meta` is allowed for any tenant
 (non-confidential schema/primer info per the plan's tenant-gate

--- a/miot-harness/src/miot_harness/runtime/nexo_graph.py
+++ b/miot-harness/src/miot_harness/runtime/nexo_graph.py
@@ -40,10 +40,11 @@ from miot_harness.agents.summarizer import summarizer_node
 from miot_harness.agents.supervisor import next_agent
 from miot_harness.agents.synthesizer import synthesizer_node
 from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.callbacks import NexoTelemetryCallback
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.node_lifecycle import wrap_node_with_lifecycle
+from miot_harness.runtime.node_lifecycle import GraphLabel, wrap_node_with_lifecycle
 from miot_harness.runtime.plan import NexoState
 from miot_harness.runtime.router import HarnessRoute
 from miot_harness.runtime.tenancy import tenancy_gate_decision
@@ -56,13 +57,17 @@ def instrument_model(
     ctx: HarnessContext,
     *,
     progress: Any = None,
+    span_prefix: str = "nexo",
 ) -> Any:
     """Wrap a chat model with a per-agent telemetry callback for this run.
 
-    The callback emits one ``nexo.<agent>`` span per LLM call with full
-    GenAI semconv attribution (tokens, cache split, cost), the internal
+    The callback emits one ``<span_prefix>.<agent>`` span per LLM call with
+    full GenAI semconv attribution (tokens, cache split, cost), the internal
     ``modular.*`` attrs we group by, AND the ``langfuse.*`` attrs the
     Langfuse UI promotes to first-class filter columns (E10).
+
+    ``span_prefix`` defaults to ``"nexo"`` so existing callers are unchanged.
+    Pass ``profile.name`` when a profile is in scope.
 
     When `progress` is set, the callback ALSO emits a `usage.recorded`
     HarnessEvent per LLM call so SSE consumers (curl, miot-chat) see
@@ -85,6 +90,7 @@ def instrument_model(
         session_id=session_id,
         tags=tags,
         progress=progress,
+        span_prefix=span_prefix,
     )
     return model.with_config(callbacks=[cb])
 
@@ -100,14 +106,19 @@ def _make_event_buffer() -> tuple[list[HarnessEvent], Any]:
     return buf, buf.append
 
 
-async def _tenant_gate_node(state: dict[str, Any], *, settings: HarnessSettings) -> dict[str, Any]:
+async def _tenant_gate_node(
+    state: dict[str, Any],
+    *,
+    settings: HarnessSettings,
+    profile: DataSourceProfile,
+) -> dict[str, Any]:
     """Defense-in-depth gate: the mode resolver should have already gated this,
     but the graph entry re-checks so a future direct-graph caller can't slip
-    past with a non-Mintral tenant.
+    past with an off-lock datasource tenant.
     """
     ctx: HarnessContext = state["ctx"]
     decision = tenancy_gate_decision(
-        ctx=ctx, route=HarnessRoute.NEXO_QUERY, settings=settings
+        ctx=ctx, route=HarnessRoute.NEXO_QUERY, settings=settings, profile=profile
     )
     if not decision.allowed:
         # Skip every LLM call; supervisor sees `answer` set and ends.
@@ -135,8 +146,14 @@ def build_nexo_graph(
     registry: ToolRegistry,
     settings: HarnessSettings,
     models: dict[str, BaseChatModel],
+    profile: DataSourceProfile,
 ) -> Any:
     graph = StateGraph(NexoState)
+    # Graph label for node-lifecycle spans. For NEXO_PROFILE this is "nexo",
+    # byte-identical to the former literal on the wire. GraphLabel is a
+    # constrained Literal today; widening it to accept any profile.name is a
+    # later-stage telemetry change, so we cast at this boundary for now.
+    graph_label = cast(GraphLabel, profile.name)
 
     def _merge_events(delta: dict[str, Any], events: list[HarnessEvent]) -> dict[str, Any]:
         if events:
@@ -151,8 +168,10 @@ def build_nexo_graph(
             cast(dict[str, Any], state),
             registry=registry,
             model=instrument_model(
-                models["filter_expert"], "filter_expert", ctx, progress=progress
+                models["filter_expert"], "filter_expert", ctx,
+                progress=progress, span_prefix=profile.name,
             ),
+            profile=profile,
         )
         return _merge_events(delta, buf)
 
@@ -163,13 +182,14 @@ def build_nexo_graph(
             registry=registry,
             settings=settings,
             progress=progress,
+            profile=profile,
         )
         return _merge_events(delta, buf)
 
     def _freshness_judge(state: NexoState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
         delta = freshness_judge_node(
-            cast(dict[str, Any], state), settings=settings, progress=progress
+            cast(dict[str, Any], state), settings=settings, progress=progress, profile=profile
         )
         return _merge_events(delta, buf)
 
@@ -179,8 +199,10 @@ def build_nexo_graph(
         delta = await domain_analyst_node(
             cast(dict[str, Any], state),
             model=instrument_model(
-                models["domain_analyst"], "domain_analyst", ctx, progress=progress
+                models["domain_analyst"], "domain_analyst", ctx,
+                progress=progress, span_prefix=profile.name,
             ),
+            profile=profile,
         )
         return _merge_events(delta, buf)
 
@@ -190,10 +212,12 @@ def build_nexo_graph(
         delta = await synthesizer_node(
             cast(dict[str, Any], state),
             model=instrument_model(
-                models["synthesizer"], "synthesizer", ctx, progress=progress
+                models["synthesizer"], "synthesizer", ctx,
+                progress=progress, span_prefix=profile.name,
             ),
             progress=progress,
             settings=settings,
+            profile=profile,
         )
         return _merge_events(delta, buf)
 
@@ -204,8 +228,10 @@ def build_nexo_graph(
             cast(dict[str, Any], state),
             settings=settings,
             model=instrument_model(
-                models["critic"], "critic", ctx, progress=progress
+                models["critic"], "critic", ctx,
+                progress=progress, span_prefix=profile.name,
             ),
+            profile=profile,
         )
         return _merge_events(delta, buf)
 
@@ -215,31 +241,42 @@ def build_nexo_graph(
         delta = await summarizer_node(
             cast(dict[str, Any], state),
             model=instrument_model(
-                models["summarizer"], "summarizer", ctx, progress=progress
+                models["summarizer"], "summarizer", ctx,
+                progress=progress, span_prefix=profile.name,
             ),
         )
         return _merge_events(delta, buf)
 
     async def _tenant_gate(state: NexoState) -> dict[str, Any]:
-        return await _tenant_gate_node(cast(dict[str, Any], state), settings=settings)
+        return await _tenant_gate_node(
+            cast(dict[str, Any], state), settings=settings, profile=profile
+        )
 
-    graph.add_node("tenant_gate", wrap_node_with_lifecycle("tenant_gate", _tenant_gate, "nexo"))
+    graph.add_node(
+        "tenant_gate", wrap_node_with_lifecycle("tenant_gate", _tenant_gate, graph_label)
+    )
     graph.add_node(
         "filter_expert",
-        wrap_node_with_lifecycle("filter_expert", _filter_expert, "nexo"),
+        wrap_node_with_lifecycle("filter_expert", _filter_expert, graph_label),
     )
-    graph.add_node("data_fetcher", wrap_node_with_lifecycle("data_fetcher", _data_fetcher, "nexo"))
+    graph.add_node(
+        "data_fetcher", wrap_node_with_lifecycle("data_fetcher", _data_fetcher, graph_label)
+    )
     graph.add_node(
         "freshness_judge",
-        wrap_node_with_lifecycle("freshness_judge", _freshness_judge, "nexo"),
+        wrap_node_with_lifecycle("freshness_judge", _freshness_judge, graph_label),
     )
     graph.add_node(
         "domain_analyst",
-        wrap_node_with_lifecycle("domain_analyst", _domain_analyst, "nexo"),
+        wrap_node_with_lifecycle("domain_analyst", _domain_analyst, graph_label),
     )
-    graph.add_node("synthesizer", wrap_node_with_lifecycle("synthesizer", _synthesizer, "nexo"))
-    graph.add_node("critic", wrap_node_with_lifecycle("critic", _critic, "nexo"))
-    graph.add_node("summarizer", wrap_node_with_lifecycle("summarizer", _summarizer, "nexo"))
+    graph.add_node(
+        "synthesizer", wrap_node_with_lifecycle("synthesizer", _synthesizer, graph_label)
+    )
+    graph.add_node("critic", wrap_node_with_lifecycle("critic", _critic, graph_label))
+    graph.add_node(
+        "summarizer", wrap_node_with_lifecycle("summarizer", _summarizer, graph_label)
+    )
 
     graph.set_entry_point("tenant_gate")
 

--- a/miot-harness/src/miot_harness/runtime/node_lifecycle.py
+++ b/miot-harness/src/miot_harness/runtime/node_lifecycle.py
@@ -2,7 +2,7 @@
 `agent.completed` events around any node function so SSE clients can
 see graph-node transitions in real time.
 
-Shared by `nexo_graph` and `agentic_graph`. Each node returns a state
+Shared by `data_graph` and `agentic_graph`. Each node returns a state
 delta dict; this wrapper:
 
 1. Reads `ctx` from the state (every node has it).
@@ -29,7 +29,7 @@ from time import monotonic
 from typing import Any, Literal, TypeVar, cast
 
 # Private langgraph types — used so the wrapper return satisfies
-# `StateGraph[NexoState].add_node` without per-call `# type: ignore`.
+# `StateGraph[DataState].add_node` without per-call `# type: ignore`.
 # Public symbols don't expose an equivalent today; langgraph's own
 # typing notes acknowledge the limitation ("we cannot use either
 # TypedDict or dataclass directly due to limitations in type
@@ -44,11 +44,11 @@ from miot_harness.runtime.events import HarnessEvent
 
 GraphLabel = Literal["nexo", "agentic"]
 
-# Generic over the graph state type so `StateGraph[NexoState].add_node`
+# Generic over the graph state type so `StateGraph[DataState].add_node`
 # accepts the wrapped node without per-call `# type: ignore`. Bounded
 # to `StateLike` (TypedDict / dataclass / pydantic BaseModel) because
 # that's what `_Node[S]` requires; in practice we only ever pass
-# `NexoState` (a `TypedDict`).
+# `DataState` (a `TypedDict`).
 S = TypeVar("S", bound=StateLike)
 
 
@@ -115,7 +115,7 @@ def wrap_node_with_lifecycle(
         merged: dict[str, Any] = dict(delta)
         merged["_events"] = [started_event, *node_events, completed_event]
         # State deltas are dict-shaped at runtime — LangGraph reducers
-        # narrow them back into `S` (NexoState / etc.) when applied.
+        # narrow them back into `S` (DataState / etc.) when applied.
         return cast("S", merged)
 
     wrapped.__name__ = f"_lifecycle_{name}"

--- a/miot-harness/src/miot_harness/runtime/node_lifecycle.py
+++ b/miot-harness/src/miot_harness/runtime/node_lifecycle.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 from time import monotonic
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 # Private langgraph types — used so the wrapper return satisfies
 # `StateGraph[DataState].add_node` without per-call `# type: ignore`.
@@ -42,7 +42,10 @@ from langgraph.graph._node import _Node
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 
-GraphLabel = Literal["nexo", "agentic"]
+# Graph-node-lifecycle span label: the datasource profile name for the data
+# graph or "agentic" for the agentic graph. Plain `str` so any profile.name
+# flows through without a per-call cast.
+GraphLabel = str
 
 # Generic over the graph state type so `StateGraph[DataState].add_node`
 # accepts the wrapped node without per-call `# type: ignore`. Bounded

--- a/miot-harness/src/miot_harness/runtime/plan.py
+++ b/miot-harness/src/miot_harness/runtime/plan.py
@@ -12,7 +12,7 @@ from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 
 
-class NexoStep(BaseModel):
+class DataStep(BaseModel):
     id: str = Field(default_factory=lambda: f"step_{uuid4().hex[:8]}")
     intent: str
     tool: str
@@ -20,12 +20,12 @@ class NexoStep(BaseModel):
     rationale: str
 
 
-class NexoPlan(BaseModel):
-    steps: list[NexoStep] = Field(default_factory=list, max_length=4)
+class DataPlan(BaseModel):
+    steps: list[DataStep] = Field(default_factory=list, max_length=4)
     final_format: Literal["answer", "story"] = "answer"
 
 
-class NexoEvidence(BaseModel):
+class DataEvidence(BaseModel):
     step_id: str
     tool: str
     source: str
@@ -35,11 +35,11 @@ class NexoEvidence(BaseModel):
     is_stale: bool = False
 
 
-class NexoState(TypedDict, total=False):
+class DataState(TypedDict, total=False):
     user_message: str
     ctx: HarnessContext
-    plan: NexoPlan | None
-    evidence: Annotated[list[NexoEvidence], operator.add]
+    plan: DataPlan | None
+    evidence: Annotated[list[DataEvidence], operator.add]
     pending_step_index: int
     answer: str | None
     failure: str | None

--- a/miot-harness/src/miot_harness/runtime/router.py
+++ b/miot-harness/src/miot_harness/runtime/router.py
@@ -52,8 +52,14 @@ class IntentRouter:
         # No built-in domain vocabulary: keywords come from the active
         # datasource profile (server.py passes profile.router_keywords). A
         # bare IntentRouter() routes only on the generic ETA token until a
-        # datasource is wired.
-        self._data_keywords = data_keywords if data_keywords is not None else frozenset()
+        # datasource is wired. Lowercased on intake: route() matches against
+        # the lowercased message, so mixed-case profile keywords would
+        # otherwise never fire.
+        self._data_keywords = (
+            frozenset(k.lower() for k in data_keywords)
+            if data_keywords is not None
+            else frozenset()
+        )
 
     def route(self, message: str) -> RouteResult:
         normalized = message.lower()

--- a/miot-harness/src/miot_harness/runtime/router.py
+++ b/miot-harness/src/miot_harness/runtime/router.py
@@ -37,9 +37,10 @@ class RouteResult(BaseModel):
     reason: str
 
 
-# High-precision Nexo tokens. Lowercased messages are searched against
-# the lowercase forms; ETA stays uppercase and word-bounded.
-_NEXO_LITERAL_TOKENS = (
+# High-precision data-route tokens (nexo defaults during the seam transition).
+# Lowercased messages are searched against the lowercase forms; ETA stays
+# uppercase and word-bounded.
+_DEFAULT_DATA_TOKENS = (
     "coordinador",
     "mintral",
     "centro de control",
@@ -56,20 +57,26 @@ _STORYTELLING_TOKENS = ("story", "dashboard widget")
 
 
 class IntentRouter:
+    def __init__(self, data_keywords: frozenset[str] | None = None) -> None:
+        self._data_keywords = (
+            data_keywords if data_keywords is not None else frozenset(_DEFAULT_DATA_TOKENS)
+        )
+
     def route(self, message: str) -> RouteResult:
         normalized = message.lower()
 
-        nexo_match = next(
-            (token for token in _NEXO_LITERAL_TOKENS if token in normalized),
+        data_match = next(
+            (token for token in self._data_keywords if token in normalized),
             None,
         )
-        if nexo_match is None and _ETA_RE.search(message):
-            nexo_match = "ETA"
+        # ETA regex is coordinador-specific; folded into profile keywords in a follow-up.
+        if data_match is None and _ETA_RE.search(message):
+            data_match = "ETA"
 
-        if nexo_match:
+        if data_match:
             return RouteResult(
                 route=HarnessRoute.NEXO_QUERY,
-                reason=f"Nexo keyword matched: {nexo_match!r}",
+                reason=f"Nexo keyword matched: {data_match!r}",
             )
 
         if any(token in normalized for token in _STORYTELLING_TOKENS):

--- a/miot-harness/src/miot_harness/runtime/router.py
+++ b/miot-harness/src/miot_harness/runtime/router.py
@@ -22,13 +22,13 @@ from pydantic import BaseModel
 class HarnessRoute(StrEnum):
     DIRECT = "direct"
     STORYTELLING_RUN = "storytelling_run"
-    NEXO_QUERY = "nexo_query"
-    # Phase E (plan 13): three Nexo modes give cost/quality tiers and
-    # let the operator dashboard split per-mode behavior. NEXO_META is
+    DATA_QUERY = "data_query"
+    # Phase E (plan 13): three data modes give cost/quality tiers and
+    # let the operator dashboard split per-mode behavior. DATA_META is
     # the only mode allowed for non-Mintral tenants (meta-info is
     # non-confidential per `decisions made -> tenant gate behavior`).
-    NEXO_META = "nexo_meta"
-    NEXO_AGENTIC = "nexo_agentic"
+    DATA_META = "data_meta"
+    DATA_AGENTIC = "data_agentic"
     OTHER = "other"
 
 
@@ -75,7 +75,7 @@ class IntentRouter:
 
         if data_match:
             return RouteResult(
-                route=HarnessRoute.NEXO_QUERY,
+                route=HarnessRoute.DATA_QUERY,
                 reason=f"Nexo keyword matched: {data_match!r}",
             )
 

--- a/miot-harness/src/miot_harness/runtime/router.py
+++ b/miot-harness/src/miot_harness/runtime/router.py
@@ -1,14 +1,16 @@
 """Intent router.
 
-v1 is keyword-based — the Nexo (Coordinador / Mintral) vocabulary is
-distinctive enough that high-precision tokens give us low false-
-positive routing without touching an LLM.
+v1 is keyword-based — a datasource's domain vocabulary is distinctive
+enough that high-precision tokens give us low false-positive routing
+without touching an LLM. The keyword set is supplied per datasource via
+``data_keywords`` (the active ``DataSourceProfile.router_keywords``); the
+core ships no built-in vocabulary.
 
-Resolution rule (review item S7): when a message has both Nexo and
-storytelling keywords, **Nexo wins**. Most operational follow-ups
-ride on top of Nexo data anyway; misrouting a Nexo question into
-storytelling is more expensive (writes a long narrative against
-mocked tools) than the reverse.
+Resolution rule (review item S7): when a message has both data-route and
+storytelling keywords, **the data route wins**. Most operational
+follow-ups ride on top of datasource data anyway; misrouting a data
+question into storytelling is more expensive (writes a long narrative
+against mocked tools) than the reverse.
 """
 
 from __future__ import annotations
@@ -25,8 +27,9 @@ class HarnessRoute(StrEnum):
     DATA_QUERY = "data_query"
     # Phase E (plan 13): three data modes give cost/quality tiers and
     # let the operator dashboard split per-mode behavior. DATA_META is
-    # the only mode allowed for non-Mintral tenants (meta-info is
-    # non-confidential per `decisions made -> tenant gate behavior`).
+    # the only mode allowed for off-lock (non-locked-tenant) requests
+    # (meta-info is non-confidential per `decisions made -> tenant gate
+    # behavior`).
     DATA_META = "data_meta"
     DATA_AGENTIC = "data_agentic"
     OTHER = "other"
@@ -37,30 +40,20 @@ class RouteResult(BaseModel):
     reason: str
 
 
-# High-precision data-route tokens (nexo defaults during the seam transition).
-# Lowercased messages are searched against the lowercase forms; ETA stays
-# uppercase and word-bounded.
-_DEFAULT_DATA_TOKENS = (
-    "coordinador",
-    "mintral",
-    "centro de control",
-    "cola crítica",
-    "cola critica",
-    "dimensionamiento",
-    "torre de control",
-    "auditoría pod",
-    "auditoria pod",
-    "fn_dx",
-)
+# Generic ETA token: matched word-bounded and case-sensitively. ETA is a
+# cross-domain logistics term, so it is a built-in data-route hint
+# regardless of the active datasource's keyword set.
 _ETA_RE = re.compile(r"\bETA\b")
 _STORYTELLING_TOKENS = ("story", "dashboard widget")
 
 
 class IntentRouter:
     def __init__(self, data_keywords: frozenset[str] | None = None) -> None:
-        self._data_keywords = (
-            data_keywords if data_keywords is not None else frozenset(_DEFAULT_DATA_TOKENS)
-        )
+        # No built-in domain vocabulary: keywords come from the active
+        # datasource profile (server.py passes profile.router_keywords). A
+        # bare IntentRouter() routes only on the generic ETA token until a
+        # datasource is wired.
+        self._data_keywords = data_keywords if data_keywords is not None else frozenset()
 
     def route(self, message: str) -> RouteResult:
         normalized = message.lower()
@@ -69,14 +62,14 @@ class IntentRouter:
             (token for token in self._data_keywords if token in normalized),
             None,
         )
-        # ETA regex is coordinador-specific; folded into profile keywords in a follow-up.
+        # Generic ETA hint, applied on top of the profile keyword set.
         if data_match is None and _ETA_RE.search(message):
             data_match = "ETA"
 
         if data_match:
             return RouteResult(
                 route=HarnessRoute.DATA_QUERY,
-                reason=f"Nexo keyword matched: {data_match!r}",
+                reason=f"data keyword matched: {data_match!r}",
             )
 
         if any(token in normalized for token in _STORYTELLING_TOKENS):

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -7,9 +7,9 @@ Routes incoming requests via either:
   fallback for "auto" mode below the LLM's confidence threshold.
 
 Then dispatches to:
-- `nexo_graph` (NEXO_QUERY, canned data path)
-- `agentic_graph` (NEXO_AGENTIC, composable-primitive exploration)
-- `meta_agent_node` (NEXO_META, schema/primer questions; no SQL)
+- `data_graph` (DATA_QUERY, canned data path)
+- `agentic_graph` (DATA_AGENTIC, composable-primitive exploration)
+- `meta_agent_node` (DATA_META, schema/primer questions; no SQL)
 - `storytelling` module (STORYTELLING_RUN, mocked narrative path)
 - direct response (DIRECT / OTHER)
 
@@ -39,11 +39,11 @@ from miot_harness.runtime.conversation import (
     ConversationTurn,
     to_messages,
 )
+from miot_harness.runtime.data_graph import instrument_model
 from miot_harness.runtime.event_bus import RunEventBus
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.intent_router import LLMIntentRouter
 from miot_harness.runtime.mode_resolver import ModeAccessDenied, resolve_mode
-from miot_harness.runtime.nexo_graph import instrument_model
 from miot_harness.runtime.router import HarnessRoute, IntentRouter, RouteResult
 from miot_harness.runtime.run_store import HarnessRunRecord, JsonRunStore
 from miot_harness.storytelling.module import StorytellingModule
@@ -59,7 +59,7 @@ class HarnessSupervisor:
         tools: ToolRegistry,
         stories: StorytellingModule,
         run_store: JsonRunStore,
-        nexo_graph: Any | None = None,
+        data_graph: Any | None = None,
         *,
         llm_router: LLMIntentRouter | None = None,
         agentic_graph: Any | None = None,
@@ -77,7 +77,7 @@ class HarnessSupervisor:
         self.tools = tools
         self.stories = stories
         self.run_store = run_store
-        self.nexo_graph = nexo_graph
+        self.data_graph = data_graph
         self.llm_router = llm_router
         self.agentic_graph = agentic_graph
         self.meta_model = meta_model
@@ -163,16 +163,16 @@ class HarnessSupervisor:
         prior_messages = self._hydrate_history(request)
 
         try:
-            if route.route == HarnessRoute.NEXO_QUERY:
-                await self._run_nexo(
+            if route.route == HarnessRoute.DATA_QUERY:
+                await self._run_data_query(
                     request, ctx, record, progress, route.route, prior_messages
                 )
-            elif route.route == HarnessRoute.NEXO_META:
-                await self._run_nexo_meta(
+            elif route.route == HarnessRoute.DATA_META:
+                await self._run_data_meta(
                     request, ctx, record, progress, route.route, prior_messages
                 )
-            elif route.route == HarnessRoute.NEXO_AGENTIC:
-                await self._run_nexo_agentic(
+            elif route.route == HarnessRoute.DATA_AGENTIC:
+                await self._run_data_agentic(
                     request, ctx, record, progress, route.route, prior_messages
                 )
             elif route.route == HarnessRoute.STORYTELLING_RUN:
@@ -358,7 +358,7 @@ class HarnessSupervisor:
             )
         )
 
-    async def _run_nexo(
+    async def _run_data_query(
         self,
         request: UserRequest,
         ctx: HarnessContext,
@@ -367,7 +367,7 @@ class HarnessSupervisor:
         route: HarnessRoute | None = None,
         prior_messages: list[BaseMessage] | None = None,
     ) -> None:
-        if self.nexo_graph is None:
+        if self.data_graph is None:
             display_name = self.profile.display_name if self.profile is not None else "Coordinador"
             answer = (
                 f"{display_name} integration is currently disabled "
@@ -392,7 +392,7 @@ class HarnessSupervisor:
             "prior_messages": prior_messages or [],
         }
         with agent_span("run", **self._root_span_kwargs(ctx, route)):
-            final_state = await self.nexo_graph.ainvoke(initial_state)
+            final_state = await self.data_graph.ainvoke(initial_state)
 
         # Drain the graph's _events channel into the run record in order
         for evt in final_state.get("_events") or []:
@@ -404,12 +404,12 @@ class HarnessSupervisor:
         else:
             record.answer = "(no answer produced by Coordinador graph)"
 
-        # Persist NexoPlan in artifacts (review item N12)
+        # Persist DataPlan in artifacts (review item N12)
         plan = final_state.get("plan")
         if plan is not None and hasattr(plan, "model_dump"):
-            record.artifacts.append({"type": "nexo_plan", **plan.model_dump()})
+            record.artifacts.append({"type": "data_plan", **plan.model_dump()})
 
-    async def _run_nexo_agentic(
+    async def _run_data_agentic(
         self,
         request: UserRequest,
         ctx: HarnessContext,
@@ -448,7 +448,7 @@ class HarnessSupervisor:
             self._emit(record, evt)
         record.answer = final_state.get("answer") or "(no answer produced by agentic graph)"
 
-    async def _run_nexo_meta(
+    async def _run_data_meta(
         self,
         request: UserRequest,
         ctx: HarnessContext,

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -468,7 +468,7 @@ class HarnessSupervisor:
         from miot_harness.config import get_settings
 
         settings = get_settings()
-        stream_enabled = settings.nexo_synthesizer_stream
+        stream_enabled = settings.agents_synthesizer_stream
         from time import monotonic
 
         progress(

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -68,7 +68,11 @@ class HarnessSupervisor:
         meta_catalog: list[MetaAgentCatalogEntry] | None = None,
         conversation_store: ConversationStore | None = None,
         conversation_token_budget: int = 24_000,
-        tenant_lock: str = "mintral",
+        # Empty default = no lock configured yet; the lifespan overwrites
+        # this from the active datasource profile at boot. An empty lock
+        # refuses gated (agentic/canned) modes until configured — secure by
+        # default rather than hardcoding any one datasource's tenant here.
+        tenant_lock: str = "",
         event_bus: RunEventBus | None = None,
         checkpoint_every_n_events: int = 10,
         approval_registry: ApprovalRegistry | None = None,
@@ -307,8 +311,8 @@ class HarnessSupervisor:
         identically. `tags` includes the resolved route when known.
 
         When a profile is set on the supervisor, ``span_prefix`` is taken
-        from ``profile.name``; otherwise it falls back to ``"nexo"`` so
-        existing deployments are unaffected.
+        from ``profile.name``; otherwise it falls back to ``"datasource"``
+        as a neutral default.
         """
 
         tags: list[str] = [f"tenant:{ctx.tenant_id}", f"mode:{ctx.mode}"]
@@ -321,7 +325,7 @@ class HarnessSupervisor:
             "user_id": ctx.user_id,
             "session_id": ctx.conversation_id or ctx.thread_id,
             "tags": tags,
-            "span_prefix": self.profile.name if self.profile is not None else "nexo",
+            "span_prefix": self.profile.name if self.profile is not None else "datasource",
         }
 
     async def _resolve_route(self, request: UserRequest) -> RouteResult:
@@ -368,7 +372,9 @@ class HarnessSupervisor:
         prior_messages: list[BaseMessage] | None = None,
     ) -> None:
         if self.data_graph is None:
-            display_name = self.profile.display_name if self.profile is not None else "Coordinador"
+            display_name = (
+                self.profile.display_name if self.profile is not None else "Datasource"
+            )
             answer = (
                 f"{display_name} integration is currently disabled "
                 "(no DB tunnel or boot failed). Try again once it's restored."
@@ -378,7 +384,7 @@ class HarnessSupervisor:
                 HarnessEvent(
                     run_id=ctx.run_id,
                     type="answer.completed",
-                    message="Nexo integration disabled",
+                    message="datasource integration disabled",
                     data={"length": len(answer)},
                 )
             )
@@ -402,7 +408,10 @@ class HarnessSupervisor:
         if answer:
             record.answer = answer
         else:
-            record.answer = "(no answer produced by Coordinador graph)"
+            display_name = (
+                self.profile.display_name if self.profile is not None else "datasource"
+            )
+            record.answer = f"(no answer produced by {display_name} graph)"
 
         # Persist DataPlan in artifacts (review item N12)
         plan = final_state.get("plan")
@@ -489,7 +498,7 @@ class HarnessSupervisor:
         # granularity (the root trace carries them, but the child
         # observation doesn't). The progress sink wires `usage.recorded`
         # too so SSE clients see token counts for the meta call.
-        _meta_span_prefix = self.profile.name if self.profile is not None else "nexo"
+        _meta_span_prefix = self.profile.name if self.profile is not None else "datasource"
         instrumented_meta_model = instrument_model(
             self.meta_model, "meta_agent", ctx,
             progress=progress, span_prefix=_meta_span_prefix,

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -30,6 +30,7 @@ from miot_harness.agents.meta_agent import (
     MetaAgentCatalogEntry,
     meta_agent_node,
 )
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.spans import agent_span
 from miot_harness.runtime.approvals import ApprovalRegistry
 from miot_harness.runtime.context import HarnessContext, UserRequest
@@ -88,6 +89,8 @@ class HarnessSupervisor:
         self.event_bus = event_bus
         self.checkpoint_every_n_events = checkpoint_every_n_events
         self.approval_registry = approval_registry
+        # Set by the lifespan after boot; None = legacy defaults.
+        self.profile: DataSourceProfile | None = None
 
     async def run(
         self,
@@ -302,6 +305,10 @@ class HarnessSupervisor:
         Centralizes the Langfuse first-class field mapping (E10) so every
         route's root span carries `user_id`, `session_id`, and `tags`
         identically. `tags` includes the resolved route when known.
+
+        When a profile is set on the supervisor, ``span_prefix`` is taken
+        from ``profile.name``; otherwise it falls back to ``"nexo"`` so
+        existing deployments are unaffected.
         """
 
         tags: list[str] = [f"tenant:{ctx.tenant_id}", f"mode:{ctx.mode}"]
@@ -314,6 +321,7 @@ class HarnessSupervisor:
             "user_id": ctx.user_id,
             "session_id": ctx.conversation_id or ctx.thread_id,
             "tags": tags,
+            "span_prefix": self.profile.name if self.profile is not None else "nexo",
         }
 
     async def _resolve_route(self, request: UserRequest) -> RouteResult:
@@ -360,8 +368,9 @@ class HarnessSupervisor:
         prior_messages: list[BaseMessage] | None = None,
     ) -> None:
         if self.nexo_graph is None:
+            display_name = self.profile.display_name if self.profile is not None else "Coordinador"
             answer = (
-                "Coordinador integration is currently disabled "
+                f"{display_name} integration is currently disabled "
                 "(no DB tunnel or boot failed). Try again once it's restored."
             )
             record.answer = answer
@@ -480,8 +489,10 @@ class HarnessSupervisor:
         # granularity (the root trace carries them, but the child
         # observation doesn't). The progress sink wires `usage.recorded`
         # too so SSE clients see token counts for the meta call.
+        _meta_span_prefix = self.profile.name if self.profile is not None else "nexo"
         instrumented_meta_model = instrument_model(
-            self.meta_model, "meta_agent", ctx, progress=progress
+            self.meta_model, "meta_agent", ctx,
+            progress=progress, span_prefix=_meta_span_prefix,
         )
 
         try:

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -472,6 +472,17 @@ class HarnessSupervisor:
                 "(no meta_model wired). Try again once it's restored."
             )
             record.answer = answer
+            # Terminal event mirrors the disabled-datasource branch in
+            # _run_data_query: SSE subscribers need answer.completed, not
+            # a silent close.
+            progress(
+                HarnessEvent(
+                    run_id=ctx.run_id,
+                    type="answer.completed",
+                    message="meta agent disabled",
+                    data={"length": len(answer)},
+                )
+            )
             return
 
         from miot_harness.config import get_settings

--- a/miot-harness/src/miot_harness/runtime/tenancy.py
+++ b/miot-harness/src/miot_harness/runtime/tenancy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.router import HarnessRoute
 
@@ -50,24 +51,37 @@ def tenancy_gate_decision(
     ctx: HarnessContext,
     route: HarnessRoute,
     settings: HarnessSettings,
+    profile: DataSourceProfile | None = None,
 ) -> TenancyDecision:
-    lock = settings.nexo_tenant_lock
+    """Evaluate tenancy for *route* and return a :class:`TenancyDecision`.
+
+    Lock resolution order (env-override layering arrives in a later stage):
+
+    1. ``profile.tenant_lock`` when a :class:`~miot_harness.datasource.provider.DataSourceProfile`
+       is supplied.
+    2. ``settings.nexo_tenant_lock`` otherwise (legacy / no-profile path).
+    """
+    lock = profile.tenant_lock if profile is not None else settings.nexo_tenant_lock
     tenant_matches = ctx.tenant_id == lock
 
     if route in _DATA_ROUTES:
         if tenant_matches:
             return TenancyDecision(allowed=True)
+        if profile is not None:
+            refusal = profile.tenant_refusal_template.format(
+                display_name=profile.display_name, lock=lock
+            )
+        else:
+            refusal = f"Coordinador is {lock}-only. I can't answer for other tenants."
         return TenancyDecision(
             allowed=False,
-            refusal_message=(
-                f"Coordinador is {lock}-only. I can't answer for other tenants."
-            ),
+            refusal_message=refusal,
         )
 
     if route in _META_ROUTES:
         # Always allowed; emit an audit attribute when the tenant is
         # off-lock so the Langfuse panel can spot "meta route used for
-        # non-Mintral tenant" patterns.
+        # non-locked tenant" patterns.
         if tenant_matches:
             return TenancyDecision(allowed=True)
         return TenancyDecision(

--- a/miot-harness/src/miot_harness/runtime/tenancy.py
+++ b/miot-harness/src/miot_harness/runtime/tenancy.py
@@ -76,7 +76,9 @@ def tenancy_gate_decision(
                 display_name=profile.display_name, lock=lock
             )
         else:
-            refusal = f"Coordinador is {lock}-only. I can't answer for other tenants."
+            refusal = (
+                f"This datasource is {lock}-only. I can't answer for other tenants."
+            )
         return TenancyDecision(
             allowed=False,
             refusal_message=refusal,

--- a/miot-harness/src/miot_harness/runtime/tenancy.py
+++ b/miot-harness/src/miot_harness/runtime/tenancy.py
@@ -55,14 +55,18 @@ def tenancy_gate_decision(
 ) -> TenancyDecision:
     """Evaluate tenancy for *route* and return a :class:`TenancyDecision`.
 
-    Lock resolution order (env-override layering arrives in a later stage):
+    Effective lock = the env override when set, else the profile's lock:
 
-    1. ``profile.tenant_lock`` when a :class:`~miot_harness.datasource.provider.DataSourceProfile`
-       is supplied.
-    2. ``settings.nexo_tenant_lock`` otherwise (legacy / no-profile path).
+        ``settings.datasource_tenant_lock or profile.tenant_lock``
+
+    When both are None (no override, no/None-lock profile) the gate
+    behaves as "no lock" — every tenant matches and data routes are
+    allowed.
     """
-    lock = profile.tenant_lock if profile is not None else settings.nexo_tenant_lock
-    tenant_matches = ctx.tenant_id == lock
+    lock = settings.datasource_tenant_lock or (
+        profile.tenant_lock if profile is not None else None
+    )
+    tenant_matches = lock is None or ctx.tenant_id == lock
 
     if route in _DATA_ROUTES:
         if tenant_matches:

--- a/miot-harness/src/miot_harness/runtime/tenancy.py
+++ b/miot-harness/src/miot_harness/runtime/tenancy.py
@@ -1,8 +1,8 @@
 """Route-aware tenancy gate (plan 13, E7).
 
 Refactor of plan 12's per-graph `tenant_gate_node` into a single
-decision function shared by `nexo_graph.py` (NEXO_QUERY) and
-`agentic_graph.py` (NEXO_AGENTIC). NEXO_META is allowed for any
+decision function shared by `data_graph.py` (DATA_QUERY) and
+`agentic_graph.py` (DATA_AGENTIC). DATA_META is allowed for any
 authenticated tenant — meta-info is non-confidential.
 
 The decision function is pure (no I/O, no LLM call) so the graphs can
@@ -24,11 +24,11 @@ from miot_harness.runtime.router import HarnessRoute
 
 # Routes that touch tenant DATA (must match the tenant lock).
 _DATA_ROUTES: frozenset[HarnessRoute] = frozenset(
-    {HarnessRoute.NEXO_QUERY, HarnessRoute.NEXO_AGENTIC}
+    {HarnessRoute.DATA_QUERY, HarnessRoute.DATA_AGENTIC}
 )
 
 # Routes that return non-confidential meta information (allow any tenant).
-_META_ROUTES: frozenset[HarnessRoute] = frozenset({HarnessRoute.NEXO_META})
+_META_ROUTES: frozenset[HarnessRoute] = frozenset({HarnessRoute.DATA_META})
 
 
 @dataclass(frozen=True, slots=True)

--- a/miot-harness/src/miot_harness/runtime/tool.py
+++ b/miot-harness/src/miot_harness/runtime/tool.py
@@ -30,9 +30,9 @@ class HarnessTool(BaseModel, Generic[InputT, OutputT]):
     read_only: bool = True
     destructive: bool = False
     # Trace badge — propagated into tool.started.data.source so the frontend
-    # can render "Coordinador · nexo" / "ModularIoT AMS" / etc. without
-    # waiting for the per-row metadata that _lift_metadata pulls from the
-    # tool output on tool.completed.
+    # can render the datasource provenance label (e.g. "ModularIoT AMS")
+    # without waiting for the per-row metadata that _lift_metadata pulls from
+    # the tool output on tool.completed.
     source: str = ""
     check_permission: Callable[[HarnessContext, InputT], Awaitable[PermissionResult]]
     call: Callable[[HarnessContext, InputT, Progress], Awaitable[OutputT]]
@@ -152,7 +152,7 @@ _METADATA_KEYS = ("source", "refreshed_at", "layer", "domain", "truncated")
 def _lift_metadata(output: Any) -> dict[str, Any]:
     """Surface a fixed set of metadata fields from the tool output into the
     tool.completed event payload. Tools that do not expose these fields get
-    a bare event; tools that do (e.g. Nexo coordinador_*) carry the
+    a bare event; tools that do (e.g. a datasource's data tools) carry the
     structured trace metadata downstream consumers (analyst, run record)
     rely on.
     """

--- a/miot-harness/tests/api/test_approvals.py
+++ b/miot-harness/tests/api/test_approvals.py
@@ -33,7 +33,7 @@ from miot_harness.runtime.tool import HarnessTool
 def _clean_settings_and_workspace(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     monkeypatch.delenv("MIOT_HARNESS_IDENTITY_SIGNING_KEY", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()

--- a/miot-harness/tests/api/test_health.py
+++ b/miot-harness/tests/api/test_health.py
@@ -14,8 +14,11 @@ from miot_harness.config import get_settings
 
 @pytest.fixture(autouse=True)
 def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    # The "Nexo disabled" assumption requires the DSN to be unset.
+    # The "Nexo disabled" assumption requires the DSN to be unset, and
+    # the provider assertions require the default kind regardless of the
+    # outer environment.
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/miot-harness/tests/api/test_health.py
+++ b/miot-harness/tests/api/test_health.py
@@ -15,14 +15,14 @@ from miot_harness.config import get_settings
 @pytest.fixture(autouse=True)
 def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     # The "Nexo disabled" assumption requires the DSN to be unset.
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
 
 
 def test_health_default_nexo_disabled() -> None:
-    """Without MIOT_HARNESS_NEXO_DSN, lifespan disables Nexo and
+    """Without MIOT_HARNESS_DATASOURCE_DSN, lifespan disables Nexo and
     /health reports the deploy-readable shape with datasource state defaults."""
     app = create_app()
     with TestClient(app) as client:
@@ -66,7 +66,7 @@ def test_health_reflects_simulated_nexo_enabled_state() -> None:
     }
 
 
-def test_health_ready_without_nexo_dsn_is_ready() -> None:
+def test_health_ready_without_datasource_dsn_is_ready() -> None:
     """No DSN configured -> Nexo not required -> readiness probe passes."""
     app = create_app()
     with TestClient(app) as client:
@@ -89,7 +89,7 @@ def test_health_ready_with_dsn_but_nexo_disabled_returns_503(
     """DSN configured but lifespan failed to enable Nexo (tunnel down,
     tools didn't register, snapshot too stale, etc.) -> readiness MUST
     fail so the Service doesn't route traffic to a half-booted pod."""
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
     get_settings.cache_clear()
 
     # Mirror tests/test_server_lifespan.py — mock pool creation to raise
@@ -120,7 +120,7 @@ def test_health_ready_reflects_simulated_nexo_enabled_state(
     lifespan mutation of app.state, identical to how
     `test_health_reflects_simulated_nexo_enabled_state` exercises /health.
     """
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
     get_settings.cache_clear()
     with patch(
         "miot_harness.integrations.nexo.provider.create_nexo_pool",

--- a/miot-harness/tests/api/test_health.py
+++ b/miot-harness/tests/api/test_health.py
@@ -90,7 +90,7 @@ def test_health_ready_with_dsn_but_nexo_disabled_returns_503(
     # so lifespan exercises the "Nexo disabled despite DSN" path without
     # attempting a real connect.
     with patch(
-        "miot_harness.api.server.create_nexo_pool",
+        "miot_harness.integrations.nexo.provider.create_nexo_pool",
         new=AsyncMock(side_effect=ConnectionRefusedError("tunnel down")),
     ):
         app = create_app()
@@ -117,7 +117,7 @@ def test_health_ready_reflects_simulated_nexo_enabled_state(
     monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
     get_settings.cache_clear()
     with patch(
-        "miot_harness.api.server.create_nexo_pool",
+        "miot_harness.integrations.nexo.provider.create_nexo_pool",
         new=AsyncMock(side_effect=ConnectionRefusedError("tunnel down")),
     ):
         app = create_app()

--- a/miot-harness/tests/api/test_health.py
+++ b/miot-harness/tests/api/test_health.py
@@ -23,7 +23,7 @@ def _clear_settings_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 def test_health_default_nexo_disabled() -> None:
     """Without MIOT_HARNESS_NEXO_DSN, lifespan disables Nexo and
-    /health reports the deploy-readable shape with Nexo state defaults."""
+    /health reports the deploy-readable shape with datasource state defaults."""
     app = create_app()
     with TestClient(app) as client:
         resp = client.get("/health")
@@ -31,10 +31,12 @@ def test_health_default_nexo_disabled() -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert "env" in body
-    nexo = body["nexo"]
-    assert nexo["enabled"] is False
-    assert nexo["tools"] == []
-    assert nexo["snapshot_age_minutes"] is None
+    assert body["datasource"] == {
+        "name": "nexo",
+        "enabled": False,
+        "tools": [],
+        "snapshot_age_minutes": None,
+    }
 
 
 def test_health_reflects_simulated_nexo_enabled_state() -> None:
@@ -45,21 +47,23 @@ def test_health_reflects_simulated_nexo_enabled_state() -> None:
     with TestClient(app) as client:
         # First call confirms baseline.
         baseline = client.get("/health").json()
-        assert baseline["nexo"]["enabled"] is False
+        assert baseline["datasource"]["enabled"] is False
 
         # Simulate post-boot state mutation as if Nexo had enabled.
-        app.state.nexo_enabled = True
-        app.state.nexo_registered = ["coordinador_centro_control", "coordinador_servicios"]
-        app.state.nexo_snapshot_age_minutes = 12.5
+        app.state.datasource_enabled = True
+        app.state.datasource_registered = ["coordinador_centro_control", "coordinador_servicios"]
+        app.state.datasource_snapshot_age_minutes = 12.5
 
         body = client.get("/health").json()
-    nexo = body["nexo"]
-    assert nexo["enabled"] is True
-    assert nexo["tools"] == [
-        "coordinador_centro_control",
-        "coordinador_servicios",
-    ]
-    assert nexo["snapshot_age_minutes"] == 12.5
+    assert body["datasource"] == {
+        "name": "nexo",
+        "enabled": True,
+        "tools": [
+            "coordinador_centro_control",
+            "coordinador_servicios",
+        ],
+        "snapshot_age_minutes": 12.5,
+    }
 
 
 def test_health_ready_without_nexo_dsn_is_ready() -> None:
@@ -70,11 +74,13 @@ def test_health_ready_without_nexo_dsn_is_ready() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ready"
-    nexo = body["nexo"]
-    assert nexo["required"] is False
-    assert nexo["enabled"] is False
-    assert nexo["tools"] == []
-    assert nexo["snapshot_age_minutes"] is None
+    assert body["datasource"] == {
+        "name": "nexo",
+        "required": False,
+        "enabled": False,
+        "tools": [],
+        "snapshot_age_minutes": None,
+    }
 
 
 def test_health_ready_with_dsn_but_nexo_disabled_returns_503(
@@ -99,9 +105,9 @@ def test_health_ready_with_dsn_but_nexo_disabled_returns_503(
     assert resp.status_code == 503
     body = resp.json()
     assert body["status"] == "not_ready"
-    nexo = body["nexo"]
-    assert nexo["required"] is True
-    assert nexo["enabled"] is False
+    ds = body["datasource"]
+    assert ds["required"] is True
+    assert ds["enabled"] is False
 
 
 def test_health_ready_reflects_simulated_nexo_enabled_state(
@@ -122,15 +128,17 @@ def test_health_ready_reflects_simulated_nexo_enabled_state(
     ):
         app = create_app()
         with TestClient(app) as client:
-            app.state.nexo_enabled = True
-            app.state.nexo_registered = ["coordinador_centro_control"]
-            app.state.nexo_snapshot_age_minutes = 7.5
+            app.state.datasource_enabled = True
+            app.state.datasource_registered = ["coordinador_centro_control"]
+            app.state.datasource_snapshot_age_minutes = 7.5
             resp = client.get("/health/ready")
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ready"
-    nexo = body["nexo"]
-    assert nexo["required"] is True
-    assert nexo["enabled"] is True
-    assert nexo["tools"] == ["coordinador_centro_control"]
-    assert nexo["snapshot_age_minutes"] == 7.5
+    assert body["datasource"] == {
+        "name": "nexo",
+        "required": True,
+        "enabled": True,
+        "tools": ["coordinador_centro_control"],
+        "snapshot_age_minutes": 7.5,
+    }

--- a/miot-harness/tests/api/test_identity.py
+++ b/miot-harness/tests/api/test_identity.py
@@ -33,6 +33,8 @@ def _clean_settings_and_workspace(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    # Pin provider selection to the default kind for deterministic boots.
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
     monkeypatch.delenv("MIOT_HARNESS_IDENTITY_SIGNING_KEY", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()

--- a/miot-harness/tests/api/test_identity.py
+++ b/miot-harness/tests/api/test_identity.py
@@ -32,7 +32,7 @@ from miot_harness.config import get_settings
 def _clean_settings_and_workspace(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     monkeypatch.delenv("MIOT_HARNESS_IDENTITY_SIGNING_KEY", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()

--- a/miot-harness/tests/api/test_runs_stream.py
+++ b/miot-harness/tests/api/test_runs_stream.py
@@ -29,7 +29,7 @@ from miot_harness.runtime.events import HarnessEvent
 def _clean_settings_and_workspace(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()
     yield
@@ -209,7 +209,7 @@ async def test_stream_receives_live_events_during_in_flight(
 
     import httpx
 
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()
 

--- a/miot-harness/tests/api/test_runs_stream.py
+++ b/miot-harness/tests/api/test_runs_stream.py
@@ -202,7 +202,7 @@ async def test_stream_receives_live_events_during_in_flight(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """While a run is in-flight, GET /stream subscribes to the RunEventBus
-    and yields events live. We slot a controllable nexo_graph onto the
+    and yields events live. We slot a controllable data_graph onto the
     harness after lifespan starts, then start a run via /runs:start and
     immediately consume the stream.
     """
@@ -218,7 +218,7 @@ async def test_stream_receives_live_events_during_in_flight(
     # Drive lifespan via TestClient, then run the actual stream test
     # against httpx.AsyncClient(transport=ASGITransport) on the same app.
     with TestClient(app):
-        # Force route to NEXO_QUERY via a scripted llm_router, and inject
+        # Force route to DATA_QUERY via a scripted llm_router, and inject
         # a slow graph that emits 2 events and blocks until released.
         gate = asyncio.Event()
 
@@ -235,16 +235,16 @@ async def test_stream_receives_live_events_during_in_flight(
             await gate.wait()
             return {"answer": "released", "_events": events}
 
-        nexo_graph = AsyncMock()
-        nexo_graph.ainvoke = slow_ainvoke
+        data_graph = AsyncMock()
+        data_graph.ainvoke = slow_ainvoke
 
-        # Attach controllable graph + force NEXO_QUERY routing keyword.
+        # Attach controllable graph + force DATA_QUERY routing keyword.
         harness = app.state.harness
-        harness.nexo_graph = nexo_graph
-        # No LLM router → keyword router picks NEXO_QUERY when the message
+        harness.data_graph = data_graph
+        # No LLM router → keyword router picks DATA_QUERY when the message
         # contains a keyword. Easiest: use a Mintral-related keyword.
-        # Looking at router.py for an actual NEXO_QUERY trigger word.
-        message = "mintral status"  # keyword router routes this to NEXO_QUERY
+        # Looking at router.py for an actual DATA_QUERY trigger word.
+        message = "mintral status"  # keyword router routes this to DATA_QUERY
 
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),

--- a/miot-harness/tests/api/test_runs_stream.py
+++ b/miot-harness/tests/api/test_runs_stream.py
@@ -30,6 +30,8 @@ def _clean_settings_and_workspace(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    # Pin provider selection to the default kind for deterministic boots.
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()
     yield
@@ -210,6 +212,8 @@ async def test_stream_receives_live_events_during_in_flight(
     import httpx
 
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    # Pin provider selection to the default kind for deterministic boots.
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     get_settings.cache_clear()
 

--- a/miot-harness/tests/api/test_server_auth.py
+++ b/miot-harness/tests/api/test_server_auth.py
@@ -48,7 +48,7 @@ def _clean_env_and_workspace(
         "AUTH0_RS256_AUDIENCE",
         "MIOT_HARNESS_AUTH_ENABLED",
         "MIOT_HARNESS_AUTH_DIRECT_ALLOWED",
-        "MIOT_HARNESS_NEXO_DSN",
+        "MIOT_HARNESS_DATASOURCE_DSN",
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))

--- a/miot-harness/tests/api/test_server_auth.py
+++ b/miot-harness/tests/api/test_server_auth.py
@@ -49,6 +49,7 @@ def _clean_env_and_workspace(
         "MIOT_HARNESS_AUTH_ENABLED",
         "MIOT_HARNESS_AUTH_DIRECT_ALLOWED",
         "MIOT_HARNESS_DATASOURCE_DSN",
+        "MIOT_HARNESS_DATASOURCE_KIND",
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))

--- a/miot-harness/tests/conftest.py
+++ b/miot-harness/tests/conftest.py
@@ -48,7 +48,9 @@ class _HarnessSpanExporter(InMemorySpanExporter):
 
     pytest-opentelemetry attaches a TracerProvider that emits one span per
     test item / fixture / runtest call. We keep only spans produced by the
-    harness (`nexo.*`) and by the auto-instrumented LLM SDKs.
+    harness datasource providers (`nexo.*`, plus the alternate prefixes
+    `fake.*` for FakeProvider tests and `datasource.*`, the neutral default
+    span_prefix when no profile is set) and by the auto-instrumented LLM SDKs.
     """
 
     def export(self, spans: tuple[ReadableSpan, ...]) -> SpanExportResult:  # type: ignore[override]

--- a/miot-harness/tests/conftest.py
+++ b/miot-harness/tests/conftest.py
@@ -31,8 +31,10 @@ from miot_harness.config import HarnessSettings
 
 _HARNESS_SPAN_PREFIXES = (
     "nexo.",
-    # Alternate datasource prefixes (e.g. "fake." used by FakeProvider tests).
+    # Alternate datasource prefixes: "fake." for FakeProvider tests, and
+    # "datasource." — the neutral default span_prefix when no profile is set.
     "fake.",
+    "datasource.",
     # Traceloop / OpenLLMetry auto-instrumentation emits spans like
     # `anthropic.chat`, `openai.chat`, `gen_ai.completion`.
     "gen_ai.",

--- a/miot-harness/tests/conftest.py
+++ b/miot-harness/tests/conftest.py
@@ -31,6 +31,8 @@ from miot_harness.config import HarnessSettings
 
 _HARNESS_SPAN_PREFIXES = (
     "nexo.",
+    # Alternate datasource prefixes (e.g. "fake." used by FakeProvider tests).
+    "fake.",
     # Traceloop / OpenLLMetry auto-instrumentation emits spans like
     # `anthropic.chat`, `openai.chat`, `gen_ai.completion`.
     "gen_ai.",

--- a/miot-harness/tests/datasource/test_fake_provider.py
+++ b/miot-harness/tests/datasource/test_fake_provider.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.config import HarnessSettings
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE, FakeProvider
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_boots_and_registers_tools() -> None:
+    provider = FakeProvider()
+    registry = ToolRegistry()
+    result = await provider.boot(registry, HarnessSettings())
+    assert result.enabled is True
+    assert result.registered == ("fake_lookup",)
+    assert "fake_lookup" in registry.names()
+    assert provider.profile is FAKE_PROFILE
+    await provider.close()

--- a/miot-harness/tests/datasource/test_provider.py
+++ b/miot-harness/tests/datasource/test_provider.py
@@ -1,0 +1,82 @@
+"""DataSourceProvider seam: profile shape and provider contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+
+
+def make_profile(**overrides) -> DataSourceProfile:
+    base = dict(
+        name="fake",
+        display_name="FakeSource",
+        source_label="FakeSource · fake (test)",
+        tool_prefix="fake_",
+        primer="FakeSource answers questions about test fixtures.",
+        router_keywords=frozenset({"fakesource", "fixture"}),
+        tenant_lock="acme",
+        tenant_refusal_template=(
+            "{display_name} is {lock}-only. I can't answer for other tenants."
+        ),
+        freshness_warn_minutes=30,
+        freshness_refuse_minutes=240,
+    )
+    base.update(overrides)
+    return DataSourceProfile(**base)
+
+
+def test_profile_is_frozen() -> None:
+    profile = make_profile()
+    with pytest.raises(AttributeError):  # dataclasses.FrozenInstanceError
+        profile.name = "other"  # type: ignore[misc]
+
+
+def test_refusal_template_formats() -> None:
+    profile = make_profile()
+    msg = profile.tenant_refusal_template.format(
+        display_name=profile.display_name, lock=profile.tenant_lock
+    )
+    assert msg == "FakeSource is acme-only. I can't answer for other tenants."
+
+
+def test_boot_result_defaults() -> None:
+    r = BootResult(enabled=False, registered=())
+    assert r.registered == ()
+    assert r.reason is None
+    assert r.snapshot_age_minutes is None
+
+
+def test_provider_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        DataSourceProvider()  # type: ignore[abstract]
+
+
+def test_provider_without_profile_is_abstract() -> None:
+    class _NoProfile(DataSourceProvider):
+        async def boot(self, registry, settings):  # type: ignore[no-untyped-def]
+            raise NotImplementedError
+
+        async def close(self) -> None: ...
+
+    with pytest.raises(TypeError):
+        _NoProfile()  # type: ignore[abstract]
+
+
+def test_provider_with_class_attribute_profile_instantiates() -> None:
+    """A subclass satisfying profile via a class attribute instantiates fine."""
+
+    class _WithProfile(DataSourceProvider):
+        profile = make_profile()
+
+        async def boot(self, registry, settings):  # type: ignore[no-untyped-def]
+            raise NotImplementedError
+
+        async def close(self) -> None: ...
+
+    provider = _WithProfile()
+    assert provider.profile == make_profile()

--- a/miot-harness/tests/datasource/test_registry.py
+++ b/miot-harness/tests/datasource/test_registry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.datasource.registry import available_kinds, resolve
+
+
+def test_nexo_is_registered() -> None:
+    assert "nexo" in available_kinds()
+
+
+def test_resolve_nexo_returns_provider_with_profile() -> None:
+    provider = resolve("nexo")
+    assert provider.profile.name == "nexo"
+    assert provider.profile.display_name == "Coordinador"
+    assert provider.profile.tool_prefix == "coordinador_"
+    assert provider.profile.tenant_lock == "mintral"
+
+
+def test_resolve_unknown_kind_fails_fast_listing_kinds() -> None:
+    with pytest.raises(ValueError) as exc:
+        resolve("definitely-not-a-datasource")
+    assert "nexo" in str(exc.value)  # lists available kinds
+
+
+def test_resolve_returns_fresh_instance_per_call() -> None:
+    # Providers own connection pools; a cached singleton would make one
+    # caller's close() break another. The registry must instantiate.
+    assert resolve("nexo") is not resolve("nexo")

--- a/miot-harness/tests/fixtures/fake_provider.py
+++ b/miot-harness/tests/fixtures/fake_provider.py
@@ -1,0 +1,85 @@
+"""A minimal second DataSourceProvider.
+
+Exists to prove the seam: core runtime/agent tests run against this
+provider so they cannot accidentally depend on Nexo/Coordinador/Mintral
+specifics. Mirrors the eval-stub tool shape used by run_golden.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import (
+    BootResult,
+    DataSourceProfile,
+    DataSourceProvider,
+)
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.permissions import PermissionResult
+from miot_harness.runtime.tool import HarnessTool
+from miot_harness.tools.registry import ToolRegistry
+
+FAKE_PROFILE = DataSourceProfile(
+    name="fake",
+    display_name="FakeSource",
+    source_label="FakeSource · fake (test)",
+    tool_prefix="fake_",
+    primer="FakeSource is a synthetic datasource used in harness tests.",
+    router_keywords=frozenset({"fakesource", "fixture"}),
+    tenant_lock="acme",
+    tenant_refusal_template=(
+        "{display_name} is {lock}-only. I can't answer for other tenants."
+    ),
+    freshness_warn_minutes=30,
+    freshness_refuse_minutes=240,
+)
+
+
+class _In(BaseModel):
+    pass
+
+
+class _Out(BaseModel):
+    rows: list[dict[str, Any]] = []
+    refreshed_at: datetime | None = None
+    source: str = FAKE_PROFILE.source_label
+
+
+async def _check(ctx: HarnessContext, inp: BaseModel) -> PermissionResult:
+    if ctx.tenant_id != FAKE_PROFILE.tenant_lock:
+        return PermissionResult.deny("FakeSource is acme-only")
+    return PermissionResult.allow()
+
+
+async def _call(
+    ctx: HarnessContext, inp: BaseModel, progress: Callable[..., None]
+) -> _Out:
+    now = datetime.now(UTC)
+    return _Out(rows=[{"value": 42}], refreshed_at=now)
+
+
+class FakeProvider(DataSourceProvider):
+    profile = FAKE_PROFILE
+
+    async def boot(
+        self, registry: ToolRegistry, settings: HarnessSettings
+    ) -> BootResult:
+        registry.register(
+            HarnessTool(
+                name="fake_lookup",
+                description="[Layer L1] fake test tool",
+                input_model=_In,
+                output_model=_Out,
+                check_permission=_check,
+                call=_call,
+            )
+        )
+        return BootResult(enabled=True, registered=("fake_lookup",))
+
+    async def close(self) -> None:
+        return None

--- a/miot-harness/tests/integrations/nexo/test_boot.py
+++ b/miot-harness/tests/integrations/nexo/test_boot.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.boot import (
     NexoBootResult,
     load_nexo_tools,
@@ -31,12 +30,19 @@ def _descriptor(name: str = "fn_dx_centro_control") -> FunctionDescriptor:
     )
 
 
-def _settings(**overrides) -> HarnessSettings:
+def _boot_kwargs(**overrides) -> dict:
+    """Resolved provider-private kwargs for ``load_nexo_tools``.
+
+    Mirrors what ``NexoProvider.boot`` passes in: schema from
+    NexoSettings, effective tenant_lock / refuse_minutes.
+    """
     base = {
-        "nexo_freshness_refuse_minutes": 240,
+        "schema": "nexo",
+        "tenant_lock": "mintral",
+        "refuse_minutes": 240,
     }
     base.update(overrides)
-    return HarnessSettings(**base)
+    return base
 
 
 def _mock_pool(centro_refreshed: datetime, fn_refresh_leak: int = 0) -> MagicMock:
@@ -79,7 +85,7 @@ async def test_happy_path_registers_tools(monkeypatch):
     registry = ToolRegistry()
     pool = _mock_pool(centro_refreshed=datetime.now(UTC) - timedelta(minutes=5))
 
-    result = await load_nexo_tools(registry, settings=_settings(), pool=pool)
+    result = await load_nexo_tools(registry, **_boot_kwargs(), pool=pool)
 
     assert isinstance(result, NexoBootResult)
     assert result.enabled is True
@@ -96,7 +102,7 @@ async def test_fn_refresh_leak_disables_nexo(monkeypatch):
     registry = ToolRegistry()
     pool = _mock_pool(centro_refreshed=datetime.now(UTC), fn_refresh_leak=3)
 
-    result = await load_nexo_tools(registry, settings=_settings(), pool=pool)
+    result = await load_nexo_tools(registry, **_boot_kwargs(), pool=pool)
 
     assert result.enabled is False
     assert "fn_refresh" in (result.reason or "").lower()
@@ -115,7 +121,7 @@ async def test_stale_centro_control_disables_nexo(monkeypatch):
 
     result = await load_nexo_tools(
         registry,
-        settings=_settings(nexo_freshness_refuse_minutes=240),
+        **_boot_kwargs(refuse_minutes=240),
         pool=pool,
     )
 
@@ -126,7 +132,7 @@ async def test_stale_centro_control_disables_nexo(monkeypatch):
 @pytest.mark.asyncio
 async def test_no_pool_disables_nexo_without_raising():
     registry = ToolRegistry()
-    result = await load_nexo_tools(registry, settings=_settings(), pool=None)
+    result = await load_nexo_tools(registry, **_boot_kwargs(), pool=None)
     assert result.enabled is False
     assert registry.names() == []
     assert (
@@ -146,7 +152,7 @@ async def test_connection_failure_disables_nexo_without_raising(monkeypatch):
     registry = ToolRegistry()
     pool = _mock_pool(centro_refreshed=datetime.now(UTC))
 
-    result = await load_nexo_tools(registry, settings=_settings(), pool=pool)
+    result = await load_nexo_tools(registry, **_boot_kwargs(), pool=pool)
     assert result.enabled is False
 
 
@@ -155,9 +161,9 @@ async def test_invalid_schema_name_disables_nexo():
     """Operator-supplied schema must match [a-z_][a-z0-9_]* — refuse otherwise."""
     registry = ToolRegistry()
     pool = _mock_pool(centro_refreshed=datetime.now(UTC))
-    bad_settings = _settings(nexo_search_path="public; DROP TABLE x")
-
-    result = await load_nexo_tools(registry, settings=bad_settings, pool=pool)
+    result = await load_nexo_tools(
+        registry, **_boot_kwargs(schema="public; DROP TABLE x"), pool=pool
+    )
 
     assert result.enabled is False
     assert "schema" in (result.reason or "").lower()

--- a/miot-harness/tests/integrations/nexo/test_graph.py
+++ b/miot-harness/tests/integrations/nexo/test_graph.py
@@ -91,7 +91,10 @@ def _models(filter_step_tool: str = "coordinador_centro_control") -> dict[str, A
 @pytest.mark.asyncio
 async def test_happy_path_mintral_run_emits_answer():
     registry, _refreshed = _registry_with_centro()
-    settings = HarnessSettings(nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240)
+    settings = HarnessSettings(
+        datasource_freshness_warn_minutes=30,
+        datasource_freshness_refuse_minutes=240,
+    )
     graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
@@ -149,7 +152,7 @@ async def test_stale_data_routes_through_synth_failure_path():
     refreshed = datetime(2026, 5, 1, tzinfo=UTC)  # 7+ days stale vs default 240min refuse
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", refreshed))
-    settings = HarnessSettings(nexo_freshness_refuse_minutes=240)
+    settings = HarnessSettings(datasource_freshness_refuse_minutes=240)
     graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )

--- a/miot-harness/tests/integrations/nexo/test_graph.py
+++ b/miot-harness/tests/integrations/nexo/test_graph.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.permissions import PermissionResult
 from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
@@ -92,7 +92,7 @@ def _models(filter_step_tool: str = "coordinador_centro_control") -> dict[str, A
 async def test_happy_path_mintral_run_emits_answer():
     registry, _refreshed = _registry_with_centro()
     settings = HarnessSettings(nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240)
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
 
@@ -126,7 +126,7 @@ async def test_non_mintral_tenant_short_circuits_at_tenant_gate():
         "critic": FakeListChatModel(responses=[]),
         "summarizer": FakeListChatModel(responses=[]),
     }
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=bare_models, profile=NEXO_PROFILE
     )
 
@@ -150,7 +150,7 @@ async def test_stale_data_routes_through_synth_failure_path():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", refreshed))
     settings = HarnessSettings(nexo_freshness_refuse_minutes=240)
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
 

--- a/miot-harness/tests/integrations/nexo/test_pool.py
+++ b/miot-harness/tests/integrations/nexo/test_pool.py
@@ -65,7 +65,7 @@ async def test_create_nexo_pool_default_sizes(monkeypatch):
 @pytest.mark.asyncio
 async def test_create_nexo_pool_with_dsn(monkeypatch):
     """The harness sources Nexo credentials from a single standard
-    Postgres connection string (`MIOT_HARNESS_NEXO_DSN`)."""
+    Postgres connection string (`MIOT_HARNESS_DATASOURCE_DSN`)."""
     captured: dict = {}
 
     async def fake_create_pool(dsn=None, **kwargs):

--- a/miot-harness/tests/integrations/nexo/test_provider.py
+++ b/miot-harness/tests/integrations/nexo/test_provider.py
@@ -1,0 +1,59 @@
+"""NexoProvider: profile carries today's exact runtime strings, and
+boot() degrades to disabled when no DSN is configured."""
+
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE, NexoProvider
+from miot_harness.tools.registry import ToolRegistry
+
+
+def test_profile_values_match_legacy_hardcodes() -> None:
+    p = NEXO_PROFILE
+    assert p.name == "nexo"
+    assert p.display_name == "Coordinador"
+    assert p.source_label == "Coordinador · nexo (Citus DB)"
+    assert p.tool_prefix == "coordinador_"
+    assert "coordinador" in p.router_keywords
+    assert "mintral" in p.router_keywords
+    assert p.tenant_lock == "mintral"
+    assert (
+        p.tenant_refusal_template.format(
+            display_name=p.display_name, lock=p.tenant_lock
+        )
+        == "Coordinador is mintral-only. I can't answer for other tenants."
+    )
+    assert p.freshness_warn_minutes == 30
+    assert p.freshness_refuse_minutes == 240
+
+
+@pytest.mark.asyncio
+async def test_boot_without_dsn_returns_disabled() -> None:
+    provider = NexoProvider()
+    settings = HarnessSettings(nexo_dsn=None)
+    result = await provider.boot(ToolRegistry(), settings)
+    assert result.enabled is False
+    assert result.registered == ()
+    assert result.reason is not None
+    await provider.close()  # no-op when never connected; must not raise
+
+
+@pytest.mark.asyncio
+async def test_boot_pool_failure_returns_disabled_and_no_leak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(
+        "miot_harness.integrations.nexo.provider.create_nexo_pool", _boom
+    )
+    provider = NexoProvider()
+    result = await provider.boot(
+        ToolRegistry(), HarnessSettings(nexo_dsn="postgresql://u:p@h:5/db")
+    )
+    assert result.enabled is False
+    assert "connection refused" in (result.reason or "")
+    assert provider._pool is None  # no leaked half-created pool

--- a/miot-harness/tests/integrations/nexo/test_provider.py
+++ b/miot-harness/tests/integrations/nexo/test_provider.py
@@ -32,7 +32,7 @@ def test_profile_values_match_legacy_hardcodes() -> None:
 @pytest.mark.asyncio
 async def test_boot_without_dsn_returns_disabled() -> None:
     provider = NexoProvider()
-    settings = HarnessSettings(nexo_dsn=None)
+    settings = HarnessSettings(datasource_dsn=None)
     result = await provider.boot(ToolRegistry(), settings)
     assert result.enabled is False
     assert result.registered == ()
@@ -52,7 +52,7 @@ async def test_boot_pool_failure_returns_disabled_and_no_leak(
     )
     provider = NexoProvider()
     result = await provider.boot(
-        ToolRegistry(), HarnessSettings(nexo_dsn="postgresql://u:p@h:5/db")
+        ToolRegistry(), HarnessSettings(datasource_dsn="postgresql://u:p@h:5/db")
     )
     assert result.enabled is False
     assert "connection refused" in (result.reason or "")

--- a/miot-harness/tests/observability/test_callbacks.py
+++ b/miot-harness/tests/observability/test_callbacks.py
@@ -45,7 +45,7 @@ def _llm_result(
 def test_callback_opens_and_closes_span_with_token_attrs(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    cb = AgentTelemetryCallback(agent_name="filter_expert", run_id="root-1", tenant_id="mintral")
+    cb = AgentTelemetryCallback(agent_name="filter_expert", run_id="root-1", tenant_id="acme")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
     cb.on_llm_end(_llm_result(input_tokens=200, output_tokens=80), run_id=rid)
@@ -53,16 +53,17 @@ def test_callback_opens_and_closes_span_with_token_attrs(
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
-    assert span.name == "nexo.filter_expert"
+    # No span_prefix passed → the neutral "datasource" default.
+    assert span.name == "datasource.filter_expert"
     attrs = dict(span.attributes)
-    assert attrs["gen_ai.operation.name"] == "nexo.filter_expert"
+    assert attrs["gen_ai.operation.name"] == "datasource.filter_expert"
     assert attrs["gen_ai.system"] == "anthropic"
     assert attrs["gen_ai.request.model"] == "claude-haiku-4-5"
     assert attrs["gen_ai.usage.input_tokens"] == 200
     assert attrs["gen_ai.usage.output_tokens"] == 80
     assert attrs["modular.agent"] == "filter_expert"
     assert attrs["modular.run_id"] == "root-1"
-    assert attrs["modular.tenant_id"] == "mintral"
+    assert attrs["modular.tenant_id"] == "acme"
     # Cost is recorded at run-time (float seconds-since pricing.compute_cost).
     assert attrs["gen_ai.usage.cost_usd"] > 0
 
@@ -138,10 +139,10 @@ def test_callback_infers_openai_provider_from_model_name(
     assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
 
 
-def test_callback_span_prefix_overrides_nexo_default(
+def test_callback_span_prefix_overrides_default(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    """When span_prefix='fake', emitted span names start with 'fake.' not 'nexo.'."""
+    """When span_prefix='fake', emitted span names start with 'fake.' not the default."""
     cb = AgentTelemetryCallback(agent_name="filter_expert", run_id="root-6", span_prefix="fake")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)

--- a/miot-harness/tests/observability/test_callbacks.py
+++ b/miot-harness/tests/observability/test_callbacks.py
@@ -136,3 +136,20 @@ def test_callback_infers_openai_provider_from_model_name(
     attrs = dict(memory_exporter.get_finished_spans()[0].attributes)
     assert attrs["gen_ai.system"] == "openai"
     assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_callback_span_prefix_overrides_nexo_default(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    """When span_prefix='fake', emitted span names start with 'fake.' not 'nexo.'."""
+    cb = NexoTelemetryCallback(agent_name="filter_expert", run_id="root-6", span_prefix="fake")
+    rid = uuid4()
+    cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
+    cb.on_llm_end(_llm_result(input_tokens=10, output_tokens=5), run_id=rid)
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "fake.filter_expert"
+    attrs = dict(span.attributes)
+    assert attrs["gen_ai.operation.name"] == "fake.filter_expert"

--- a/miot-harness/tests/observability/test_callbacks.py
+++ b/miot-harness/tests/observability/test_callbacks.py
@@ -1,4 +1,4 @@
-"""NexoTelemetryCallback span emission (A2)."""
+"""AgentTelemetryCallback span emission (A2)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from miot_harness.observability.callbacks import NexoTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback
 
 
 def _serialized_anthropic(model: str = "claude-haiku-4-5") -> dict[str, object]:
@@ -45,7 +45,7 @@ def _llm_result(
 def test_callback_opens_and_closes_span_with_token_attrs(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    cb = NexoTelemetryCallback(agent_name="filter_expert", run_id="root-1", tenant_id="mintral")
+    cb = AgentTelemetryCallback(agent_name="filter_expert", run_id="root-1", tenant_id="mintral")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
     cb.on_llm_end(_llm_result(input_tokens=200, output_tokens=80), run_id=rid)
@@ -70,7 +70,7 @@ def test_callback_opens_and_closes_span_with_token_attrs(
 def test_callback_emits_cache_token_attrs_when_present(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    cb = NexoTelemetryCallback(agent_name="domain_analyst", run_id="root-2")
+    cb = AgentTelemetryCallback(agent_name="domain_analyst", run_id="root-2")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
     cb.on_llm_end(
@@ -89,7 +89,7 @@ def test_callback_handles_multiple_concurrent_runs(
 ) -> None:
     """Each run_id gets its own span — no cross-talk between concurrent calls."""
 
-    cb = NexoTelemetryCallback(agent_name="executor", run_id="root-3")
+    cb = AgentTelemetryCallback(agent_name="executor", run_id="root-3")
     a, b = uuid4(), uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="a")]], run_id=a)
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="b")]], run_id=b)
@@ -108,7 +108,7 @@ def test_callback_records_error_status_on_llm_error(
 ) -> None:
     from opentelemetry.trace import StatusCode
 
-    cb = NexoTelemetryCallback(agent_name="critic", run_id="root-4")
+    cb = AgentTelemetryCallback(agent_name="critic", run_id="root-4")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="x")]], run_id=rid)
     cb.on_llm_error(RuntimeError("provider 5xx"), run_id=rid)
@@ -121,7 +121,7 @@ def test_callback_records_error_status_on_llm_error(
 def test_callback_infers_openai_provider_from_model_name(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    cb = NexoTelemetryCallback(agent_name="meta_agent", run_id="root-5")
+    cb = AgentTelemetryCallback(agent_name="meta_agent", run_id="root-5")
     rid = uuid4()
     serialized = {
         "lc": 1,
@@ -142,7 +142,7 @@ def test_callback_span_prefix_overrides_nexo_default(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
     """When span_prefix='fake', emitted span names start with 'fake.' not 'nexo.'."""
-    cb = NexoTelemetryCallback(agent_name="filter_expert", run_id="root-6", span_prefix="fake")
+    cb = AgentTelemetryCallback(agent_name="filter_expert", run_id="root-6", span_prefix="fake")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
     cb.on_llm_end(_llm_result(input_tokens=10, output_tokens=5), run_id=rid)

--- a/miot-harness/tests/observability/test_graph_wiring.py
+++ b/miot-harness/tests/observability/test_graph_wiring.py
@@ -18,6 +18,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from pydantic import BaseModel
 
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.nexo_graph import build_nexo_graph
 from miot_harness.runtime.permissions import PermissionResult
@@ -90,7 +91,9 @@ async def test_graph_emits_per_agent_spans_with_run_attribution(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_models())
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
+    )
 
     ctx = _ctx(run_id="run_a3_test_001")
     await graph.ainvoke(
@@ -142,7 +145,9 @@ async def test_root_nexo_run_span_parents_per_agent_spans(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_models())
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
+    )
     ctx = _ctx(run_id="run_root_span_test")
 
     with agent_span("run", run_id=ctx.run_id, tenant_id=ctx.tenant_id):

--- a/miot-harness/tests/observability/test_graph_wiring.py
+++ b/miot-harness/tests/observability/test_graph_wiring.py
@@ -150,7 +150,9 @@ async def test_root_nexo_run_span_parents_per_agent_spans(
     )
     ctx = _ctx(run_id="run_root_span_test")
 
-    with agent_span("run", run_id=ctx.run_id, tenant_id=ctx.tenant_id):
+    with agent_span(
+        "run", run_id=ctx.run_id, tenant_id=ctx.tenant_id, span_prefix=NEXO_PROFILE.name
+    ):
         await graph.ainvoke(
             {
                 "user_message": "estado operativo",

--- a/miot-harness/tests/observability/test_graph_wiring.py
+++ b/miot-harness/tests/observability/test_graph_wiring.py
@@ -1,6 +1,6 @@
 """A3 — telemetry callbacks wired into every LLM-bearing node of the Nexo graph.
 
-Invokes the real `build_nexo_graph(...)` with scripted `FakeListChatModel`s
+Invokes the real `build_data_graph(...)` with scripted `FakeListChatModel`s
 and asserts that running it emits one ``nexo.<agent>`` span per agent seat
 with the correct ``modular.agent``/``modular.run_id``/``modular.tenant_id``
 attribution. The 3-node propagation gotcha test (A6) is separate.
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.permissions import PermissionResult
 from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
@@ -91,7 +91,7 @@ async def test_graph_emits_per_agent_spans_with_run_attribution(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
 
@@ -145,7 +145,7 @@ async def test_root_nexo_run_span_parents_per_agent_spans(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
     ctx = _ctx(run_id="run_root_span_test")

--- a/miot-harness/tests/observability/test_graph_wiring.py
+++ b/miot-harness/tests/observability/test_graph_wiring.py
@@ -89,7 +89,7 @@ async def test_graph_emits_per_agent_spans_with_run_attribution(
     registry = ToolRegistry()
     registry.register(_stub_tool(refreshed))
     settings = HarnessSettings(
-        nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
+        datasource_freshness_warn_minutes=30, datasource_freshness_refuse_minutes=240
     )
     graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
@@ -143,7 +143,7 @@ async def test_root_nexo_run_span_parents_per_agent_spans(
     registry = ToolRegistry()
     registry.register(_stub_tool(refreshed))
     settings = HarnessSettings(
-        nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
+        datasource_freshness_warn_minutes=30, datasource_freshness_refuse_minutes=240
     )
     graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE

--- a/miot-harness/tests/observability/test_langfuse_attribution.py
+++ b/miot-harness/tests/observability/test_langfuse_attribution.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from langchain_core.messages import HumanMessage
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from miot_harness.observability.callbacks import NexoTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback
 from miot_harness.observability.spans import agent_span
 
 
@@ -29,7 +29,7 @@ def test_agent_span_emits_langfuse_user_session_tags(
         mode="agentic",
         user_id="odtorres",
         session_id="conv-abc-123",
-        tags=["tenant:mintral", "mode:agentic", "route:nexo_agentic"],
+        tags=["tenant:mintral", "mode:agentic", "route:data_agentic"],
         environment="local",
     ):
         pass
@@ -44,7 +44,7 @@ def test_agent_span_emits_langfuse_user_session_tags(
     assert json.loads(attrs["langfuse.tags"]) == [
         "tenant:mintral",
         "mode:agentic",
-        "route:nexo_agentic",
+        "route:data_agentic",
     ]
 
 
@@ -72,7 +72,7 @@ def test_callback_emits_langfuse_attrs_on_llm_call(
     from langchain_core.messages import AIMessage
     from langchain_core.outputs import ChatGeneration, LLMResult
 
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name="filter_expert",
         run_id="run_e10_002",
         tenant_id="mintral",
@@ -130,7 +130,7 @@ def test_callback_omits_langfuse_attrs_when_not_provided(
     from langchain_core.messages import AIMessage
     from langchain_core.outputs import ChatGeneration, LLMResult
 
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name="critic", run_id="run_old", tenant_id="mintral"
     )
 

--- a/miot-harness/tests/observability/test_lifespan_init.py
+++ b/miot-harness/tests/observability/test_lifespan_init.py
@@ -21,7 +21,7 @@ def _settings_cache() -> None:
 def test_lifespan_skips_telemetry_when_otel_disabled(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
     monkeypatch.setenv("MIOT_HARNESS_OTEL_ENABLED", "false")
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
 
     with (
         patch("miot_harness.api.server.configure_tracing") as configure_mock,
@@ -46,7 +46,7 @@ def test_lifespan_inits_traceloop_when_otel_enabled(monkeypatch, tmp_path) -> No
     monkeypatch.setenv("MIOT_HARNESS_OTEL_ENDPOINT", "http://otel:4317")
     monkeypatch.setenv("MIOT_HARNESS_OTEL_SERVICE_NAME", "miot-harness-itest")
     monkeypatch.setenv("MIOT_HARNESS_OTEL_ENVIRONMENT", "itest")
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
 
     fake_provider = MagicMock(name="TracerProvider")
     with (

--- a/miot-harness/tests/observability/test_mode_telemetry.py
+++ b/miot-harness/tests/observability/test_mode_telemetry.py
@@ -90,7 +90,13 @@ async def test_root_run_span_carries_mode_attribute(
     """`agent_span("run", mode=...)` must surface mode on the root span."""
 
     ctx = _ctx(mode="agentic")
-    with agent_span("run", run_id=ctx.run_id, tenant_id=ctx.tenant_id, mode=ctx.mode):
+    with agent_span(
+        "run",
+        run_id=ctx.run_id,
+        tenant_id=ctx.tenant_id,
+        mode=ctx.mode,
+        span_prefix=NEXO_PROFILE.name,
+    ):
         pass
     root = next(
         s for s in memory_exporter.get_finished_spans() if s.name == "nexo.run"

--- a/miot-harness/tests/observability/test_mode_telemetry.py
+++ b/miot-harness/tests/observability/test_mode_telemetry.py
@@ -20,7 +20,7 @@ from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.observability.spans import agent_span
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.runtime.permissions import PermissionResult
 from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
@@ -111,7 +111,7 @@ async def test_per_agent_callback_emits_mode_attribute(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(
+    graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
     )
 

--- a/miot-harness/tests/observability/test_mode_telemetry.py
+++ b/miot-harness/tests/observability/test_mode_telemetry.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from pydantic import BaseModel
 
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.observability.spans import agent_span
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.nexo_graph import build_nexo_graph
@@ -110,7 +111,9 @@ async def test_per_agent_callback_emits_mode_attribute(
     settings = HarnessSettings(
         nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
     )
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_models())
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
+    )
 
     ctx = _ctx(mode="canned")
     await graph.ainvoke(

--- a/miot-harness/tests/observability/test_mode_telemetry.py
+++ b/miot-harness/tests/observability/test_mode_telemetry.py
@@ -109,7 +109,7 @@ async def test_per_agent_callback_emits_mode_attribute(
     registry = ToolRegistry()
     registry.register(_stub_tool(refreshed))
     settings = HarnessSettings(
-        nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240
+        datasource_freshness_warn_minutes=30, datasource_freshness_refuse_minutes=240
     )
     graph = build_data_graph(
         registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE

--- a/miot-harness/tests/observability/test_propagation.py
+++ b/miot-harness/tests/observability/test_propagation.py
@@ -56,7 +56,7 @@ def _build_parallel_graph(run_id: str) -> Any:
 
     async def branch_a(state: _State) -> dict[str, Any]:
         cb = AgentTelemetryCallback(
-            agent_name="branch_a", run_id=run_id, tenant_id="mintral"
+            agent_name="branch_a", run_id=run_id, tenant_id="acme"
         )
         model = _model("a-answer").with_config(callbacks=[cb])
         await asyncio.sleep(0)  # let branch_b interleave
@@ -66,7 +66,7 @@ def _build_parallel_graph(run_id: str) -> Any:
 
     async def branch_b(state: _State) -> dict[str, Any]:
         cb = AgentTelemetryCallback(
-            agent_name="branch_b", run_id=run_id, tenant_id="mintral"
+            agent_name="branch_b", run_id=run_id, tenant_id="acme"
         )
         model = _model("b-answer").with_config(callbacks=[cb])
         await asyncio.sleep(0)  # let branch_a interleave
@@ -104,7 +104,10 @@ async def test_parallel_branches_keep_per_agent_attribution(
     final = await graph.ainvoke({})
     assert final["final"] == "a-answer|b-answer"
 
-    spans = [s for s in memory_exporter.get_finished_spans() if s.name.startswith("nexo.")]
+    # Callbacks use the neutral default span_prefix ("datasource.") here.
+    spans = [
+        s for s in memory_exporter.get_finished_spans() if s.name.startswith("datasource.")
+    ]
     by_agent = {
         s.attributes["modular.agent"]: s for s in spans if s.attributes.get("modular.agent")
     }
@@ -116,7 +119,7 @@ async def test_parallel_branches_keep_per_agent_attribution(
     for name, span in by_agent.items():
         attrs = dict(span.attributes or {})
         assert attrs["modular.run_id"] == run_id, name
-        assert attrs["modular.tenant_id"] == "mintral", name
+        assert attrs["modular.tenant_id"] == "acme", name
         assert attrs["modular.agent"] == name
 
 

--- a/miot-harness/tests/observability/test_propagation.py
+++ b/miot-harness/tests/observability/test_propagation.py
@@ -4,7 +4,7 @@ Known late-2025 issue: when LangGraph fans out into parallel branches, OTel
 context propagation can break — child LLM spans from one branch may land
 under a sibling, and `usage_metadata` may be misattributed.
 
-Our defense (built into `NexoTelemetryCallback`): every span carries
+Our defense (built into `AgentTelemetryCallback`): every span carries
 `modular.agent` AND `modular.run_id` set from the callback's init args at
 callback-construction time, BEFORE the LLM call's context is captured. Even
 if OTel's parent-context propagation breaks, Langfuse can regroup by these
@@ -30,7 +30,7 @@ from langgraph.graph import END, StateGraph
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from typing_extensions import TypedDict
 
-from miot_harness.observability.callbacks import NexoTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback
 
 
 class _State(TypedDict, total=False):
@@ -48,14 +48,14 @@ def _build_parallel_graph(run_id: str) -> Any:
     """3-node graph: planner → (branch_a ∥ branch_b) → joiner.
 
     Branches run in parallel via LangGraph fan-out. Each branch's model
-    invocation is wired to its own `NexoTelemetryCallback`.
+    invocation is wired to its own `AgentTelemetryCallback`.
     """
 
     async def planner(state: _State) -> dict[str, Any]:
         return {"run_id": run_id}
 
     async def branch_a(state: _State) -> dict[str, Any]:
-        cb = NexoTelemetryCallback(
+        cb = AgentTelemetryCallback(
             agent_name="branch_a", run_id=run_id, tenant_id="mintral"
         )
         model = _model("a-answer").with_config(callbacks=[cb])
@@ -65,7 +65,7 @@ def _build_parallel_graph(run_id: str) -> Any:
         return {"answer_a": resp.content}
 
     async def branch_b(state: _State) -> dict[str, Any]:
-        cb = NexoTelemetryCallback(
+        cb = AgentTelemetryCallback(
             agent_name="branch_b", run_id=run_id, tenant_id="mintral"
         )
         model = _model("b-answer").with_config(callbacks=[cb])
@@ -129,7 +129,7 @@ async def test_callback_attribution_survives_high_concurrency() -> None:
     """
 
     async def emit(run_id: str, agent: str) -> str:
-        cb = NexoTelemetryCallback(
+        cb = AgentTelemetryCallback(
             agent_name=agent, run_id=run_id, tenant_id="mintral"
         )
         model = _model(f"resp-{run_id}").with_config(callbacks=[cb])

--- a/miot-harness/tests/observability/test_provenance.py
+++ b/miot-harness/tests/observability/test_provenance.py
@@ -19,12 +19,12 @@ def test_provenance_entry_contains_all_required_fields(tmp_path: Path) -> None:
     refreshed_at = datetime(2026, 5, 12, 10, 0, tzinfo=UTC)
     entry = ProvenanceEntry(
         question="show services with delta_eta_horas > 6",
-        sql="SELECT * FROM nexo.dx_servicios WHERE delta_eta_horas > 6",
+        sql="SELECT * FROM analytics.dx_servicios WHERE delta_eta_horas > 6",
         plan_cost=42.5,
         rows_returned=37,
         refreshed_at=refreshed_at,
         run_id="run_abc",
-        tenant_id="mintral",
+        tenant_id="acme",
     )
     log.append(entry, now=datetime(2026, 5, 12, 12, 30, tzinfo=UTC))
 
@@ -33,12 +33,12 @@ def test_provenance_entry_contains_all_required_fields(tmp_path: Path) -> None:
     line = written.read_text().strip()
     payload = json.loads(line)
     assert payload["question"] == "show services with delta_eta_horas > 6"
-    assert payload["sql"].startswith("SELECT * FROM nexo.dx_servicios")
+    assert payload["sql"].startswith("SELECT * FROM analytics.dx_servicios")
     assert payload["plan_cost"] == 42.5
     assert payload["rows_returned"] == 37
     assert payload["refreshed_at"] == refreshed_at.isoformat()
     assert payload["run_id"] == "run_abc"
-    assert payload["tenant_id"] == "mintral"
+    assert payload["tenant_id"] == "acme"
     assert "logged_at" in payload
 
 
@@ -49,12 +49,12 @@ def test_provenance_log_appends_one_line_per_call(tmp_path: Path) -> None:
         log.append(
             ProvenanceEntry(
                 question=f"q{i}",
-                sql="SELECT * FROM nexo.dx_servicios LIMIT 1",
+                sql="SELECT * FROM analytics.dx_servicios LIMIT 1",
                 plan_cost=10.0 + i,
                 rows_returned=i,
                 refreshed_at=now,
                 run_id=f"run_{i}",
-                tenant_id="mintral",
+                tenant_id="acme",
             ),
             now=now,
         )
@@ -71,12 +71,12 @@ def test_provenance_partitions_by_date(tmp_path: Path) -> None:
         log.append(
             ProvenanceEntry(
                 question=f"q-{suffix}",
-                sql="SELECT 1 FROM nexo.dx_servicios LIMIT 1",
+                sql="SELECT 1 FROM analytics.dx_servicios LIMIT 1",
                 plan_cost=1.0,
                 rows_returned=0,
                 refreshed_at=ts,
                 run_id=f"r-{suffix}",
-                tenant_id="mintral",
+                tenant_id="acme",
             ),
             now=ts,
         )
@@ -94,12 +94,12 @@ def test_provenance_creates_parent_dir_if_missing(tmp_path: Path) -> None:
     log.append(
         ProvenanceEntry(
             question="q",
-            sql="SELECT 1 FROM nexo.dx_servicios LIMIT 1",
+            sql="SELECT 1 FROM analytics.dx_servicios LIMIT 1",
             plan_cost=1.0,
             rows_returned=0,
             refreshed_at=now,
             run_id="r",
-            tenant_id="mintral",
+            tenant_id="acme",
         ),
         now=now,
     )
@@ -114,12 +114,12 @@ def test_provenance_no_op_when_disabled(tmp_path: Path) -> None:
     log.append(
         ProvenanceEntry(
             question="q",
-            sql="SELECT 1 FROM nexo.dx_servicios LIMIT 1",
+            sql="SELECT 1 FROM analytics.dx_servicios LIMIT 1",
             plan_cost=1.0,
             rows_returned=0,
             refreshed_at=datetime(2026, 5, 12, tzinfo=UTC),
             run_id="r",
-            tenant_id="mintral",
+            tenant_id="acme",
         ),
         now=datetime(2026, 5, 12, 9, 0, tzinfo=UTC),
     )
@@ -136,12 +136,12 @@ def test_provenance_handles_missing_refreshed_at(
     log.append(
         ProvenanceEntry(
             question="q",
-            sql="SELECT 1 FROM nexo.dx_servicios LIMIT 1",
+            sql="SELECT 1 FROM analytics.dx_servicios LIMIT 1",
             plan_cost=1.0,
             rows_returned=0,
             refreshed_at=refreshed_at,
             run_id="r",
-            tenant_id="mintral",
+            tenant_id="acme",
         ),
         now=datetime(2026, 5, 12, 9, 0, tzinfo=UTC),
     )

--- a/miot-harness/tests/observability/test_report.py
+++ b/miot-harness/tests/observability/test_report.py
@@ -151,7 +151,7 @@ def _langfuse_trace_fixture(**overrides: object) -> dict[str, object]:
         "name": "nexo.run",
         "userId": "odtorres",
         "sessionId": "conv-1",
-        "tags": ["tenant:mintral", "mode:auto", "agent:filter_expert", "route:nexo_query"],
+        "tags": ["tenant:mintral", "mode:auto", "agent:filter_expert", "route:data_query"],
         "metadata": {},
         "totalCost": 0.0521,
         "timestamp": "2026-05-13T10:00:00Z",

--- a/miot-harness/tests/observability/test_spans.py
+++ b/miot-harness/tests/observability/test_spans.py
@@ -13,7 +13,7 @@ def test_agent_span_emits_required_attributes(
     with agent_span(
         "filter_expert",
         run_id="run-123",
-        tenant_id="mintral",
+        tenant_id="acme",
         mode="agentic",
     ):
         pass
@@ -21,10 +21,11 @@ def test_agent_span_emits_required_attributes(
     finished = memory_exporter.get_finished_spans()
     assert len(finished) == 1
     span = finished[0]
-    assert span.name == "nexo.filter_expert"
-    assert span.attributes["gen_ai.operation.name"] == "nexo.filter_expert"
+    # No span_prefix passed → the neutral "datasource" default.
+    assert span.name == "datasource.filter_expert"
+    assert span.attributes["gen_ai.operation.name"] == "datasource.filter_expert"
     assert span.attributes["modular.run_id"] == "run-123"
-    assert span.attributes["modular.tenant_id"] == "mintral"
+    assert span.attributes["modular.tenant_id"] == "acme"
     assert span.attributes["modular.mode"] == "agentic"
 
 
@@ -34,7 +35,7 @@ def test_agent_span_omits_optional_attrs_when_unset(
     with agent_span("synthesizer", run_id="run-9"):
         pass
     finished = memory_exporter.get_finished_spans()
-    assert finished[0].name == "nexo.synthesizer"
+    assert finished[0].name == "datasource.synthesizer"
     attrs = dict(finished[0].attributes)
     assert "modular.tenant_id" not in attrs
     assert "modular.mode" not in attrs
@@ -50,7 +51,7 @@ def test_agent_span_nests_under_parent(memory_exporter: InMemorySpanExporter) ->
 
     spans = memory_exporter.get_finished_spans()
     # SimpleSpanProcessor emits in finish order: child first, then parent.
-    child = next(s for s in spans if s.name == "nexo.filter_expert")
-    parent = next(s for s in spans if s.name == "nexo.supervisor")
+    child = next(s for s in spans if s.name == "datasource.filter_expert")
+    parent = next(s for s in spans if s.name == "datasource.supervisor")
     assert child.parent is not None
     assert child.parent.span_id == parent.context.span_id

--- a/miot-harness/tests/observability/test_usage_recorded_event.py
+++ b/miot-harness/tests/observability/test_usage_recorded_event.py
@@ -1,4 +1,4 @@
-"""Verifies NexoTelemetryCallback emits a usage.recorded SSE event when
+"""Verifies AgentTelemetryCallback emits a usage.recorded SSE event when
 a `progress` sink is wired (plan: SSE rich events §B5).
 """
 
@@ -10,7 +10,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from miot_harness.observability.callbacks import NexoTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback
 from miot_harness.runtime.events import HarnessEvent
 
 
@@ -44,7 +44,7 @@ def test_callback_emits_usage_recorded_when_progress_wired(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
     events: list[HarnessEvent] = []
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name="filter_expert",
         run_id="run_abc",
         progress=events.append,
@@ -73,7 +73,7 @@ def test_callback_emits_usage_recorded_when_progress_wired(
 def test_callback_skips_usage_event_when_no_progress(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
-    cb = NexoTelemetryCallback(agent_name="critic", run_id="run_xyz")
+    cb = AgentTelemetryCallback(agent_name="critic", run_id="run_xyz")
     rid = uuid4()
     cb.on_chat_model_start(_serialized_anthropic(), [[HumanMessage(content="hi")]], run_id=rid)
     cb.on_llm_end(_llm_result(), run_id=rid)
@@ -95,7 +95,7 @@ def test_callback_swallows_progress_sink_failure(
     def _exploding(_event: HarnessEvent) -> None:
         raise RuntimeError("event bus is on fire")
 
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name="filter_expert",
         run_id="run_boom",
         progress=_exploding,
@@ -116,7 +116,7 @@ def test_callback_omits_cost_usd_when_model_unknown(
     memory_exporter: InMemorySpanExporter,
 ) -> None:
     events: list[HarnessEvent] = []
-    cb = NexoTelemetryCallback(
+    cb = AgentTelemetryCallback(
         agent_name="planner",
         run_id="run_unknown",
         progress=events.append,

--- a/miot-harness/tests/runtime/test_agentic_graph.py
+++ b/miot-harness/tests/runtime/test_agentic_graph.py
@@ -156,7 +156,7 @@ async def test_agentic_synthesizer_includes_prior_messages_in_llm_call() -> None
 
     # Disable streaming so this test's ainvoke recorder works. Streaming
     # path uses astream_events which the recorder doesn't intercept.
-    settings = HarnessSettings(nexo_synthesizer_stream=False)
+    settings = HarnessSettings(agents_synthesizer_stream=False)
     graph = build_agentic_graph(
         settings=settings, models=models, provenance_log=None, profile=NEXO_PROFILE
     )
@@ -208,7 +208,7 @@ async def test_agentic_synthesizer_handles_empty_prior_messages() -> None:
     models = _models(plan_response="{}", synthesizer_text="ok")
     models["synthesizer"] = _RecordingModel(responses=["first-turn"])
 
-    settings = HarnessSettings(nexo_synthesizer_stream=False)
+    settings = HarnessSettings(agents_synthesizer_stream=False)
     graph = build_agentic_graph(
         settings=settings, models=models, provenance_log=None, profile=NEXO_PROFILE
     )

--- a/miot-harness/tests/runtime/test_agentic_graph.py
+++ b/miot-harness/tests/runtime/test_agentic_graph.py
@@ -9,6 +9,7 @@ import pytest
 from langchain_core.language_models import FakeListChatModel
 
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.agentic_graph import build_agentic_graph
 from miot_harness.runtime.context import HarnessContext
 
@@ -42,6 +43,7 @@ async def test_agentic_graph_refuses_non_mintral_tenant() -> None:
         settings=settings,
         models=_models(plan_response="(unused)"),
         provenance_log=None,
+        profile=NEXO_PROFILE,
     )
     state = await graph.ainvoke(
         {
@@ -76,6 +78,7 @@ async def test_agentic_graph_happy_path_runs_to_synthesis() -> None:
         settings=settings,
         models=_models(plan_response, synthesizer_text="Estado operativo: ok."),
         provenance_log=None,
+        profile=NEXO_PROFILE,
     )
     final = await graph.ainvoke(
         {
@@ -97,6 +100,7 @@ async def test_agentic_graph_caps_turns_at_12() -> None:
         settings=settings,
         models=_models(plan_response="{}", synthesizer_text="fallback"),
         provenance_log=None,
+        profile=NEXO_PROFILE,
     )
     final = await graph.ainvoke(
         {
@@ -118,6 +122,7 @@ def test_agentic_graph_topology_has_required_nodes() -> None:
         settings=settings,
         models=_models(plan_response="{}"),
         provenance_log=None,
+        profile=NEXO_PROFILE,
     )
     nodes = set(graph.get_graph().nodes)
     # Plan 13 §E6 names these explicitly. Each must be a node in the graph.
@@ -153,7 +158,7 @@ async def test_agentic_synthesizer_includes_prior_messages_in_llm_call() -> None
     # path uses astream_events which the recorder doesn't intercept.
     settings = HarnessSettings(nexo_synthesizer_stream=False)
     graph = build_agentic_graph(
-        settings=settings, models=models, provenance_log=None
+        settings=settings, models=models, provenance_log=None, profile=NEXO_PROFILE
     )
 
     prior = [
@@ -205,7 +210,7 @@ async def test_agentic_synthesizer_handles_empty_prior_messages() -> None:
 
     settings = HarnessSettings(nexo_synthesizer_stream=False)
     graph = build_agentic_graph(
-        settings=settings, models=models, provenance_log=None
+        settings=settings, models=models, provenance_log=None, profile=NEXO_PROFILE
     )
     await graph.ainvoke(
         {

--- a/miot-harness/tests/runtime/test_intent_router.py
+++ b/miot-harness/tests/runtime/test_intent_router.py
@@ -8,9 +8,17 @@ from collections.abc import Iterable
 import pytest
 from langchain_core.language_models import FakeListChatModel
 
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.intent_router import LLMIntentRouter, _render_system_prompt
 from miot_harness.runtime.router import HarnessRoute, IntentRouter
 from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+def _nexo_fallback() -> IntentRouter:
+    # The core router ships no built-in vocabulary; the keyword fallback in
+    # these tests uses the nexo profile keyword set (the provider-under-test's
+    # own vocabulary) so the "Mintral status" fallback prompts route to data.
+    return IntentRouter(data_keywords=NEXO_PROFILE.router_keywords)
 
 
 def _scripted_json(route: str, confidence: float = 0.9, reasoning: str = "test") -> str:
@@ -66,7 +74,7 @@ _FIXTURES: tuple[tuple[str, str, float, HarnessRoute], ...] = (
     ("forecast tomorrow's weather", "OTHER", 0.82, HarnessRoute.OTHER),
     ("translate this to Klingon", "OTHER", 0.80, HarnessRoute.OTHER),
     ("solve x^2 + 2x + 1 = 0", "OTHER", 0.79, HarnessRoute.OTHER),
-    # Low confidence → keyword fallback (this message has no Nexo keyword
+    # Low confidence → keyword fallback (this message has no data keyword
     # so the deterministic router returns DIRECT).
     ("ambiguous something", "DATA_QUERY", 0.50, HarnessRoute.DIRECT),
     ("eep doop", "OTHER", 0.30, HarnessRoute.DIRECT),
@@ -75,7 +83,7 @@ _FIXTURES: tuple[tuple[str, str, float, HarnessRoute], ...] = (
 
 def _build_router(responses: Iterable[str]) -> LLMIntentRouter:
     model = FakeListChatModel(responses=list(responses))
-    return LLMIntentRouter(model, confidence_threshold=0.7, keyword_fallback=IntentRouter())
+    return LLMIntentRouter(model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback())
 
 
 @pytest.mark.asyncio
@@ -106,12 +114,12 @@ async def test_low_confidence_falls_back_to_keyword_router() -> None:
     """Below the threshold the LLM label is dropped; keyword router decides."""
 
     # LLM says DATA_AGENTIC with low confidence; keyword router sees no
-    # Nexo keyword in "hola amigo", so the final route is DIRECT.
+    # data keyword in "hola amigo", so the final route is DIRECT.
     model = FakeListChatModel(
         responses=[_scripted_json("DATA_AGENTIC", confidence=0.3, reasoning="unsure")]
     )
     router = LLMIntentRouter(
-        model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
+        model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback()
     )
 
     result = await router.route("hola amigo")
@@ -125,7 +133,7 @@ async def test_unparseable_llm_response_falls_back_to_keyword() -> None:
 
     model = FakeListChatModel(responses=["I'm not sure honestly..."])
     router = LLMIntentRouter(
-        model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
+        model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback()
     )
     result = await router.route("Mintral fleet status")  # contains 'mintral'
     assert result.route is HarnessRoute.DATA_QUERY
@@ -138,7 +146,7 @@ async def test_router_accepts_fenced_json_response() -> None:
     fenced = "```json\n" + _scripted_json("DATA_META", confidence=0.9) + "\n```"
     model = FakeListChatModel(responses=[fenced])
     router = LLMIntentRouter(
-        model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
+        model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback()
     )
     result = await router.route("what is fn_dx_eta_hoy?")
     assert result.route is HarnessRoute.DATA_META
@@ -152,7 +160,7 @@ async def test_invalid_route_name_falls_back_to_keyword() -> None:
         responses=[json.dumps({"route": "MAGIC_ROUTE", "confidence": 0.99})]
     )
     router = LLMIntentRouter(
-        model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
+        model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback()
     )
     result = await router.route("Mintral status")  # mintral keyword
     assert result.route is HarnessRoute.DATA_QUERY
@@ -179,7 +187,7 @@ async def test_non_dict_json_falls_back_to_keyword(raw_response: str) -> None:
 
     model = FakeListChatModel(responses=[raw_response])
     router = LLMIntentRouter(
-        model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
+        model, confidence_threshold=0.7, keyword_fallback=_nexo_fallback()
     )
     # "Mintral status" has the `mintral` keyword so the fallback returns DATA_QUERY.
     result = await router.route("Mintral status")

--- a/miot-harness/tests/runtime/test_intent_router.py
+++ b/miot-harness/tests/runtime/test_intent_router.py
@@ -8,8 +8,9 @@ from collections.abc import Iterable
 import pytest
 from langchain_core.language_models import FakeListChatModel
 
-from miot_harness.runtime.intent_router import LLMIntentRouter
+from miot_harness.runtime.intent_router import LLMIntentRouter, _render_system_prompt
 from miot_harness.runtime.router import HarnessRoute, IntentRouter
+from tests.fixtures.fake_provider import FAKE_PROFILE
 
 
 def _scripted_json(route: str, confidence: float = 0.9, reasoning: str = "test") -> str:
@@ -21,29 +22,29 @@ def _scripted_json(route: str, confidence: float = 0.9, reasoning: str = "test")
 # When confidence >= 0.7 the LLM label wins; when below 0.7 the keyword
 # fallback takes over (and the expected route reflects that).
 _FIXTURES: tuple[tuple[str, str, float, HarnessRoute], ...] = (
-    # NEXO_QUERY — 5 prompts
-    ("¿estado del centro de control hoy?", "NEXO_QUERY", 0.92, HarnessRoute.NEXO_QUERY),
-    ("dame KPI de cola crítica", "NEXO_QUERY", 0.85, HarnessRoute.NEXO_QUERY),
-    ("ETA en riesgo del turno actual", "NEXO_QUERY", 0.88, HarnessRoute.NEXO_QUERY),
-    ("dimensionamiento para mañana", "NEXO_QUERY", 0.80, HarnessRoute.NEXO_QUERY),
-    ("torre de control: KPIs en vivo", "NEXO_QUERY", 0.78, HarnessRoute.NEXO_QUERY),
-    # NEXO_META — 5 prompts
-    ("what data do you have available?", "NEXO_META", 0.91, HarnessRoute.NEXO_META),
-    ("how is es_critico calculated?", "NEXO_META", 0.86, HarnessRoute.NEXO_META),
-    ("what does fn_dx_centro_control do?", "NEXO_META", 0.84, HarnessRoute.NEXO_META),
-    ("explain the schema of the nexo tables", "NEXO_META", 0.83, HarnessRoute.NEXO_META),
-    ("which fn_dx_* are available?", "NEXO_META", 0.82, HarnessRoute.NEXO_META),
-    # NEXO_AGENTIC — 5 prompts
-    ("show me services where delta_eta_horas > 6", "NEXO_AGENTIC", 0.90, HarnessRoute.NEXO_AGENTIC),
-    ("tell me more about that", "NEXO_AGENTIC", 0.75, HarnessRoute.NEXO_AGENTIC),
+    # DATA_QUERY — 5 prompts
+    ("¿estado del centro de control hoy?", "DATA_QUERY", 0.92, HarnessRoute.DATA_QUERY),
+    ("dame KPI de cola crítica", "DATA_QUERY", 0.85, HarnessRoute.DATA_QUERY),
+    ("ETA en riesgo del turno actual", "DATA_QUERY", 0.88, HarnessRoute.DATA_QUERY),
+    ("dimensionamiento para mañana", "DATA_QUERY", 0.80, HarnessRoute.DATA_QUERY),
+    ("torre de control: KPIs en vivo", "DATA_QUERY", 0.78, HarnessRoute.DATA_QUERY),
+    # DATA_META — 5 prompts
+    ("what data do you have available?", "DATA_META", 0.91, HarnessRoute.DATA_META),
+    ("how is es_critico calculated?", "DATA_META", 0.86, HarnessRoute.DATA_META),
+    ("what does fn_dx_centro_control do?", "DATA_META", 0.84, HarnessRoute.DATA_META),
+    ("explain the schema of the nexo tables", "DATA_META", 0.83, HarnessRoute.DATA_META),
+    ("which fn_dx_* are available?", "DATA_META", 0.82, HarnessRoute.DATA_META),
+    # DATA_AGENTIC — 5 prompts
+    ("show me services where delta_eta_horas > 6", "DATA_AGENTIC", 0.90, HarnessRoute.DATA_AGENTIC),
+    ("tell me more about that", "DATA_AGENTIC", 0.75, HarnessRoute.DATA_AGENTIC),
     (
         "filter by region=norte and order by ETA desc",
-        "NEXO_AGENTIC",
+        "DATA_AGENTIC",
         0.81,
-        HarnessRoute.NEXO_AGENTIC,
+        HarnessRoute.DATA_AGENTIC,
     ),
-    ("any rows with refreshed_at older than 4h?", "NEXO_AGENTIC", 0.79, HarnessRoute.NEXO_AGENTIC),
-    ("explora la tabla dx_servicios", "NEXO_AGENTIC", 0.77, HarnessRoute.NEXO_AGENTIC),
+    ("any rows with refreshed_at older than 4h?", "DATA_AGENTIC", 0.79, HarnessRoute.DATA_AGENTIC),
+    ("explora la tabla dx_servicios", "DATA_AGENTIC", 0.77, HarnessRoute.DATA_AGENTIC),
     # STORYTELLING_RUN — 5 prompts
     (
         "draft a story about today's incident",
@@ -67,7 +68,7 @@ _FIXTURES: tuple[tuple[str, str, float, HarnessRoute], ...] = (
     ("solve x^2 + 2x + 1 = 0", "OTHER", 0.79, HarnessRoute.OTHER),
     # Low confidence → keyword fallback (this message has no Nexo keyword
     # so the deterministic router returns DIRECT).
-    ("ambiguous something", "NEXO_QUERY", 0.50, HarnessRoute.DIRECT),
+    ("ambiguous something", "DATA_QUERY", 0.50, HarnessRoute.DIRECT),
     ("eep doop", "OTHER", 0.30, HarnessRoute.DIRECT),
 )
 
@@ -104,10 +105,10 @@ async def test_confusion_matrix_30_prompts() -> None:
 async def test_low_confidence_falls_back_to_keyword_router() -> None:
     """Below the threshold the LLM label is dropped; keyword router decides."""
 
-    # LLM says NEXO_AGENTIC with low confidence; keyword router sees no
+    # LLM says DATA_AGENTIC with low confidence; keyword router sees no
     # Nexo keyword in "hola amigo", so the final route is DIRECT.
     model = FakeListChatModel(
-        responses=[_scripted_json("NEXO_AGENTIC", confidence=0.3, reasoning="unsure")]
+        responses=[_scripted_json("DATA_AGENTIC", confidence=0.3, reasoning="unsure")]
     )
     router = LLMIntentRouter(
         model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
@@ -127,20 +128,20 @@ async def test_unparseable_llm_response_falls_back_to_keyword() -> None:
         model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
     )
     result = await router.route("Mintral fleet status")  # contains 'mintral'
-    assert result.route is HarnessRoute.NEXO_QUERY
+    assert result.route is HarnessRoute.DATA_QUERY
 
 
 @pytest.mark.asyncio
 async def test_router_accepts_fenced_json_response() -> None:
     """LLMs often wrap JSON in ```json fences; we must tolerate that."""
 
-    fenced = "```json\n" + _scripted_json("NEXO_META", confidence=0.9) + "\n```"
+    fenced = "```json\n" + _scripted_json("DATA_META", confidence=0.9) + "\n```"
     model = FakeListChatModel(responses=[fenced])
     router = LLMIntentRouter(
         model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
     )
     result = await router.route("what is fn_dx_eta_hoy?")
-    assert result.route is HarnessRoute.NEXO_META
+    assert result.route is HarnessRoute.DATA_META
 
 
 @pytest.mark.asyncio
@@ -154,7 +155,7 @@ async def test_invalid_route_name_falls_back_to_keyword() -> None:
         model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
     )
     result = await router.route("Mintral status")  # mintral keyword
-    assert result.route is HarnessRoute.NEXO_QUERY
+    assert result.route is HarnessRoute.DATA_QUERY
 
 
 @pytest.mark.parametrize(
@@ -164,7 +165,7 @@ async def test_invalid_route_name_falls_back_to_keyword() -> None:
         "42",          # bare number
         "true",        # bare bool
         "null",        # bare null
-        '["NEXO_QUERY", 0.9]',  # array, not an object
+        '["DATA_QUERY", 0.9]',  # array, not an object
     ],
 )
 @pytest.mark.asyncio
@@ -180,6 +181,28 @@ async def test_non_dict_json_falls_back_to_keyword(raw_response: str) -> None:
     router = LLMIntentRouter(
         model, confidence_threshold=0.7, keyword_fallback=IntentRouter()
     )
-    # "Mintral status" has the `mintral` keyword so the fallback returns NEXO_QUERY.
+    # "Mintral status" has the `mintral` keyword so the fallback returns DATA_QUERY.
     result = await router.route("Mintral status")
-    assert result.route is HarnessRoute.NEXO_QUERY
+    assert result.route is HarnessRoute.DATA_QUERY
+
+
+def test_system_prompt_parameterized_by_profile() -> None:
+    """The rendered prompt names the active datasource and its keywords."""
+
+    prompt = _render_system_prompt(FAKE_PROFILE)
+    # display_name appears (the example wording is profile-driven, not hardcoded).
+    assert FAKE_PROFILE.display_name in prompt
+    # router_keywords seed the DATA_QUERY example list.
+    for keyword in FAKE_PROFILE.router_keywords:
+        assert keyword in prompt
+    # The route vocabulary is profile-agnostic and always present.
+    for route_name in ("DATA_QUERY", "DATA_META", "DATA_AGENTIC"):
+        assert route_name in prompt
+
+
+def test_system_prompt_falls_back_without_profile() -> None:
+    """With no profile, the prompt still renders (legacy default wording)."""
+
+    prompt = _render_system_prompt(None)
+    assert "DATA_QUERY" in prompt
+    assert "the data source" in prompt

--- a/miot-harness/tests/runtime/test_mode_resolver.py
+++ b/miot-harness/tests/runtime/test_mode_resolver.py
@@ -34,7 +34,7 @@ async def test_explicit_canned_mode_bypasses_router() -> None:
     result = await resolve_mode(
         request, llm_router=_llm_router_that_must_not_be_called(), tenant_lock="mintral"
     )
-    assert result.route is HarnessRoute.NEXO_QUERY
+    assert result.route is HarnessRoute.DATA_QUERY
     assert "canned" in result.reason
 
 
@@ -45,7 +45,7 @@ async def test_explicit_meta_mode_bypasses_router() -> None:
         request, llm_router=_llm_router_that_must_not_be_called(), tenant_lock="mintral"
     )
     # Meta is allowed for any tenant — non-confidential by spec.
-    assert result.route is HarnessRoute.NEXO_META
+    assert result.route is HarnessRoute.DATA_META
 
 
 @pytest.mark.asyncio
@@ -54,7 +54,7 @@ async def test_explicit_agentic_mode_for_mintral_tenant() -> None:
     result = await resolve_mode(
         request, llm_router=_llm_router_that_must_not_be_called(), tenant_lock="mintral"
     )
-    assert result.route is HarnessRoute.NEXO_AGENTIC
+    assert result.route is HarnessRoute.DATA_AGENTIC
 
 
 @pytest.mark.asyncio
@@ -88,12 +88,12 @@ async def test_explicit_canned_mode_rejected_for_non_mintral_tenant() -> None:
 @pytest.mark.asyncio
 async def test_auto_mode_delegates_to_llm_router() -> None:
     model = FakeListChatModel(
-        responses=[json.dumps({"route": "NEXO_AGENTIC", "confidence": 0.95})]
+        responses=[json.dumps({"route": "DATA_AGENTIC", "confidence": 0.95})]
     )
     router = LLMIntentRouter(model, confidence_threshold=0.7, keyword_fallback=IntentRouter())
     request = UserRequest(message="show me services", tenant_id="mintral")  # mode default "auto"
     result = await resolve_mode(request, llm_router=router, tenant_lock="mintral")
-    assert result.route is HarnessRoute.NEXO_AGENTIC
+    assert result.route is HarnessRoute.DATA_AGENTIC
 
 
 def test_user_request_rejects_unknown_mode() -> None:

--- a/miot-harness/tests/runtime/test_node_lifecycle.py
+++ b/miot-harness/tests/runtime/test_node_lifecycle.py
@@ -32,15 +32,15 @@ def test_lifecycle_ok_branch_emits_started_then_completed_ok() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         return {"answer": "hi"}
 
-    wrapped = wrap_node_with_lifecycle("synthesizer", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("synthesizer", node, "fake")
     delta = _run(wrapped, _make_state())
 
     assert delta["answer"] == "hi"
     started = _events_of_type(delta, "agent.started")[0]
     completed = _events_of_type(delta, "agent.completed")[0]
-    assert started.data == {"agent": "synthesizer", "graph": "nexo", "turn": 2}
+    assert started.data == {"agent": "synthesizer", "graph": "fake", "turn": 2}
     assert completed.data["agent"] == "synthesizer"
-    assert completed.data["graph"] == "nexo"
+    assert completed.data["graph"] == "fake"
     assert completed.data["exit_reason"] == "ok"
     assert isinstance(completed.data["duration_ms"], int)
 
@@ -49,7 +49,7 @@ def test_lifecycle_failure_branch_overrides_next_action() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         return {"failure": "tunnel down", "next_action": "analyze"}
 
-    wrapped = wrap_node_with_lifecycle("data_fetcher", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("data_fetcher", node, "fake")
     delta = _run(wrapped, _make_state())
 
     completed = _events_of_type(delta, "agent.completed")[0]
@@ -60,7 +60,7 @@ def test_lifecycle_next_action_branch() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         return {"next_action": "need_more_tools"}
 
-    wrapped = wrap_node_with_lifecycle("freshness_judge", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("freshness_judge", node, "fake")
     delta = _run(wrapped, _make_state())
 
     completed = _events_of_type(delta, "agent.completed")[0]
@@ -75,7 +75,7 @@ def test_lifecycle_preserves_node_events_in_order() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         return {"_events": [inner_event]}
 
-    wrapped = wrap_node_with_lifecycle("filter_expert", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("filter_expert", node, "fake")
     delta = _run(wrapped, _make_state())
 
     types = [e.type for e in delta["_events"]]
@@ -97,7 +97,7 @@ def test_lifecycle_handles_empty_delta() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         return {}
 
-    wrapped = wrap_node_with_lifecycle("summarizer", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("summarizer", node, "fake")
     delta = _run(wrapped, _make_state())
 
     completed = _events_of_type(delta, "agent.completed")[0]
@@ -121,7 +121,7 @@ def test_lifecycle_attaches_boundary_events_on_exception() -> None:
     async def node(_state: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError("kaboom")
 
-    wrapped = wrap_node_with_lifecycle("filter_expert", node, "nexo")
+    wrapped = wrap_node_with_lifecycle("filter_expert", node, "fake")
     with pytest.raises(RuntimeError, match="kaboom") as excinfo:
         _run(wrapped, _make_state())
 
@@ -131,12 +131,12 @@ def test_lifecycle_attaches_boundary_events_on_exception() -> None:
     assert started.type == "agent.started"
     assert started.data == {
         "agent": "filter_expert",
-        "graph": "nexo",
+        "graph": "fake",
         "turn": 2,
     }
     assert failed.type == "agent.completed"
     assert failed.data["agent"] == "filter_expert"
-    assert failed.data["graph"] == "nexo"
+    assert failed.data["graph"] == "fake"
     assert failed.data["exit_reason"] == "failure"
     assert failed.data["error"] == "kaboom"
     assert isinstance(failed.data["duration_ms"], int)

--- a/miot-harness/tests/runtime/test_supervisor_event_bus.py
+++ b/miot-harness/tests/runtime/test_supervisor_event_bus.py
@@ -38,7 +38,7 @@ def _scripted_router(route: str) -> LLMIntentRouter:
 def _supervisor(
     tmp_path: Any,
     *,
-    nexo_graph: Any = None,
+    data_graph: Any = None,
     agentic_graph: Any = None,
     llm_router: LLMIntentRouter | None = None,
     event_bus: RunEventBus | None = None,
@@ -48,7 +48,7 @@ def _supervisor(
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
-        nexo_graph=nexo_graph,
+        data_graph=data_graph,
         agentic_graph=agentic_graph,
         llm_router=llm_router,
         tenant_lock="mintral",
@@ -66,8 +66,8 @@ async def test_events_published_to_bus_match_record_events(tmp_path: Any) -> Non
     bus = RunEventBus()
     received: list[HarnessEvent] = []
 
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(
         return_value={
             "answer": "ok",
             "_events": [
@@ -78,8 +78,8 @@ async def test_events_published_to_bus_match_record_events(tmp_path: Any) -> Non
     )
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=bus,
     )
 
@@ -128,12 +128,12 @@ async def test_bus_closed_on_happy_completion(tmp_path: Any) -> None:
     """
 
     bus = RunEventBus()
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=bus,
     )
 
@@ -199,12 +199,12 @@ async def test_bus_closed_on_run_failure(tmp_path: Any) -> None:
     """
 
     bus = RunEventBus()
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=bus,
     )
 
@@ -223,12 +223,12 @@ async def test_bus_emits_cancelled_run_failed_on_task_cancel(tmp_path: Any) -> N
     """
 
     bus = RunEventBus()
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(side_effect=asyncio.CancelledError())
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(side_effect=asyncio.CancelledError())
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=bus,
     )
 
@@ -256,12 +256,12 @@ async def test_supervisor_without_bus_behaves_unchanged(tmp_path: Any) -> None:
     the eval / demo-CLI path.
     """
 
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=None,
     )
     record = await sup.run(UserRequest(message="q", tenant_id="mintral"))
@@ -277,12 +277,12 @@ async def test_supervisor_honors_run_id_override(tmp_path: Any) -> None:
     any events. `run_id_override` is the seam.
     """
 
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "ok", "_events": []})
     sup = _supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
     )
     record = await sup.run(
         UserRequest(message="q", tenant_id="mintral"),
@@ -316,8 +316,8 @@ async def test_supervisor_checkpoints_during_long_run(tmp_path: Any) -> None:
         HarnessEvent(run_id="x", type="agent.turn", message=f"m{i}")
         for i in range(5)
     ]
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(
         return_value={"answer": "ok", "_events": graph_events}
     )
     sup = HarnessSupervisor(
@@ -325,8 +325,8 @@ async def test_supervisor_checkpoints_during_long_run(tmp_path: Any) -> None:
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=CountingStore(tmp_path),
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=RunEventBus(),
         checkpoint_every_n_events=2,
         tenant_lock="mintral",
@@ -359,8 +359,8 @@ async def test_supervisor_skips_checkpoint_when_no_event_bus(tmp_path: Any) -> N
         HarnessEvent(run_id="x", type="agent.turn", message=f"m{i}")
         for i in range(5)
     ]
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(
         return_value={"answer": "ok", "_events": graph_events}
     )
     sup = HarnessSupervisor(
@@ -368,8 +368,8 @@ async def test_supervisor_skips_checkpoint_when_no_event_bus(tmp_path: Any) -> N
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=CountingStore(tmp_path),
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_router("DATA_QUERY"),
         event_bus=None,  # eval path
         checkpoint_every_n_events=2,
         tenant_lock="mintral",

--- a/miot-harness/tests/runtime/test_supervisor_phase_e.py
+++ b/miot-harness/tests/runtime/test_supervisor_phase_e.py
@@ -31,6 +31,7 @@ from miot_harness.runtime.run_store import JsonRunStore
 from miot_harness.runtime.supervisor import HarnessSupervisor
 from miot_harness.storytelling.module import StorytellingModule
 from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE
 
 
 def _scripted_llm_router(route: str, confidence: float = 0.95) -> LLMIntentRouter:
@@ -252,16 +253,18 @@ async def test_backward_compatibility_when_llm_router_not_provided(tmp_path: Any
     data_graph = AsyncMock()
     data_graph.ainvoke = AsyncMock(return_value={"answer": "via keyword", "_events": []})
     # No llm_router, no agentic_graph, no meta_model — the original Plan 12 surface.
+    # The core router ships no built-in vocabulary; route on the neutral
+    # FakeProvider profile keywords.
     supervisor = HarnessSupervisor(
-        router=IntentRouter(),
+        router=IntentRouter(data_keywords=FAKE_PROFILE.router_keywords),
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
         data_graph=data_graph,
     )
-    # "Mintral" keyword triggers DATA_QUERY in the keyword router.
+    # A "fakesource" keyword triggers DATA_QUERY in the keyword router.
     record = await supervisor.run(
-        UserRequest(message="Mintral fleet status", tenant_id="mintral")
+        UserRequest(message="fakesource fleet status", tenant_id="acme")
     )
     data_graph.ainvoke.assert_awaited_once()
     assert record.answer == "via keyword"

--- a/miot-harness/tests/runtime/test_supervisor_phase_e.py
+++ b/miot-harness/tests/runtime/test_supervisor_phase_e.py
@@ -353,10 +353,10 @@ async def test_meta_agent_sees_prior_turn_via_history(
     # Force the legacy ainvoke path so the recorder below intercepts.
     # The streaming code path goes through astream_events which the
     # FakeListChatModel doesn't surface to a simple ainvoke override.
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_SYNTHESIZER_STREAM", "0")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_SYNTHESIZER_STREAM", "0")
     get_settings.cache_clear()
     # Re-clear after the test body so the cached settings (which still
-    # reflect MIOT_HARNESS_NEXO_SYNTHESIZER_STREAM=0) don't leak into
+    # reflect MIOT_HARNESS_AGENTS_SYNTHESIZER_STREAM=0) don't leak into
     # the next test. monkeypatch reverts the env var on teardown but
     # doesn't know about the lru_cache; without this finalizer the
     # next get_settings() call would hand back the stale, stream=False

--- a/miot-harness/tests/runtime/test_supervisor_phase_e.py
+++ b/miot-harness/tests/runtime/test_supervisor_phase_e.py
@@ -54,7 +54,7 @@ def _meta_catalog() -> list[MetaAgentCatalogEntry]:
 def _build_supervisor(
     tmp_path: Any,
     *,
-    nexo_graph: Any = None,
+    data_graph: Any = None,
     llm_router: LLMIntentRouter | None = None,
     agentic_graph: Any = None,
     meta_model: Any = None,
@@ -65,7 +65,7 @@ def _build_supervisor(
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
-        nexo_graph=nexo_graph,
+        data_graph=data_graph,
         llm_router=llm_router,
         agentic_graph=agentic_graph,
         meta_model=meta_model,
@@ -77,19 +77,19 @@ def _build_supervisor(
 
 
 @pytest.mark.asyncio
-async def test_explicit_canned_mode_dispatches_to_nexo_graph(tmp_path: Any) -> None:
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "canned answer", "_events": []})
+async def test_explicit_canned_mode_dispatches_to_data_graph(tmp_path: Any) -> None:
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "canned answer", "_events": []})
     supervisor = _build_supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
+        data_graph=data_graph,
         llm_router=_scripted_llm_router("DIRECT"),  # should NOT be consulted
     )
 
     record = await supervisor.run(
         UserRequest(message="anything", tenant_id="mintral", mode="canned")
     )
-    nexo_graph.ainvoke.assert_awaited_once()
+    data_graph.ainvoke.assert_awaited_once()
     assert record.answer == "canned answer"
 
 
@@ -111,13 +111,13 @@ async def test_explicit_meta_mode_calls_meta_agent(tmp_path: Any) -> None:
 async def test_meta_mode_per_agent_span_carries_tenant_tag(
     tmp_path: Any, memory_exporter: Any
 ) -> None:
-    """NEXO_META observation-level attribution: the harness-emitted
+    """DATA_META observation-level attribution: the harness-emitted
     per-agent ``nexo.meta_agent`` span carries the same
     ``modular.{agent, tenant_id, mode}`` + ``langfuse.tags`` attrs as
     canned/agentic paths.
 
     Scope: covers the harness-side wrap (the per-agent span emitted by
-    ``NexoTelemetryCallback`` when ``_run_nexo_meta`` calls
+    ``AgentTelemetryCallback`` when ``_run_data_meta`` calls
     ``instrument_model(self.meta_model, "meta_agent", ctx)``). It does
     NOT exercise Traceloop's auto-instrumented ``anthropic.chat`` child
     observation — ``FakeListChatModel`` doesn't trigger the Anthropic
@@ -205,8 +205,8 @@ async def test_auto_mode_uses_llm_router_to_pick_route(tmp_path: Any) -> None:
     supervisor = _build_supervisor(
         tmp_path,
         agentic_graph=agentic_graph,
-        # LLM router classifies any message as NEXO_AGENTIC.
-        llm_router=_scripted_llm_router("NEXO_AGENTIC"),
+        # LLM router classifies any message as DATA_AGENTIC.
+        llm_router=_scripted_llm_router("DATA_AGENTIC"),
     )
     record = await supervisor.run(
         UserRequest(message="show me stuff", tenant_id="mintral")  # mode default "auto"
@@ -223,12 +223,12 @@ async def test_conversation_id_round_trips_via_store(tmp_path: Any) -> None:
     """
 
     store = InMemoryConversationStore()
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "first answer", "_events": []})
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "first answer", "_events": []})
     supervisor = _build_supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_llm_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_llm_router("DATA_QUERY"),
         conversation_store=store,
     )
     record = await supervisor.run(
@@ -249,21 +249,21 @@ async def test_conversation_id_round_trips_via_store(tmp_path: Any) -> None:
 async def test_backward_compatibility_when_llm_router_not_provided(tmp_path: Any) -> None:
     """Existing call sites that pass only the keyword router must still work."""
 
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(return_value={"answer": "via keyword", "_events": []})
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "via keyword", "_events": []})
     # No llm_router, no agentic_graph, no meta_model — the original Plan 12 surface.
     supervisor = HarnessSupervisor(
         router=IntentRouter(),
         tools=ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
-        nexo_graph=nexo_graph,
+        data_graph=data_graph,
     )
-    # "Mintral" keyword triggers NEXO_QUERY in the keyword router.
+    # "Mintral" keyword triggers DATA_QUERY in the keyword router.
     record = await supervisor.run(
         UserRequest(message="Mintral fleet status", tenant_id="mintral")
     )
-    nexo_graph.ainvoke.assert_awaited_once()
+    data_graph.ainvoke.assert_awaited_once()
     assert record.answer == "via keyword"
 
 
@@ -271,7 +271,7 @@ async def test_backward_compatibility_when_llm_router_not_provided(tmp_path: Any
 
 
 @pytest.mark.asyncio
-async def test_supervisor_hydrates_prior_messages_into_nexo_graph_state(
+async def test_supervisor_hydrates_prior_messages_into_data_graph_state(
     tmp_path: Any,
 ) -> None:
     """Two `/runs` calls with the same `conversation_id`: turn-2's graph
@@ -286,14 +286,14 @@ async def test_supervisor_hydrates_prior_messages_into_nexo_graph_state(
     from langchain_core.messages import AIMessage, HumanMessage
 
     store = InMemoryConversationStore()
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(
         return_value={"answer": "first-turn answer", "_events": []}
     )
     supervisor = _build_supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_llm_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_llm_router("DATA_QUERY"),
         conversation_store=store,
     )
 
@@ -305,19 +305,19 @@ async def test_supervisor_hydrates_prior_messages_into_nexo_graph_state(
             conversation_id="conv-hydrate-1",
         )
     )
-    turn1_state = nexo_graph.ainvoke.call_args[0][0]
+    turn1_state = data_graph.ainvoke.call_args[0][0]
     assert turn1_state.get("prior_messages") == []
 
     # Turn 2: the store now has turn-1's append → prior_messages must
     # carry [HumanMessage("estado del coordinador"), AIMessage("first-turn answer")].
-    nexo_graph.ainvoke.reset_mock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph.ainvoke.reset_mock()
+    data_graph.ainvoke = AsyncMock(
         return_value={"answer": "second-turn answer", "_events": []}
     )
-    supervisor.nexo_graph = nexo_graph
+    supervisor.data_graph = data_graph
     # New scripted LLM router response so the second run's "auto" mode
-    # still classifies as NEXO_QUERY.
-    supervisor.llm_router = _scripted_llm_router("NEXO_QUERY")
+    # still classifies as DATA_QUERY.
+    supervisor.llm_router = _scripted_llm_router("DATA_QUERY")
     await supervisor.run(
         UserRequest(
             message="tell me more about that",
@@ -325,7 +325,7 @@ async def test_supervisor_hydrates_prior_messages_into_nexo_graph_state(
             conversation_id="conv-hydrate-1",
         )
     )
-    turn2_state = nexo_graph.ainvoke.call_args[0][0]
+    turn2_state = data_graph.ainvoke.call_args[0][0]
     prior = turn2_state.get("prior_messages")
     assert prior is not None and len(prior) == 2
     assert isinstance(prior[0], HumanMessage)
@@ -436,14 +436,14 @@ async def test_run_record_events_have_contiguous_monotonic_seq(tmp_path: Any) ->
         HarnessEvent(run_id="ignored", type="agent.turn", message="planner"),
         HarnessEvent(run_id="ignored", type="tool.completed", message="done"),
     ]
-    nexo_graph = AsyncMock()
-    nexo_graph.ainvoke = AsyncMock(
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(
         return_value={"answer": "result", "_events": graph_events}
     )
     supervisor = _build_supervisor(
         tmp_path,
-        nexo_graph=nexo_graph,
-        llm_router=_scripted_llm_router("NEXO_QUERY"),
+        data_graph=data_graph,
+        llm_router=_scripted_llm_router("DATA_QUERY"),
     )
 
     record = await supervisor.run(
@@ -455,13 +455,13 @@ async def test_run_record_events_have_contiguous_monotonic_seq(tmp_path: Any) ->
         f"expected contiguous seq from 0, got {seqs}"
     )
     # Sanity: at least run.started + route.selected + 3 graph events +
-    # run.completed = 6 events on the happy NEXO_QUERY path.
+    # run.completed = 6 events on the happy DATA_QUERY path.
     assert len(seqs) >= 6
 
 
 @pytest.mark.asyncio
 async def test_seq_monotonic_across_agentic_path(tmp_path: Any) -> None:
-    """Same contract on the NEXO_AGENTIC drain — events from the agentic
+    """Same contract on the DATA_AGENTIC drain — events from the agentic
     graph also get stamped with monotonic seq when appended.
     """
 

--- a/miot-harness/tests/runtime/test_tenancy_gate.py
+++ b/miot-harness/tests/runtime/test_tenancy_gate.py
@@ -7,6 +7,12 @@ The plan's matrix:
 
 Plus: when meta is allowed for a non-locked tenant, emit an audit
 attribute `tenant.bypass: meta_route` on the gate's emitted event.
+
+The effective lock is ``settings.datasource_tenant_lock or
+profile.tenant_lock``. With no profile, the no-profile tests below set
+the lock via the env override; the profile-based tests at the bottom
+exercise the profile-default path. When neither is set the gate has no
+lock and allows every tenant.
 """
 
 from __future__ import annotations
@@ -31,7 +37,7 @@ def test_data_routes_refuse_non_mintral(route: HarnessRoute) -> None:
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="other-tenant"),
         route=route,
-        settings=HarnessSettings(),
+        settings=HarnessSettings(datasource_tenant_lock="mintral"),
     )
     assert decision.allowed is False
     assert "mintral" in (decision.refusal_message or "").lower()
@@ -57,7 +63,7 @@ def test_data_meta_allows_any_tenant_with_audit_attr() -> None:
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="ams-customer"),
         route=HarnessRoute.DATA_META,
-        settings=HarnessSettings(),
+        settings=HarnessSettings(datasource_tenant_lock="mintral"),
     )
     assert decision.allowed is True
     # Audit attr fires only when the gate is "bypassed" for a non-locked tenant.
@@ -80,7 +86,7 @@ def test_unknown_route_defaults_to_strict_refuse_for_safety() -> None:
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="other"),
         route=HarnessRoute.OTHER,
-        settings=HarnessSettings(),
+        settings=HarnessSettings(datasource_tenant_lock="mintral"),
     )
     assert decision.allowed is False
 
@@ -108,5 +114,19 @@ def test_gate_profile_lock_allows_matching_tenant() -> None:
         route=HarnessRoute.DATA_QUERY,
         settings=HarnessSettings(),
         profile=FAKE_PROFILE,
+    )
+    assert decision.allowed is True
+
+
+def test_gate_without_lock_or_profile_allows_any_tenant() -> None:
+    """No profile and no env override means no lock — allowed. Pins the
+    Stage-4 semantics so a future re-introduction of a default lock
+    can't regress silently: production locks come from the provider's
+    profile (or the env override), never from a settings default."""
+    decision = tenancy_gate_decision(
+        ctx=_ctx(tenant="anyone"),
+        route=HarnessRoute.DATA_QUERY,
+        settings=HarnessSettings(),
+        profile=None,
     )
     assert decision.allowed is True

--- a/miot-harness/tests/runtime/test_tenancy_gate.py
+++ b/miot-harness/tests/runtime/test_tenancy_gate.py
@@ -83,3 +83,30 @@ def test_unknown_route_defaults_to_strict_refuse_for_safety() -> None:
         settings=HarnessSettings(),
     )
     assert decision.allowed is False
+
+
+def test_gate_uses_profile_lock_and_template() -> None:
+    from tests.fixtures.fake_provider import FAKE_PROFILE
+
+    decision = tenancy_gate_decision(
+        ctx=_ctx(tenant="intruder"),
+        route=HarnessRoute.NEXO_QUERY,
+        settings=HarnessSettings(),
+        profile=FAKE_PROFILE,
+    )
+    assert decision.allowed is False
+    assert decision.refusal_message == (
+        "FakeSource is acme-only. I can't answer for other tenants."
+    )
+
+
+def test_gate_profile_lock_allows_matching_tenant() -> None:
+    from tests.fixtures.fake_provider import FAKE_PROFILE
+
+    decision = tenancy_gate_decision(
+        ctx=_ctx(tenant="acme"),
+        route=HarnessRoute.NEXO_QUERY,
+        settings=HarnessSettings(),
+        profile=FAKE_PROFILE,
+    )
+    assert decision.allowed is True

--- a/miot-harness/tests/runtime/test_tenancy_gate.py
+++ b/miot-harness/tests/runtime/test_tenancy_gate.py
@@ -49,10 +49,12 @@ def test_data_routes_refuse_non_mintral(route: HarnessRoute) -> None:
     [HarnessRoute.DATA_QUERY, HarnessRoute.DATA_AGENTIC],
 )
 def test_data_routes_allow_locked_tenant(route: HarnessRoute) -> None:
+    # The lock must be SET for this to test "locked tenant allowed";
+    # default settings carry no lock and would pass vacuously.
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="mintral"),
         route=route,
-        settings=HarnessSettings(),
+        settings=HarnessSettings(datasource_tenant_lock="mintral"),
     )
     assert decision.allowed is True
     assert decision.refusal_message is None
@@ -71,10 +73,12 @@ def test_data_meta_allows_any_tenant_with_audit_attr() -> None:
 
 
 def test_data_meta_for_locked_tenant_does_not_emit_bypass_attr() -> None:
+    # Lock set explicitly: with no lock, tenant_matches is trivially True
+    # and the no-bypass assertion would pass vacuously.
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="mintral"),
         route=HarnessRoute.DATA_META,
-        settings=HarnessSettings(),
+        settings=HarnessSettings(datasource_tenant_lock="mintral"),
     )
     assert decision.allowed is True
     assert decision.audit_attr is None

--- a/miot-harness/tests/runtime/test_tenancy_gate.py
+++ b/miot-harness/tests/runtime/test_tenancy_gate.py
@@ -1,9 +1,9 @@
 """E7 — tenancy gate behavior matrix.
 
 The plan's matrix:
-- NEXO_QUERY  → refuse non-Mintral.
-- NEXO_AGENTIC → refuse non-Mintral (composable primitives touch data).
-- NEXO_META   → allow ANY tenant (meta-info is non-confidential).
+- DATA_QUERY  → refuse non-Mintral.
+- DATA_AGENTIC → refuse non-Mintral (composable primitives touch data).
+- DATA_META   → allow ANY tenant (meta-info is non-confidential).
 
 Plus: when meta is allowed for a non-locked tenant, emit an audit
 attribute `tenant.bypass: meta_route` on the gate's emitted event.
@@ -25,7 +25,7 @@ def _ctx(tenant: str = "mintral") -> HarnessContext:
 
 @pytest.mark.parametrize(
     "route",
-    [HarnessRoute.NEXO_QUERY, HarnessRoute.NEXO_AGENTIC],
+    [HarnessRoute.DATA_QUERY, HarnessRoute.DATA_AGENTIC],
 )
 def test_data_routes_refuse_non_mintral(route: HarnessRoute) -> None:
     decision = tenancy_gate_decision(
@@ -40,7 +40,7 @@ def test_data_routes_refuse_non_mintral(route: HarnessRoute) -> None:
 
 @pytest.mark.parametrize(
     "route",
-    [HarnessRoute.NEXO_QUERY, HarnessRoute.NEXO_AGENTIC],
+    [HarnessRoute.DATA_QUERY, HarnessRoute.DATA_AGENTIC],
 )
 def test_data_routes_allow_locked_tenant(route: HarnessRoute) -> None:
     decision = tenancy_gate_decision(
@@ -53,10 +53,10 @@ def test_data_routes_allow_locked_tenant(route: HarnessRoute) -> None:
     assert decision.audit_attr is None
 
 
-def test_nexo_meta_allows_any_tenant_with_audit_attr() -> None:
+def test_data_meta_allows_any_tenant_with_audit_attr() -> None:
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="ams-customer"),
-        route=HarnessRoute.NEXO_META,
+        route=HarnessRoute.DATA_META,
         settings=HarnessSettings(),
     )
     assert decision.allowed is True
@@ -64,10 +64,10 @@ def test_nexo_meta_allows_any_tenant_with_audit_attr() -> None:
     assert decision.audit_attr == {"tenant.bypass": "meta_route"}
 
 
-def test_nexo_meta_for_locked_tenant_does_not_emit_bypass_attr() -> None:
+def test_data_meta_for_locked_tenant_does_not_emit_bypass_attr() -> None:
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="mintral"),
-        route=HarnessRoute.NEXO_META,
+        route=HarnessRoute.DATA_META,
         settings=HarnessSettings(),
     )
     assert decision.allowed is True
@@ -90,7 +90,7 @@ def test_gate_uses_profile_lock_and_template() -> None:
 
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="intruder"),
-        route=HarnessRoute.NEXO_QUERY,
+        route=HarnessRoute.DATA_QUERY,
         settings=HarnessSettings(),
         profile=FAKE_PROFILE,
     )
@@ -105,7 +105,7 @@ def test_gate_profile_lock_allows_matching_tenant() -> None:
 
     decision = tenancy_gate_decision(
         ctx=_ctx(tenant="acme"),
-        route=HarnessRoute.NEXO_QUERY,
+        route=HarnessRoute.DATA_QUERY,
         settings=HarnessSettings(),
         profile=FAKE_PROFILE,
     )

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -13,46 +13,68 @@ def _clear_settings_cache():
     get_settings.cache_clear()
 
 
-def test_default_nexo_settings():
+def test_default_datasource_and_agents_settings():
     settings = HarnessSettings()
 
-    assert settings.nexo_dsn is None
-    assert settings.nexo_tenant_lock == "mintral"
-    assert settings.nexo_search_path == "nexo"
-    assert settings.nexo_freshness_warn_minutes == 30
-    assert settings.nexo_freshness_refuse_minutes == 240
-    assert settings.nexo_max_turns == 8
-    assert settings.nexo_critic_enabled is False
-    assert settings.nexo_supervisor_mode == "rule"
-    assert settings.nexo_filter_expert_model == "claude-haiku-4-5"
-    assert settings.nexo_analyst_model == "claude-sonnet-4-6"
-    assert settings.nexo_synthesizer_model == "claude-sonnet-4-6"
-    assert settings.nexo_critic_model == "claude-sonnet-4-6"
-    assert settings.nexo_summarizer_model == "claude-haiku-4-5"
+    assert settings.datasource_kind == "nexo"
+    assert settings.datasource_dsn is None
+    assert settings.datasource_application_name == "miot-harness"
+    # None → profile default; the provider resolves the effective values.
+    assert settings.datasource_tenant_lock is None
+    assert settings.datasource_freshness_warn_minutes is None
+    assert settings.datasource_freshness_refuse_minutes is None
+    assert settings.agents_max_turns == 8
+    assert settings.agents_critic_enabled is False
+    assert settings.agents_supervisor_mode == "rule"
+    assert settings.agents_filter_expert_model == "claude-haiku-4-5"
+    assert settings.agents_analyst_model == "claude-sonnet-4-6"
+    assert settings.agents_synthesizer_model == "claude-sonnet-4-6"
+    assert settings.agents_critic_model == "claude-sonnet-4-6"
+    assert settings.agents_summarizer_model == "claude-haiku-4-5"
 
 
-def test_nexo_settings_from_env(monkeypatch):
+def test_datasource_and_agents_settings_from_env(monkeypatch):
     monkeypatch.setenv(
-        "MIOT_HARNESS_NEXO_DSN", "postgresql://harness:secret@db:6432/citus"
+        "MIOT_HARNESS_DATASOURCE_DSN", "postgresql://harness:secret@db:6432/citus"
     )
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_TENANT_LOCK", "mintral")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_FRESHNESS_WARN_MINUTES", "15")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_FRESHNESS_REFUSE_MINUTES", "60")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_MAX_TURNS", "12")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_CRITIC_ENABLED", "true")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_FILTER_EXPERT_MODEL", "claude-haiku-4-5")
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_ANALYST_MODEL", "gpt-4o")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "mintral")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_FRESHNESS_WARN_MINUTES", "15")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_FRESHNESS_REFUSE_MINUTES", "60")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_MAX_TURNS", "12")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_CRITIC_ENABLED", "true")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_FILTER_EXPERT_MODEL", "claude-haiku-4-5")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_ANALYST_MODEL", "gpt-4o")
 
     settings = HarnessSettings()
 
-    assert settings.nexo_dsn == "postgresql://harness:secret@db:6432/citus"
-    assert settings.nexo_tenant_lock == "mintral"
-    assert settings.nexo_freshness_warn_minutes == 15
-    assert settings.nexo_freshness_refuse_minutes == 60
-    assert settings.nexo_max_turns == 12
-    assert settings.nexo_critic_enabled is True
-    assert settings.nexo_filter_expert_model == "claude-haiku-4-5"
-    assert settings.nexo_analyst_model == "gpt-4o"
+    assert settings.datasource_dsn == "postgresql://harness:secret@db:6432/citus"
+    assert settings.datasource_tenant_lock == "mintral"
+    assert settings.datasource_freshness_warn_minutes == 15
+    assert settings.datasource_freshness_refuse_minutes == 60
+    assert settings.agents_max_turns == 12
+    assert settings.agents_critic_enabled is True
+    assert settings.agents_filter_expert_model == "claude-haiku-4-5"
+    assert settings.agents_analyst_model == "gpt-4o"
+
+
+def test_datasource_and_agents_settings_env_names(monkeypatch) -> None:
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_KIND", "nexo")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@h:5432/db")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_MAX_TURNS", "5")
+    s = HarnessSettings()
+    assert s.datasource_kind == "nexo"
+    assert s.datasource_dsn == "postgresql://u:p@h:5432/db"
+    assert s.agents_max_turns == 5
+    assert not hasattr(s, "nexo_dsn")  # clean break — old name is gone
+
+
+def test_nexo_provider_private_settings(monkeypatch) -> None:
+    from miot_harness.integrations.nexo.settings import NexoSettings
+
+    monkeypatch.setenv("MIOT_HARNESS_NEXO_SEARCH_PATH", "custom_schema")
+    ns = NexoSettings()
+    assert ns.nexo_search_path == "custom_schema"
+    assert ns.nexo_explain_cost_threshold == 10000.0
 
 
 def test_provider_api_keys_read_from_env(monkeypatch):
@@ -66,7 +88,7 @@ def test_provider_api_keys_read_from_env(monkeypatch):
 
 
 def test_supervisor_mode_validates_literal(monkeypatch):
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_SUPERVISOR_MODE", "bogus")
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_SUPERVISOR_MODE", "bogus")
     with pytest.raises(ValidationError):
         HarnessSettings()
 

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -173,3 +173,14 @@ def test_debug_tenant_allowed_trims_both_sides():
 def test_debug_tenant_allowed_denies_when_unset():
     settings = HarnessSettings(allow_debug_tenants=None)
     assert settings.debug_tenant_allowed("mintral-dev") is False
+
+
+def test_empty_tenant_lock_rejected_at_boot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty MIOT_HARNESS_DATASOURCE_TENANT_LOCK is ambiguous (silently
+    fall back to the profile lock vs an unmatchable refuse-everyone lock) —
+    reject at boot instead, same pattern as identity_signing_key."""
+    from pydantic import ValidationError
+
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "")
+    with pytest.raises(ValidationError):
+        HarnessSettings()

--- a/miot-harness/tests/test_critic.py
+++ b/miot-harness/tests/test_critic.py
@@ -17,7 +17,7 @@ def _ctx() -> HarnessContext:
 
 @pytest.mark.asyncio
 async def test_critic_disabled_passes_through_without_llm():
-    """Default config: nexo_critic_enabled=False. The critic returns
+    """Default config: agents_critic_enabled=False. The critic returns
     state delta without invoking the model."""
     state: dict[str, Any] = {
         "user_message": "?",
@@ -31,7 +31,7 @@ async def test_critic_disabled_passes_through_without_llm():
 
     update = await critic_node(
         state,
-        settings=HarnessSettings(nexo_critic_enabled=False),
+        settings=HarnessSettings(agents_critic_enabled=False),
         model=model,
         profile=NEXO_PROFILE,
     )
@@ -55,7 +55,7 @@ async def test_critic_enabled_runs_check_and_can_pass_answer():
 
     update = await critic_node(
         state,
-        settings=HarnessSettings(nexo_critic_enabled=True),
+        settings=HarnessSettings(agents_critic_enabled=True),
         model=model,
         profile=NEXO_PROFILE,
     )
@@ -80,7 +80,7 @@ async def test_critic_enabled_flags_concerns_in_state():
 
     update = await critic_node(
         state,
-        settings=HarnessSettings(nexo_critic_enabled=True),
+        settings=HarnessSettings(agents_critic_enabled=True),
         model=model,
         profile=NEXO_PROFILE,
     )

--- a/miot-harness/tests/test_critic.py
+++ b/miot-harness/tests/test_critic.py
@@ -7,6 +7,7 @@ from langchain_core.language_models import FakeListChatModel
 
 from miot_harness.agents.critic import critic_node
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 
 
@@ -29,7 +30,10 @@ async def test_critic_disabled_passes_through_without_llm():
     model = FakeListChatModel(responses=[])
 
     update = await critic_node(
-        state, settings=HarnessSettings(nexo_critic_enabled=False), model=model
+        state,
+        settings=HarnessSettings(nexo_critic_enabled=False),
+        model=model,
+        profile=NEXO_PROFILE,
     )
 
     # Pass-through: no changes
@@ -50,7 +54,10 @@ async def test_critic_enabled_runs_check_and_can_pass_answer():
     }
 
     update = await critic_node(
-        state, settings=HarnessSettings(nexo_critic_enabled=True), model=model
+        state,
+        settings=HarnessSettings(nexo_critic_enabled=True),
+        model=model,
+        profile=NEXO_PROFILE,
     )
     # No state change on pass
     assert update == {} or "answer" not in update or update["answer"] == state["answer"]
@@ -72,7 +79,10 @@ async def test_critic_enabled_flags_concerns_in_state():
     }
 
     update = await critic_node(
-        state, settings=HarnessSettings(nexo_critic_enabled=True), model=model
+        state,
+        settings=HarnessSettings(nexo_critic_enabled=True),
+        model=model,
+        profile=NEXO_PROFILE,
     )
     assert "critic_concerns" in update
     assert "refreshed_at" in update["critic_concerns"]

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from miot_harness.agents.data_fetcher import data_fetcher_node
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.permissions import PermissionResult
@@ -76,7 +77,11 @@ async def test_fetcher_invokes_pending_step_and_appends_evidence():
     events: list[HarnessEvent] = []
 
     update = await data_fetcher_node(
-        state, registry=registry, settings=HarnessSettings(), progress=events.append
+        state,
+        registry=registry,
+        settings=HarnessSettings(),
+        progress=events.append,
+        profile=NEXO_PROFILE,
     )
 
     assert update["pending_step_index"] == 1
@@ -129,7 +134,11 @@ async def test_fetcher_records_failure_on_tool_error():
     events: list[HarnessEvent] = []
 
     update = await data_fetcher_node(
-        state, registry=registry, settings=HarnessSettings(), progress=events.append
+        state,
+        registry=registry,
+        settings=HarnessSettings(),
+        progress=events.append,
+        profile=NEXO_PROFILE,
     )
 
     assert update.get("failure")
@@ -175,7 +184,11 @@ async def test_fetcher_denied_permission_records_failure():
     }
 
     update = await data_fetcher_node(
-        state, registry=registry, settings=HarnessSettings(), progress=lambda e: None
+        state,
+        registry=registry,
+        settings=HarnessSettings(),
+        progress=lambda e: None,
+        profile=NEXO_PROFILE,
     )
     assert update.get("failure")
     assert "Mintral" in update["failure"] or "permission" in update["failure"].lower()
@@ -211,6 +224,7 @@ async def test_fetcher_unregistered_tool_emits_canonical_failure_schema():
         registry=ToolRegistry(),
         settings=HarnessSettings(),
         progress=events.append,
+        profile=NEXO_PROFILE,
     )
 
     # State delta carries the structured fields.
@@ -242,6 +256,10 @@ async def test_fetcher_no_pending_step_is_noop():
         "turn_count": 2,
     }
     update = await data_fetcher_node(
-        state, registry=ToolRegistry(), settings=HarnessSettings(), progress=lambda e: None
+        state,
+        registry=ToolRegistry(),
+        settings=HarnessSettings(),
+        progress=lambda e: None,
+        profile=NEXO_PROFILE,
     )
     assert update.get("next_action") == "ready_to_synthesize"

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -12,7 +12,7 @@ from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.permissions import PermissionResult
-from miot_harness.runtime.plan import NexoEvidence, NexoPlan, NexoStep
+from miot_harness.runtime.plan import DataEvidence, DataPlan, DataStep
 from miot_harness.runtime.tool import HarnessTool
 from miot_harness.tools.registry import ToolRegistry
 
@@ -48,7 +48,7 @@ def _stub_tool(name: str, output_payload: dict[str, Any]) -> HarnessTool:
 
 @pytest.mark.asyncio
 async def test_fetcher_invokes_pending_step_and_appends_evidence():
-    """Reads the pending NexoStep from state.plan, invokes via registry,
+    """Reads the pending DataStep from state.plan, invokes via registry,
     appends evidence, advances pending_step_index, sets next_action."""
     refreshed = datetime(2026, 5, 8, 10, 0, tzinfo=UTC)
     registry = ToolRegistry()
@@ -61,9 +61,9 @@ async def test_fetcher_invokes_pending_step_and_appends_evidence():
             },
         )
     )
-    plan = NexoPlan(
+    plan = DataPlan(
         steps=[
-            NexoStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r"),
+            DataStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r"),
         ]
     )
     state: dict[str, Any] = {
@@ -88,7 +88,7 @@ async def test_fetcher_invokes_pending_step_and_appends_evidence():
     assert update["next_action"] == "judge_freshness"
     assert len(update["evidence"]) == 1
     ev = update["evidence"][0]
-    assert isinstance(ev, NexoEvidence)
+    assert isinstance(ev, DataEvidence)
     assert ev.tool == "coordinador_centro_control"
     assert ev.refreshed_at == refreshed
     assert "tool.completed" in {e.type for e in events}
@@ -122,7 +122,7 @@ async def test_fetcher_records_failure_on_tool_error():
     registry = ToolRegistry()
     registry.register(failing_tool)
 
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),
@@ -173,7 +173,7 @@ async def test_fetcher_denied_permission_records_failure():
     registry = ToolRegistry()
     registry.register(locked_tool)
 
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),
@@ -206,8 +206,8 @@ async def test_fetcher_unregistered_tool_emits_canonical_failure_schema():
     context, not just a stringified message.
     """
 
-    plan = NexoPlan(
-        steps=[NexoStep(intent="i", tool="not_a_real_tool", args={}, rationale="r")]
+    plan = DataPlan(
+        steps=[DataStep(intent="i", tool="not_a_real_tool", args={}, rationale="r")]
     )
     state = {
         "user_message": "?",
@@ -246,7 +246,7 @@ async def test_fetcher_unregistered_tool_emits_canonical_failure_schema():
 async def test_fetcher_no_pending_step_is_noop():
     """If pending_step_index >= len(steps), fetcher reports done without
     re-running anything."""
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="coordinador_x", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -263,3 +263,27 @@ async def test_fetcher_no_pending_step_is_noop():
         profile=NEXO_PROFILE,
     )
     assert update.get("next_action") == "ready_to_synthesize"
+
+
+def test_evidence_source_none_falls_back_to_profile_label() -> None:
+    """A tool payload carrying source=None (or "") must fall back to the
+    profile's source label instead of stringifying to the literal "None"."""
+    from miot_harness.agents.data_fetcher import _evidence_from_output
+
+    evidence = _evidence_from_output(
+        "step_1",
+        "fake_lookup",
+        {"rows": [], "source": None},
+        warn_minutes=30,
+        source_label=NEXO_PROFILE.source_label,
+    )
+    assert evidence.source == NEXO_PROFILE.source_label
+
+    evidence = _evidence_from_output(
+        "step_1",
+        "fake_lookup",
+        {"rows": [], "source": ""},
+        warn_minutes=30,
+        source_label=NEXO_PROFILE.source_label,
+    )
+    assert evidence.source == NEXO_PROFILE.source_label

--- a/miot-harness/tests/test_data_supervisor.py
+++ b/miot-harness/tests/test_data_supervisor.py
@@ -145,7 +145,7 @@ def test_turn_cap_forces_synthesizer():
         "turn_count": 8,
         "next_action": "need_more_tools",
     }
-    assert next_agent(state, _settings(nexo_max_turns=8)) == "synthesizer"
+    assert next_agent(state, _settings(agents_max_turns=8)) == "synthesizer"
 
 
 def test_summarizer_triggered_when_messages_exceed_threshold():

--- a/miot-harness/tests/test_data_supervisor.py
+++ b/miot-harness/tests/test_data_supervisor.py
@@ -5,7 +5,7 @@ from typing import Any
 from miot_harness.agents.supervisor import next_agent
 from miot_harness.config import HarnessSettings
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.plan import NexoEvidence, NexoPlan, NexoStep
+from miot_harness.runtime.plan import DataEvidence, DataPlan, DataStep
 
 
 def _settings(**overrides: Any) -> HarnessSettings:
@@ -22,7 +22,7 @@ def test_no_plan_routes_to_filter_expert():
 
 
 def test_pending_step_routes_to_data_fetcher():
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="t", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="t", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),
@@ -37,8 +37,8 @@ def test_pending_step_routes_to_data_fetcher():
 def test_fresh_evidence_routes_to_freshness_judge():
     """After data_fetcher emits evidence, supervisor routes through
     freshness_judge before the analyst sees it."""
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="t", args={}, rationale="r")])
-    ev = NexoEvidence(
+    plan = DataPlan(steps=[DataStep(intent="i", tool="t", args={}, rationale="r")])
+    ev = DataEvidence(
         step_id="s1",
         tool="t",
         source="src",
@@ -60,14 +60,14 @@ def test_fresh_evidence_routes_to_freshness_judge():
 
 
 def test_analyst_requests_more_data_loops_back_to_filter_expert():
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="t", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="t", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),
         "plan": plan,
         "pending_step_index": 1,
         "evidence": [
-            NexoEvidence(
+            DataEvidence(
                 step_id="s",
                 tool="t",
                 source="x",
@@ -88,7 +88,7 @@ def test_analyst_ready_routes_to_synthesizer():
         "user_message": "?",
         "ctx": _ctx(),
         "evidence": [
-            NexoEvidence(
+            DataEvidence(
                 step_id="s",
                 tool="t",
                 source="x",
@@ -132,7 +132,7 @@ def test_turn_cap_forces_synthesizer():
         "user_message": "?",
         "ctx": _ctx(),
         "evidence": [
-            NexoEvidence(
+            DataEvidence(
                 step_id="s",
                 tool="t",
                 source="x",
@@ -161,14 +161,14 @@ def test_summarizer_triggered_when_messages_exceed_threshold():
 
 
 def test_default_after_freshness_judge_routes_to_analyst():
-    plan = NexoPlan(steps=[NexoStep(intent="i", tool="t", args={}, rationale="r")])
+    plan = DataPlan(steps=[DataStep(intent="i", tool="t", args={}, rationale="r")])
     state = {
         "user_message": "?",
         "ctx": _ctx(),
         "plan": plan,
         "pending_step_index": 1,
         "evidence": [
-            NexoEvidence(
+            DataEvidence(
                 step_id="s",
                 tool="t",
                 source="x",

--- a/miot-harness/tests/test_domain_analyst.py
+++ b/miot-harness/tests/test_domain_analyst.py
@@ -10,15 +10,15 @@ from langchain_core.language_models import FakeListChatModel
 from miot_harness.agents.domain_analyst import domain_analyst_node
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 
 
 def _ctx() -> HarnessContext:
     return HarnessContext(thread_id="t", tenant_id="mintral", user_id="u")
 
 
-def _ev(output: dict[str, Any] | None = None, is_stale: bool = False) -> NexoEvidence:
-    return NexoEvidence(
+def _ev(output: dict[str, Any] | None = None, is_stale: bool = False) -> DataEvidence:
+    return DataEvidence(
         step_id="s",
         tool="coordinador_centro_control",
         source="src",

--- a/miot-harness/tests/test_domain_analyst.py
+++ b/miot-harness/tests/test_domain_analyst.py
@@ -8,6 +8,7 @@ import pytest
 from langchain_core.language_models import FakeListChatModel
 
 from miot_harness.agents.domain_analyst import domain_analyst_node
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.plan import NexoEvidence
 
@@ -47,7 +48,7 @@ async def test_analyst_signals_ready_to_synthesize():
         "turn_count": 1,
     }
 
-    update = await domain_analyst_node(state, model=model)
+    update = await domain_analyst_node(state, model=model, profile=NEXO_PROFILE)
     assert update["next_action"] == "ready_to_synthesize"
     assert update.get("turn_count") == 2
 
@@ -71,7 +72,7 @@ async def test_analyst_requests_more_tools():
         "turn_count": 1,
     }
 
-    update = await domain_analyst_node(state, model=model)
+    update = await domain_analyst_node(state, model=model, profile=NEXO_PROFILE)
     assert update["next_action"] == "need_more_tools"
 
 
@@ -85,7 +86,7 @@ async def test_analyst_handles_malformed_response():
         "turn_count": 1,
     }
 
-    update = await domain_analyst_node(state, model=model)
+    update = await domain_analyst_node(state, model=model, profile=NEXO_PROFILE)
     # Default to ready_to_synthesize so the synthesizer can render with what we have
     assert update["next_action"] == "ready_to_synthesize"
 
@@ -102,5 +103,5 @@ async def test_analyst_no_evidence_routes_to_filter_expert():
     }
     model = FakeListChatModel(responses=[])  # should not be called
 
-    update = await domain_analyst_node(state, model=model)
+    update = await domain_analyst_node(state, model=model, profile=NEXO_PROFILE)
     assert update["next_action"] == "need_more_tools"

--- a/miot-harness/tests/test_filter_expert.py
+++ b/miot-harness/tests/test_filter_expert.py
@@ -307,3 +307,23 @@ async def test_filter_expert_refuses_unknown_tool():
         state, registry=registry, model=model, profile=NEXO_PROFILE
     )
     assert update.get("failure")
+
+
+@pytest.mark.asyncio
+async def test_filter_expert_non_object_json_is_malformed_step():
+    """Valid JSON that isn't an object (e.g. "[]") must hit the
+    malformed-step fallback, not raise AttributeError on payload.get."""
+    registry = ToolRegistry()
+    registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI summary"))
+    model = FakeListChatModel(responses=["[]"])
+
+    state: dict[str, Any] = {
+        "user_message": "¿estado operativo de hoy?",
+        "ctx": _ctx(),
+        "evidence": [],
+        "turn_count": 0,
+    }
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
+    assert update.get("failure") == "filter_expert returned malformed step"

--- a/miot-harness/tests/test_filter_expert.py
+++ b/miot-harness/tests/test_filter_expert.py
@@ -10,6 +10,7 @@ from miot_harness.agents.filter_expert import (
     build_tool_catalog,
     filter_expert_node,
 )
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.plan import NexoPlan, NexoStep
 from miot_harness.runtime.tool import HarnessTool  # noqa: F401
@@ -54,7 +55,7 @@ def test_build_tool_catalog_includes_all_coordinador_tools():
     registry.register(_stub_tool("coordinador_kpi_servicio", "[Layer L3] per-service KPI"))
     registry.register(_stub_tool("get_delivery_compliance_metrics", "non-Nexo"))
 
-    catalog = build_tool_catalog(registry)
+    catalog = build_tool_catalog(registry, profile=NEXO_PROFILE)
 
     assert "coordinador_centro_control" in catalog
     assert "coordinador_kpi_servicio" in catalog
@@ -65,7 +66,7 @@ def test_build_tool_catalog_includes_all_coordinador_tools():
 def test_build_tool_catalog_includes_layer_hint():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI summary text"))
-    catalog = build_tool_catalog(registry)
+    catalog = build_tool_catalog(registry, profile=NEXO_PROFILE)
     assert "L1" in catalog
     assert "KPI summary text" in catalog
 
@@ -94,7 +95,9 @@ async def test_filter_expert_produces_single_step():
         "turn_count": 0,
     }
 
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
 
     plan = update["plan"]
     assert isinstance(plan, NexoPlan)
@@ -138,7 +141,9 @@ async def test_filter_expert_appends_to_existing_plan():
         "turn_count": 1,
     }
 
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     new_plan = update["plan"]
 
     assert len(new_plan.steps) == 2
@@ -169,7 +174,9 @@ async def test_filter_expert_clears_next_action():
         "turn_count": 1,
         "next_action": "need_more_tools",
     }
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     assert update.get("next_action") is None
 
 
@@ -186,7 +193,9 @@ async def test_filter_expert_handles_json_fenced_response():
     )
     model = FakeListChatModel(responses=[fenced])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     assert "plan" in update
     assert update["plan"].steps[0].tool == "coordinador_centro_control"
 
@@ -219,7 +228,9 @@ async def test_filter_expert_handles_plan_max_steps():
         "evidence": [],
         "turn_count": 4,
     }
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     assert update.get("failure")
     assert update.get("next_action") == "ready_to_synthesize"
 
@@ -240,7 +251,9 @@ async def test_filter_expert_refuses_non_coordinador_tool():
     )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     assert update.get("failure")
     assert "out-of-scope" in update["failure"] or "scope" in update["failure"].lower()
 
@@ -259,7 +272,9 @@ async def test_filter_expert_emits_plan_created_event_on_first_step():
     )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     events = update.get("_events") or []
     assert any(e.type == "plan.created" for e in events)
 
@@ -288,5 +303,7 @@ async def test_filter_expert_refuses_unknown_tool():
         "turn_count": 0,
     }
 
-    update = await filter_expert_node(state, registry=registry, model=model)
+    update = await filter_expert_node(
+        state, registry=registry, model=model, profile=NEXO_PROFILE
+    )
     assert update.get("failure")

--- a/miot-harness/tests/test_filter_expert.py
+++ b/miot-harness/tests/test_filter_expert.py
@@ -12,7 +12,7 @@ from miot_harness.agents.filter_expert import (
 )
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
-from miot_harness.runtime.plan import NexoPlan, NexoStep
+from miot_harness.runtime.plan import DataPlan, DataStep
 from miot_harness.runtime.tool import HarnessTool  # noqa: F401
 from miot_harness.tools.registry import ToolRegistry
 
@@ -74,7 +74,7 @@ def test_build_tool_catalog_includes_layer_hint():
 @pytest.mark.asyncio
 async def test_filter_expert_produces_single_step():
     """Given a user message and a tool catalog, filter_expert returns a
-    state update with a NexoStep added to the plan."""
+    state update with a DataStep added to the plan."""
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI summary"))
 
@@ -100,10 +100,10 @@ async def test_filter_expert_produces_single_step():
     )
 
     plan = update["plan"]
-    assert isinstance(plan, NexoPlan)
+    assert isinstance(plan, DataPlan)
     assert len(plan.steps) == 1
     step = plan.steps[0]
-    assert isinstance(step, NexoStep)
+    assert isinstance(step, DataStep)
     assert step.tool == "coordinador_centro_control"
     assert step.intent
     assert step.rationale
@@ -127,9 +127,9 @@ async def test_filter_expert_appends_to_existing_plan():
     )
     model = FakeListChatModel(responses=[fake_response])
 
-    existing_plan = NexoPlan(
+    existing_plan = DataPlan(
         steps=[
-            NexoStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r")
+            DataStep(intent="initial", tool="coordinador_centro_control", args={}, rationale="r")
         ]
     )
     state = {
@@ -202,7 +202,7 @@ async def test_filter_expert_handles_json_fenced_response():
 
 @pytest.mark.asyncio
 async def test_filter_expert_handles_plan_max_steps():
-    """When NexoPlan's max_length=4 cap is hit, fail soft → route to synth."""
+    """When DataPlan's max_length=4 cap is hit, fail soft → route to synth."""
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
     fake_response = json.dumps(
@@ -214,9 +214,9 @@ async def test_filter_expert_handles_plan_max_steps():
         }
     )
     model = FakeListChatModel(responses=[fake_response])
-    full_plan = NexoPlan(
+    full_plan = DataPlan(
         steps=[
-            NexoStep(intent=f"i{i}", tool="coordinador_centro_control", args={}, rationale="r")
+            DataStep(intent=f"i{i}", tool="coordinador_centro_control", args={}, rationale="r")
             for i in range(4)
         ]
     )

--- a/miot-harness/tests/test_freshness_judge.py
+++ b/miot-harness/tests/test_freshness_judge.py
@@ -10,6 +10,7 @@ from miot_harness.agents.freshness_judge import (
     freshness_judge_node,
 )
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoEvidence
@@ -39,7 +40,9 @@ def test_fresh_evidence_passes_through():
     }
     events: list[HarnessEvent] = []
 
-    update = freshness_judge_node(state, settings=HarnessSettings(), progress=events.append)
+    update = freshness_judge_node(
+        state, settings=HarnessSettings(), progress=events.append, profile=NEXO_PROFILE
+    )
 
     assert update["next_action"] == "analyze"
     assert "evidence" not in update  # judge does not mutate evidence (operator.add reducer)
@@ -58,7 +61,9 @@ def test_warn_zone_marks_is_stale_and_emits_warning_event():
     events: list[HarnessEvent] = []
     settings = HarnessSettings(nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240)
 
-    update = freshness_judge_node(state, settings=settings, progress=events.append)
+    update = freshness_judge_node(
+        state, settings=settings, progress=events.append, profile=NEXO_PROFILE
+    )
 
     assert update["next_action"] == "analyze"
     assert "evidence" not in update  # judge does not mutate evidence
@@ -75,7 +80,9 @@ def test_refuse_zone_blocks_synthesizer():
     events: list[HarnessEvent] = []
     settings = HarnessSettings(nexo_freshness_refuse_minutes=240)
 
-    update = freshness_judge_node(state, settings=settings, progress=events.append)
+    update = freshness_judge_node(
+        state, settings=settings, progress=events.append, profile=NEXO_PROFILE
+    )
 
     assert update.get("freshness") == FRESHNESS_REFUSE
     assert update.get("failure")  # synth will render the refusal
@@ -90,6 +97,8 @@ def test_no_refreshed_at_treated_as_warn_not_refuse():
         "evidence": [_ev(None)],
         "turn_count": 1,
     }
-    update = freshness_judge_node(state, settings=HarnessSettings(), progress=lambda e: None)
+    update = freshness_judge_node(
+        state, settings=HarnessSettings(), progress=lambda e: None, profile=NEXO_PROFILE
+    )
     assert update.get("freshness") == FRESHNESS_WARN
     assert update["next_action"] == "analyze"

--- a/miot-harness/tests/test_freshness_judge.py
+++ b/miot-harness/tests/test_freshness_judge.py
@@ -59,7 +59,9 @@ def test_warn_zone_marks_is_stale_and_emits_warning_event():
         "turn_count": 1,
     }
     events: list[HarnessEvent] = []
-    settings = HarnessSettings(nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240)
+    settings = HarnessSettings(
+        datasource_freshness_warn_minutes=30, datasource_freshness_refuse_minutes=240
+    )
 
     update = freshness_judge_node(
         state, settings=settings, progress=events.append, profile=NEXO_PROFILE
@@ -78,7 +80,7 @@ def test_refuse_zone_blocks_synthesizer():
         "turn_count": 1,
     }
     events: list[HarnessEvent] = []
-    settings = HarnessSettings(nexo_freshness_refuse_minutes=240)
+    settings = HarnessSettings(datasource_freshness_refuse_minutes=240)
 
     update = freshness_judge_node(
         state, settings=settings, progress=events.append, profile=NEXO_PROFILE
@@ -87,6 +89,37 @@ def test_refuse_zone_blocks_synthesizer():
     assert update.get("freshness") == FRESHNESS_REFUSE
     assert update.get("failure")  # synth will render the refusal
     assert update["next_action"] == "ready_to_synthesize"
+    assert "freshness.warning" in {e.type for e in events}
+
+
+def test_settings_warn_override_beats_profile_default():
+    """`datasource_freshness_warn_minutes` overrides the profile's 30.
+
+    Evidence aged 10 min is FRESH under the profile default (30) but
+    WARN once the env override tightens warn to 5 — proving the
+    settings layer wins over the profile in the resolution.
+    """
+    state: dict[str, Any] = {
+        "ctx": _ctx(),
+        "evidence": [_ev(datetime.now(UTC) - timedelta(minutes=10))],
+        "turn_count": 1,
+    }
+
+    # Profile default (warn=30): 10-min-old evidence is fresh.
+    fresh_update = freshness_judge_node(
+        state, settings=HarnessSettings(), progress=lambda e: None, profile=NEXO_PROFILE
+    )
+    assert fresh_update.get("freshness") == FRESHNESS_FRESH
+
+    # Override warn=5: the same evidence is now in the warn zone.
+    events: list[HarnessEvent] = []
+    warn_update = freshness_judge_node(
+        state,
+        settings=HarnessSettings(datasource_freshness_warn_minutes=5),
+        progress=events.append,
+        profile=NEXO_PROFILE,
+    )
+    assert warn_update.get("freshness") == FRESHNESS_WARN
     assert "freshness.warning" in {e.type for e in events}
 
 

--- a/miot-harness/tests/test_freshness_judge.py
+++ b/miot-harness/tests/test_freshness_judge.py
@@ -13,15 +13,15 @@ from miot_harness.config import HarnessSettings
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 
 
 def _ctx() -> HarnessContext:
     return HarnessContext(thread_id="t", tenant_id="mintral", user_id="u")
 
 
-def _ev(refreshed_at) -> NexoEvidence:
-    return NexoEvidence(
+def _ev(refreshed_at) -> DataEvidence:
+    return DataEvidence(
         step_id="s",
         tool="coordinador_centro_control",
         source="src",

--- a/miot-harness/tests/test_graph_profile_seam.py
+++ b/miot-harness/tests/test_graph_profile_seam.py
@@ -1,0 +1,35 @@
+"""Building the data graph with the FakeProvider profile must produce a
+graph — proof no Coordinador hardcode is required by core code."""
+
+from __future__ import annotations
+
+from langchain_core.language_models import FakeListChatModel
+
+from miot_harness.config import HarnessSettings
+from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+def _models() -> dict[str, FakeListChatModel]:
+    """Cheapest model pool: one empty FakeListChatModel per LLM seat. The
+    seam test only compiles the graph (no ainvoke), so no responses needed.
+    Mirrors the seat list used by tests/test_nexo_graph.py::_models.
+    """
+    return {
+        "filter_expert": FakeListChatModel(responses=[]),
+        "domain_analyst": FakeListChatModel(responses=[]),
+        "synthesizer": FakeListChatModel(responses=[]),
+        "critic": FakeListChatModel(responses=[]),
+        "summarizer": FakeListChatModel(responses=[]),
+    }
+
+
+def test_build_nexo_graph_with_fake_profile_compiles() -> None:
+    graph = build_nexo_graph(
+        registry=ToolRegistry(),
+        settings=HarnessSettings(),
+        models=_models(),
+        profile=FAKE_PROFILE,
+    )
+    assert graph is not None

--- a/miot-harness/tests/test_graph_profile_seam.py
+++ b/miot-harness/tests/test_graph_profile_seam.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from langchain_core.language_models import FakeListChatModel
 
 from miot_harness.config import HarnessSettings
-from miot_harness.runtime.nexo_graph import build_nexo_graph
+from miot_harness.runtime.data_graph import build_data_graph
 from miot_harness.tools.registry import ToolRegistry
 from tests.fixtures.fake_provider import FAKE_PROFILE
 
@@ -14,7 +14,7 @@ from tests.fixtures.fake_provider import FAKE_PROFILE
 def _models() -> dict[str, FakeListChatModel]:
     """Cheapest model pool: one empty FakeListChatModel per LLM seat. The
     seam test only compiles the graph (no ainvoke), so no responses needed.
-    Mirrors the seat list used by tests/test_nexo_graph.py::_models.
+    Mirrors the seat list used by tests/integrations/nexo/test_graph.py::_models.
     """
     return {
         "filter_expert": FakeListChatModel(responses=[]),
@@ -25,8 +25,8 @@ def _models() -> dict[str, FakeListChatModel]:
     }
 
 
-def test_build_nexo_graph_with_fake_profile_compiles() -> None:
-    graph = build_nexo_graph(
+def test_build_data_graph_with_fake_profile_compiles() -> None:
+    graph = build_data_graph(
         registry=ToolRegistry(),
         settings=HarnessSettings(),
         models=_models(),

--- a/miot-harness/tests/test_nexo_graph.py
+++ b/miot-harness/tests/test_nexo_graph.py
@@ -9,6 +9,7 @@ from langchain_core.language_models import FakeListChatModel
 from pydantic import BaseModel
 
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.nexo_graph import build_nexo_graph
 from miot_harness.runtime.permissions import PermissionResult
@@ -91,7 +92,9 @@ def _models(filter_step_tool: str = "coordinador_centro_control") -> dict[str, A
 async def test_happy_path_mintral_run_emits_answer():
     registry, _refreshed = _registry_with_centro()
     settings = HarnessSettings(nexo_freshness_warn_minutes=30, nexo_freshness_refuse_minutes=240)
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_models())
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
+    )
 
     initial: dict[str, Any] = {
         "user_message": "¿estado operativo de hoy?",
@@ -123,7 +126,9 @@ async def test_non_mintral_tenant_short_circuits_at_tenant_gate():
         "critic": FakeListChatModel(responses=[]),
         "summarizer": FakeListChatModel(responses=[]),
     }
-    graph = build_nexo_graph(registry=registry, settings=settings, models=bare_models)
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=bare_models, profile=NEXO_PROFILE
+    )
 
     initial = {
         "user_message": "for client X?",
@@ -145,7 +150,9 @@ async def test_stale_data_routes_through_synth_failure_path():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", refreshed))
     settings = HarnessSettings(nexo_freshness_refuse_minutes=240)
-    graph = build_nexo_graph(registry=registry, settings=settings, models=_models())
+    graph = build_nexo_graph(
+        registry=registry, settings=settings, models=_models(), profile=NEXO_PROFILE
+    )
 
     initial = {
         "user_message": "?",

--- a/miot-harness/tests/test_plan.py
+++ b/miot-harness/tests/test_plan.py
@@ -7,15 +7,15 @@ import pytest
 from pydantic import ValidationError
 
 from miot_harness.runtime.plan import (
-    NexoEvidence,
-    NexoPlan,
-    NexoState,
-    NexoStep,
+    DataEvidence,
+    DataPlan,
+    DataState,
+    DataStep,
 )
 
 
-def test_nexo_step_auto_id():
-    step = NexoStep(
+def test_data_step_auto_id():
+    step = DataStep(
         intent="fetch today's KPIs",
         tool="coordinador_centro_control",
         args={},
@@ -25,27 +25,27 @@ def test_nexo_step_auto_id():
     assert len(step.id) == len("step_") + 8
 
 
-def test_nexo_plan_steps_max_length_four():
-    steps = [NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(4)]
-    plan = NexoPlan(steps=steps)
+def test_data_plan_steps_max_length_four():
+    steps = [DataStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(4)]
+    plan = DataPlan(steps=steps)
     assert len(plan.steps) == 4
     assert plan.final_format == "answer"
 
     with pytest.raises(ValidationError):
-        NexoPlan(
-            steps=[NexoStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(5)]
+        DataPlan(
+            steps=[DataStep(intent=f"i{i}", tool="t", args={}, rationale="r") for i in range(5)]
         )
 
 
-def test_nexo_plan_final_format_literal():
-    plan = NexoPlan(steps=[], final_format="story")
+def test_data_plan_final_format_literal():
+    plan = DataPlan(steps=[], final_format="story")
     assert plan.final_format == "story"
     with pytest.raises(ValidationError):
-        NexoPlan(steps=[], final_format="bogus")
+        DataPlan(steps=[], final_format="bogus")
 
 
-def test_nexo_evidence_fields():
-    ev = NexoEvidence(
+def test_data_evidence_fields():
+    ev = DataEvidence(
         step_id="step_abc",
         tool="coordinador_centro_control",
         source="Coordinador · nexo (Citus DB)",
@@ -58,8 +58,8 @@ def test_nexo_evidence_fields():
     assert ev.is_stale is False
 
 
-def test_nexo_evidence_refreshed_at_optional():
-    ev = NexoEvidence(
+def test_data_evidence_refreshed_at_optional():
+    ev = DataEvidence(
         step_id="step_abc",
         tool="t",
         source="Coordinador · nexo (Citus DB)",
@@ -71,13 +71,13 @@ def test_nexo_evidence_refreshed_at_optional():
     assert ev.refreshed_at is None
 
 
-def test_nexo_state_evidence_uses_add_reducer():
+def test_data_state_evidence_uses_add_reducer():
     """C3: LangGraph requires Annotated[..., operator.add] for accumulating lists."""
     import operator
 
-    hints = get_type_hints(NexoState, include_extras=True)
+    hints = get_type_hints(DataState, include_extras=True)
     evidence_hint = hints["evidence"]
-    # Annotated[list[NexoEvidence], operator.add]
+    # Annotated[list[DataEvidence], operator.add]
     assert getattr(evidence_hint, "__metadata__", None) is not None, (
         "evidence field must be Annotated to provide a LangGraph reducer"
     )
@@ -85,8 +85,8 @@ def test_nexo_state_evidence_uses_add_reducer():
     assert operator.add in metadata, "evidence reducer must be operator.add (or list_append alias)"
 
 
-def test_nexo_state_required_fields_present():
-    hints = get_type_hints(NexoState)
+def test_data_state_required_fields_present():
+    hints = get_type_hints(DataState)
     for field in (
         "user_message",
         "ctx",
@@ -96,4 +96,4 @@ def test_nexo_state_required_fields_present():
         "answer",
         "failure",
     ):
-        assert field in hints, f"NexoState missing field: {field}"
+        assert field in hints, f"DataState missing field: {field}"

--- a/miot-harness/tests/test_router.py
+++ b/miot-harness/tests/test_router.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import pytest
 
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.router import HarnessRoute, IntentRouter
 
 
 @pytest.fixture
 def router() -> IntentRouter:
-    return IntentRouter()
+    # The core router ships no built-in vocabulary; keywords come from the
+    # active datasource profile. These tests exercise the nexo profile's
+    # keyword set (the provider-under-test's own domain vocabulary).
+    return IntentRouter(data_keywords=NEXO_PROFILE.router_keywords)
 
 
 @pytest.mark.parametrize(
@@ -24,7 +28,7 @@ def router() -> IntentRouter:
         "ETA en riesgo",
     ],
 )
-def test_default_keywords_route_to_data_query(router: IntentRouter, message: str):
+def test_profile_keywords_route_to_data_query(router: IntentRouter, message: str):
     result = router.route(message)
     assert result.route == HarnessRoute.DATA_QUERY
 

--- a/miot-harness/tests/test_router.py
+++ b/miot-harness/tests/test_router.py
@@ -65,3 +65,16 @@ def test_etapa_with_eta_word_doesnt_match():
 def test_uppercase_eta_matches():
     router = IntentRouter()
     assert router.route("¿qué ETA tenemos?").route == HarnessRoute.NEXO_QUERY
+
+
+def test_router_accepts_custom_keywords() -> None:
+    router = IntentRouter(data_keywords=frozenset({"fakesource"}))
+    result = router.route("estado de fakesource hoy")
+    assert result.route == HarnessRoute.NEXO_QUERY
+
+
+def test_router_custom_keywords_replace_defaults() -> None:
+    # With custom keywords, the default nexo literals must NOT route to data.
+    router = IntentRouter(data_keywords=frozenset({"fakesource"}))
+    result = router.route("estado del coordinador?")
+    assert result.route == HarnessRoute.DIRECT

--- a/miot-harness/tests/test_router.py
+++ b/miot-harness/tests/test_router.py
@@ -24,9 +24,9 @@ def router() -> IntentRouter:
         "ETA en riesgo",
     ],
 )
-def test_nexo_keywords_route_to_nexo_query(router: IntentRouter, message: str):
+def test_default_keywords_route_to_data_query(router: IntentRouter, message: str):
     result = router.route(message)
-    assert result.route == HarnessRoute.NEXO_QUERY
+    assert result.route == HarnessRoute.DATA_QUERY
 
 
 def test_eta_word_boundary_does_not_match_etapa(router: IntentRouter):
@@ -34,7 +34,7 @@ def test_eta_word_boundary_does_not_match_etapa(router: IntentRouter):
     'etapa', 'meta', and 'completada' don't trigger the Nexo path."""
     for false_positive in ("etapa siguiente", "meta cumplida", "completada"):
         result = router.route(false_positive)
-        assert result.route != HarnessRoute.NEXO_QUERY, (
+        assert result.route != HarnessRoute.DATA_QUERY, (
             f"unexpected NEXO match for {false_positive!r}"
         )
 
@@ -44,10 +44,10 @@ def test_storytelling_still_routes_correctly(router: IntentRouter):
     assert result.route == HarnessRoute.STORYTELLING_RUN
 
 
-def test_storytelling_with_nexo_keyword_resolves_to_nexo_first(router: IntentRouter):
+def test_storytelling_with_data_keyword_resolves_to_data_first(router: IntentRouter):
     """Plan resolution: when both keywords appear, Nexo wins."""
     result = router.route("write a story about Mintral coordinador status")
-    assert result.route == HarnessRoute.NEXO_QUERY
+    assert result.route == HarnessRoute.DATA_QUERY
 
 
 def test_unrelated_message_routes_direct(router: IntentRouter):
@@ -59,18 +59,18 @@ def test_etapa_with_eta_word_doesnt_match():
     """Lowercase 'eta' inside other words must NOT trigger; the regex is
     \\bETA\\b (uppercase, word boundary)."""
     router = IntentRouter()
-    assert router.route("la etapa siguiente").route != HarnessRoute.NEXO_QUERY
+    assert router.route("la etapa siguiente").route != HarnessRoute.DATA_QUERY
 
 
 def test_uppercase_eta_matches():
     router = IntentRouter()
-    assert router.route("¿qué ETA tenemos?").route == HarnessRoute.NEXO_QUERY
+    assert router.route("¿qué ETA tenemos?").route == HarnessRoute.DATA_QUERY
 
 
 def test_router_accepts_custom_keywords() -> None:
     router = IntentRouter(data_keywords=frozenset({"fakesource"}))
     result = router.route("estado de fakesource hoy")
-    assert result.route == HarnessRoute.NEXO_QUERY
+    assert result.route == HarnessRoute.DATA_QUERY
 
 
 def test_router_custom_keywords_replace_defaults() -> None:

--- a/miot-harness/tests/test_router.py
+++ b/miot-harness/tests/test_router.py
@@ -82,3 +82,11 @@ def test_router_custom_keywords_replace_defaults() -> None:
     router = IntentRouter(data_keywords=frozenset({"fakesource"}))
     result = router.route("estado del coordinador?")
     assert result.route == HarnessRoute.DIRECT
+
+
+def test_router_lowercases_mixed_case_keywords() -> None:
+    """Profile keywords are normalized on intake — route() matches against
+    the lowercased message, so a mixed-case keyword must still fire."""
+    router = IntentRouter(data_keywords=frozenset({"FakeSource"}))
+    result = router.route("estado de fakesource?")
+    assert result.route is HarnessRoute.DATA_QUERY

--- a/miot-harness/tests/test_run_golden.py
+++ b/miot-harness/tests/test_run_golden.py
@@ -4,7 +4,12 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from miot_harness.evals.run_golden import run_golden, validate_entries
+from miot_harness.evals.run_golden import (
+    DEFAULT_FALLBACK_TOOL,
+    _build_fake_registry,
+    run_golden,
+    validate_entries,
+)
 
 GOLDEN_YAML = Path(__file__).resolve().parents[1] / "evals" / "golden" / "nexo" / "examples.yaml"
 
@@ -83,6 +88,27 @@ def test_validate_rejects_bad_refusal_mechanism() -> None:
 
 def test_validate_accepts_valid_refusal_mechanism() -> None:
     assert validate_entries([_refusal_entry()]) == []
+
+
+def test_build_fake_registry_stubs_arbitrary_expected_tools() -> None:
+    """The fake registry builds a stub for EVERY expected_tools name verbatim,
+    with no prefix filter — so a dataset can ask for any tool name."""
+    entry = {
+        "id": "x",
+        "tenant_id": "mintral",
+        "expected_tools": ["weather_lookup", "ams_inventory", "totally_custom"],
+    }
+    registry = _build_fake_registry(entry)
+    names = set(registry.names())
+    assert {"weather_lookup", "ams_inventory", "totally_custom"} <= names
+    # The fallback is always present so refusal cases still resolve.
+    assert DEFAULT_FALLBACK_TOOL in names
+
+
+def test_build_fake_registry_empty_expected_uses_fallback() -> None:
+    """Refusal cases (empty expected_tools) still get the fallback tool."""
+    registry = _build_fake_registry({"id": "x", "tenant_id": "mintral", "expected_tools": []})
+    assert registry.names() == [DEFAULT_FALLBACK_TOOL]
 
 
 def test_fake_mode_nulls_semantic_refusals(tmp_path: Path) -> None:

--- a/miot-harness/tests/test_run_golden.py
+++ b/miot-harness/tests/test_run_golden.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import Any
 
 from miot_harness.evals.run_golden import (
-    DEFAULT_FALLBACK_TOOL,
+    _active_profile,
     _build_fake_registry,
+    default_fallback_tool,
     run_golden,
     validate_entries,
 )
@@ -98,17 +99,21 @@ def test_build_fake_registry_stubs_arbitrary_expected_tools() -> None:
         "tenant_id": "mintral",
         "expected_tools": ["weather_lookup", "ams_inventory", "totally_custom"],
     }
-    registry = _build_fake_registry(entry)
+    profile = _active_profile()
+    registry = _build_fake_registry(entry, profile)
     names = set(registry.names())
     assert {"weather_lookup", "ams_inventory", "totally_custom"} <= names
     # The fallback is always present so refusal cases still resolve.
-    assert DEFAULT_FALLBACK_TOOL in names
+    assert default_fallback_tool(profile) in names
 
 
 def test_build_fake_registry_empty_expected_uses_fallback() -> None:
     """Refusal cases (empty expected_tools) still get the fallback tool."""
-    registry = _build_fake_registry({"id": "x", "tenant_id": "mintral", "expected_tools": []})
-    assert registry.names() == [DEFAULT_FALLBACK_TOOL]
+    profile = _active_profile()
+    registry = _build_fake_registry(
+        {"id": "x", "tenant_id": "mintral", "expected_tools": []}, profile
+    )
+    assert registry.names() == [default_fallback_tool(profile)]
 
 
 def test_fake_mode_nulls_semantic_refusals(tmp_path: Path) -> None:

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -113,3 +113,54 @@ def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
             resp = client.get("/health")
             assert resp.status_code == 200
             assert app.state.datasource_enabled is False
+
+
+def test_graph_build_failure_tears_down_partial_wiring(monkeypatch, tmp_path):
+    """If graph/model wiring fails AFTER a successful boot, every graph
+    and meta entry point must be cleared (a live agentic_graph behind a
+    disabled /health would silently keep serving) and the provider's
+    pool must be closed immediately, not at app shutdown."""
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    fake_pool = MagicMock()
+    fake_pool.close = AsyncMock()
+
+    with (
+        patch(
+            "miot_harness.integrations.nexo.provider.create_nexo_pool",
+            new=AsyncMock(return_value=fake_pool),
+        ),
+        patch(
+            "miot_harness.integrations.nexo.provider.load_nexo_tools",
+            new=AsyncMock(
+                return_value=NexoBootResult(
+                    enabled=True,
+                    registered=["coordinador_centro_control"],
+                )
+            ),
+        ),
+        # Late failure: data_graph builds fine, agentic_graph raises —
+        # exercising the partial-wiring branch of the except handler.
+        patch(
+            "miot_harness.api.server.build_agentic_graph",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            assert app.state.datasource_enabled is False
+            assert resp.json()["datasource"]["tools"] == []
+            harness = app.state.harness
+            assert harness.data_graph is None
+            assert harness.agentic_graph is None
+            assert harness.meta_model is None
+            assert harness.llm_router is None
+            # Keyword routing survives so the data routes can still
+            # serve the "integration disabled" answer.
+            assert harness.router.route("estado del coordinador?").route.value == "data_query"
+            # Pool released during boot, not deferred to shutdown.
+            fake_pool.close.assert_awaited_once()

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -18,7 +18,7 @@ def _settings_cache():
 
 
 def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
-    monkeypatch.delenv("MIOT_HARNESS_NEXO_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
 
     app = create_app()
@@ -30,7 +30,7 @@ def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
 
 
 def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
     # Provider keys required by the chat-model factory once Nexo enables
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
@@ -66,7 +66,7 @@ def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
 def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
     """ACL leak / stale snapshot — load_nexo_tools returns enabled=False
     with a reason. The app must still boot and the pool must close."""
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
 
     fake_pool = MagicMock()
@@ -93,7 +93,7 @@ def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
 
 def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
     """Tunnel down — asyncpg.create_pool raises. App still boots."""
-    monkeypatch.setenv("MIOT_HARNESS_NEXO_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
 
     with patch(

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -26,7 +26,7 @@ def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
         resp = client.get("/health")
         assert resp.status_code == 200
         # Without env var, Nexo state is disabled
-        assert getattr(app.state, "nexo_enabled", False) is False
+        assert getattr(app.state, "datasource_enabled", False) is False
 
 
 def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
@@ -57,7 +57,7 @@ def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
         with TestClient(app) as client:
             resp = client.get("/health")
             assert resp.status_code == 200
-            assert app.state.nexo_enabled is True
+            assert app.state.datasource_enabled is True
             assert app.state.datasource_provider is not None
 
     fake_pool.close.assert_awaited_once()
@@ -87,7 +87,7 @@ def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
         with TestClient(app) as client:
             resp = client.get("/health")
             assert resp.status_code == 200
-            assert app.state.nexo_enabled is False
+            assert app.state.datasource_enabled is False
     fake_pool.close.assert_awaited_once()
 
 
@@ -104,4 +104,4 @@ def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
         with TestClient(app) as client:
             resp = client.get("/health")
             assert resp.status_code == 200
-            assert app.state.nexo_enabled is False
+            assert app.state.datasource_enabled is False

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -27,6 +27,14 @@ def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
         assert resp.status_code == 200
         # Without env var, Nexo state is disabled
         assert getattr(app.state, "datasource_enabled", False) is False
+        # The profile's keyword vocabulary and tenant lock are wired
+        # even when the datasource is disabled: a data-keyword message
+        # must still route to DATA_QUERY (where the "integration
+        # disabled" answer lives), not fall through to DIRECT/OTHER.
+        harness = app.state.harness
+        route = harness.router.route("estado del coordinador?")
+        assert route.route.value == "data_query"
+        assert harness.tenant_lock == "mintral"
 
 
 def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -27,7 +27,6 @@ def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
         assert resp.status_code == 200
         # Without env var, Nexo state is disabled
         assert getattr(app.state, "nexo_enabled", False) is False
-        assert getattr(app.state, "nexo_pool", None) is None
 
 
 def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
@@ -40,9 +39,12 @@ def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
     fake_pool.close = AsyncMock()
 
     with (
-        patch("miot_harness.api.server.create_nexo_pool", new=AsyncMock(return_value=fake_pool)),
         patch(
-            "miot_harness.api.server.load_nexo_tools",
+            "miot_harness.integrations.nexo.provider.create_nexo_pool",
+            new=AsyncMock(return_value=fake_pool),
+        ),
+        patch(
+            "miot_harness.integrations.nexo.provider.load_nexo_tools",
             new=AsyncMock(
                 return_value=NexoBootResult(
                     enabled=True,
@@ -56,7 +58,7 @@ def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
             resp = client.get("/health")
             assert resp.status_code == 200
             assert app.state.nexo_enabled is True
-            assert app.state.nexo_pool is fake_pool
+            assert app.state.datasource_provider is not None
 
     fake_pool.close.assert_awaited_once()
 
@@ -70,9 +72,12 @@ def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
     fake_pool = MagicMock()
     fake_pool.close = AsyncMock()
     with (
-        patch("miot_harness.api.server.create_nexo_pool", new=AsyncMock(return_value=fake_pool)),
         patch(
-            "miot_harness.api.server.load_nexo_tools",
+            "miot_harness.integrations.nexo.provider.create_nexo_pool",
+            new=AsyncMock(return_value=fake_pool),
+        ),
+        patch(
+            "miot_harness.integrations.nexo.provider.load_nexo_tools",
             new=AsyncMock(
                 return_value=NexoBootResult(enabled=False, registered=[], reason="stale")
             ),
@@ -92,7 +97,7 @@ def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
 
     with patch(
-        "miot_harness.api.server.create_nexo_pool",
+        "miot_harness.integrations.nexo.provider.create_nexo_pool",
         new=AsyncMock(side_effect=ConnectionRefusedError("tunnel down")),
     ):
         app = create_app()
@@ -100,4 +105,3 @@ def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
             resp = client.get("/health")
             assert resp.status_code == 200
             assert app.state.nexo_enabled is False
-            assert app.state.nexo_pool is None

--- a/miot-harness/tests/test_supervisor_data_branch.py
+++ b/miot-harness/tests/test_supervisor_data_branch.py
@@ -96,3 +96,26 @@ async def test_disabled_message_uses_profile_display_name(tmp_path):
     assert record.status == "completed"
     assert record.answer is not None
     assert "FakeSource integration is currently disabled" in record.answer
+
+
+@pytest.mark.asyncio
+async def test_meta_disabled_emits_answer_completed(tmp_path):
+    """The meta-disabled early return must emit answer.completed (like the
+    disabled-datasource branch) so SSE subscribers get a terminal event,
+    not a silent close. Driven directly: DATA_META is only reachable via
+    the LLM router, which unit tests don't wire."""
+    from miot_harness.runtime.run_store import HarnessRunRecord
+
+    sup = _supervisor(tmp_path, data_graph=None)
+    sup.profile = FAKE_PROFILE  # meta_model stays None
+
+    request = UserRequest(message="what can you do?", mode="meta")
+    ctx = request.to_context()
+    record = HarnessRunRecord(run_id=ctx.run_id, status="running")
+    events = []
+
+    await sup._run_data_meta(request, ctx, record, events.append, None, [])
+
+    assert record.answer is not None
+    assert "Meta agent is currently disabled" in record.answer
+    assert any(e.type == "answer.completed" for e in events)

--- a/miot-harness/tests/test_supervisor_data_branch.py
+++ b/miot-harness/tests/test_supervisor_data_branch.py
@@ -17,8 +17,10 @@ from tests.fixtures.fake_provider import FAKE_PROFILE
 def _supervisor(
     tmp_path, data_graph=None, *, registry: ToolRegistry | None = None
 ) -> HarnessSupervisor:
+    # Neutral FakeProvider vocabulary: the core router ships no built-in
+    # keywords, so route on the FakeProvider profile's keywords here.
     return HarnessSupervisor(
-        router=IntentRouter(),
+        router=IntentRouter(data_keywords=FAKE_PROFILE.router_keywords),
         tools=registry if registry is not None else ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
@@ -40,7 +42,7 @@ async def test_data_route_invokes_graph_when_present(tmp_path):
     )
     sup = _supervisor(tmp_path, data_graph=fake_graph)
 
-    record = await sup.run(UserRequest(message="estado coordinador?", tenant_id="mintral"))
+    record = await sup.run(UserRequest(message="estado fakesource?", tenant_id="acme"))
 
     assert record.answer == "Operativo OK"
     assert any(e.type == "answer.completed" for e in record.events)
@@ -54,7 +56,7 @@ async def test_data_route_handles_disabled_graph(tmp_path):
     """When the datasource is disabled (graph=None), the supervisor must
     produce a graceful refusal without raising."""
     sup = _supervisor(tmp_path, data_graph=None)
-    record = await sup.run(UserRequest(message="coordinador status?", tenant_id="mintral"))
+    record = await sup.run(UserRequest(message="fakesource status?", tenant_id="acme"))
     assert record.status == "completed"
     assert record.answer
     assert "disabled" in record.answer.lower() or "unavailable" in record.answer.lower()
@@ -62,7 +64,7 @@ async def test_data_route_handles_disabled_graph(tmp_path):
 
 @pytest.mark.asyncio
 async def test_storytelling_path_unchanged(tmp_path):
-    """Existing storytelling flow must still work — no nexo keywords trigger
+    """Existing storytelling flow must still work — no data keywords trigger
     the legacy path with the default tool registry."""
     sup = _supervisor(tmp_path, data_graph=None, registry=build_default_registry())
     record = await sup.run(UserRequest(message="write a story about delivery"))
@@ -77,7 +79,7 @@ async def test_data_route_handles_graph_exception(tmp_path):
     fake_graph.ainvoke = AsyncMock(side_effect=RuntimeError("graph blew up"))
     sup = _supervisor(tmp_path, data_graph=fake_graph)
 
-    record = await sup.run(UserRequest(message="coordinador?", tenant_id="mintral"))
+    record = await sup.run(UserRequest(message="fakesource?", tenant_id="acme"))
     assert record.status == "failed"
     failed = [e for e in record.events if e.type == "run.failed"]
     assert failed
@@ -86,11 +88,11 @@ async def test_data_route_handles_graph_exception(tmp_path):
 @pytest.mark.asyncio
 async def test_disabled_message_uses_profile_display_name(tmp_path):
     """When profile is set on the supervisor, the disabled message uses
-    profile.display_name instead of the legacy "Coordinador" literal."""
+    profile.display_name rather than any hardcoded datasource name."""
     sup = _supervisor(tmp_path, data_graph=None)
     sup.profile = FAKE_PROFILE
 
-    record = await sup.run(UserRequest(message="coordinador status?", tenant_id="mintral"))
+    record = await sup.run(UserRequest(message="fakesource status?", tenant_id="acme"))
     assert record.status == "completed"
     assert record.answer is not None
     assert "FakeSource integration is currently disabled" in record.answer

--- a/miot-harness/tests/test_supervisor_data_branch.py
+++ b/miot-harness/tests/test_supervisor_data_branch.py
@@ -15,21 +15,21 @@ from tests.fixtures.fake_provider import FAKE_PROFILE
 
 
 def _supervisor(
-    tmp_path, nexo_graph=None, *, registry: ToolRegistry | None = None
+    tmp_path, data_graph=None, *, registry: ToolRegistry | None = None
 ) -> HarnessSupervisor:
     return HarnessSupervisor(
         router=IntentRouter(),
         tools=registry if registry is not None else ToolRegistry(),
         stories=StorytellingModule(),
         run_store=JsonRunStore(tmp_path),
-        nexo_graph=nexo_graph,
+        data_graph=data_graph,
     )
 
 
 @pytest.mark.asyncio
-async def test_nexo_route_invokes_graph_when_present(tmp_path):
-    """When the request matches a Nexo keyword, the supervisor must
-    invoke the compiled nexo graph and surface the answer + events."""
+async def test_data_route_invokes_graph_when_present(tmp_path):
+    """When the request matches a data keyword, the supervisor must
+    invoke the compiled data graph and surface the answer + events."""
     fake_event = HarnessEvent(run_id="r", type="answer.completed", message="done", data={})
     fake_graph = type("FakeGraph", (), {})()
     fake_graph.ainvoke = AsyncMock(
@@ -38,22 +38,22 @@ async def test_nexo_route_invokes_graph_when_present(tmp_path):
             "_events": [fake_event],
         }
     )
-    sup = _supervisor(tmp_path, nexo_graph=fake_graph)
+    sup = _supervisor(tmp_path, data_graph=fake_graph)
 
     record = await sup.run(UserRequest(message="estado coordinador?", tenant_id="mintral"))
 
     assert record.answer == "Operativo OK"
     assert any(e.type == "answer.completed" for e in record.events)
-    # route.selected must include NEXO_QUERY
+    # route.selected must include DATA_QUERY
     selected = [e for e in record.events if e.type == "route.selected"]
-    assert selected and "nexo_query" in str(selected[0].data.get("route", ""))
+    assert selected and "data_query" in str(selected[0].data.get("route", ""))
 
 
 @pytest.mark.asyncio
-async def test_nexo_route_handles_disabled_graph(tmp_path):
-    """When Nexo is disabled (graph=None), the supervisor must produce
-    a graceful refusal without raising."""
-    sup = _supervisor(tmp_path, nexo_graph=None)
+async def test_data_route_handles_disabled_graph(tmp_path):
+    """When the datasource is disabled (graph=None), the supervisor must
+    produce a graceful refusal without raising."""
+    sup = _supervisor(tmp_path, data_graph=None)
     record = await sup.run(UserRequest(message="coordinador status?", tenant_id="mintral"))
     assert record.status == "completed"
     assert record.answer
@@ -64,18 +64,18 @@ async def test_nexo_route_handles_disabled_graph(tmp_path):
 async def test_storytelling_path_unchanged(tmp_path):
     """Existing storytelling flow must still work — no nexo keywords trigger
     the legacy path with the default tool registry."""
-    sup = _supervisor(tmp_path, nexo_graph=None, registry=build_default_registry())
+    sup = _supervisor(tmp_path, data_graph=None, registry=build_default_registry())
     record = await sup.run(UserRequest(message="write a story about delivery"))
     assert record.status == "completed"
     assert any(e.type == "artifact.created" for e in record.events)
 
 
 @pytest.mark.asyncio
-async def test_nexo_route_handles_graph_exception(tmp_path):
+async def test_data_route_handles_graph_exception(tmp_path):
     """A graph crash must fail the run gracefully, not propagate."""
     fake_graph = type("FakeGraph", (), {})()
     fake_graph.ainvoke = AsyncMock(side_effect=RuntimeError("graph blew up"))
-    sup = _supervisor(tmp_path, nexo_graph=fake_graph)
+    sup = _supervisor(tmp_path, data_graph=fake_graph)
 
     record = await sup.run(UserRequest(message="coordinador?", tenant_id="mintral"))
     assert record.status == "failed"
@@ -87,7 +87,7 @@ async def test_nexo_route_handles_graph_exception(tmp_path):
 async def test_disabled_message_uses_profile_display_name(tmp_path):
     """When profile is set on the supervisor, the disabled message uses
     profile.display_name instead of the legacy "Coordinador" literal."""
-    sup = _supervisor(tmp_path, nexo_graph=None)
+    sup = _supervisor(tmp_path, data_graph=None)
     sup.profile = FAKE_PROFILE
 
     record = await sup.run(UserRequest(message="coordinador status?", tenant_id="mintral"))

--- a/miot-harness/tests/test_supervisor_nexo_branch.py
+++ b/miot-harness/tests/test_supervisor_nexo_branch.py
@@ -11,6 +11,7 @@ from miot_harness.runtime.run_store import JsonRunStore
 from miot_harness.runtime.supervisor import HarnessSupervisor
 from miot_harness.storytelling.module import StorytellingModule
 from miot_harness.tools.registry import ToolRegistry, build_default_registry
+from tests.fixtures.fake_provider import FAKE_PROFILE
 
 
 def _supervisor(
@@ -80,3 +81,16 @@ async def test_nexo_route_handles_graph_exception(tmp_path):
     assert record.status == "failed"
     failed = [e for e in record.events if e.type == "run.failed"]
     assert failed
+
+
+@pytest.mark.asyncio
+async def test_disabled_message_uses_profile_display_name(tmp_path):
+    """When profile is set on the supervisor, the disabled message uses
+    profile.display_name instead of the legacy "Coordinador" literal."""
+    sup = _supervisor(tmp_path, nexo_graph=None)
+    sup.profile = FAKE_PROFILE
+
+    record = await sup.run(UserRequest(message="coordinador status?", tenant_id="mintral"))
+    assert record.status == "completed"
+    assert record.answer is not None
+    assert "FakeSource integration is currently disabled" in record.answer

--- a/miot-harness/tests/test_synthesizer.py
+++ b/miot-harness/tests/test_synthesizer.py
@@ -7,6 +7,7 @@ import pytest
 from langchain_core.language_models import FakeListChatModel
 
 from miot_harness.agents.synthesizer import synthesizer_node
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 from miot_harness.runtime.plan import NexoEvidence
@@ -40,7 +41,9 @@ async def test_synthesizes_answer_from_evidence():
     }
     events: list[HarnessEvent] = []
 
-    update = await synthesizer_node(state, model=model, progress=events.append)
+    update = await synthesizer_node(
+        state, model=model, progress=events.append, profile=NEXO_PROFILE
+    )
 
     assert update["answer"] == fake
     assert "answer.completed" in {e.type for e in events}
@@ -61,7 +64,9 @@ async def test_synthesizes_refusal_when_failure_set():
     events: list[HarnessEvent] = []
     model = FakeListChatModel(responses=[])  # would fail if invoked
 
-    update = await synthesizer_node(state, model=model, progress=events.append)
+    update = await synthesizer_node(
+        state, model=model, progress=events.append, profile=NEXO_PROFILE
+    )
 
     assert update["answer"]
     assert "stale" in update["answer"].lower() or "snapshot" in update["answer"].lower()
@@ -87,7 +92,9 @@ async def test_planning_failure_does_not_leak_snapshot_retry_advice():
     events: list[HarnessEvent] = []
     model = FakeListChatModel(responses=[])
 
-    update = await synthesizer_node(state, model=model, progress=events.append)
+    update = await synthesizer_node(
+        state, model=model, progress=events.append, profile=NEXO_PROFILE
+    )
 
     answer = update["answer"]
     assert answer
@@ -114,7 +121,9 @@ async def test_synthesizes_tenant_refusal_for_non_mintral():
     events: list[HarnessEvent] = []
     model = FakeListChatModel(responses=[])
 
-    update = await synthesizer_node(state, model=model, progress=events.append)
+    update = await synthesizer_node(
+        state, model=model, progress=events.append, profile=NEXO_PROFILE
+    )
     assert update["answer"]
     assert "Mintral" in update["answer"] or "mintral" in update["answer"].lower()
 
@@ -129,5 +138,7 @@ async def test_includes_stale_warning_when_evidence_is_stale():
         "evidence": [_ev(is_stale=True)],
         "turn_count": 1,
     }
-    update = await synthesizer_node(state, model=model, progress=lambda e: None)
+    update = await synthesizer_node(
+        state, model=model, progress=lambda e: None, profile=NEXO_PROFILE
+    )
     assert update["answer"] == fake

--- a/miot-harness/tests/test_synthesizer.py
+++ b/miot-harness/tests/test_synthesizer.py
@@ -10,15 +10,15 @@ from miot_harness.agents.synthesizer import synthesizer_node
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
-from miot_harness.runtime.plan import NexoEvidence
+from miot_harness.runtime.plan import DataEvidence
 
 
 def _ctx() -> HarnessContext:
     return HarnessContext(thread_id="t", tenant_id="mintral", user_id="u")
 
 
-def _ev(refreshed=None, is_stale=False) -> NexoEvidence:
-    return NexoEvidence(
+def _ev(refreshed=None, is_stale=False) -> DataEvidence:
+    return DataEvidence(
         step_id="s",
         tool="coordinador_centro_control",
         source="src",

--- a/miot-harness/tests/test_synthesizer_streaming.py
+++ b/miot-harness/tests/test_synthesizer_streaming.py
@@ -11,6 +11,7 @@ import pytest
 
 from miot_harness.agents.synthesizer import synthesizer_node
 from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.events import HarnessEvent
 
@@ -98,7 +99,11 @@ async def test_streaming_synthesizer_emits_thinking_then_text() -> None:
         "failure": None,
     }
     delta = await synthesizer_node(
-        state, model=model, progress=events.append, settings=settings  # type: ignore[arg-type]
+        state,
+        model=model,
+        progress=events.append,
+        settings=settings,  # type: ignore[arg-type]
+        profile=NEXO_PROFILE,
     )
 
     types = [e.type for e in events]
@@ -144,7 +149,11 @@ async def test_streaming_synthesizer_disabled_falls_back_to_ainvoke() -> None:
         "failure": None,
     }
     delta = await synthesizer_node(
-        state, model=_AinvokeOnlyModel(), progress=events.append, settings=settings  # type: ignore[arg-type]
+        state,
+        model=_AinvokeOnlyModel(),
+        progress=events.append,
+        settings=settings,  # type: ignore[arg-type]
+        profile=NEXO_PROFILE,
     )
     assert delta == {"answer": "ainvoke path."}
     assert "thinking.delta" not in {e.type for e in events}

--- a/miot-harness/tests/test_synthesizer_streaming.py
+++ b/miot-harness/tests/test_synthesizer_streaming.py
@@ -91,7 +91,7 @@ def _streaming_events() -> list[dict[str, Any]]:
 async def test_streaming_synthesizer_emits_thinking_then_text() -> None:
     events: list[HarnessEvent] = []
     model = _FakeStreamingModel(_streaming_events())
-    settings = HarnessSettings(nexo_synthesizer_stream=True)
+    settings = HarnessSettings(agents_synthesizer_stream=True)
     state = {
         "ctx": HarnessContext(thread_id="t", tenant_id="mintral", user_id="u"),
         "user_message": "hola",
@@ -141,7 +141,7 @@ async def test_streaming_synthesizer_disabled_falls_back_to_ainvoke() -> None:
             yield  # pragma: no cover
 
     events: list[HarnessEvent] = []
-    settings = HarnessSettings(nexo_synthesizer_stream=False)
+    settings = HarnessSettings(agents_synthesizer_stream=False)
     state = {
         "ctx": HarnessContext(thread_id="t", tenant_id="mintral", user_id="u"),
         "user_message": "hola",

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/App.smoke.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/App.smoke.test.tsx
@@ -130,7 +130,7 @@ describe("<App /> smoke", () => {
   });
 
   it(
-    "renders the final record.answer when answer.completed has no data.text (nexo_meta case)",
+    "renders the final record.answer when answer.completed has no data.text (data_meta case)",
     { timeout: 15000 },
     async () => {
       // Reproduces the user-reported flow: harness emits
@@ -141,7 +141,7 @@ describe("<App /> smoke", () => {
       const ctx = deterministicCtx();
       const events: HarnessEvent[] = [
         evt("run.started"),
-        evt("route.selected", { data: { route: "nexo_meta" } }),
+        evt("route.selected", { data: { route: "data_meta" } }),
         evt("answer.completed", {
           message: "Meta agent answered",
           data: { length: 42 },
@@ -192,7 +192,7 @@ describe("<App /> smoke", () => {
     { timeout: 15000 },
     async () => {
       // Matches the screenshot the user reported:
-      //   route.selected nexo_query
+      //   route.selected data_query
       //   plan.created
       //   tool.started "Starting coordinador_eta_riesgo_hoy"
       //   tool.completed "Completed coordinador_eta_riesgo_hoy"
@@ -202,7 +202,7 @@ describe("<App /> smoke", () => {
       const ctx = deterministicCtx();
       const events: HarnessEvent[] = [
         evt("run.started"),
-        evt("route.selected", { data: { route: "nexo_query" } }),
+        evt("route.selected", { data: { route: "data_query" } }),
         evt("plan.created", { message: "Initial plan created by filter_expert" }),
         evt("tool.started", {
           data: { name: "Starting coordinador_eta_riesgo_hoy" },


### PR DESCRIPTION
Closes #608

## Summary

The harness hardcoded one specific deployment everywhere: **Nexo** (a Citus/Postgres DB — 330 occurrences across 32 files, 16 env vars), **Coordinador** (tool prefix `coordinador_*`, primer, agent prompts), and **mintral** (tenant-lock default, refusal copy, router keywords). The harness is meant to be environment-independent — the datasource could be a DB, a filesystem, a cloud API, and in the future a skill/plugin or an MCP server.

This PR introduces a **datasource seam** and moves every domain-specific value behind it:

- **`src/miot_harness/datasource/`** — `DataSourceProvider` ABC (async `boot`/`close`, owns its connection) + frozen **`DataSourceProfile`** (declarative domain values: `name`, `display_name`, `source_label`, `tool_prefix`, `primer`, `router_keywords`, `tenant_lock` + refusal template, freshness thresholds) + a **named registry** selected by `MIOT_HARNESS_DATASOURCE_KIND` (default `nexo`). The registry is the future plugin/MCP hook: a new provider implements `boot()` and ships a profile — no core changes.
- **`integrations/nexo/`** is now the **only** package that says Nexo/Coordinador/mintral. Enforced by a grep gate: outside it, the core's only mentions are the registry binding and the `datasource_kind="nexo"` default (a registry key, not behavior).
- A **`FakeProvider`** test fixture acts as the second provider that proves the seam — core runtime/agent tests run against it and cannot depend on Nexo specifics.

## Behavior: byte-identical for nexo

Agent prompts were diffed **byte-for-byte** against the previous hardcoded text after templating (`{display_name}`, primer, tool prefix, tenant naming). Unchanged on the wire: tool names (`coordinador_*`), SSE `source` strings, tenant-refusal copy, OTel span names (`nexo.*` via `profile.name`), node-lifecycle graph labels. Fake-mode golden evals pass **25/25 at every stage**.

## Breaking changes

### 1. Env vars (deployments must rename — no aliases)

| Old | New |
|---|---|
| `MIOT_HARNESS_NEXO_DSN` | `MIOT_HARNESS_DATASOURCE_DSN` |
| `MIOT_HARNESS_NEXO_APPLICATION_NAME` | `MIOT_HARNESS_DATASOURCE_APPLICATION_NAME` |
| `MIOT_HARNESS_NEXO_TENANT_LOCK` | `MIOT_HARNESS_DATASOURCE_TENANT_LOCK` (now optional; unset → provider profile default `mintral`) |
| `MIOT_HARNESS_NEXO_FRESHNESS_WARN_MINUTES` | `MIOT_HARNESS_DATASOURCE_FRESHNESS_WARN_MINUTES` (unset → profile default 30; explicit `0` honored) |
| `MIOT_HARNESS_NEXO_FRESHNESS_REFUSE_MINUTES` | `MIOT_HARNESS_DATASOURCE_FRESHNESS_REFUSE_MINUTES` (unset → profile default 240) |
| `MIOT_HARNESS_NEXO_MAX_TURNS` | `MIOT_HARNESS_AGENTS_MAX_TURNS` |
| `MIOT_HARNESS_NEXO_CRITIC_ENABLED` | `MIOT_HARNESS_AGENTS_CRITIC_ENABLED` |
| `MIOT_HARNESS_NEXO_SUPERVISOR_MODE` | `MIOT_HARNESS_AGENTS_SUPERVISOR_MODE` |
| `MIOT_HARNESS_NEXO_FILTER_EXPERT_MODEL` | `MIOT_HARNESS_AGENTS_FILTER_EXPERT_MODEL` |
| `MIOT_HARNESS_NEXO_ANALYST_MODEL` | `MIOT_HARNESS_AGENTS_ANALYST_MODEL` |
| `MIOT_HARNESS_NEXO_SYNTHESIZER_MODEL` | `MIOT_HARNESS_AGENTS_SYNTHESIZER_MODEL` |
| `MIOT_HARNESS_NEXO_CRITIC_MODEL` | `MIOT_HARNESS_AGENTS_CRITIC_MODEL` |
| `MIOT_HARNESS_NEXO_SUMMARIZER_MODEL` | `MIOT_HARNESS_AGENTS_SUMMARIZER_MODEL` |
| `MIOT_HARNESS_NEXO_SYNTHESIZER_STREAM` | `MIOT_HARNESS_AGENTS_SYNTHESIZER_STREAM` |
| `MIOT_HARNESS_NEXO_SYNTHESIZER_THINKING_BUDGET` | `MIOT_HARNESS_AGENTS_SYNTHESIZER_THINKING_BUDGET` |
| — (new) | `MIOT_HARNESS_DATASOURCE_KIND=nexo` |

**Unchanged** (Postgres concepts, honestly Nexo's — moved into provider-private `integrations/nexo/settings.py`): `MIOT_HARNESS_NEXO_SEARCH_PATH`, `MIOT_HARNESS_NEXO_EXPLAIN_COST_THRESHOLD`.

### 2. Wire contract

| Surface | Old | New |
|---|---|---|
| `route.selected` SSE data | `nexo_query` / `nexo_meta` / `nexo_agentic` | `data_query` / `data_meta` / `data_agentic` |
| Run-record artifact type | `nexo_plan` | `data_plan` |
| `/health`, `/health/ready` | `"nexo": {...}` | `"datasource": {"name": "nexo", "enabled": ..., "tools": ..., "snapshot_age_minutes": ...}` |
| Node-lifecycle `graph` label, OTel spans, tool names, source strings, refusal copy | | **unchanged** |

`miot-harness-client` types and `miot-chat` test fixtures are updated in this PR (`graph: "nexo"` stays valid).

## Notable design points

- **Disabled-datasource path preserved**: the lifespan wires the profile's keyword router and tenant lock **before** `provider.boot()`, so with no DSN a "coordinador?" message still routes to the data path (where the "integration disabled" answer lives) and mode gating keeps refusing off-lock tenants. Pinned by test.
- **Freshness split-brain fixed**: `data_fetcher.is_stale` and `freshness_judge` now share one `is not None` resolution (env override > profile default), so an explicit `0` is honored.
- **Tenancy semantics**: locks come from the provider profile (or env override), never from a settings default. No profile + no override = no lock — production always has the profile, behavior unchanged (verified call-chain in review).
- `evals/run_golden.py` imports the *provider under test* (`NEXO_PROFILE`) instead of hardcoding its strings; real mode boots via the registry; `--yaml` defaults to `evals/golden/<datasource_kind>/examples.yaml`.

## Commits (each stage independently green)

1. `feat(harness)`: the seam — provider/profile/registry + NexoProvider + FakeProvider + lifespan via registry
2. `refactor(harness)`: core consumes the profile (router, tenancy, agents, supervisor, telemetry)
3. `refactor(harness)`: symbol + wire renames (`Data*` types, `data_graph`, `DATA_*` routes, health block, client TS)
4. `refactor(harness)!`: the env-var break
5. `refactor(evals)`: golden-runner de-hardcode + final sweep + grep gate

## Test plan

- [x] `uv run pytest -q` — 496 passed, 2 skipped (was 467 on trunk; +29 new seam/override/regression tests)
- [x] `uv run ruff check src tests` + `uv run mypy` — clean
- [x] `uv run miot-harness-evals --mode fake` — 25/25, at every stage
- [x] `MIOT_HARNESS_DATASOURCE_DSN="" uv run miot-harness-evals --mode real` — refuses, exit 1
- [x] `npx turbo run test --filter=@microboxlabs/miot-chat --filter=@microboxlabs/miot-harness-client` — 348 + 22 green, tsc clean
- [x] Grep gate: `nexo|coordinador|mintral` in `src/` only inside `integrations/nexo`, the registry binding, and run_golden's provider-under-test import
- [ ] Ops follow-up at deploy time: rename env vars per the table above (Helm/compose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable datasource abstraction with provider registry, built-in Nexo provider and a FakeProvider for testing; selectable via MIOT_HARNESS_DATASOURCE_KIND.

* **Configuration Changes**
  * Environment variables reorganized into MIOT_HARNESS_DATASOURCE_* and MIOT_HARNESS_AGENTS_* namespaces; freshness and explain-cost knobs added/renamed.

* **API Improvements**
  * /health and readiness report datasource status, registered tools and snapshot age.

* **Observability**
  * Telemetry span prefix made datasource-configurable (neutral default).

* **Documentation**
  * Run modes, dispatch routing and design docs updated for datasource-driven operation.

* **Tests**
  * Expanded tests for providers, registry, graphs, tenancy, evals and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->