### PR TITLE
ci(app): use Opus 4.8 for release notes

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -22,7 +22,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
   IMAGE_NAME: miot-app
-  RELEASE_NOTES_MODEL: gpt-5-mini
+  RELEASE_NOTES_MODEL: claude-opus-4-8
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary
- Change the app release train release-notes model default to `claude-opus-4-8`.

## Notes
- Opus 4.8 provides the 1M-token context window at the model/provider level; the workflow only needs to select the model id.

## Validation
- ruby YAML parse for `.github/workflows/app-release-train.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure for release note generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->