### PR TITLE
fix(harness): compose DIRECT/OTHER answers harness-side

### DIFF
--- a/miot-harness/src/miot_harness/agents/direct_agent.py
+++ b/miot-harness/src/miot_harness/agents/direct_agent.py
@@ -1,0 +1,78 @@
+"""Direct-response agent (cheapest tier).
+
+Composes the answer for DIRECT / OTHER routes — greetings, small talk,
+and anything the intent router can't map to a data path. Before #628
+the supervisor left ``answer`` null here ("client renders"), but no
+client ever implemented that side of the contract, so users saw
+"(no answer recorded)". The harness now owns the reply.
+
+No primer, no catalog, no tools — the system prompt is intentionally
+tiny so the call costs almost nothing. Capability questions route to
+DATA_META (which carries the primer + catalog); this agent only needs
+to respond conversationally and point there.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from miot_harness.agents.llm_streaming import stream_llm_with_thinking
+from miot_harness.runtime.tool import Progress
+
+_DIRECT_SYSTEM_PROMPT = """You are the ModularIoT assistant for fleet \
+coordination data. The user said something conversational (a greeting, \
+thanks, small talk) or something outside your data scope.
+
+Reply in the user's language, briefly and warmly (1-3 sentences). If it \
+fits naturally, mention you can answer questions about the fleet data \
+(services, ETAs, critical queues) or explain what data is available. \
+Do not invent data or capabilities. No headings, no lists.
+"""
+
+# Deterministic fallback when no model is wired (mirrors the meta
+# path's disabled branch, but a greeting must still greet). Bilingual
+# because the deployment serves Spanish-first users.
+FALLBACK_DIRECT_ANSWER = (
+    "Hola — soy el asistente de ModularIoT. Puedo responder preguntas "
+    "sobre los datos de la flota o explicarte qué datos existen. / "
+    "Hi — I'm the ModularIoT assistant. Ask me about the fleet data or "
+    "what data is available."
+)
+
+
+async def direct_agent_node(
+    state: dict[str, Any],
+    *,
+    model: BaseChatModel,
+    prior_messages: list[BaseMessage] | None = None,
+    progress: Progress | None = None,
+    stream: bool = False,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Answer a DIRECT/OTHER turn; return ``{"answer": str}`` delta.
+
+    Mirrors ``meta_agent_node``'s contract (prior-message splicing,
+    optional ``stream_llm_with_thinking`` streaming) minus the primer
+    and catalog — see the module docstring for why it stays tiny.
+    """
+    messages: list[BaseMessage] = [SystemMessage(content=_DIRECT_SYSTEM_PROMPT)]
+    if prior_messages:
+        messages.extend(prior_messages)
+    messages.append(HumanMessage(content=state.get("user_message", "")))
+
+    if stream and progress is not None and run_id is not None:
+        text = await stream_llm_with_thinking(
+            model=model,
+            messages=messages,
+            progress=progress,
+            run_id=run_id,
+            agent_name="direct_agent",
+        )
+        return {"answer": text or "(no answer)"}
+
+    response = await model.ainvoke(messages)
+    raw_content = response.content if hasattr(response, "content") else str(response)
+    return {"answer": raw_content if isinstance(raw_content, str) else str(raw_content)}

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -11,7 +11,9 @@ Then dispatches to:
 - `agentic_graph` (DATA_AGENTIC, composable-primitive exploration)
 - `meta_agent_node` (DATA_META, schema/primer questions; no SQL)
 - `storytelling` module (STORYTELLING_RUN, mocked narrative path)
-- direct response (DIRECT / OTHER)
+- `direct_agent_node` (DIRECT / OTHER, small talk — the harness
+  composes the reply; the old "client renders" contract left
+  ``answer`` null and no client implemented it, see #628)
 
 `conversation_id` is hydrated/appended via `ConversationStore` so
 multi-turn chats accumulate context across `/runs` calls.
@@ -26,6 +28,10 @@ from typing import Any
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage
 
+from miot_harness.agents.direct_agent import (
+    FALLBACK_DIRECT_ANSWER,
+    direct_agent_node,
+)
 from miot_harness.agents.meta_agent import (
     MetaAgentCatalogEntry,
     meta_agent_node,
@@ -181,7 +187,14 @@ class HarnessSupervisor:
                 )
             elif route.route == HarnessRoute.STORYTELLING_RUN:
                 await self._run_storytelling(ctx, record, progress)
-            # DIRECT / OTHER: nothing to do; client renders.
+            else:
+                # DIRECT / OTHER (and any future unrouted kind): the
+                # harness composes the reply (#628). Leaving answer
+                # null here surfaced as "(no answer recorded)" in every
+                # client.
+                await self._run_direct(
+                    request, ctx, record, progress, route.route, prior_messages
+                )
         except asyncio.CancelledError:
             # POST /runs/{id}/cancel cancelled this task. Surface a
             # terminal `run.failed` with `reason=cancelled` so SSE
@@ -563,6 +576,109 @@ class HarnessSupervisor:
                 run_id=ctx.run_id,
                 type="answer.completed",
                 message="Meta agent answered",
+                data={"length": len(record.answer or "")},
+            )
+        )
+
+    async def _run_direct(
+        self,
+        request: UserRequest,
+        ctx: HarnessContext,
+        record: HarnessRunRecord,
+        progress: Any,
+        route: HarnessRoute | None = None,
+        prior_messages: list[BaseMessage] | None = None,
+    ) -> None:
+        """Compose the DIRECT / OTHER reply harness-side (#628).
+
+        Reuses ``meta_model`` (same cheap tier) so no extra wiring or
+        env is needed; falls back to a canned bilingual greeting when
+        no model is wired so ``answer`` is never null.
+        """
+        if self.meta_model is None:
+            record.answer = FALLBACK_DIRECT_ANSWER
+            progress(
+                HarnessEvent(
+                    run_id=ctx.run_id,
+                    type="answer.completed",
+                    message="direct fallback (no model wired)",
+                    data={"length": len(record.answer)},
+                )
+            )
+            return
+
+        from time import monotonic
+
+        from miot_harness.config import get_settings
+
+        settings = get_settings()
+        stream_enabled = settings.agents_synthesizer_stream
+
+        progress(
+            HarnessEvent(
+                run_id=ctx.run_id,
+                type="agent.started",
+                message="Entering direct_agent",
+                data={"agent": "direct_agent", "graph": "direct", "turn": 0},
+            )
+        )
+        start = monotonic()
+
+        # Same telemetry wrap as _run_data_meta: the per-agent span and
+        # `usage.recorded` events keep direct-route LLM cost visible in
+        # tenant rollups even though the call is tiny.
+        _span_prefix = self.profile.name if self.profile is not None else "datasource"
+        instrumented_model = instrument_model(
+            self.meta_model, "direct_agent", ctx,
+            progress=progress, span_prefix=_span_prefix,
+        )
+
+        try:
+            with agent_span("run", **self._root_span_kwargs(ctx, route)):
+                delta = await direct_agent_node(
+                    {"user_message": request.message},
+                    model=instrumented_model,
+                    prior_messages=prior_messages or [],
+                    progress=progress if stream_enabled else None,
+                    stream=stream_enabled,
+                    run_id=ctx.run_id,
+                )
+            exit_reason = "ok"
+        except Exception:
+            progress(
+                HarnessEvent(
+                    run_id=ctx.run_id,
+                    type="agent.completed",
+                    message="Failed direct_agent",
+                    data={
+                        "agent": "direct_agent",
+                        "graph": "direct",
+                        "duration_ms": int((monotonic() - start) * 1000),
+                        "exit_reason": "failure",
+                    },
+                )
+            )
+            raise
+        progress(
+            HarnessEvent(
+                run_id=ctx.run_id,
+                type="agent.completed",
+                message="Completed direct_agent",
+                data={
+                    "agent": "direct_agent",
+                    "graph": "direct",
+                    "duration_ms": int((monotonic() - start) * 1000),
+                    "exit_reason": exit_reason,
+                },
+            )
+        )
+
+        record.answer = delta.get("answer") or "(no answer produced by direct agent)"
+        progress(
+            HarnessEvent(
+                run_id=ctx.run_id,
+                type="answer.completed",
+                message="Direct agent answered",
                 data={"length": len(record.answer or "")},
             )
         )

--- a/miot-harness/tests/runtime/test_supervisor_direct.py
+++ b/miot-harness/tests/runtime/test_supervisor_direct.py
@@ -1,0 +1,111 @@
+"""DIRECT / OTHER routes compose an answer harness-side (#628).
+
+Before #628 the supervisor left ``record.answer`` null on these routes
+("client renders"), but no client implemented that side of the
+contract — users saw "(no answer recorded)". These tests pin the new
+behavior: the run always carries a non-null answer and the standard
+agent/answer event envelope.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from langchain_core.language_models import FakeListChatModel
+
+from miot_harness.agents.direct_agent import FALLBACK_DIRECT_ANSWER
+from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.intent_router import LLMIntentRouter
+from miot_harness.runtime.router import IntentRouter
+from miot_harness.runtime.run_store import JsonRunStore
+from miot_harness.runtime.supervisor import HarnessSupervisor
+from miot_harness.storytelling.module import StorytellingModule
+from miot_harness.tools.registry import ToolRegistry
+
+
+def _scripted_llm_router(route: str, confidence: float = 0.95) -> LLMIntentRouter:
+    model = FakeListChatModel(
+        responses=[json.dumps({"route": route, "confidence": confidence})]
+    )
+    return LLMIntentRouter(model, confidence_threshold=0.7, keyword_fallback=IntentRouter())
+
+
+def _build_supervisor(
+    tmp_path: Any,
+    *,
+    llm_router: LLMIntentRouter,
+    meta_model: Any = None,
+) -> HarnessSupervisor:
+    return HarnessSupervisor(
+        router=IntentRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        llm_router=llm_router,
+        meta_model=meta_model,
+        tenant_lock="mintral",
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_route_composes_answer(tmp_path: Any) -> None:
+    supervisor = _build_supervisor(
+        tmp_path,
+        llm_router=_scripted_llm_router("DIRECT"),
+        meta_model=FakeListChatModel(responses=["¡Hola! ¿En qué te ayudo con la flota?"]),
+    )
+    record = await supervisor.run(
+        UserRequest(message="hola", tenant_id="any-tenant", mode="auto")
+    )
+    assert record.status == "completed"
+    assert record.answer == "¡Hola! ¿En qué te ayudo con la flota?"
+
+
+@pytest.mark.asyncio
+async def test_direct_route_emits_agent_and_answer_events(tmp_path: Any) -> None:
+    supervisor = _build_supervisor(
+        tmp_path,
+        llm_router=_scripted_llm_router("DIRECT"),
+        meta_model=FakeListChatModel(responses=["hi there"]),
+    )
+    record = await supervisor.run(
+        UserRequest(message="hi", tenant_id="any-tenant", mode="auto")
+    )
+    types = [e.type for e in record.events]
+    assert "agent.started" in types
+    assert "agent.completed" in types
+    assert "answer.completed" in types
+    started = next(e for e in record.events if e.type == "agent.started")
+    assert started.data["agent"] == "direct_agent"
+
+
+@pytest.mark.asyncio
+async def test_other_route_composes_answer(tmp_path: Any) -> None:
+    supervisor = _build_supervisor(
+        tmp_path,
+        llm_router=_scripted_llm_router("OTHER"),
+        meta_model=FakeListChatModel(responses=["I can't help with that, but ask me about the fleet."]),
+    )
+    record = await supervisor.run(
+        UserRequest(message="write me a poem", tenant_id="any-tenant", mode="auto")
+    )
+    assert record.answer is not None
+    assert "fleet" in record.answer
+
+
+@pytest.mark.asyncio
+async def test_direct_route_without_model_uses_fallback(tmp_path: Any) -> None:
+    """No meta_model wired (e.g. datasource boot failed) must still
+    greet — never a null answer."""
+    supervisor = _build_supervisor(
+        tmp_path,
+        llm_router=_scripted_llm_router("DIRECT"),
+        meta_model=None,
+    )
+    record = await supervisor.run(
+        UserRequest(message="hola", tenant_id="any-tenant", mode="auto")
+    )
+    assert record.answer == FALLBACK_DIRECT_ANSWER
+    assert any(e.type == "answer.completed" for e in record.events)

--- a/miot-harness/tests/runtime/test_supervisor_direct.py
+++ b/miot-harness/tests/runtime/test_supervisor_direct.py
@@ -86,7 +86,9 @@ async def test_other_route_composes_answer(tmp_path: Any) -> None:
     supervisor = _build_supervisor(
         tmp_path,
         llm_router=_scripted_llm_router("OTHER"),
-        meta_model=FakeListChatModel(responses=["I can't help with that, but ask me about the fleet."]),
+        meta_model=FakeListChatModel(
+            responses=["I can't help with that, but ask me about the fleet."]
+        ),
     )
     record = await supervisor.run(
         UserRequest(message="write me a poem", tenant_id="any-tenant", mode="auto")


### PR DESCRIPTION
Closes #628

## Problem

`miot chat ask hi` → `route: direct` → `(no answer recorded)`. The supervisor deliberately skipped DIRECT/OTHER (`# DIRECT / OTHER: nothing to do; client renders.`) leaving `answer: null`, and no client (TUI, `chat ask`, web) ever implemented the rendering side. Verified in prod run `run_743055bfecbd44309b8a18d54a55bdc7`: events go `run.started → route.selected(direct) → run.completed` with nothing in between.

This also polluted ops signals: a greeting smoke test prints the same `(no answer recorded)` whether the system is healthy or the datasource is down (it masked part of today's incident).

## Fix

- New `agents/direct_agent.py` — `direct_agent_node` with a deliberately tiny system prompt (no primer/catalog/tools; capability questions already route to DATA_META). Replies briefly in the user's language. Supports the same `stream_llm_with_thinking` streaming as the meta agent.
- `HarnessSupervisor._run_direct` — mirrors `_run_data_meta`: reuses `meta_model` (same cheap tier, zero new wiring/env), emits the standard `agent.started` / `agent.completed` / `answer.completed` envelope, same `instrument_model` telemetry wrap so the (tiny) LLM cost lands in tenant rollups.
- Dispatch: DIRECT / OTHER — and any future unrouted kind — now go through `_run_direct` (`else` branch instead of a silent fall-through).
- No model wired (e.g. degraded boot) → canned bilingual greeting fallback; `answer` is never null.

## Test

- 4 new tests in `tests/runtime/test_supervisor_direct.py` (DIRECT answer persisted, event envelope, OTHER route, no-model fallback).
- Full suite: `uv run pytest tests/ -q` → **507 passed, 2 skipped**.

## Deploy note

After merge + image build, bump `image.tag` in coordinator-helm-acr `values-prod.yaml` and `helm_install_harness prod`; verify with `npx @microboxlabs/miot-cli chat ask hi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for direct/fallback response routing to handle alternative request paths
  * Automatic fallback messaging when model services are unavailable
  * Enhanced lifecycle event tracking for all response routing paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->