### PR TITLE
ci(app): use available Opus model for release notes

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -22,7 +22,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
   IMAGE_NAME: miot-app
-  RELEASE_NOTES_MODEL: claude-opus-4.8
+  RELEASE_NOTES_MODEL: claude-opus-4.7
   RELEASE_NOTES_CONTEXT: long_context
 
 jobs:


### PR DESCRIPTION
## Summary
- Change the release-notes model from unavailable `claude-opus-4.8` to available `claude-opus-4.7`.
- Keep Copilot CLI `--context long_context` enabled.

## Why
The release train failed because Copilot CLI reported `Model "claude-opus-4.8" from --model flag is not available.`

## Validation
- ruby YAML parse for `.github/workflows/app-release-train.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This pull request contains no user-visible changes. It updates an internal workflow configuration for release note generation tooling.

* **Chores**
  * Updated internal release note generation workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->