### PR TITLE
fix(auth): don't block sign-in on unverified email (Entra ID)

### DIFF
--- a/turbo-repo/apps/app/src/auth.config.ts
+++ b/turbo-repo/apps/app/src/auth.config.ts
@@ -117,13 +117,11 @@ export const authConfig: NextAuthConfig = {
         return true;
       }
 
-      // Reject social logins whose IdP reports the email as unverified, so a
-      // spoofed/unverified address in an allowed domain can't slip through.
-      if ((profile as { email_verified?: boolean } | undefined)?.email_verified === false) {
-        authAuthzLogger.warn({ email: user?.email }, "Sign-in denied: email not verified");
-        return false;
-      }
-
+      // NOTE: we intentionally do NOT require profile.email_verified. Enterprise IdP
+      // connections (e.g. Microsoft Entra ID) routinely report email_verified=false for
+      // valid corporate users, so requiring it locks them out. The email address from the
+      // federated login — gated by the domain allowlist below — is the trust anchor, and
+      // domains we own (Workspace/Entra) can't be self-asserted by an outside attacker.
       const email =
         user?.email ?? (profile as { email?: string } | undefined)?.email ?? null;
       if (!isEmailDomainAllowed(email, allowedDomains)) {


### PR DESCRIPTION
Follow-up to #631 (merged). That change added an email-domain sign-in guard but also rejected logins whose IdP reports `email_verified: false`. **Microsoft Entra ID** (Auth0 `waad` connection) issues tokens with `email_verified: false` even for valid corporate users, so users were locked out of prod despite being in `AUTH_ALLOWED_EMAIL_DOMAINS`.

## Fix
Drop the `email_verified` check. The domain allowlist is the trust anchor — domains we own via Entra/Workspace can't be self-asserted by an outsider — and credentials (Alfresco) logins still bypass.

Refs #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)