### PR TITLE
fix(harness): pass application_name to asyncpg via server_settings

### DIFF
--- a/miot-harness/src/miot_harness/integrations/nexo/pool.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/pool.py
@@ -21,7 +21,9 @@ transaction, so mutation attempts are blocked at the DB layer.
 NEXO_SERVER_SETTINGS is kept as an exported (empty) dict for tests
 and any future settings PgBouncer's `track_extra_parameters` allows
 (client_encoding, datestyle, timezone, geqo, intervalstyle,
-application_name).
+application_name). The one startup parameter we DO send is
+`application_name` (via the explicit kwarg below) — PgBouncer tracks
+it natively, and it surfaces in `pg_stat_activity` for DBAs.
 """
 
 from __future__ import annotations
@@ -38,6 +40,7 @@ async def create_nexo_pool(
     *,
     min_size: int = 1,
     max_size: int = 4,
+    application_name: str | None = None,
     **extra: Any,
 ) -> asyncpg.Pool:
     """Create an asyncpg.Pool for Nexo, PgBouncer-safe.
@@ -46,13 +49,18 @@ async def create_nexo_pool(
     (`postgresql://user:password@host:port/database`), sourced from the
     `MIOT_HARNESS_DATASOURCE_DSN` setting.
 
-    Does NOT pass `server_settings` (PgBouncer rejects unknown startup
-    parameters in transaction-pooling mode). Read-only enforcement is
-    applied per-transaction via `conn.transaction(readonly=True)` at
-    each call site.
+    `application_name` rides `server_settings` — asyncpg's `connect()`
+    has no `application_name` kwarg, and PgBouncer tracks
+    `application_name` natively, so it is safe in transaction-pooling
+    mode. No OTHER server_settings are passed (PgBouncer rejects
+    unknown startup parameters such as `default_transaction_read_only`).
+    Read-only enforcement is applied per-transaction via
+    `conn.transaction(readonly=True)` at each call site.
     """
     if not dsn:
         raise ValueError("create_nexo_pool requires a non-empty `dsn`")
+    if application_name:
+        extra["server_settings"] = {"application_name": application_name}
     return await asyncpg.create_pool(
         dsn=dsn,
         min_size=min_size,

--- a/miot-harness/tests/integrations/nexo/test_pool.py
+++ b/miot-harness/tests/integrations/nexo/test_pool.py
@@ -85,6 +85,33 @@ async def test_create_nexo_pool_with_dsn(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_nexo_pool_application_name_rides_server_settings(monkeypatch):
+    """Regression for the prod boot failure `connect() got an unexpected
+    keyword argument 'application_name'`: asyncpg has no such kwarg, so
+    the pool factory must translate it into `server_settings` — the one
+    startup parameter PgBouncer tracks natively (unlike the read-only /
+    timeout parameters guarded against above)."""
+    captured: dict = {}
+
+    async def fake_create_pool(dsn=None, **kwargs):
+        captured["kwargs"] = kwargs
+        return "POOL_APPNAME"
+
+    import asyncpg
+
+    monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+
+    pool = await create_nexo_pool(
+        "postgresql://u:p@h:6432/citus", application_name="miot-harness"
+    )
+
+    assert pool == "POOL_APPNAME"
+    assert captured["kwargs"]["server_settings"] == {
+        "application_name": "miot-harness"
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_nexo_pool_rejects_empty_dsn():
     """An empty DSN is a caller/config bug — surface it loudly rather
     than handing asyncpg a meaningless connection string."""


### PR DESCRIPTION
## Problem

Since #604, `NexoProvider.boot` passes `application_name=` through `create_nexo_pool(**extra)` into `asyncpg.create_pool()`. asyncpg's `connect()` has **no `application_name` kwarg**, so boot crashes:

```
Nexo: boot failed (connect() got an unexpected keyword argument 'application_name')
```

`datasource_application_name` is non-nullable (defaults to `"miot-harness"`), so **every boot with a configured DSN fails** — observed in prod today on `sha-06a8ea9`: the pod serves `/health` 200 but `/health/ready` stays 503 (`datasource.enabled: false`), and the rollout never completes. There is no env-side workaround.

The boundary tests mock `create_nexo_pool` itself, which is why the bad kwarg pass-through wasn't caught.

## Fix

`create_nexo_pool` now takes `application_name` as an explicit kwarg and translates it into `server_settings={"application_name": ...}`. PgBouncer tracks `application_name` natively, so it's safe through the transaction-pooling tunnel — unlike `default_transaction_read_only` & friends, which remain banned (existing regression tests unchanged and still passing). It still surfaces in `pg_stat_activity.application_name` as intended by the config comment.

Added a regression test asserting the kwarg→server_settings translation.

## Test

`uv run pytest tests/ -q` → 503 passed, 2 skipped.

## Deploy note

Prod (`coordinator-helm-acr`) is waiting on this to complete the chart-0.3.0 rollout: once merged and the image builds, bump `image.tag` in `packages/mintral-harness/values-prod.yaml` and run `helm_install_harness prod`. Heads-up: the nexo snapshot (`fn_dx_centro_control.refreshed_at_torre`) is stale since **2026-05-09**, so the freshness gate (240 min) will still refuse until the snapshot pipeline runs — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional application name parameter for database pool configuration.

* **Tests**
  * Added test coverage for application name parameter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->