### PR TITLE
fix(multimedia): guard Alfresco entry.properties against undefined

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/document.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/document.tsx
@@ -114,7 +114,7 @@ export default function Document({
           {document.file.entry.name}
         </p>
         {document?.file?.entry?.properties?.["mintral:contentType"] &&
-          document.file.entry.properties["mintral:contentType"] !== null && (
+          document.file.entry.properties?.["mintral:contentType"] !== null && (
             <div
               className={`text-xs z-10 rounded-full flex items-center justify-center px-2 py-1 w-fit whitespace-nowrap ${
                 modified
@@ -124,7 +124,7 @@ export default function Document({
             >
               {
                 categories[
-                  document.file.entry.properties[
+                  document.file.entry.properties?.[
                     "mintral:contentType"
                   ] as keyof typeof categories
                 ]?.label

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-viewer/image-viewer-connector.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/file-viewer/image-viewer-connector.tsx
@@ -21,7 +21,7 @@ export default function ImageViewerConnector({
   const data = useMemo(() => {
     return images.map((image) => {
       return {
-        tag: image.file.entry.properties["mintral:contentType"],
+        tag: image.file.entry.properties?.["mintral:contentType"],
         name: image.file.entry.name,
         modifiedAt: image.file.entry.modifiedAt,
         modifiedByUser: image.file.entry.modifiedByUser,

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -791,13 +791,13 @@ export default function FileImages({
       documentsData.data.forEach((document: any, index: number) => {
         if (!document.error && files[index]) {
           const entry = files[index] as AlfrescoFileEntry;
-          const alfrescoState = entry.entry.properties["mintral:reviewStatus"];
+          const alfrescoState = entry.entry.properties?.["mintral:reviewStatus"];
           if (alfrescoState === "APPROVED") loadedStatuses.set(entry.entry.id, "approved");
           else if (alfrescoState === "REJECTED") loadedStatuses.set(entry.entry.id, "rejected");
           else loadedStatuses.set(entry.entry.id, "pending");
-          const reviewedAt = entry.entry.properties["mintral:reviewedAt"];
+          const reviewedAt = entry.entry.properties?.["mintral:reviewedAt"];
           if (reviewedAt) loadedTimestamps.set(entry.entry.id, new Date(reviewedAt));
-          const reviewedBy = entry.entry.properties["mintral:reviewedBy"];
+          const reviewedBy = entry.entry.properties?.["mintral:reviewedBy"];
           if (reviewedBy) loadedUsers.set(entry.entry.id, reviewedBy);
           if (entry.entry.content.mimeType.includes("image")) {
             newImages.push({ file: entry, data: document });

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/image-element.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/image-element.tsx
@@ -46,7 +46,7 @@ export default function ImageElement({
       stepped={false}
       tag={
         categories[
-          file.entry.properties[
+          file.entry.properties?.[
             "mintral:contentType"
           ] as keyof typeof categories
         ]?.label

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/media-row.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/media-row.tsx
@@ -61,11 +61,11 @@ export default function MediaRow({
   }, [data]);
 
   const categories = getCategories(dictionary);
-  const tag = file.entry.properties["mintral:contentType"];
+  const tag = file.entry.properties?.["mintral:contentType"];
   const categoryLabel = categories[tag as keyof typeof categories]?.label;
   const FallbackIcon = type === "image" ? IoImagesOutline : FaRegFilePdf;
 
-  const version = file.entry.properties["cm:versionLabel"];
+  const version = file.entry.properties?.["cm:versionLabel"];
   const lastEditor = file.entry.modifiedByUser?.displayName;
   const modifiedAt = file.entry.modifiedAt ? formatDateString(file.entry.modifiedAt) : null;
   const secondaryParts = [

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image.types.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image.types.ts
@@ -22,7 +22,10 @@ export interface AlfrescoFileEntry {
     };
     nodeType: string;
     parentId: string;
-    properties: Record<string, string | undefined>;
+    // Alfresco omits `properties` entirely for nodes that carry no custom
+    // properties (e.g. a freshly uploaded file with only cm:auditable), so this
+    // is optional — every read must guard with `?.` or it crashes at runtime.
+    properties?: Record<string, string | undefined>;
     // Aspect QNames applied to the node (requested via include=aspectNames in the
     // /app/api/bento/multimedia route). Used to tell reviewable from non-reviewable
     // content — see isReviewableEntry in ./reviewable.

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/media-inline-viewer.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/media-inline-viewer.tsx
@@ -111,12 +111,12 @@ export default function MediaInlineViewer({
   const id = current?.file?.entry?.id;
 
   const [currentCategory, setCurrentCategory] = useState<string | null>(
-    current?.file?.entry?.properties["mintral:contentType"] ?? null
+    current?.file?.entry?.properties?.["mintral:contentType"] ?? null
   );
 
   const isCurrentReviewable = current?.file?.entry?.aspectNames?.includes("mintral:reviewableAspect") ?? false;
   useEffect(() => {
-    setCurrentCategory(items[currentIndex]?.file?.entry?.properties["mintral:contentType"] ?? null);
+    setCurrentCategory(items[currentIndex]?.file?.entry?.properties?.["mintral:contentType"] ?? null);
   }, [currentIndex, items]);
 
   const handleCategoryChange = (newCategory: string) => {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
@@ -14,7 +14,7 @@ type PropertiesGridProps = Readonly<{
 }>;
 
 export function PropertiesGrid({ entry, categoryLabel, onRename, dictionary }: PropertiesGridProps) {
-  const reviewStatus = entry.properties["mintral:reviewStatus"];
+  const reviewStatus = entry.properties?.["mintral:reviewStatus"];
   let reviewStatusLabel: string | null = null;
   if (reviewStatus && reviewStatus !== "PENDING") {
     reviewStatusLabel =
@@ -43,13 +43,13 @@ export function PropertiesGrid({ entry, categoryLabel, onRename, dictionary }: P
         }
       />
       {categoryLabel && <MetaRow label={tr("bento.multimedia.sidebar_prop_type", dictionary)} value={categoryLabel} />}
-      {entry.properties["cm:versionLabel"] && (
-        <MetaRow label={tr("bento.multimedia.sidebar_prop_version", dictionary)} value={`v${entry.properties["cm:versionLabel"]}`} />
+      {entry.properties?.["cm:versionLabel"] && (
+        <MetaRow label={tr("bento.multimedia.sidebar_prop_version", dictionary)} value={`v${entry.properties?.["cm:versionLabel"]}`} />
       )}
       <MetaRow label={tr("bento.multimedia.sidebar_prop_format", dictionary)} value={entry.content.mimeTypeName ?? entry.content.mimeType} />
       <MetaRow label={tr("bento.multimedia.sidebar_prop_size", dictionary)} value={formatBytes(entry.content.sizeInBytes)} />
-      {entry.properties["exif:pixelXDimension"] != null && entry.properties["exif:pixelYDimension"] != null && (
-        <MetaRow label="Resolution" value={`${entry.properties["exif:pixelXDimension"]} × ${entry.properties["exif:pixelYDimension"]}`} />
+      {entry.properties?.["exif:pixelXDimension"] != null && entry.properties?.["exif:pixelYDimension"] != null && (
+        <MetaRow label="Resolution" value={`${entry.properties?.["exif:pixelXDimension"]} × ${entry.properties?.["exif:pixelYDimension"]}`} />
       )}
       {entry.modifiedAt && (
         <MetaRow label={tr("bento.multimedia.sidebar_prop_modified", dictionary)} value={formatDateString(entry.modifiedAt)} />
@@ -66,11 +66,11 @@ export function PropertiesGrid({ entry, categoryLabel, onRename, dictionary }: P
       {reviewStatusLabel && (
         <MetaRow label={tr("bento.multimedia.sidebar_prop_review_status", dictionary)} value={reviewStatusLabel} />
       )}
-      {entry.properties["mintral:reviewedBy"] && (
-        <MetaRow label={tr("bento.multimedia.sidebar_prop_reviewed_by", dictionary)} value={entry.properties["mintral:reviewedBy"]} />
+      {entry.properties?.["mintral:reviewedBy"] && (
+        <MetaRow label={tr("bento.multimedia.sidebar_prop_reviewed_by", dictionary)} value={entry.properties?.["mintral:reviewedBy"]} />
       )}
-      {entry.properties["mintral:reviewedAt"] && (
-        <MetaRow label={tr("bento.multimedia.sidebar_prop_reviewed_at", dictionary)} value={formatDateString(entry.properties["mintral:reviewedAt"])} />
+      {entry.properties?.["mintral:reviewedAt"] && (
+        <MetaRow label={tr("bento.multimedia.sidebar_prop_reviewed_at", dictionary)} value={formatDateString(entry.properties?.["mintral:reviewedAt"])} />
       )}
     </dl>
   );


### PR DESCRIPTION
## What

Fixes a crash in the multimedia content-review UI when an Alfresco file node comes back **without a `properties` object**.

## Why

Alfresco omits the entire `properties` key for nodes that have no custom properties (e.g. a freshly uploaded file carrying only the `cm:auditable` aspect — its audit fields are returned as top-level `entry` fields, not inside `properties`). Several components indexed `entry.properties["mintral:reviewStatus"]` (and `mintral:contentType`, `cm:versionLabel`, `exif:*`, `mintral:reviewedBy/At`) without optional chaining, throwing `TypeError: Cannot read properties of undefined`.

This is **not** a request issue: `bento/multimedia/route.ts` already requests `include: ["properties", "aspectNames"]`. The field is simply absent server-side when a node has zero properties — Alfresco does not return an empty `properties: {}`.

### Response that triggers the crash
```json
{ "entry": { "name": "ho-firmado.pdf", "nodeType": "cm:content",
  "aspectNames": ["cm:auditable"] } }   // no "properties" key
```

## How

- `AlfrescoFileEntry.properties` is now optional (it genuinely can be absent).
- Every read is guarded with `?.` across `file-images.tsx`, `properties-grid.tsx`, `media-row.tsx`, `image-element.tsx`, `media-inline-viewer.tsx`, `image-viewer-connector.tsx`, `document.tsx`.

The element type is unchanged (`string | undefined`), so there is no downstream type impact. This aligns the UI with `task/end/route.ts`, which already used `?.`.

## Testing

- `check-types`: my 8 files produce **zero** errors. (The 18 pre-existing errors on the branch are all the unbuilt `@microboxlabs/miot-resource-client` workspace package + its `fleet/*` fallout — unrelated to this change and present on `trunk`.)

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in document and multimedia display components when certain file metadata is unavailable
  * Improved stability when viewing files that lack optional property information
  * Enhanced data handling to gracefully process files with missing optional metadata fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->