### PR TITLE
feat(auth): restrict OAuth sign-in to allowlisted email domains

### DIFF
--- a/turbo-repo/apps/app/.env.example
+++ b/turbo-repo/apps/app/.env.example
@@ -14,6 +14,11 @@ AUTH_PROVIDER=ECM
 # Use * to mark primary providers (highlighted button)
 AUTH_PROVIDERS=google,github,saml*
 
+# Restrict who may sign in via OAuth/social (Auth0 → Google/Microsoft/etc.) to these
+# email domains. Comma-separated; set per environment/instance. Leave unset/empty to
+# allow all domains. Credentials (Alfresco) logins are not affected by this list.
+# AUTH_ALLOWED_EMAIL_DOMAINS=microboxlabs.com,vialabs.net
+
 # ─── ECM / Alfresco ─────────────────────────────────────────────
 ECM_API_URL=https://your-ecm-host.com
 NEXT_PUBLIC_ECM_API_URL=https://your-ecm-host.com

--- a/turbo-repo/apps/app/src/app/[lang]/sign-in/page.tsx
+++ b/turbo-repo/apps/app/src/app/[lang]/sign-in/page.tsx
@@ -1,4 +1,4 @@
-import { Card } from "flowbite-react";
+import { Alert, Card } from "flowbite-react";
 import React from "react";
 import { getDictionary } from "@/features/i18n/i18n.service";
 import NavbarSignIn from "@/features/auth/components/navbar-sign-in";
@@ -78,15 +78,22 @@ function buildSamlLabels(
 
 export default async function SignInPage(
   params: ParamsWithLang & {
-    searchParams?: Promise<{ callbackUrl?: string }>;
+    searchParams?: Promise<{ callbackUrl?: string; error?: string }>;
   }
 ) {
   const { lang } = await params.params;
+  const resolvedSearchParams = await params.searchParams;
   // Post-sign-in destination (e.g. the CLI auth handoff page). Resolved
   // server-side and passed as a prop so FormSignIn stays free of
   // useSearchParams (which would require a Suspense boundary).
-  const callbackUrl = (await params.searchParams)?.callbackUrl ?? null;
+  const callbackUrl = resolvedSearchParams?.callbackUrl ?? null;
   const [dict, , dictDynamic] = await getDictionary(lang);
+  // NextAuth redirects here with ?error=AccessDenied when the signIn callback
+  // rejects a login (e.g. email domain not in AUTH_ALLOWED_EMAIL_DOMAINS).
+  const accessDeniedMessage =
+    resolvedSearchParams?.error === "AccessDenied"
+      ? dict("pages.login.errors.accessDenied")
+      : null;
   const signInMessages = buildSignInFormMessages({ messages: dict });
   const orgLogo = await getPublicOrgLogo();
   const authConfig = getAuthConfig();
@@ -118,6 +125,15 @@ export default async function SignInPage(
             <h2 className="text-2xl font-bold text-gray-900 lg:text-3xl dark:text-white w-full text-center">
               {dict("pages.login.welcome")}
             </h2>
+            {accessDeniedMessage && (
+              <Alert
+                color="failure"
+                data-testid="sign-in-access-denied"
+                className="w-full"
+              >
+                {accessDeniedMessage}
+              </Alert>
+            )}
             <FormSignIn
               messages={signInMessages}
               authConfig={authConfig}

--- a/turbo-repo/apps/app/src/auth.config.ts
+++ b/turbo-repo/apps/app/src/auth.config.ts
@@ -54,6 +54,31 @@ function buildAuthProviders(): NextAuthConfig["providers"] {
   return providers;
 }
 
+/**
+ * Email domains permitted to sign in via federated/OAuth providers (e.g. Auth0 → Google).
+ * Configured via AUTH_ALLOWED_EMAIL_DOMAINS as a comma-separated list, e.g.
+ * "microboxlabs.com,vialabs.net". Each deployment/instance sets its own value, so the
+ * allowlist lives in environment config rather than code. When unset/empty the guard is
+ * disabled and all domains are allowed (preserving prior behavior); set it per environment
+ * to lock down.
+ */
+function getAllowedEmailDomains(): string[] {
+  return (process.env.AUTH_ALLOWED_EMAIL_DOMAINS ?? "")
+    .split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** Returns true when the email's domain is in the allowlist (or the allowlist is empty). */
+function isEmailDomainAllowed(
+  email: string | null | undefined,
+  allowedDomains: string[]
+): boolean {
+  if (allowedDomains.length === 0) return true; // guard disabled
+  const domain = (email ?? "").toLowerCase().split("@")[1];
+  return !!domain && allowedDomains.includes(domain);
+}
+
 // Create hierarchical auth loggers for better management
 const authLogger = createManagedLogger("auth", "Authentication System");
 const authJwtLogger = createManagedLogger("auth.jwt", "JWT Processing", undefined, "auth");
@@ -66,8 +91,52 @@ export const authConfig: NextAuthConfig = {
   basePath: "/app/api/auth",
   pages: {
     signIn: "/app/sign-in",
+    // Surface AccessDenied (and other auth errors) on the sign-in page itself
+    // rather than NextAuth's default error page.
+    error: "/app/sign-in",
   },
   callbacks: {
+    /**
+     * Gates *who* may sign in. (The `authorized` callback only decides whether a
+     * route requires a logged-in user, not which users are allowed at all.)
+     * Federated/OAuth logins (Auth0 → Google/Microsoft/etc.) are restricted to the
+     * domains in AUTH_ALLOWED_EMAIL_DOMAINS. Credentials logins are already validated
+     * upstream against Alfresco, so they bypass this domain guard.
+     */
+    async signIn({ user, account, profile }) {
+      if (account?.provider === "credentials") {
+        return true;
+      }
+
+      const allowedDomains = getAllowedEmailDomains();
+      if (allowedDomains.length === 0) {
+        authAuthzLogger.warn(
+          {},
+          "AUTH_ALLOWED_EMAIL_DOMAINS is not set; email-domain sign-in guard is disabled (all domains allowed)"
+        );
+        return true;
+      }
+
+      // Reject social logins whose IdP reports the email as unverified, so a
+      // spoofed/unverified address in an allowed domain can't slip through.
+      if ((profile as { email_verified?: boolean } | undefined)?.email_verified === false) {
+        authAuthzLogger.warn({ email: user?.email }, "Sign-in denied: email not verified");
+        return false;
+      }
+
+      const email =
+        user?.email ?? (profile as { email?: string } | undefined)?.email ?? null;
+      if (!isEmailDomainAllowed(email, allowedDomains)) {
+        authAuthzLogger.warn(
+          { email, allowedDomains },
+          "Sign-in denied: email domain not in AUTH_ALLOWED_EMAIL_DOMAINS allowlist"
+        );
+        return false;
+      }
+
+      authAuthzLogger.debug({ email }, "Sign-in allowed by email-domain guard");
+      return true;
+    },
     authorized({ auth, request }) {
       try {
         const nextUrl = new URL(request.nextUrl);

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -40,7 +40,8 @@
       },
       "errors": {
         "invalidCredentials": "Access denied. Please verify your credentials and try again.",
-        "invalidFromData": "Invalid form data. Please verify your credentials and try again."
+        "invalidFromData": "Invalid form data. Please verify your credentials and try again.",
+        "accessDenied": "Access is restricted to authorized email domains. Please sign in with an approved company account."
       }
     },
     "shippingv1": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -40,7 +40,8 @@
       },
       "errors": {
         "invalidCredentials": "Acceso denegado. Por favor, verifique sus credenciales e intente nuevamente.",
-        "invalidFromData": "Datos de formulario inválidos. Por favor, verifique sus credenciales e intente nuevamente."
+        "invalidFromData": "Datos de formulario inválidos. Por favor, verifique sus credenciales e intente nuevamente.",
+        "accessDenied": "El acceso está restringido a dominios de correo autorizados. Inicia sesión con una cuenta corporativa aprobada."
       }
     },
     "shippingv1": {


### PR DESCRIPTION
## What & why
`apps/app` (NextAuth + Auth0 fronting Google/Microsoft) had no `signIn` callback — the `authorized` callback only checks whether a user is logged in, not *who* is allowed. So **any** Google/Auth0 account could sign in. This adds an email-domain allowlist gate.

Closes #630

## Approach
- **`auth.config.ts`** — new `signIn` callback gating federated/OAuth logins by email domain. The allowlist is read from **`AUTH_ALLOWED_EMAIL_DOMAINS`** (comma-separated), so it lives in **environment config, not code**, and each instance/environment sets its own list.
  - Empty/unset ⇒ guard **disabled** (preserves current behavior; opt-in per instance).
  - Credentials (Alfresco) logins **bypass** the guard — already validated upstream.
  - Social logins with `email_verified === false` are rejected.
  - `pages.error` now points at the sign-in page so denials land there with `?error=AccessDenied`.
- **`sign-in/page.tsx`** — shows a localized `Alert` on `?error=AccessDenied`.
- **`lang/en.json`, `lang/es.json`** — `pages.login.errors.accessDenied`.
- **`.env.example`** — documents `AUTH_ALLOWED_EMAIL_DOMAINS`.

## Configuring per instance
```bash
# microboxlabs prod
AUTH_ALLOWED_EMAIL_DOMAINS=example.com,some.co
# dev (unset) → allow all
```

## Why app-layer (not Google / Auth0 / ECM)
- **Google OAuth app**: can't express multiple domains (single `hd` / Internal-org only).
- **Auth0 post-login Action**: viable tenant-level gate, but needs hand-maintained Action code and no per-instance lists without separate tenants. Can be added later as defense-in-depth.
- **ecm-coordinator (Alfresco)**: wrong layer for login gating; it should keep validating the JWT.

## Testing
- `npm run check-types` — passes (after building the `miot-resource-client` workspace dep, unrelated to this change).
- `npm run test:run` — 547 passed, 1 skipped.
- `npm run lint` — warnings only (advisory `only-warn`); no new errors.

> Manual verification of the live sign-in denial flow against a real Auth0 tenant was not performed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to restrict OAuth/social sign-ins to specified email domains via configuration.
  * Display error messages when sign-in access is denied due to domain restrictions.

* **Documentation**
  * Added configuration guidance for email domain allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->