### PR TITLE
fix(app): build the CLI handoff sign-in redirect from the public orig…

### DIFF
--- a/turbo-repo/apps/app/src/app/cli/auth/login/route.ts
+++ b/turbo-repo/apps/app/src/app/cli/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/auth";
 import { resolveTenantScope } from "@/app/api/utils/tenant-scope";
 import { createCliAuthHandoff } from "../handoff-store";
+import { resolvePublicOrigin } from "../public-origin";
 import { getLocaleFromHeaders } from "@/features/i18n/i18n.service";
 import { NextResponse } from "next/server";
 
@@ -175,11 +176,13 @@ export async function GET(request: Request): Promise<Response> {
       rawRedirectUri ?? ""
     )}&state=${encodeURIComponent(state)}`;
     // Route handlers redirect with absolute URLs, so the app basePath is
-    // included explicitly (pages got it implicitly from the router).
+    // included explicitly (pages got it implicitly from the router). The base
+    // must be the PUBLIC origin — behind the proxy, url.origin is the internal
+    // bind address and the browser can't reach it.
     return NextResponse.redirect(
       new URL(
         `/app/${locale}/sign-in?callbackUrl=${encodeURIComponent(callbackUrl)}`,
-        url.origin
+        resolvePublicOrigin(request)
       )
     );
   }

--- a/turbo-repo/apps/app/src/app/cli/auth/public-origin.test.ts
+++ b/turbo-repo/apps/app/src/app/cli/auth/public-origin.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvePublicOrigin } from "./public-origin";
+
+function req(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers });
+}
+
+describe("resolvePublicOrigin", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers the configured AUTH_URL origin over the internal request origin", () => {
+    vi.stubEnv("AUTH_URL", "https://coordinador.mintral.cl/app/api/auth");
+    // The proxy makes the request look like it came in on 0.0.0.0:3000.
+    const origin = resolvePublicOrigin(
+      req("http://0.0.0.0:3000/app/cli/auth/login", {
+        "x-forwarded-host": "0.0.0.0:3000",
+      }),
+    );
+    expect(origin).toBe("https://coordinador.mintral.cl");
+  });
+
+  it("falls back to NEXTAUTH_URL when AUTH_URL is empty/unset", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "https://app.example.com/app/api/auth");
+    expect(resolvePublicOrigin(req("http://0.0.0.0:3000/x"))).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  it("uses forwarded host/proto when no configured URL is set", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    const origin = resolvePublicOrigin(
+      req("http://0.0.0.0:3000/x", {
+        "x-forwarded-host": "coordinador.mintral.cl",
+        "x-forwarded-proto": "https",
+      }),
+    );
+    expect(origin).toBe("https://coordinador.mintral.cl");
+  });
+
+  it("defaults forwarded proto to https and takes the first of a comma list", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    const origin = resolvePublicOrigin(
+      req("http://0.0.0.0:3000/x", {
+        "x-forwarded-host": "coordinador.mintral.cl, internal-svc",
+        "x-forwarded-proto": "https, http",
+      }),
+    );
+    expect(origin).toBe("https://coordinador.mintral.cl");
+  });
+
+  it("falls back to the request origin for local dev (no config, no proxy)", () => {
+    vi.stubEnv("AUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    expect(
+      resolvePublicOrigin(req("http://localhost:3050/app/cli/auth/login")),
+    ).toBe("http://localhost:3050");
+  });
+
+  it("ignores a malformed configured URL and falls through to the proxy host", () => {
+    vi.stubEnv("AUTH_URL", "not-a-valid-url");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    const origin = resolvePublicOrigin(
+      req("http://0.0.0.0:3000/x", {
+        "x-forwarded-host": "coordinador.mintral.cl",
+      }),
+    );
+    expect(origin).toBe("https://coordinador.mintral.cl");
+  });
+});

--- a/turbo-repo/apps/app/src/app/cli/auth/public-origin.ts
+++ b/turbo-repo/apps/app/src/app/cli/auth/public-origin.ts
@@ -1,0 +1,36 @@
+/**
+ * The app's PUBLIC origin, for building absolute redirects (e.g. to the
+ * sign-in page) from a route handler.
+ *
+ * Behind the reverse proxy, the incoming request's origin is the container's
+ * internal bind address (e.g. `http://0.0.0.0:3000`), so a redirect built from
+ * it is unreachable by the browser. Resolution order:
+ *  1. The configured NextAuth public URL (`AUTH_URL` / `NEXTAUTH_URL`) — not
+ *     spoofable, and already required for NextAuth's basePath in any deployed
+ *     environment.
+ *  2. The reverse proxy's forwarded host/proto (the ingress sets these).
+ *  3. The request origin — correct for local dev (e.g. `http://localhost:3050`).
+ */
+export function resolvePublicOrigin(request: Request): string {
+  const configured = process.env.AUTH_URL || process.env.NEXTAUTH_URL;
+  if (configured) {
+    try {
+      return new URL(configured).origin;
+    } catch {
+      // Malformed env value — fall through to proxy/header resolution.
+    }
+  }
+
+  const forwardedHost = request.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  if (forwardedHost) {
+    const forwardedProto =
+      request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ||
+      "https";
+    return `${forwardedProto}://${forwardedHost}`;
+  }
+
+  return new URL(request.url).origin;
+}


### PR DESCRIPTION
…in (#619)

When an unauthenticated user starts `miot auth login` against a deployed environment, the handoff redirected to the sign-in page using the incoming request's origin. Behind the nginx ingress that origin is the container's internal bind address (http://0.0.0.0:3000), so the browser got ERR_CONNECTION_REFUSED and CLI login was impossible in any proxied env.

Resolve the public origin instead, via a new `resolvePublicOrigin(request)`: configured NextAuth URL (AUTH_URL / NEXTAUTH_URL — not spoofable, and already required for the basePath in deployed envs) → reverse-proxy X-Forwarded-Host / -Proto → request origin (local dev). Extracted to its own module with unit tests covering all tiers (config, NEXTAUTH fallback, forwarded headers, comma-lists, malformed config, local fallback).

The already-authenticated path is unaffected (it redirects to the loopback redirect_uri directly), and local login is unchanged (AUTH_URL resolves to http://localhost:3050).

Closes #619

<!-- Provide a clear, concise description of your change. -->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->
Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI / tooling

## Affected workspace(s)

- [ ] `quarkus-srv/` (Integration)
- [ ] `ecm-srv/` (Coordinator)
- [ ] `turbo-repo/` (Frontend)
- [ ] `miot-harness/` (AI harness)

## How was this tested?

<!-- Commands run, manual steps, screenshots, etc. -->

## Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat(app): ...`, `fix(bff): ...`)
- [ ] Lint and tests pass locally
- [ ] Documentation updated where needed
- [ ] I have read the [Contributing guidelines](../CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved CLI authentication login flow to correctly resolve the application's public origin across different deployment environments, including proxy configurations and environment-based URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->