### PR TITLE
feat(auth): validate username/password against Auth0, env-driven conn…

### DIFF
--- a/turbo-repo/apps/app/.env.example
+++ b/turbo-repo/apps/app/.env.example
@@ -3,9 +3,18 @@ AUTH_SECRET=your_auth_secret
 AUTH_PROVIDER=ECM
 
 # Auth0 (single OIDC broker — required for all OAuth/SAML providers)
+# When set, username/password sign-in also validates against Auth0 (database
+# connection, password-realm grant — requires the Password grant enabled on the
+# Auth0 application) instead of the legacy Alfresco ticket login.
 # AUTH_AUTH0_ID=your_auth0_client_id
 # AUTH_AUTH0_SECRET=your_auth0_client_secret
 # AUTH_AUTH0_ISSUER=https://your-tenant.auth0.com
+
+# Auth0 connection names per provider (defaults shown; override per tenant).
+# AUTH_AUTH0_CONNECTION_GOOGLE=google-oauth2
+# AUTH_AUTH0_CONNECTION_GITHUB=github
+# AUTH_AUTH0_CONNECTION_ENTRA_ID=Mintral-Entra-ID
+# AUTH_AUTH0_CONNECTION_CREDENTIALS=Username-Password-Authentication
 
 # Auth providers configuration (controls which login buttons are shown)
 # All OAuth/SAML providers route through Auth0 — AUTH_AUTH0_* vars must be set.

--- a/turbo-repo/apps/app/.env.example
+++ b/turbo-repo/apps/app/.env.example
@@ -2,10 +2,11 @@
 AUTH_SECRET=your_auth_secret
 AUTH_PROVIDER=ECM
 
-# Auth0 (single OIDC broker — required for all OAuth/SAML providers)
-# When set, username/password sign-in also validates against Auth0 (database
-# connection, password-realm grant — requires the Password grant enabled on the
-# Auth0 application) instead of the legacy Alfresco ticket login.
+# Auth0 (single OIDC broker — required for all OAuth/SAML providers, and for
+# username/password sign-in). Username/password is validated against the Auth0
+# database connection (password-realm grant — requires the Password grant
+# enabled on the Auth0 application). When AUTH_AUTH0_* is unset, the
+# username/password form is not offered.
 # AUTH_AUTH0_ID=your_auth0_client_id
 # AUTH_AUTH0_SECRET=your_auth0_client_secret
 # AUTH_AUTH0_ISSUER=https://your-tenant.auth0.com

--- a/turbo-repo/apps/app/src/auth.config.ts
+++ b/turbo-repo/apps/app/src/auth.config.ts
@@ -1,6 +1,11 @@
 import { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { signInWithCredentials } from "@/features/auth/services/auth.service";
+import {
+  authenticateWithAuth0Password,
+  tokenFieldsForCredentialsUser,
+} from "@/features/auth/services/auth0-password";
+import { isAuth0Configured } from "@/features/auth/config/auth0-connections";
 import type { SignInCredentials } from "@/features/auth/services/auth.service.types";
 import Auth0 from "next-auth/providers/auth0"
 
@@ -36,7 +41,10 @@ function buildAuthProviders(): NextAuthConfig["providers"] {
   }
 
 
-  // Credentials provider - always available
+  // Credentials provider - always available. When Auth0 is configured the
+  // username/password is validated against the Auth0 database connection
+  // (password-realm grant) and yields a JWT session like the OAuth providers;
+  // otherwise it falls back to the legacy Alfresco ticket-based login.
   providers.push(
     Credentials({
       id: "credentials",
@@ -46,6 +54,11 @@ function buildAuthProviders(): NextAuthConfig["providers"] {
         password: { label: "Password", type: "password" },
       },
       authorize: async (credentials) => {
+        if (isAuth0Configured()) {
+          return authenticateWithAuth0Password(
+            credentials as SignInCredentials
+          );
+        }
         return signInWithCredentials(credentials as SignInCredentials);
       },
     })
@@ -100,8 +113,9 @@ export const authConfig: NextAuthConfig = {
      * Gates *who* may sign in. (The `authorized` callback only decides whether a
      * route requires a logged-in user, not which users are allowed at all.)
      * Federated/OAuth logins (Auth0 → Google/Microsoft/etc.) are restricted to the
-     * domains in AUTH_ALLOWED_EMAIL_DOMAINS. Credentials logins are already validated
-     * upstream against Alfresco, so they bypass this domain guard.
+     * domains in AUTH_ALLOWED_EMAIL_DOMAINS. Credentials logins bypass this domain
+     * guard: those users are provisioned by us (Auth0 database connection, or the
+     * legacy Alfresco fallback), not self-asserted via a federated IdP.
      */
     async signIn({ user, account, profile }) {
       if (account?.provider === "credentials") {
@@ -250,25 +264,25 @@ export const authConfig: NextAuthConfig = {
           }
         }
 
-        // Handle credentials provider
+        // Handle credentials provider. Auth0-validated users carry an idToken
+        // and get a JWT-shaped token (same as OAuth users, including refresh);
+        // legacy Alfresco users keep the ticket-shaped token.
         if (account && account.provider === "credentials") {
             authCredentialsLogger.debug( {
               hasUser: !!user,
               email: user?.email,
             }, "Processing credentials-based authentication");
-      
+
 
           if (user) {
-            token.ticket = user.ticket;
-            token.rawJWT = undefined;
+            Object.assign(token, tokenFieldsForCredentialsUser(user));
             authJwtLogger.debug( {
               email: user.email,
-              hasTicket: !!user.ticket,
+              hasTicket: !!token.ticket,
+              hasRawJWT: !!token.rawJWT,
               provider: account?.provider,
-              ticket: token.ticket,
-              rawJWT: token.rawJWT,
             }, "Processing user in JWT callback");
-            
+
           }
         }
 

--- a/turbo-repo/apps/app/src/auth.config.ts
+++ b/turbo-repo/apps/app/src/auth.config.ts
@@ -1,6 +1,5 @@
 import { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
-import { signInWithCredentials } from "@/features/auth/services/auth.service";
 import {
   authenticateWithAuth0Password,
   tokenFieldsForCredentialsUser,
@@ -41,28 +40,23 @@ function buildAuthProviders(): NextAuthConfig["providers"] {
   }
 
 
-  // Credentials provider - always available. When Auth0 is configured the
+  // Credentials provider - only available when Auth0 is configured, since
   // username/password is validated against the Auth0 database connection
-  // (password-realm grant) and yields a JWT session like the OAuth providers;
-  // otherwise it falls back to the legacy Alfresco ticket-based login.
-  providers.push(
-    Credentials({
-      id: "credentials",
-      name: "Credentials",
-      credentials: {
-        username: { label: "Username", type: "text", placeholder: "jsmith" },
-        password: { label: "Password", type: "password" },
-      },
-      authorize: async (credentials) => {
-        if (isAuth0Configured()) {
-          return authenticateWithAuth0Password(
-            credentials as SignInCredentials
-          );
-        }
-        return signInWithCredentials(credentials as SignInCredentials);
-      },
-    })
-  );
+  // (password-realm grant) and yields a JWT session like the OAuth providers.
+  if (isAuth0Configured()) {
+    providers.push(
+      Credentials({
+        id: "credentials",
+        name: "Credentials",
+        credentials: {
+          username: { label: "Username", type: "text", placeholder: "jsmith" },
+          password: { label: "Password", type: "password" },
+        },
+        authorize: async (credentials) =>
+          authenticateWithAuth0Password(credentials as SignInCredentials),
+      })
+    );
+  }
 
   return providers;
 }
@@ -114,8 +108,8 @@ export const authConfig: NextAuthConfig = {
      * route requires a logged-in user, not which users are allowed at all.)
      * Federated/OAuth logins (Auth0 → Google/Microsoft/etc.) are restricted to the
      * domains in AUTH_ALLOWED_EMAIL_DOMAINS. Credentials logins bypass this domain
-     * guard: those users are provisioned by us (Auth0 database connection, or the
-     * legacy Alfresco fallback), not self-asserted via a federated IdP.
+     * guard: those users are provisioned by us (Auth0 database connection), not
+     * self-asserted via a federated IdP.
      */
     async signIn({ user, account, profile }) {
       if (account?.provider === "credentials") {
@@ -264,9 +258,9 @@ export const authConfig: NextAuthConfig = {
           }
         }
 
-        // Handle credentials provider. Auth0-validated users carry an idToken
-        // and get a JWT-shaped token (same as OAuth users, including refresh);
-        // legacy Alfresco users keep the ticket-shaped token.
+        // Handle credentials provider. Credentials users are validated against
+        // Auth0 (password-realm grant), so they carry an idToken and get a
+        // JWT-shaped token, same as OAuth users (including refresh).
         if (account && account.provider === "credentials") {
             authCredentialsLogger.debug( {
               hasUser: !!user,

--- a/turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  getAuth0Connection,
+  getCredentialsConnection,
+  isAuth0Configured,
+} from "./auth0-connections";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getAuth0Connection", () => {
+  it("maps google to the default Auth0 connection", () => {
+    expect(getAuth0Connection("google")).toBe("google-oauth2");
+  });
+
+  it("maps github to the default Auth0 connection", () => {
+    expect(getAuth0Connection("github")).toBe("github");
+  });
+
+  it("maps both microsoft provider ids to the default Entra connection", () => {
+    expect(getAuth0Connection("microsoft-entra-id")).toBe("Mintral-Entra-ID");
+    expect(getAuth0Connection("microsoft")).toBe("Mintral-Entra-ID");
+  });
+
+  it("returns undefined for providers not brokered through Auth0", () => {
+    expect(getAuth0Connection("saml")).toBeUndefined();
+    expect(getAuth0Connection("unknown")).toBeUndefined();
+  });
+
+  it("honors AUTH_AUTH0_CONNECTION_GOOGLE override", () => {
+    vi.stubEnv("AUTH_AUTH0_CONNECTION_GOOGLE", "my-google-conn");
+    expect(getAuth0Connection("google")).toBe("my-google-conn");
+  });
+
+  it("honors AUTH_AUTH0_CONNECTION_GITHUB override", () => {
+    vi.stubEnv("AUTH_AUTH0_CONNECTION_GITHUB", "my-github-conn");
+    expect(getAuth0Connection("github")).toBe("my-github-conn");
+  });
+
+  it("honors AUTH_AUTH0_CONNECTION_ENTRA_ID override for both microsoft ids", () => {
+    vi.stubEnv("AUTH_AUTH0_CONNECTION_ENTRA_ID", "Acme-Entra-ID");
+    expect(getAuth0Connection("microsoft-entra-id")).toBe("Acme-Entra-ID");
+    expect(getAuth0Connection("microsoft")).toBe("Acme-Entra-ID");
+  });
+});
+
+describe("getCredentialsConnection", () => {
+  it("defaults to the Auth0 default database connection", () => {
+    expect(getCredentialsConnection()).toBe("Username-Password-Authentication");
+  });
+
+  it("honors AUTH_AUTH0_CONNECTION_CREDENTIALS override", () => {
+    vi.stubEnv("AUTH_AUTH0_CONNECTION_CREDENTIALS", "my-users-db");
+    expect(getCredentialsConnection()).toBe("my-users-db");
+  });
+});
+
+describe("isAuth0Configured", () => {
+  it("is false when the Auth0 client env vars are missing", () => {
+    vi.stubEnv("AUTH_AUTH0_ID", "");
+    vi.stubEnv("AUTH_AUTH0_SECRET", "");
+    vi.stubEnv("AUTH_AUTH0_ISSUER", "");
+    expect(isAuth0Configured()).toBe(false);
+  });
+
+  it("is false when only some Auth0 client env vars are set", () => {
+    vi.stubEnv("AUTH_AUTH0_ID", "client-id");
+    vi.stubEnv("AUTH_AUTH0_SECRET", "");
+    vi.stubEnv("AUTH_AUTH0_ISSUER", "https://tenant.auth0.com");
+    expect(isAuth0Configured()).toBe(false);
+  });
+
+  it("is true when id, secret and issuer are all set", () => {
+    vi.stubEnv("AUTH_AUTH0_ID", "client-id");
+    vi.stubEnv("AUTH_AUTH0_SECRET", "client-secret");
+    vi.stubEnv("AUTH_AUTH0_ISSUER", "https://tenant.auth0.com");
+    expect(isAuth0Configured()).toBe(true);
+  });
+});

--- a/turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts
@@ -71,6 +71,13 @@ describe("isAuth0Configured", () => {
     expect(isAuth0Configured()).toBe(false);
   });
 
+  it("is false when an Auth0 client env var is whitespace-only", () => {
+    vi.stubEnv("AUTH_AUTH0_ID", "   ");
+    vi.stubEnv("AUTH_AUTH0_SECRET", "client-secret");
+    vi.stubEnv("AUTH_AUTH0_ISSUER", "https://tenant.auth0.com");
+    expect(isAuth0Configured()).toBe(false);
+  });
+
   it("is true when id, secret and issuer are all set", () => {
     vi.stubEnv("AUTH_AUTH0_ID", "client-id");
     vi.stubEnv("AUTH_AUTH0_SECRET", "client-secret");

--- a/turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts
@@ -1,0 +1,53 @@
+/**
+ * Auth0 connection names, configurable per deployment via environment
+ * variables. The defaults preserve the values that were previously hardcoded
+ * so existing deployments keep working without new configuration.
+ */
+
+const DEFAULT_CONNECTIONS = {
+  google: "google-oauth2",
+  github: "github",
+  entraId: "Mintral-Entra-ID",
+  credentials: "Username-Password-Authentication",
+} as const;
+
+function envOr(name: string, fallback: string): string {
+  const value = process.env[name];
+  return value && value.trim() !== "" ? value : fallback;
+}
+
+/**
+ * Maps UI provider IDs to Auth0 connection names.
+ * All identity providers are routed through Auth0 as the single OIDC broker.
+ * Returns undefined for providers not brokered through Auth0.
+ */
+export function getAuth0Connection(providerId: string): string | undefined {
+  switch (providerId) {
+    case "google":
+      return envOr("AUTH_AUTH0_CONNECTION_GOOGLE", DEFAULT_CONNECTIONS.google);
+    case "github":
+      return envOr("AUTH_AUTH0_CONNECTION_GITHUB", DEFAULT_CONNECTIONS.github);
+    case "microsoft-entra-id":
+    case "microsoft":
+      return envOr("AUTH_AUTH0_CONNECTION_ENTRA_ID", DEFAULT_CONNECTIONS.entraId);
+    default:
+      return undefined;
+  }
+}
+
+/** The Auth0 database connection used for username/password sign-in. */
+export function getCredentialsConnection(): string {
+  return envOr(
+    "AUTH_AUTH0_CONNECTION_CREDENTIALS",
+    DEFAULT_CONNECTIONS.credentials
+  );
+}
+
+/** True when the Auth0 OIDC client is fully configured for this deployment. */
+export function isAuth0Configured(): boolean {
+  return !!(
+    process.env.AUTH_AUTH0_ID &&
+    process.env.AUTH_AUTH0_SECRET &&
+    process.env.AUTH_AUTH0_ISSUER
+  );
+}

--- a/turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts
@@ -45,9 +45,9 @@ export function getCredentialsConnection(): string {
 
 /** True when the Auth0 OIDC client is fully configured for this deployment. */
 export function isAuth0Configured(): boolean {
-  return !!(
-    process.env.AUTH_AUTH0_ID &&
-    process.env.AUTH_AUTH0_SECRET &&
-    process.env.AUTH_AUTH0_ISSUER
-  );
+  return [
+    process.env.AUTH_AUTH0_ID,
+    process.env.AUTH_AUTH0_SECRET,
+    process.env.AUTH_AUTH0_ISSUER,
+  ].every((value) => !!value && value.trim().length > 0);
 }

--- a/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
@@ -9,6 +9,7 @@ import {
   SignInCredentials,
 } from "./auth.service.types";
 import { PeopleApi, AlfrescoApi } from "@alfresco/js-api";
+import { getAuth0Connection } from "@/features/auth/config/auth0-connections";
 import { auth, signIn } from "@/auth";
 import { redirectWithLang } from "./navigation.service";
 import { logger } from "@/lib/logger";
@@ -44,36 +45,6 @@ export async function signInWithCredentials(
 }
 
 /**
- * Sign in with Auth0 database connection (username/password).
- * Redirects to Auth0 with connection hint for the database.
- *
- * @param email - Optional email to pre-fill (login_hint)
- */
-export async function signInWithAuth0Credentials(
-  email?: string
-): Promise<void> {
-  await signIn(
-    "auth0",
-    { redirectTo: "/app" },
-    {
-      connection: "Username-Password-Authentication",
-      ...(email && { login_hint: email }),
-    }
-  );
-}
-
-/**
- * Maps UI provider IDs to Auth0 connection names.
- * All identity providers are routed through Auth0 as the single OIDC broker.
- */
-const AUTH0_CONNECTION_MAP: Record<string, string> = {
-  google: "google-oauth2",
-  github: "github",
-  "microsoft-entra-id": "Mintral-Entra-ID",
-  microsoft: "Mintral-Entra-ID",
-};
-
-/**
  * Resolves a post-sign-in redirect target from an optional callbackUrl.
  * Only same-origin relative paths are honored (open-redirect guard); the
  * app's basePath is prefixed when missing so NextAuth lands on the right
@@ -102,7 +73,7 @@ export async function signInWithProvider(
   providerId: string,
   redirectTo?: string | null
 ): Promise<void> {
-  const auth0Connection = AUTH0_CONNECTION_MAP[providerId];
+  const auth0Connection = getAuth0Connection(providerId);
   const target = resolveRedirectTarget(redirectTo);
 
   // If Auth0 is configured and we have a connection mapping, use Auth0 as broker

--- a/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth.service.ts
@@ -1,48 +1,15 @@
 "use server";
 import "server-only";
 
-import { AuthError, CredentialsSignin } from "next-auth";
-import type { User } from "next-auth";
+import { AuthError } from "next-auth";
 import {
   AuthenticateActionState,
   formSchema,
-  SignInCredentials,
 } from "./auth.service.types";
-import { PeopleApi, AlfrescoApi } from "@alfresco/js-api";
 import { getAuth0Connection } from "@/features/auth/config/auth0-connections";
 import { auth, signIn } from "@/auth";
 import { redirectWithLang } from "./navigation.service";
 import { logger } from "@/lib/logger";
-
-export async function signInWithCredentials(
-  credentials: Record<keyof SignInCredentials, string>
-): Promise<User | null> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const alfrescoApi = new AlfrescoApi({
-      hostEcm: process.env.ECM_API_URL,
-      provider: process.env.AUTH_PROVIDER,
-      contextRoot: process.env.CONTEXT_ROOT,
-    });
-    const ticket: string = (await alfrescoApi.login(
-      credentials.email as string,
-      credentials.password as string
-    )) as string;
-
-    const peopleApi = new PeopleApi(alfrescoApi);
-    const person = await peopleApi.getPerson("-me-");
-
-    return {
-      id: person.entry.id,
-      name: person.entry.displayName || person.entry.email || "Unknown User",
-      email: person.entry.email,
-      groups: [],
-      ticket,
-    };
-  } catch (error) {
-    throw new CredentialsSignin("Invalid credentials");
-  }
-}
 
 /**
  * Resolves a post-sign-in redirect target from an optional callbackUrl.

--- a/turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts
@@ -174,19 +174,4 @@ describe("tokenFieldsForCredentialsUser", () => {
       ticket: undefined,
     });
   });
-
-  it("maps a legacy Alfresco user to a ticket-shaped token (no JWT)", async () => {
-    const { tokenFieldsForCredentialsUser } = await import("./auth0-password");
-    const fields = tokenFieldsForCredentialsUser({
-      id: "jane",
-      name: "Jane Doe",
-      email: "jane@example.com",
-      groups: [],
-      ticket: "TICKET_abc",
-    });
-    expect(fields).toEqual({
-      ticket: "TICKET_abc",
-      rawJWT: undefined,
-    });
-  });
 });

--- a/turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CredentialsSignin } from "next-auth";
+import { authenticateWithAuth0Password } from "./auth0-password";
+
+function makeIdToken(payload: Record<string, unknown>): string {
+  const encode = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${encode({ alg: "RS256", typ: "JWT" })}.${encode(payload)}.fake-signature`;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubEnv("AUTH_AUTH0_ID", "client-id");
+  vi.stubEnv("AUTH_AUTH0_SECRET", "client-secret");
+  vi.stubEnv("AUTH_AUTH0_ISSUER", "https://tenant.auth0.com");
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+function mockTokenResponse(idTokenPayload: Record<string, unknown>) {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      id_token: makeIdToken(idTokenPayload),
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    }),
+  });
+}
+
+describe("authenticateWithAuth0Password", () => {
+  it("returns a JWT-carrying user on valid credentials", async () => {
+    mockTokenResponse({
+      sub: "auth0|abc123",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      picture: "https://cdn.example.com/jane.png",
+    });
+
+    const before = Math.floor(Date.now() / 1000);
+    const user = await authenticateWithAuth0Password({
+      email: "jane@example.com",
+      password: "s3cret-pass",
+    });
+
+    expect(user.id).toBe("auth0|abc123");
+    expect(user.name).toBe("Jane Doe");
+    expect(user.email).toBe("jane@example.com");
+    expect(user.idToken).toContain(".");
+    expect(user.refreshToken).toBe("refresh-token");
+    expect(user.expiresAt).toBeGreaterThanOrEqual(before + 3600);
+    expect(user.ticket).toBeUndefined();
+  });
+
+  it("posts the password-realm grant to the issuer token endpoint", async () => {
+    mockTokenResponse({ sub: "auth0|abc123", email: "jane@example.com" });
+
+    await authenticateWithAuth0Password({
+      email: "jane@example.com",
+      password: "s3cret-pass",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://tenant.auth0.com/oauth/token");
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+      realm: "Username-Password-Authentication",
+      username: "jane@example.com",
+      password: "s3cret-pass",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      scope: "openid profile email offline_access",
+    });
+    expect(body.audience).toBeUndefined();
+  });
+
+  it("uses the configured credentials connection as realm", async () => {
+    vi.stubEnv("AUTH_AUTH0_CONNECTION_CREDENTIALS", "my-users-db");
+    mockTokenResponse({ sub: "auth0|abc123", email: "jane@example.com" });
+
+    await authenticateWithAuth0Password({
+      email: "jane@example.com",
+      password: "s3cret-pass",
+    });
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(body.realm).toBe("my-users-db");
+  });
+
+  it("includes the audience only when AUTH_AUTH0_AUDIENCE is set", async () => {
+    vi.stubEnv("AUTH_AUTH0_AUDIENCE", "https://api.example.com");
+    mockTokenResponse({ sub: "auth0|abc123", email: "jane@example.com" });
+
+    await authenticateWithAuth0Password({
+      email: "jane@example.com",
+      password: "s3cret-pass",
+    });
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(body.audience).toBe("https://api.example.com");
+  });
+
+  it("falls back to the email when the id_token has no name", async () => {
+    mockTokenResponse({ sub: "auth0|abc123", email: "jane@example.com" });
+
+    const user = await authenticateWithAuth0Password({
+      email: "jane@example.com",
+      password: "s3cret-pass",
+    });
+
+    expect(user.name).toBe("jane@example.com");
+  });
+
+  it("throws CredentialsSignin on invalid credentials without leaking details", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        error: "invalid_grant",
+        error_description: "Wrong email or password.",
+      }),
+    });
+
+    await expect(
+      authenticateWithAuth0Password({
+        email: "jane@example.com",
+        password: "wrong",
+      })
+    ).rejects.toBeInstanceOf(CredentialsSignin);
+  });
+
+  it("throws CredentialsSignin when the token endpoint is unreachable", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(
+      authenticateWithAuth0Password({
+        email: "jane@example.com",
+        password: "s3cret-pass",
+      })
+    ).rejects.toBeInstanceOf(CredentialsSignin);
+  });
+});
+
+describe("tokenFieldsForCredentialsUser", () => {
+  it("maps an Auth0-credentials user to a JWT-shaped token (no ticket)", async () => {
+    const { tokenFieldsForCredentialsUser } = await import("./auth0-password");
+    const fields = tokenFieldsForCredentialsUser({
+      id: "auth0|abc123",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      groups: [],
+      idToken: "header.payload.sig",
+      refreshToken: "refresh-token",
+      expiresAt: 1750000000,
+    });
+    expect(fields).toEqual({
+      rawJWT: "header.payload.sig",
+      accessTokenExpiresAt: 1750000000,
+      refreshToken: "refresh-token",
+      ticket: undefined,
+    });
+  });
+
+  it("maps a legacy Alfresco user to a ticket-shaped token (no JWT)", async () => {
+    const { tokenFieldsForCredentialsUser } = await import("./auth0-password");
+    const fields = tokenFieldsForCredentialsUser({
+      id: "jane",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      groups: [],
+      ticket: "TICKET_abc",
+    });
+    expect(fields).toEqual({
+      ticket: "TICKET_abc",
+      rawJWT: undefined,
+    });
+  });
+});

--- a/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
@@ -31,10 +31,10 @@ function decodeJwtPayload(token: string): IdTokenClaims {
 }
 
 /**
- * Token fields to persist for a credentials sign-in. Auth0-authenticated users
- * carry an id_token and get the same JWT-shaped token as OAuth users (so the
- * session/refresh/Bearer-forwarding paths treat them identically); legacy
- * Alfresco users keep the ticket-shaped token.
+ * Token fields to persist for a credentials sign-in. Credentials users are
+ * validated against Auth0 and carry an id_token, so they get the same
+ * JWT-shaped token as OAuth users (the session/refresh/Bearer-forwarding paths
+ * treat them identically).
  */
 export function tokenFieldsForCredentialsUser(user: User): {
   rawJWT?: string;
@@ -42,17 +42,11 @@ export function tokenFieldsForCredentialsUser(user: User): {
   refreshToken?: string;
   ticket?: string;
 } {
-  if (user.idToken) {
-    return {
-      rawJWT: user.idToken,
-      accessTokenExpiresAt: user.expiresAt,
-      refreshToken: user.refreshToken,
-      ticket: undefined,
-    };
-  }
   return {
-    ticket: user.ticket,
-    rawJWT: undefined,
+    rawJWT: user.idToken,
+    accessTokenExpiresAt: user.expiresAt,
+    refreshToken: user.refreshToken,
+    ticket: undefined,
   };
 }
 

--- a/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
@@ -1,0 +1,119 @@
+import "server-only";
+
+import { CredentialsSignin } from "next-auth";
+import type { User } from "next-auth";
+import type { SignInCredentials } from "./auth.service.types";
+import { getCredentialsConnection } from "@/features/auth/config/auth0-connections";
+import { logger } from "@/lib/logger";
+
+type Auth0TokenResponse = {
+  id_token: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+};
+
+type IdTokenClaims = {
+  sub?: string;
+  name?: string;
+  email?: string;
+  picture?: string;
+};
+
+/** Decodes a JWT payload without verifying the signature. Safe here because
+ * the token comes straight from the Auth0 token endpoint over TLS. */
+function decodeJwtPayload(token: string): IdTokenClaims {
+  const payload = token.split(".")[1];
+  if (!payload) {
+    throw new Error("Malformed id_token");
+  }
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+}
+
+/**
+ * Token fields to persist for a credentials sign-in. Auth0-authenticated users
+ * carry an id_token and get the same JWT-shaped token as OAuth users (so the
+ * session/refresh/Bearer-forwarding paths treat them identically); legacy
+ * Alfresco users keep the ticket-shaped token.
+ */
+export function tokenFieldsForCredentialsUser(user: User): {
+  rawJWT?: string;
+  accessTokenExpiresAt?: number;
+  refreshToken?: string;
+  ticket?: string;
+} {
+  if (user.idToken) {
+    return {
+      rawJWT: user.idToken,
+      accessTokenExpiresAt: user.expiresAt,
+      refreshToken: user.refreshToken,
+      ticket: undefined,
+    };
+  }
+  return {
+    ticket: user.ticket,
+    rawJWT: undefined,
+  };
+}
+
+/**
+ * Validates username/password against the Auth0 database connection using the
+ * password-realm grant, so credentials users get the same JWT-shaped session
+ * as users brokered through Auth0 social connections (Google, Entra ID, ...).
+ *
+ * Requires the Password grant to be enabled on the Auth0 application.
+ */
+export async function authenticateWithAuth0Password(
+  credentials: SignInCredentials
+): Promise<User> {
+  try {
+    const response = await fetch(
+      new URL("/oauth/token", process.env.AUTH_AUTH0_ISSUER).toString(),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+          realm: getCredentialsConnection(),
+          username: credentials.email,
+          password: credentials.password,
+          client_id: process.env.AUTH_AUTH0_ID,
+          client_secret: process.env.AUTH_AUTH0_SECRET,
+          ...(process.env.AUTH_AUTH0_AUDIENCE && {
+            audience: process.env.AUTH_AUTH0_AUDIENCE,
+          }),
+          scope: "openid profile email offline_access",
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error: unknown = await response.json().catch(() => undefined);
+      logger.warn(
+        { status: response.status, error },
+        "Auth0 password-realm grant rejected"
+      );
+      throw new CredentialsSignin("Invalid credentials");
+    }
+
+    const tokens = (await response.json()) as Auth0TokenResponse;
+    const claims = decodeJwtPayload(tokens.id_token);
+
+    return {
+      id: claims.sub ?? credentials.email,
+      name: claims.name || claims.email || credentials.email,
+      email: claims.email ?? credentials.email,
+      image: claims.picture,
+      groups: [],
+      idToken: tokens.id_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: Math.floor(Date.now() / 1000) + tokens.expires_in,
+    };
+  } catch (error) {
+    if (error instanceof CredentialsSignin) {
+      throw error;
+    }
+    logger.error({ error }, "Auth0 password-realm sign-in failed");
+    throw new CredentialsSignin("Invalid credentials");
+  }
+}

--- a/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
+++ b/turbo-repo/apps/app/src/features/auth/services/auth0-password.ts
@@ -73,6 +73,8 @@ export async function authenticateWithAuth0Password(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          // OAuth 2.0 extension grant-type identifier (RFC 6749 §4.5) — an
+          // exact-match name, not a URL; Auth0 rejects any variation of it.
           grant_type: "http://auth0.com/oauth/grant-type/password-realm",
           realm: getCredentialsConnection(),
           username: credentials.email,

--- a/turbo-repo/apps/app/src/test/server-only-stub.ts
+++ b/turbo-repo/apps/app/src/test/server-only-stub.ts
@@ -1,3 +1,5 @@
-// Empty stand-in for the "server-only" guard package so server modules can be
-// unit-tested outside the Next.js server runtime.
-export {};
+// Stand-in for the "server-only" guard package so server modules can be
+// unit-tested outside the Next.js server runtime. The real package has no
+// exports (it's imported for its side effect only); this named export exists
+// solely to keep the file a module under isolatedModules.
+export const serverOnlyTestStub = true;

--- a/turbo-repo/apps/app/src/test/server-only-stub.ts
+++ b/turbo-repo/apps/app/src/test/server-only-stub.ts
@@ -1,0 +1,3 @@
+// Empty stand-in for the "server-only" guard package so server modules can be
+// unit-tested outside the Next.js server runtime.
+export {};

--- a/turbo-repo/apps/app/src/types/next-auth.d.ts
+++ b/turbo-repo/apps/app/src/types/next-auth.d.ts
@@ -20,6 +20,11 @@ declare module "next-auth" {
     name: string;
     groups: string[];
     ticket?: string;
+    /** Auth0 id_token from the password-realm grant (credentials via Auth0). */
+    idToken?: string;
+    refreshToken?: string;
+    /** Epoch seconds when idToken expires. */
+    expiresAt?: number;
   }
 }
 

--- a/turbo-repo/apps/app/vitest.config.ts
+++ b/turbo-repo/apps/app/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    server: {
+      deps: {
+        // next-auth imports "next/server" extensionless; inline it so the
+        // resolve alias below applies (externalized deps bypass aliases).
+        inline: [/next-auth/, /@auth\/core/],
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
@@ -43,6 +50,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@assets': path.resolve(__dirname, './public'),
+      // next-auth imports "next/server" without an extension, which Vite can't
+      // resolve against Next's exports map outside the Next.js build.
+      'next/server': 'next/server.js',
+      'server-only': path.resolve(__dirname, './src/test/server-only-stub.ts'),
     },
   },
 }) 


### PR DESCRIPTION
…ection IDs

Username/password sign-in now uses the Auth0 database connection via the password-realm grant, yielding the same JWT-shaped session (rawJWT + refresh token) as the OAuth providers brokered through Auth0. The legacy Alfresco ticket login remains as automatic fallback when AUTH_AUTH0_* is not configured.

The Auth0 connection names previously hardcoded in AUTH0_CONNECTION_MAP (google-oauth2, github, Mintral-Entra-ID, Username-Password-Authentication) move to AUTH_AUTH0_CONNECTION_* env vars, with the old literals as defaults.

Requires the Password grant enabled on the Auth0 application.

<!-- Provide a clear, concise description of your change. -->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->
Closes #635

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI / tooling

## Affected workspace(s)

- [ ] `quarkus-srv/` (Integration)
- [ ] `ecm-srv/` (Coordinator)
- [x] `turbo-repo/` (Frontend)
- [ ] `miot-harness/` (AI harness)

## How was this tested?

<!-- Commands run, manual steps, screenshots, etc. -->

## Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat(app): ...`, `fix(bff): ...`)
- [ ] Lint and tests pass locally
- [ ] Documentation updated where needed
- [ ] I have read the [Contributing guidelines](../CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Auth0 password/username sign-in support alongside existing authentication methods.
  * Introduced support for multiple identity providers (Google, GitHub, Entra ID) through Auth0.
  * Enabled per-provider and per-tenant Auth0 connection customization via environment variables.

* **Documentation**
  * Expanded configuration documentation with Auth0 setup instructions and provider-specific defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
