### PR TITLE
feat(app): show task candidate groups in bento header

### DIFF
--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
@@ -65,6 +65,12 @@ export type TaskResponse = {
   persistentState: PersistentState;
   isEditable: boolean;
   takenBy?: string;
+  /**
+   * Alfresco group authorities the task is offered to (e.g. "GROUP_<name>").
+   * Present for pooled tasks; absent until the backend surfaces it. Display
+   * names strip the "GROUP_" prefix.
+   */
+  candidateGroups?: string[];
 };
 
 export type Task = {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-head.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-head.tsx
@@ -6,6 +6,7 @@ import { TaskResponse } from "@/features/common/providers/alfresco-api/alfresco-
 import DownloadSignedDocument from "@/features/shipping/components/download-signed-document/download-signed-document";
 import { ShippingCoordinatorProcessFormsV2 } from "../../services/form.service.types";
 import TimeElement from "./time-element";
+import CandidateGroupsElement from "./candidate-groups-element";
 import Link from "next/link";
 import { Button } from "flowbite-react";
 import { FaRegEye } from "react-icons/fa";
@@ -103,6 +104,10 @@ export default function BentoHead({
         </div>
       </div>
       <div className="flex flex-row gap-1">
+        <CandidateGroupsElement
+          candidateGroups={task.candidateGroups}
+          dict={dict}
+        />
         <TimeElement
           task={task}
           dict={dict}

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/candidate-groups-element.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/candidate-groups-element.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { HiUserGroup } from "react-icons/hi";
+import { Tooltip } from "flowbite-react";
+import { I18nRecord } from "@/features/i18n/i18n.service.types";
+
+/**
+ * Strip the Alfresco "GROUP_" authority prefix so candidate groups read as a
+ * plain name (e.g. "GROUP_<name>" -> "<name>").
+ */
+function toGroupDisplayName(group: string): string {
+  return group.replace(/^group_/i, "");
+}
+
+/**
+ * Bento-header badge listing the candidate groups a pooled task is offered to.
+ * Mirrors {@link TimeElement}'s bordered icon + tooltip styling. Renders nothing
+ * when the task has no candidate groups.
+ */
+export default function CandidateGroupsElement({
+  candidateGroups,
+  dict,
+}: {
+  readonly candidateGroups?: string[];
+  readonly dict: I18nRecord;
+}) {
+  const groups = (candidateGroups ?? [])
+    .filter((g): g is string => typeof g === "string" && g.trim().length > 0)
+    .map(toGroupDisplayName);
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  const label = (dict.bento as I18nRecord).candidate_groups as string;
+  const groupNames = groups.join(", ");
+
+  return (
+    <Tooltip
+      style="auto"
+      content={
+        <div className="text-sm text-gray-800 dark:text-gray-200 whitespace-nowrap flex flex-col">
+          <span className="font-medium">{label}</span>
+          <span className="text-gray-900 dark:text-gray-100">{groupNames}</span>
+        </div>
+      }
+    >
+      <div className="h-10 flex justify-center items-center p-2 border border-gray-300 dark:border-gray-700 hover:border-gray-500 dark:hover:border-gray-500 rounded-lg transition-all duration-100 bg-white dark:bg-gray-800 gap-2 w-fit text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer">
+        <div className="flex flex-row gap-2 items-center">
+          <HiUserGroup className="w-5 h-5" width={30} height={30} />
+          <p className="text-sm text-gray-900 dark:text-gray-100 lg:block hidden whitespace-nowrap">
+            {groupNames}
+          </p>
+        </div>
+      </div>
+    </Tooltip>
+  );
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2665,6 +2665,7 @@
     "verified": "Verified",
     "not_verified": "Not verified",
     "trip_duration": "Trip duration",
+    "candidate_groups": "Candidate groups",
     "process_state": "Process state",
     "planificado": "Planified",
     "asignado": "Assigned",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2665,6 +2665,7 @@
     "verified": "Verificado",
     "not_verified": "No verificado",
     "trip_duration": "Tiempo de viaje",
+    "candidate_groups": "Grupos candidatos",
     "process_state": "Estado de proceso",
     "planificado": "Planificado",
     "asignado": "Asignado",


### PR DESCRIPTION
## Summary

`TaskDetails` now delivers a task's current candidate groups (e.g. `"candidateGroups": ["GROUP_MINTRAL_EJECUTIVO_TRANSPORTE"]`). This surfaces them in the task bento header as a display badge, stripping the Alfresco `GROUP_` prefix from the shown name.

## Changes

- **`TaskResponse` type** — add typed `candidateGroups?: string[]` field.
- **New `CandidateGroupsElement` component** — bordered icon + tooltip badge styled exactly like the existing `TimeElement` (`HiUserGroup` icon from `react-icons/hi`). Strips `GROUP_` case-insensitively, joins multiple groups, hides text on narrow screens (icon only, full names in tooltip), and renders nothing when there are no candidate groups.
- **`BentoHead`** — render the badge in the right-hand action row, before the trip-duration badge.
- **i18n** — add `bento.candidate_groups` label to `en.json` ("Candidate groups") and `es.json` ("Grupos candidatos").

## Notes

- This worktree had no installed `node_modules`, so `tsc`/build was not run locally. The code mirrors the neighboring `TimeElement` patterns (typing, `dict` access, icon import source) and both locale JSON files were validated to parse.
- The unrelated `package-lock.json` churn (`dev` → `devOptional`) present in the worktree was intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidate groups now display in the task header, providing visibility into which groups are eligible to claim pooled tasks
  * Group identifiers are automatically normalized by removing technical prefixes for cleaner display
  * Localized candidate groups labels added with support for English and Spanish

<!-- end of auto-generated comment: release notes by coderabbit.ai -->