### PR TITLE
feat(miot-integrations): async_jobs ledger + control-plane API for integration jobs

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
@@ -36,6 +36,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
 public class OrgAsyncJobsResource {
 
+    private static final String ERROR_KEY = "error";
+
     private final TenantContext tenantContext;
     private final OrganizationContext organizationContext;
     private final AsyncJobService service;
@@ -134,7 +136,7 @@ public class OrgAsyncJobsResource {
         if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
                     .type(MediaType.APPLICATION_JSON)
-                    .entity(Map.of("error", "Organization context does not match request path"))
+                    .entity(Map.of(ERROR_KEY, "Organization context does not match request path"))
                     .build());
         }
         return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
@@ -143,21 +145,21 @@ public class OrgAsyncJobsResource {
     private WebApplicationException badRequest(String message) {
         return new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(Map.of("error", message == null ? "Bad request" : message))
+                .entity(Map.of(ERROR_KEY, message == null ? "Bad request" : message))
                 .build());
     }
 
     private WebApplicationException conflict(String message) {
         return new WebApplicationException(Response.status(Response.Status.CONFLICT)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(Map.of("error", message == null ? "Conflict" : message))
+                .entity(Map.of(ERROR_KEY, message == null ? "Conflict" : message))
                 .build());
     }
 
     private Response notFound(String jobId) {
         return Response.status(Response.Status.NOT_FOUND)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(Map.of("error", "Job not found: " + jobId))
+                .entity(Map.of(ERROR_KEY, "Job not found: " + jobId))
                 .build();
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
@@ -1,0 +1,163 @@
+package com.microboxlabs.miot.integrations.api;
+
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Objects;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/api/v1/orgs/{organizationId}/integrations/jobs")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Async Jobs", description = "Durable ledger and control plane for externally-executed integration jobs")
+@SecurityRequirement(name = "oidc")
+@Authenticated
+@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class OrgAsyncJobsResource {
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final AsyncJobService service;
+
+    @Inject
+    public OrgAsyncJobsResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            AsyncJobService service) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.service = service;
+    }
+
+    @POST
+    @Path("/enqueue")
+    @Operation(summary = "Idempotently enqueue a batch of jobs (dedupe-key aware)")
+    public Response enqueue(@PathParam("organizationId") String organizationId, EnqueueJobsRequest request) {
+        try {
+            return Response.ok(service.enqueue(tenantCode(organizationId), request)).build();
+        } catch (IllegalArgumentException e) {
+            throw badRequest(e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/claim")
+    @Operation(summary = "Claim runnable jobs for an executor with a lease")
+    public Response claim(@PathParam("organizationId") String organizationId, ClaimJobsRequest request) {
+        tenantCode(organizationId); // enforce org context
+        try {
+            return Response.ok(service.claim(request)).build();
+        } catch (IllegalArgumentException e) {
+            throw badRequest(e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/{jobId}/report")
+    @Operation(summary = "Report the outcome of a claimed job")
+    public Response report(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobId") String jobId,
+            ReportJobRequest request) {
+        try {
+            AsyncJob job = service.report(tenantCode(organizationId), jobId, request);
+            return job == null ? notFound(jobId) : Response.ok(job).build();
+        } catch (IllegalArgumentException e) {
+            throw badRequest(e.getMessage());
+        } catch (IllegalStateException e) {
+            throw conflict(e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/{jobId}/retry")
+    @Operation(summary = "Manually reset a parked job so workers pick it up again")
+    public Response retry(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobId") String jobId) {
+        try {
+            AsyncJob job = service.retry(tenantCode(organizationId), jobId, tenantContext.getClientId());
+            return job == null ? notFound(jobId) : Response.ok(job).build();
+        } catch (IllegalStateException e) {
+            throw conflict(e.getMessage());
+        }
+    }
+
+    @GET
+    @Operation(summary = "List jobs with optional filters")
+    public Response list(
+            @PathParam("organizationId") String organizationId,
+            @QueryParam("state") String state,
+            @QueryParam("correlationKey") String correlationKey,
+            @QueryParam("jobType") String jobType,
+            @QueryParam("limit") @DefaultValue("100") int limit) {
+        try {
+            return Response.ok(
+                    service.list(tenantCode(organizationId), state, correlationKey, jobType, Math.min(limit, 500)))
+                    .build();
+        } catch (IllegalArgumentException e) {
+            throw badRequest("Invalid state filter: " + state);
+        }
+    }
+
+    @GET
+    @Path("/{jobId}")
+    @Operation(summary = "Get a job with its full attempt history")
+    public Response get(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobId") String jobId) {
+        AsyncJob job = service.get(tenantCode(organizationId), jobId);
+        return job == null ? notFound(jobId) : Response.ok(job).build();
+    }
+
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity("{\"error\":\"Organization context does not match request path\"}")
+                    .build());
+        }
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+
+    private WebApplicationException badRequest(String message) {
+        return new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON)
+                .entity("{\"error\":\"" + message + "\"}")
+                .build());
+    }
+
+    private WebApplicationException conflict(String message) {
+        return new WebApplicationException(Response.status(Response.Status.CONFLICT)
+                .type(MediaType.APPLICATION_JSON)
+                .entity("{\"error\":\"" + message + "\"}")
+                .build());
+    }
+
+    private Response notFound(String jobId) {
+        return Response.status(Response.Status.NOT_FOUND)
+                .type(MediaType.APPLICATION_JSON)
+                .entity("{\"error\":\"Job not found: " + jobId + "\"}")
+                .build();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import java.util.Objects;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
@@ -64,9 +65,8 @@ public class OrgAsyncJobsResource {
     @Path("/claim")
     @Operation(summary = "Claim runnable jobs for an executor with a lease")
     public Response claim(@PathParam("organizationId") String organizationId, ClaimJobsRequest request) {
-        tenantCode(organizationId); // enforce org context
         try {
-            return Response.ok(service.claim(request)).build();
+            return Response.ok(service.claim(tenantCode(organizationId), request)).build();
         } catch (IllegalArgumentException e) {
             throw badRequest(e.getMessage());
         }
@@ -134,7 +134,7 @@ public class OrgAsyncJobsResource {
         if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
                     .type(MediaType.APPLICATION_JSON)
-                    .entity("{\"error\":\"Organization context does not match request path\"}")
+                    .entity(Map.of("error", "Organization context does not match request path"))
                     .build());
         }
         return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
@@ -143,21 +143,21 @@ public class OrgAsyncJobsResource {
     private WebApplicationException badRequest(String message) {
         return new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
                 .type(MediaType.APPLICATION_JSON)
-                .entity("{\"error\":\"" + message + "\"}")
+                .entity(Map.of("error", message == null ? "Bad request" : message))
                 .build());
     }
 
     private WebApplicationException conflict(String message) {
         return new WebApplicationException(Response.status(Response.Status.CONFLICT)
                 .type(MediaType.APPLICATION_JSON)
-                .entity("{\"error\":\"" + message + "\"}")
+                .entity(Map.of("error", message == null ? "Conflict" : message))
                 .build());
     }
 
     private Response notFound(String jobId) {
         return Response.status(Response.Status.NOT_FOUND)
                 .type(MediaType.APPLICATION_JSON)
-                .entity("{\"error\":\"Job not found: " + jobId + "\"}")
+                .entity(Map.of("error", "Job not found: " + jobId))
                 .build();
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/AsyncJob.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/AsyncJob.java
@@ -1,0 +1,40 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A unit of asynchronous work executed by an external worker (e.g. an ECM
+ * instance running delivery integrations) and tracked here as a durable,
+ * auditable ledger entry.
+ *
+ * <p>Jobs sharing a {@code chainKey} form an ordered chain: a job is only
+ * claimable once every lower {@code chainSequence} in the chain has reached
+ * SUCCEEDED or CANCELLED (fail-fast with resume). {@code dedupeKey} makes
+ * enqueueing idempotent so the enqueuing listener and the reconciler converge
+ * on the same rows.
+ */
+public record AsyncJob(
+        String id,
+        String tenantCode,
+        String sourceInstance,
+        String executor,
+        String jobType,
+        String correlationKey,
+        String chainKey,
+        int chainSequence,
+        String dedupeKey,
+        Map<String, Object> payload,
+        JobState state,
+        int attempts,
+        int maxAttempts,
+        OffsetDateTime nextRetryAt,
+        String lockedBy,
+        OffsetDateTime lockedUntil,
+        String lastError,
+        List<Map<String, Object>> attemptHistory,
+        String enqueuedBy,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/JobState.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/JobState.java
@@ -1,0 +1,17 @@
+package com.microboxlabs.miot.integrations.domain;
+
+/**
+ * Lifecycle states of an {@link AsyncJob}.
+ *
+ * <p>PENDING jobs are runnable (immediately or at {@code nextRetryAt}). RUNNING
+ * jobs hold a lease ({@code lockedUntil}); an expired lease makes the job
+ * claimable again. FAILED is a parked state reached when attempts are exhausted
+ * or the worker reports a non-retryable error — only a manual retry leaves it.
+ */
+public enum JobState {
+    PENDING,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    CANCELLED
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/AsyncJobSpec.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/AsyncJobSpec.java
@@ -1,0 +1,19 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.util.Map;
+
+/**
+ * One job to enqueue. {@code dedupeKey} must be deterministic for the same
+ * logical work (convention: {@code sourceInstance:chainKey:jobType}) so that
+ * the listener fast path and the reconciler converge on the same row.
+ */
+public record AsyncJobSpec(
+        String jobType,
+        String executor,
+        String correlationKey,
+        String chainKey,
+        Integer chainSequence,
+        String dedupeKey,
+        Map<String, Object> payload,
+        Integer maxAttempts) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ClaimJobsRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ClaimJobsRequest.java
@@ -1,0 +1,13 @@
+package com.microboxlabs.miot.integrations.dto;
+
+/**
+ * Worker claim request. {@code chainKey} optionally narrows the claim to one
+ * chain (used by the enqueuer's fast path to drive its own chain to completion).
+ */
+public record ClaimJobsRequest(
+        String executor,
+        String workerId,
+        Integer limit,
+        Integer leaseSeconds,
+        String chainKey) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/EnqueueJobsRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/EnqueueJobsRequest.java
@@ -1,0 +1,9 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.util.List;
+
+public record EnqueueJobsRequest(
+        String sourceInstance,
+        String enqueuedBy,
+        List<AsyncJobSpec> jobs) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/EnqueueJobsResponse.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/EnqueueJobsResponse.java
@@ -1,0 +1,9 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import java.util.List;
+
+public record EnqueueJobsResponse(
+        List<AsyncJob> created,
+        int duplicates) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
@@ -1,0 +1,13 @@
+package com.microboxlabs.miot.integrations.dto;
+
+/**
+ * Worker outcome report. {@code outcome} is SUCCEEDED, SKIPPED (nothing to do —
+ * recorded as SUCCEEDED with detail) or FAILED. {@code retryable=false} parks a
+ * FAILED job immediately regardless of remaining attempts.
+ */
+public record ReportJobRequest(
+        String workerId,
+        String outcome,
+        String detail,
+        Boolean retryable) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
@@ -3,11 +3,15 @@ package com.microboxlabs.miot.integrations.dto;
 /**
  * Worker outcome report. {@code outcome} is SUCCEEDED, SKIPPED (nothing to do —
  * recorded as SUCCEEDED with detail) or FAILED. {@code retryable=false} parks a
- * FAILED job immediately regardless of remaining attempts.
+ * FAILED job immediately regardless of remaining attempts. {@code attempts}
+ * echoes the attempt number the worker observed at claim time and is used as a
+ * compare-and-set guard so stale reports (expired lease, job reclaimed) are
+ * rejected.
  */
 public record ReportJobRequest(
         String workerId,
         String outcome,
         String detail,
-        Boolean retryable) {
+        Boolean retryable,
+        Integer attempts) {
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
@@ -1,0 +1,254 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.RowSet;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class AsyncJobRepository {
+
+    private static final String COLUMNS = """
+            id, tenant_code, source_instance, executor, job_type, correlation_key,
+            chain_key, chain_sequence, dedupe_key, payload, state, attempts, max_attempts,
+            next_retry_at, locked_by, locked_until, last_error, attempt_history,
+            enqueued_by, created_at, updated_at""";
+
+    private static final String INSERT = """
+            INSERT INTO miot_integrations.async_jobs (
+                tenant_code, source_instance, executor, job_type, correlation_key,
+                chain_key, chain_sequence, dedupe_key, payload, max_attempts, enqueued_by
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (dedupe_key) WHERE dedupe_key IS NOT NULL DO NOTHING
+            RETURNING %s""".formatted(COLUMNS);
+
+    /**
+     * Claims runnable jobs for an executor with a lease. A job is runnable when it
+     * is PENDING and due, or RUNNING with an expired lease (crashed worker), has
+     * attempts left, and is the head of its chain (no earlier sequence unfinished).
+     * Attempts increment at claim time so crashed attempts still count toward
+     * max_attempts (poison-pill protection).
+     */
+    private static final String CLAIM = """
+            WITH runnable AS (
+                SELECT j.id
+                FROM miot_integrations.async_jobs j
+                WHERE j.executor = $1
+                  AND j.attempts < j.max_attempts
+                  AND (
+                      (j.state = 'PENDING' AND (j.next_retry_at IS NULL OR j.next_retry_at <= now()))
+                      OR (j.state = 'RUNNING' AND j.locked_until IS NOT NULL AND j.locked_until < now())
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM miot_integrations.async_jobs p
+                      WHERE j.chain_key IS NOT NULL
+                        AND p.chain_key = j.chain_key
+                        AND p.chain_sequence < j.chain_sequence
+                        AND p.state NOT IN ('SUCCEEDED', 'CANCELLED')
+                  )
+                  AND ($4::varchar IS NULL OR j.chain_key = $4)
+                ORDER BY j.created_at
+                LIMIT $2
+                FOR UPDATE OF j SKIP LOCKED
+            )
+            UPDATE miot_integrations.async_jobs a
+            SET state = 'RUNNING',
+                locked_by = $3,
+                locked_until = now() + make_interval(secs => $5::int),
+                attempts = a.attempts + 1,
+                updated_at = now()
+            FROM runnable r
+            WHERE a.id = r.id
+            RETURNING %s""".formatted(COLUMNS);
+
+    private static final String REPORT = """
+            UPDATE miot_integrations.async_jobs
+            SET state = $2,
+                next_retry_at = $3,
+                last_error = $4,
+                attempt_history = attempt_history || $5::jsonb,
+                locked_by = NULL,
+                locked_until = NULL,
+                updated_at = now()
+            WHERE id = $1
+            RETURNING %s""".formatted(COLUMNS);
+
+    private static final String RETRY = """
+            UPDATE miot_integrations.async_jobs
+            SET state = 'PENDING',
+                attempts = 0,
+                next_retry_at = NULL,
+                locked_by = NULL,
+                locked_until = NULL,
+                attempt_history = attempt_history || $2::jsonb,
+                enqueued_by = 'manual',
+                updated_at = now()
+            WHERE id = $1 AND state IN ('FAILED', 'CANCELLED', 'PENDING')
+            RETURNING %s""".formatted(COLUMNS);
+
+    private static final String FIND_BY_ID = """
+            SELECT %s
+            FROM miot_integrations.async_jobs
+            WHERE id = $1 AND tenant_code = $2""".formatted(COLUMNS);
+
+    private static final String LIST = """
+            SELECT %s
+            FROM miot_integrations.async_jobs
+            WHERE tenant_code = $1
+              AND ($2::varchar IS NULL OR state = $2)
+              AND ($3::varchar IS NULL OR correlation_key = $3)
+              AND ($4::varchar IS NULL OR job_type = $4)
+            ORDER BY created_at DESC
+            LIMIT $5""".formatted(COLUMNS);
+
+    private final Instance<Pool> clientInstance;
+
+    protected AsyncJobRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    /**
+     * Inserts a job; returns null when the dedupe key already exists (idempotent
+     * enqueue — the existing row wins).
+     */
+    public AsyncJob insert(AsyncJob job) {
+        Tuple params = Tuple.tuple()
+                .addString(job.tenantCode())
+                .addString(job.sourceInstance())
+                .addString(job.executor())
+                .addString(job.jobType())
+                .addString(job.correlationKey())
+                .addString(job.chainKey())
+                .addInteger(job.chainSequence())
+                .addString(job.dedupeKey())
+                .addJsonObject(toJson(job.payload()))
+                .addInteger(job.maxAttempts())
+                .addString(job.enqueuedBy());
+        RowSet<Row> rows = client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public List<AsyncJob> claim(String executor, String workerId, int limit, int leaseSeconds, String chainKey) {
+        Tuple params = Tuple.tuple()
+                .addString(executor)
+                .addInteger(limit)
+                .addString(workerId)
+                .addString(chainKey)
+                .addInteger(leaseSeconds);
+        return client().preparedQuery(CLAIM)
+                .execute(params)
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public AsyncJob report(String jobId, JobState newState, OffsetDateTime nextRetryAt,
+            String lastError, Map<String, Object> attemptEntry) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(jobId))
+                .addString(newState.name())
+                .addOffsetDateTime(nextRetryAt)
+                .addString(lastError)
+                .addJsonArray(new JsonArray().add(new JsonObject(attemptEntry)));
+        RowSet<Row> rows = client().preparedQuery(REPORT)
+                .execute(params)
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public AsyncJob retry(String jobId, Map<String, Object> attemptEntry) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(jobId))
+                .addJsonArray(new JsonArray().add(new JsonObject(attemptEntry)));
+        RowSet<Row> rows = client().preparedQuery(RETRY)
+                .execute(params)
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public AsyncJob findByTenantAndId(String tenantCode, String jobId) {
+        RowSet<Row> rows = client().preparedQuery(FIND_BY_ID)
+                .execute(Tuple.of(UUID.fromString(jobId), tenantCode))
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType, int limit) {
+        Tuple params = Tuple.tuple()
+                .addString(tenantCode)
+                .addString(state)
+                .addString(correlationKey)
+                .addString(jobType)
+                .addInteger(limit);
+        return client().preparedQuery(LIST)
+                .execute(params)
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private AsyncJob mapRow(Row row) {
+        return new AsyncJob(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("source_instance"),
+                row.getString("executor"),
+                row.getString("job_type"),
+                row.getString("correlation_key"),
+                row.getString("chain_key"),
+                row.getInteger("chain_sequence"),
+                row.getString("dedupe_key"),
+                toMap(row.getJsonObject("payload")),
+                JobState.valueOf(row.getString("state")),
+                row.getInteger("attempts"),
+                row.getInteger("max_attempts"),
+                row.getOffsetDateTime("next_retry_at"),
+                row.getString("locked_by"),
+                row.getOffsetDateTime("locked_until"),
+                row.getString("last_error"),
+                toHistory(row.getJsonArray("attempt_history")),
+                row.getString("enqueued_by"),
+                row.getOffsetDateTime("created_at"),
+                row.getOffsetDateTime("updated_at"));
+    }
+
+    private JsonObject toJson(Map<String, Object> value) {
+        return new JsonObject(value == null ? Map.of() : value);
+    }
+
+    private Map<String, Object> toMap(JsonObject value) {
+        return value == null ? Map.of() : new LinkedHashMap<>(value.getMap());
+    }
+
+    private List<Map<String, Object>> toHistory(JsonArray value) {
+        if (value == null) {
+            return List.of();
+        }
+        List<Map<String, Object>> entries = new ArrayList<>(value.size());
+        for (int i = 0; i < value.size(); i++) {
+            entries.add(new LinkedHashMap<>(value.getJsonObject(i).getMap()));
+        }
+        return entries;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
@@ -31,7 +31,7 @@ public class AsyncJobRepository {
                 tenant_code, source_instance, executor, job_type, correlation_key,
                 chain_key, chain_sequence, dedupe_key, payload, max_attempts, enqueued_by
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            ON CONFLICT (dedupe_key) WHERE dedupe_key IS NOT NULL DO NOTHING
+            ON CONFLICT (tenant_code, dedupe_key) WHERE dedupe_key IS NOT NULL DO NOTHING
             RETURNING %s""".formatted(COLUMNS);
 
     /**
@@ -45,7 +45,8 @@ public class AsyncJobRepository {
             WITH runnable AS (
                 SELECT j.id
                 FROM miot_integrations.async_jobs j
-                WHERE j.executor = $1
+                WHERE j.tenant_code = $1
+                  AND j.executor = $2
                   AND j.attempts < j.max_attempts
                   AND (
                       (j.state = 'PENDING' AND (j.next_retry_at IS NULL OR j.next_retry_at <= now()))
@@ -55,25 +56,32 @@ public class AsyncJobRepository {
                       SELECT 1
                       FROM miot_integrations.async_jobs p
                       WHERE j.chain_key IS NOT NULL
+                        AND p.tenant_code = j.tenant_code
                         AND p.chain_key = j.chain_key
                         AND p.chain_sequence < j.chain_sequence
                         AND p.state NOT IN ('SUCCEEDED', 'CANCELLED')
                   )
-                  AND ($4::varchar IS NULL OR j.chain_key = $4)
+                  AND ($5::varchar IS NULL OR j.chain_key = $5)
                 ORDER BY j.created_at
-                LIMIT $2
+                LIMIT $3
                 FOR UPDATE OF j SKIP LOCKED
             )
             UPDATE miot_integrations.async_jobs a
             SET state = 'RUNNING',
-                locked_by = $3,
-                locked_until = now() + make_interval(secs => $5::int),
+                locked_by = $4,
+                locked_until = now() + make_interval(secs => $6::int),
                 attempts = a.attempts + 1,
                 updated_at = now()
             FROM runnable r
             WHERE a.id = r.id
             RETURNING %s""".formatted(COLUMNS);
 
+    /**
+     * Compare-and-set on the active lease: the update only lands when the row is
+     * still RUNNING, held by the reporting worker, and on the attempt the worker
+     * claimed. A stale report (lease expired and the job was reclaimed — possibly
+     * by the same workerId via fast path + poller overlap) matches zero rows.
+     */
     private static final String REPORT = """
             UPDATE miot_integrations.async_jobs
             SET state = $2,
@@ -84,6 +92,9 @@ public class AsyncJobRepository {
                 locked_until = NULL,
                 updated_at = now()
             WHERE id = $1
+              AND state = 'RUNNING'
+              AND locked_by = $6
+              AND attempts = $7
             RETURNING %s""".formatted(COLUMNS);
 
     private static final String RETRY = """
@@ -143,8 +154,10 @@ public class AsyncJobRepository {
         return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
     }
 
-    public List<AsyncJob> claim(String executor, String workerId, int limit, int leaseSeconds, String chainKey) {
+    public List<AsyncJob> claim(String tenantCode, String executor, String workerId,
+            int limit, int leaseSeconds, String chainKey) {
         Tuple params = Tuple.tuple()
+                .addString(tenantCode)
                 .addString(executor)
                 .addInteger(limit)
                 .addString(workerId)
@@ -158,14 +171,20 @@ public class AsyncJobRepository {
                 .toList();
     }
 
-    public AsyncJob report(String jobId, JobState newState, OffsetDateTime nextRetryAt,
-            String lastError, Map<String, Object> attemptEntry) {
+    /**
+     * @return the updated job, or null when the lease CAS failed (the job was
+     *         reclaimed since this worker's claim — the report is stale)
+     */
+    public AsyncJob report(String jobId, String workerId, int expectedAttempts, JobState newState,
+            OffsetDateTime nextRetryAt, String lastError, Map<String, Object> attemptEntry) {
         Tuple params = Tuple.tuple()
                 .addUUID(UUID.fromString(jobId))
                 .addString(newState.name())
                 .addOffsetDateTime(nextRetryAt)
                 .addString(lastError)
-                .addJsonArray(new JsonArray().add(new JsonObject(attemptEntry)));
+                .addJsonArray(new JsonArray().add(new JsonObject(attemptEntry)))
+                .addString(workerId)
+                .addInteger(expectedAttempts);
         RowSet<Row> rows = client().preparedQuery(REPORT)
                 .execute(params)
                 .await().indefinitely();

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -53,6 +53,7 @@ public class AsyncJobService {
      * state, wins — re-running a SUCCEEDED job requires an explicit manual retry).
      */
     public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
+        requireBody(request);
         String enqueuedBy = validateEnqueueRequest(request);
 
         List<AsyncJob> created = new ArrayList<>();
@@ -100,16 +101,24 @@ public class AsyncJobService {
         }
     }
 
-    public List<AsyncJob> claim(ClaimJobsRequest request) {
+    public List<AsyncJob> claim(String tenantCode, ClaimJobsRequest request) {
+        requireBody(request);
         if (request.executor() == null || request.executor().isBlank()) {
             throw new IllegalArgumentException("executor is required");
         }
         if (request.workerId() == null || request.workerId().isBlank()) {
             throw new IllegalArgumentException("workerId is required");
         }
+        if (request.limit() != null && request.limit() < 1) {
+            throw new IllegalArgumentException("limit must be >= 1");
+        }
+        if (request.leaseSeconds() != null && request.leaseSeconds() < 1) {
+            throw new IllegalArgumentException("leaseSeconds must be >= 1");
+        }
         int limit = request.limit() == null ? DEFAULT_CLAIM_LIMIT : Math.min(request.limit(), MAX_CLAIM_LIMIT);
         int lease = request.leaseSeconds() == null ? DEFAULT_LEASE_SECONDS : request.leaseSeconds();
-        return repository.claim(request.executor(), request.workerId(), limit, lease, request.chainKey());
+        return repository.claim(tenantCode, request.executor(), request.workerId(), limit, lease,
+                request.chainKey());
     }
 
     /**
@@ -119,6 +128,10 @@ public class AsyncJobService {
      * which parks it as FAILED for the babysitter.
      */
     public AsyncJob report(String tenantCode, String jobId, ReportJobRequest request) {
+        requireBody(request);
+        if (request.workerId() == null || request.workerId().isBlank()) {
+            throw new IllegalArgumentException("workerId is required");
+        }
         if (request.outcome() == null || !VALID_OUTCOMES.contains(request.outcome())) {
             throw new IllegalArgumentException("outcome must be one of " + VALID_OUTCOMES);
         }
@@ -146,9 +159,19 @@ public class AsyncJobService {
             }
         }
 
+        // CAS on the lease: workers echo the attempt number they claimed so a
+        // stale report (lease expired, job reclaimed — possibly by the same
+        // workerId via fast path + poller overlap) cannot overwrite the newer
+        // attempt's state.
+        int expectedAttempts = request.attempts() != null ? request.attempts() : job.attempts();
         Map<String, Object> entry = attemptEntry(request.outcome(), request.detail(), request.workerId());
-        AsyncJob updated = repository.report(jobId, newState, nextRetryAt,
+        AsyncJob updated = repository.report(jobId, request.workerId(), expectedAttempts, newState, nextRetryAt,
                 failed ? request.detail() : null, entry);
+        if (updated == null) {
+            throw new IllegalStateException(
+                    "Stale report for job " + jobId + ": lease no longer held by " + request.workerId()
+                            + " on attempt " + expectedAttempts);
+        }
         if (newState == JobState.FAILED) {
             LOG.errorf("Job %s (%s, correlation=%s) parked as FAILED after %d attempt(s): %s",
                     jobId, job.jobType(), job.correlationKey(), job.attempts(), request.detail());
@@ -156,7 +179,13 @@ public class AsyncJobService {
         return updated;
     }
 
-    /** Manual babysitter action: resets a parked job so workers pick it up again. */
+    /**
+     * Manual babysitter action: resets a job so workers pick it up again with a
+     * fresh attempt budget. Deliberately also accepts PENDING jobs — a job
+     * sitting in backoff (nextRetryAt in the future) is forced to run now
+     * instead of waiting out the delay. Only RUNNING (lease held) and SUCCEEDED
+     * jobs are rejected.
+     */
     public AsyncJob retry(String tenantCode, String jobId, String actor) {
         AsyncJob job = repository.findByTenantAndId(tenantCode, jobId);
         if (job == null) {
@@ -174,10 +203,19 @@ public class AsyncJobService {
     }
 
     public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType, int limit) {
+        if (limit < 1) {
+            throw new IllegalArgumentException("limit must be >= 1");
+        }
         if (state != null) {
             JobState.valueOf(state); // validate
         }
         return repository.list(tenantCode, state, correlationKey, jobType, limit);
+    }
+
+    private static void requireBody(Object request) {
+        if (request == null) {
+            throw new IllegalArgumentException("request body is required");
+        }
     }
 
     /** Exponential backoff: base * 2^(attempts-1), capped. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -25,8 +25,9 @@ public class AsyncJobService {
 
     private static final Logger LOG = Logger.getLogger(AsyncJobService.class);
 
+    private static final String OUTCOME_FAILED = "FAILED";
     private static final Set<String> VALID_ENQUEUED_BY = Set.of("listener", "reconciler", "manual");
-    private static final Set<String> VALID_OUTCOMES = Set.of("SUCCEEDED", "SKIPPED", "FAILED");
+    private static final Set<String> VALID_OUTCOMES = Set.of("SUCCEEDED", "SKIPPED", OUTCOME_FAILED);
 
     private static final int DEFAULT_MAX_ATTEMPTS = 5;
     private static final int DEFAULT_CLAIM_LIMIT = 10;
@@ -128,13 +129,7 @@ public class AsyncJobService {
      * which parks it as FAILED for the babysitter.
      */
     public AsyncJob report(String tenantCode, String jobId, ReportJobRequest request) {
-        requireBody(request);
-        if (request.workerId() == null || request.workerId().isBlank()) {
-            throw new IllegalArgumentException("workerId is required");
-        }
-        if (request.outcome() == null || !VALID_OUTCOMES.contains(request.outcome())) {
-            throw new IllegalArgumentException("outcome must be one of " + VALID_OUTCOMES);
-        }
+        validateReportRequest(request);
         AsyncJob job = repository.findByTenantAndId(tenantCode, jobId);
         if (job == null) {
             return null;
@@ -144,20 +139,11 @@ public class AsyncJobService {
                     "Job " + jobId + " is " + job.state() + ", only RUNNING jobs accept reports");
         }
 
-        JobState newState;
-        OffsetDateTime nextRetryAt = null;
-        boolean failed = "FAILED".equals(request.outcome());
-        if (!failed) {
-            newState = JobState.SUCCEEDED;
-        } else {
-            boolean retryable = !Boolean.FALSE.equals(request.retryable());
-            if (retryable && job.attempts() < job.maxAttempts()) {
-                newState = JobState.PENDING;
-                nextRetryAt = OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(backoffSeconds(job.attempts()));
-            } else {
-                newState = JobState.FAILED;
-            }
-        }
+        JobState newState = resolveReportState(job, request);
+        OffsetDateTime nextRetryAt = newState == JobState.PENDING
+                ? OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(backoffSeconds(job.attempts()))
+                : null;
+        String lastError = OUTCOME_FAILED.equals(request.outcome()) ? request.detail() : null;
 
         // CAS on the lease: workers echo the attempt number they claimed so a
         // stale report (lease expired, job reclaimed — possibly by the same
@@ -166,7 +152,7 @@ public class AsyncJobService {
         int expectedAttempts = request.attempts() != null ? request.attempts() : job.attempts();
         Map<String, Object> entry = attemptEntry(request.outcome(), request.detail(), request.workerId());
         AsyncJob updated = repository.report(jobId, request.workerId(), expectedAttempts, newState, nextRetryAt,
-                failed ? request.detail() : null, entry);
+                lastError, entry);
         if (updated == null) {
             throw new IllegalStateException(
                     "Stale report for job " + jobId + ": lease no longer held by " + request.workerId()
@@ -216,6 +202,29 @@ public class AsyncJobService {
         if (request == null) {
             throw new IllegalArgumentException("request body is required");
         }
+    }
+
+    private void validateReportRequest(ReportJobRequest request) {
+        requireBody(request);
+        if (request.workerId() == null || request.workerId().isBlank()) {
+            throw new IllegalArgumentException("workerId is required");
+        }
+        if (request.outcome() == null || !VALID_OUTCOMES.contains(request.outcome())) {
+            throw new IllegalArgumentException("outcome must be one of " + VALID_OUTCOMES);
+        }
+    }
+
+    /**
+     * Target state for a reported outcome: SUCCEEDED/SKIPPED close the job;
+     * FAILED retries (PENDING) while attempts remain and the failure is
+     * retryable, otherwise parks the job as FAILED.
+     */
+    private static JobState resolveReportState(AsyncJob job, ReportJobRequest request) {
+        if (!OUTCOME_FAILED.equals(request.outcome())) {
+            return JobState.SUCCEEDED;
+        }
+        boolean retryable = !Boolean.FALSE.equals(request.retryable());
+        return retryable && job.attempts() < job.maxAttempts() ? JobState.PENDING : JobState.FAILED;
     }
 
     /** Exponential backoff: base * 2^(attempts-1), capped. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -11,6 +11,7 @@ import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,16 +53,7 @@ public class AsyncJobService {
      * state, wins — re-running a SUCCEEDED job requires an explicit manual retry).
      */
     public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
-        if (request.sourceInstance() == null || request.sourceInstance().isBlank()) {
-            throw new IllegalArgumentException("sourceInstance is required");
-        }
-        if (request.jobs() == null || request.jobs().isEmpty()) {
-            throw new IllegalArgumentException("jobs must not be empty");
-        }
-        String enqueuedBy = request.enqueuedBy() == null ? "listener" : request.enqueuedBy();
-        if (!VALID_ENQUEUED_BY.contains(enqueuedBy)) {
-            throw new IllegalArgumentException("enqueuedBy must be one of " + VALID_ENQUEUED_BY);
-        }
+        String enqueuedBy = validateEnqueueRequest(request);
 
         List<AsyncJob> created = new ArrayList<>();
         int duplicates = 0;
@@ -76,6 +68,26 @@ public class AsyncJobService {
                 created.add(row);
             }
         }
+        logEnqueueOutcome(tenantCode, enqueuedBy, created, duplicates);
+        return new EnqueueJobsResponse(created, duplicates);
+    }
+
+    /** @return the validated enqueuing actor (defaults to "listener") */
+    private String validateEnqueueRequest(EnqueueJobsRequest request) {
+        if (request.sourceInstance() == null || request.sourceInstance().isBlank()) {
+            throw new IllegalArgumentException("sourceInstance is required");
+        }
+        if (request.jobs() == null || request.jobs().isEmpty()) {
+            throw new IllegalArgumentException("jobs must not be empty");
+        }
+        String enqueuedBy = request.enqueuedBy() == null ? "listener" : request.enqueuedBy();
+        if (!VALID_ENQUEUED_BY.contains(enqueuedBy)) {
+            throw new IllegalArgumentException("enqueuedBy must be one of " + VALID_ENQUEUED_BY);
+        }
+        return enqueuedBy;
+    }
+
+    private void logEnqueueOutcome(String tenantCode, String enqueuedBy, List<AsyncJob> created, int duplicates) {
         if (duplicates > 0) {
             LOG.infof("Enqueue for tenant %s: %d created, %d duplicates (by=%s)",
                     tenantCode, created.size(), duplicates, enqueuedBy);
@@ -86,7 +98,6 @@ public class AsyncJobService {
             LOG.warnf("Reconciler backfilled %d job(s) for tenant %s — fast-path enqueue missed them",
                     created.size(), tenantCode);
         }
-        return new EnqueueJobsResponse(created, duplicates);
     }
 
     public List<AsyncJob> claim(ClaimJobsRequest request) {
@@ -129,7 +140,7 @@ public class AsyncJobService {
             boolean retryable = !Boolean.FALSE.equals(request.retryable());
             if (retryable && job.attempts() < job.maxAttempts()) {
                 newState = JobState.PENDING;
-                nextRetryAt = OffsetDateTime.now().plusSeconds(backoffSeconds(job.attempts()));
+                nextRetryAt = OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(backoffSeconds(job.attempts()));
             } else {
                 newState = JobState.FAILED;
             }
@@ -198,7 +209,7 @@ public class AsyncJobService {
 
     private Map<String, Object> attemptEntry(String outcome, String detail, String by) {
         Map<String, Object> entry = new LinkedHashMap<>();
-        entry.put("at", OffsetDateTime.now().toString());
+        entry.put("at", OffsetDateTime.now(ZoneOffset.UTC).toString());
         entry.put("outcome", outcome);
         if (detail != null) {
             entry.put("detail", detail);

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -1,0 +1,211 @@
+package com.microboxlabs.miot.integrations.service;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
+import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class AsyncJobService {
+
+    private static final Logger LOG = Logger.getLogger(AsyncJobService.class);
+
+    private static final Set<String> VALID_ENQUEUED_BY = Set.of("listener", "reconciler", "manual");
+    private static final Set<String> VALID_OUTCOMES = Set.of("SUCCEEDED", "SKIPPED", "FAILED");
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 5;
+    private static final int DEFAULT_CLAIM_LIMIT = 10;
+    private static final int DEFAULT_LEASE_SECONDS = 300;
+    private static final int MAX_CLAIM_LIMIT = 50;
+
+    private final AsyncJobRepository repository;
+    private final int retryBaseSeconds;
+    private final int retryMaxSeconds;
+
+    @Inject
+    public AsyncJobService(
+            AsyncJobRepository repository,
+            @ConfigProperty(name = "miot.integrations.jobs.retry-base-seconds", defaultValue = "60") int retryBaseSeconds,
+            @ConfigProperty(name = "miot.integrations.jobs.retry-max-seconds", defaultValue = "3600") int retryMaxSeconds) {
+        this.repository = repository;
+        this.retryBaseSeconds = retryBaseSeconds;
+        this.retryMaxSeconds = retryMaxSeconds;
+    }
+
+    /**
+     * Idempotently enqueues a batch of jobs. Rows whose dedupe key already exists
+     * are counted as duplicates and not re-created (the existing row, whatever its
+     * state, wins — re-running a SUCCEEDED job requires an explicit manual retry).
+     */
+    public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
+        if (request.sourceInstance() == null || request.sourceInstance().isBlank()) {
+            throw new IllegalArgumentException("sourceInstance is required");
+        }
+        if (request.jobs() == null || request.jobs().isEmpty()) {
+            throw new IllegalArgumentException("jobs must not be empty");
+        }
+        String enqueuedBy = request.enqueuedBy() == null ? "listener" : request.enqueuedBy();
+        if (!VALID_ENQUEUED_BY.contains(enqueuedBy)) {
+            throw new IllegalArgumentException("enqueuedBy must be one of " + VALID_ENQUEUED_BY);
+        }
+
+        List<AsyncJob> created = new ArrayList<>();
+        int duplicates = 0;
+        for (AsyncJobSpec spec : request.jobs()) {
+            if (spec.jobType() == null || spec.jobType().isBlank()) {
+                throw new IllegalArgumentException("jobType is required for every job spec");
+            }
+            AsyncJob row = repository.insert(toJob(tenantCode, request.sourceInstance(), enqueuedBy, spec));
+            if (row == null) {
+                duplicates++;
+            } else {
+                created.add(row);
+            }
+        }
+        if (duplicates > 0) {
+            LOG.infof("Enqueue for tenant %s: %d created, %d duplicates (by=%s)",
+                    tenantCode, created.size(), duplicates, enqueuedBy);
+        }
+        // Reconciler-created rows mean the fast path missed an enqueue — keep this
+        // loud so a backfill spike is visible in logs/metrics.
+        if ("reconciler".equals(enqueuedBy) && !created.isEmpty()) {
+            LOG.warnf("Reconciler backfilled %d job(s) for tenant %s — fast-path enqueue missed them",
+                    created.size(), tenantCode);
+        }
+        return new EnqueueJobsResponse(created, duplicates);
+    }
+
+    public List<AsyncJob> claim(ClaimJobsRequest request) {
+        if (request.executor() == null || request.executor().isBlank()) {
+            throw new IllegalArgumentException("executor is required");
+        }
+        if (request.workerId() == null || request.workerId().isBlank()) {
+            throw new IllegalArgumentException("workerId is required");
+        }
+        int limit = request.limit() == null ? DEFAULT_CLAIM_LIMIT : Math.min(request.limit(), MAX_CLAIM_LIMIT);
+        int lease = request.leaseSeconds() == null ? DEFAULT_LEASE_SECONDS : request.leaseSeconds();
+        return repository.claim(request.executor(), request.workerId(), limit, lease, request.chainKey());
+    }
+
+    /**
+     * Records a worker's outcome for a claimed job and computes the next state:
+     * SUCCEEDED/SKIPPED close the job; FAILED schedules a backoff retry (job back
+     * to PENDING) until attempts are exhausted or the failure is non-retryable,
+     * which parks it as FAILED for the babysitter.
+     */
+    public AsyncJob report(String tenantCode, String jobId, ReportJobRequest request) {
+        if (request.outcome() == null || !VALID_OUTCOMES.contains(request.outcome())) {
+            throw new IllegalArgumentException("outcome must be one of " + VALID_OUTCOMES);
+        }
+        AsyncJob job = repository.findByTenantAndId(tenantCode, jobId);
+        if (job == null) {
+            return null;
+        }
+        if (job.state() != JobState.RUNNING) {
+            throw new IllegalStateException(
+                    "Job " + jobId + " is " + job.state() + ", only RUNNING jobs accept reports");
+        }
+
+        JobState newState;
+        OffsetDateTime nextRetryAt = null;
+        boolean failed = "FAILED".equals(request.outcome());
+        if (!failed) {
+            newState = JobState.SUCCEEDED;
+        } else {
+            boolean retryable = !Boolean.FALSE.equals(request.retryable());
+            if (retryable && job.attempts() < job.maxAttempts()) {
+                newState = JobState.PENDING;
+                nextRetryAt = OffsetDateTime.now().plusSeconds(backoffSeconds(job.attempts()));
+            } else {
+                newState = JobState.FAILED;
+            }
+        }
+
+        Map<String, Object> entry = attemptEntry(request.outcome(), request.detail(), request.workerId());
+        AsyncJob updated = repository.report(jobId, newState, nextRetryAt,
+                failed ? request.detail() : null, entry);
+        if (newState == JobState.FAILED) {
+            LOG.errorf("Job %s (%s, correlation=%s) parked as FAILED after %d attempt(s): %s",
+                    jobId, job.jobType(), job.correlationKey(), job.attempts(), request.detail());
+        }
+        return updated;
+    }
+
+    /** Manual babysitter action: resets a parked job so workers pick it up again. */
+    public AsyncJob retry(String tenantCode, String jobId, String actor) {
+        AsyncJob job = repository.findByTenantAndId(tenantCode, jobId);
+        if (job == null) {
+            return null;
+        }
+        if (job.state() == JobState.RUNNING || job.state() == JobState.SUCCEEDED) {
+            throw new IllegalStateException(
+                    "Job " + jobId + " is " + job.state() + " and cannot be manually retried");
+        }
+        return repository.retry(jobId, attemptEntry("RETRY_REQUESTED", "Manual retry", actor));
+    }
+
+    public AsyncJob get(String tenantCode, String jobId) {
+        return repository.findByTenantAndId(tenantCode, jobId);
+    }
+
+    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType, int limit) {
+        if (state != null) {
+            JobState.valueOf(state); // validate
+        }
+        return repository.list(tenantCode, state, correlationKey, jobType, limit);
+    }
+
+    /** Exponential backoff: base * 2^(attempts-1), capped. */
+    private long backoffSeconds(int attempts) {
+        long delay = (long) (retryBaseSeconds * Math.pow(2, Math.max(0, attempts - 1)));
+        return Math.min(delay, retryMaxSeconds);
+    }
+
+    private AsyncJob toJob(String tenantCode, String sourceInstance, String enqueuedBy, AsyncJobSpec spec) {
+        return new AsyncJob(
+                null,
+                tenantCode,
+                sourceInstance,
+                spec.executor() == null ? "ecm" : spec.executor(),
+                spec.jobType(),
+                spec.correlationKey(),
+                spec.chainKey(),
+                spec.chainSequence() == null ? 0 : spec.chainSequence(),
+                spec.dedupeKey(),
+                spec.payload() == null ? Map.of() : spec.payload(),
+                JobState.PENDING,
+                0,
+                spec.maxAttempts() == null ? DEFAULT_MAX_ATTEMPTS : spec.maxAttempts(),
+                null, null, null, null,
+                List.of(),
+                enqueuedBy,
+                null, null);
+    }
+
+    private Map<String, Object> attemptEntry(String outcome, String detail, String by) {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("at", OffsetDateTime.now().toString());
+        entry.put("outcome", outcome);
+        if (detail != null) {
+            entry.put("detail", detail);
+        }
+        if (by != null) {
+            entry.put("by", by);
+        }
+        return entry;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__create_async_jobs.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__create_async_jobs.sql
@@ -1,0 +1,52 @@
+-- Async job ledger: durable record + control plane for jobs executed by external
+-- workers (e.g. ECM delivery integrations). The source system's state remains the
+-- source of truth; this table is the auditable ledger that drives retries and the
+-- babysitter UI. See ecm-coordinator docs/architecture/integration-outbox.md.
+CREATE TABLE miot_integrations.async_jobs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       BIGINT REFERENCES miot_core.tenants(id),
+    tenant_code     VARCHAR(128) NOT NULL,
+    source_instance VARCHAR(128) NOT NULL,
+    executor        VARCHAR(64)  NOT NULL DEFAULT 'ecm',
+    job_type        VARCHAR(64)  NOT NULL,
+    correlation_key VARCHAR(255),
+    chain_key       VARCHAR(512),
+    chain_sequence  INTEGER      NOT NULL DEFAULT 0,
+    dedupe_key      VARCHAR(640),
+    payload         JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    state           VARCHAR(32)  NOT NULL DEFAULT 'PENDING',
+    attempts        INTEGER      NOT NULL DEFAULT 0,
+    max_attempts    INTEGER      NOT NULL DEFAULT 5,
+    next_retry_at   TIMESTAMPTZ,
+    locked_by       VARCHAR(128),
+    locked_until    TIMESTAMPTZ,
+    last_error      TEXT,
+    attempt_history JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    enqueued_by     VARCHAR(32)  NOT NULL DEFAULT 'listener',
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_async_jobs_state CHECK (
+        state IN ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELLED')
+    ),
+    CONSTRAINT chk_async_jobs_enqueued_by CHECK (
+        enqueued_by IN ('listener', 'reconciler', 'manual')
+    )
+);
+
+-- Idempotent enqueue: listener and reconciler converge on the same deterministic key.
+CREATE UNIQUE INDEX idx_async_jobs_dedupe
+    ON miot_integrations.async_jobs(dedupe_key)
+    WHERE dedupe_key IS NOT NULL;
+-- Worker claim scan.
+CREATE INDEX idx_async_jobs_claim
+    ON miot_integrations.async_jobs(executor, state, next_retry_at)
+    WHERE state IN ('PENDING', 'RUNNING');
+-- Chain-ordering gate.
+CREATE INDEX idx_async_jobs_chain
+    ON miot_integrations.async_jobs(chain_key, chain_sequence)
+    WHERE chain_key IS NOT NULL;
+CREATE INDEX idx_async_jobs_correlation
+    ON miot_integrations.async_jobs(correlation_key);
+-- Babysitter UI listing.
+CREATE INDEX idx_async_jobs_tenant_created
+    ON miot_integrations.async_jobs(tenant_code, created_at DESC);

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__create_async_jobs.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__create_async_jobs.sql
@@ -33,9 +33,10 @@ CREATE TABLE miot_integrations.async_jobs (
     )
 );
 
--- Idempotent enqueue: listener and reconciler converge on the same deterministic key.
+-- Idempotent enqueue: listener and reconciler converge on the same deterministic
+-- key. Tenant-scoped so one tenant's keys can never collide with another's.
 CREATE UNIQUE INDEX idx_async_jobs_dedupe
-    ON miot_integrations.async_jobs(dedupe_key)
+    ON miot_integrations.async_jobs(tenant_code, dedupe_key)
     WHERE dedupe_key IS NOT NULL;
 -- Worker claim scan.
 CREATE INDEX idx_async_jobs_claim

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.integrations.domain.AsyncJob;
 import com.microboxlabs.miot.integrations.domain.JobState;
@@ -12,6 +11,7 @@ import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +31,17 @@ class AsyncJobServiceTest {
 
         assertEquals(JobState.PENDING, repo.reportedState);
         assertNotNull(repo.reportedNextRetryAt);
-        // attempt 1 → base * 2^0 = 60s
-        assertTrue(repo.reportedNextRetryAt.isAfter(OffsetDateTime.now().plusSeconds(BASE_SECONDS - 10)));
-        assertTrue(repo.reportedNextRetryAt.isBefore(OffsetDateTime.now().plusSeconds(BASE_SECONDS + 10)));
+    }
+
+    @Test
+    void backoffDoublesPerAttemptAndIsCapped() throws Exception {
+        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+        Method backoff = AsyncJobService.class.getDeclaredMethod("backoffSeconds", int.class);
+        backoff.setAccessible(true);
+
+        assertEquals(60L, backoff.invoke(service, 1));   // base * 2^0
+        assertEquals(120L, backoff.invoke(service, 2));  // base * 2^1
+        assertEquals(3600L, backoff.invoke(service, 10)); // capped at max
     }
 
     @Test
@@ -72,9 +80,10 @@ class AsyncJobServiceTest {
     void reportRejectsJobsThatAreNotRunning() {
         var repo = new FakeRepository(jobInState(JobState.PENDING, 0, 5));
         var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var request = failed();
 
         assertThrows(IllegalStateException.class,
-                () -> service.report("t", "job-1", failed()));
+                () -> service.report("t", "job-1", request));
     }
 
     @Test
@@ -88,13 +97,13 @@ class AsyncJobServiceTest {
     @Test
     void enqueueValidatesRequiredFields() {
         var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+        var missingSource = new EnqueueJobsRequest(null, "listener", List.of(spec()));
+        var emptyJobs = new EnqueueJobsRequest("ecm-1", "listener", List.of());
+        var bogusActor = new EnqueueJobsRequest("ecm-1", "bogus", List.of(spec()));
 
-        assertThrows(IllegalArgumentException.class,
-                () -> service.enqueue("t", new EnqueueJobsRequest(null, "listener", List.of(spec()))));
-        assertThrows(IllegalArgumentException.class,
-                () -> service.enqueue("t", new EnqueueJobsRequest("ecm-1", "listener", List.of())));
-        assertThrows(IllegalArgumentException.class,
-                () -> service.enqueue("t", new EnqueueJobsRequest("ecm-1", "bogus", List.of(spec()))));
+        assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", missingSource));
+        assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", emptyJobs));
+        assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", bogusActor));
     }
 
     @Test

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.microboxlabs.miot.integrations.domain.AsyncJob;
 import com.microboxlabs.miot.integrations.domain.JobState;
 import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
@@ -60,7 +61,7 @@ class AsyncJobServiceTest {
         var repo = new FakeRepository(runningJob(1, 5));
         var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
 
-        service.report("t", "job-1", new ReportJobRequest("w", "FAILED", "bad config", false));
+        service.report("t", "job-1", new ReportJobRequest("w", "FAILED", "bad config", false, null));
 
         assertEquals(JobState.FAILED, repo.reportedState);
     }
@@ -70,7 +71,7 @@ class AsyncJobServiceTest {
         var repo = new FakeRepository(runningJob(1, 5));
         var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
 
-        service.report("t", "job-1", new ReportJobRequest("w", "SKIPPED", "already delivered", null));
+        service.report("t", "job-1", new ReportJobRequest("w", "SKIPPED", "already delivered", null, null));
 
         assertEquals(JobState.SUCCEEDED, repo.reportedState);
         assertNull(repo.reportedNextRetryAt);
@@ -126,10 +127,54 @@ class AsyncJobServiceTest {
         assertEquals(1, response.duplicates());
     }
 
+    @Test
+    void nullRequestBodiesAreRejected() {
+        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+
+        assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", null));
+        assertThrows(IllegalArgumentException.class, () -> service.claim("t", null));
+        assertThrows(IllegalArgumentException.class, () -> service.report("t", "job-1", null));
+    }
+
+    @Test
+    void claimScopesByTenantAndValidatesBounds() {
+        var repo = new FakeRepository(null);
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var badLimit = new ClaimJobsRequest("ecm", "w1", 0, null, null);
+        var badLease = new ClaimJobsRequest("ecm", "w1", null, 0, null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.claim("t", badLimit));
+        assertThrows(IllegalArgumentException.class, () -> service.claim("t", badLease));
+
+        service.claim("tenant-1", new ClaimJobsRequest("ecm", "w1", 5, 60, null));
+        assertEquals("tenant-1", repo.claimedTenant);
+    }
+
+    @Test
+    void staleReportIsRejectedWhenLeaseCasFails() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        repo.reportStale = true;
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var request = failed();
+
+        assertThrows(IllegalStateException.class, () -> service.report("t", "job-1", request));
+    }
+
+    @Test
+    void reportEchoesWorkerAndAttemptIntoLeaseCas() {
+        var repo = new FakeRepository(runningJob(2, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", new ReportJobRequest("worker-1", "SUCCEEDED", "ok", null, 2));
+
+        assertEquals("worker-1", repo.reportedWorkerId);
+        assertEquals(2, repo.reportedExpectedAttempts);
+    }
+
     // -----------------------------------------------------------------------
 
     private static ReportJobRequest failed() {
-        return new ReportJobRequest("worker-1", "FAILED", "Alerce 500", null);
+        return new ReportJobRequest("worker-1", "FAILED", "Alerce 500", null, null);
     }
 
     private static AsyncJobSpec spec() {
@@ -152,6 +197,10 @@ class AsyncJobServiceTest {
         private final AsyncJob existing;
         JobState reportedState;
         OffsetDateTime reportedNextRetryAt;
+        String reportedWorkerId;
+        Integer reportedExpectedAttempts;
+        String claimedTenant;
+        boolean reportStale;
 
         FakeRepository(AsyncJob existing) {
             super(null);
@@ -164,11 +213,20 @@ class AsyncJobServiceTest {
         }
 
         @Override
-        public AsyncJob report(String jobId, JobState newState, OffsetDateTime nextRetryAt,
-                String lastError, Map<String, Object> attemptEntry) {
+        public AsyncJob report(String jobId, String workerId, int expectedAttempts, JobState newState,
+                OffsetDateTime nextRetryAt, String lastError, Map<String, Object> attemptEntry) {
             this.reportedState = newState;
             this.reportedNextRetryAt = nextRetryAt;
-            return existing;
+            this.reportedWorkerId = workerId;
+            this.reportedExpectedAttempts = expectedAttempts;
+            return reportStale ? null : existing;
+        }
+
+        @Override
+        public List<AsyncJob> claim(String tenantCode, String executor, String workerId,
+                int limit, int leaseSeconds, String chainKey) {
+            this.claimedTenant = tenantCode;
+            return List.of();
         }
 
         @Override

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -1,0 +1,175 @@
+package com.microboxlabs.miot.integrations.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AsyncJobServiceTest {
+
+    private static final int BASE_SECONDS = 60;
+    private static final int MAX_SECONDS = 3600;
+
+    @Test
+    void reportFailureSchedulesBackoffRetryWhileAttemptsRemain() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("tenant-less-id", "job-1", failed());
+
+        assertEquals(JobState.PENDING, repo.reportedState);
+        assertNotNull(repo.reportedNextRetryAt);
+        // attempt 1 → base * 2^0 = 60s
+        assertTrue(repo.reportedNextRetryAt.isAfter(OffsetDateTime.now().plusSeconds(BASE_SECONDS - 10)));
+        assertTrue(repo.reportedNextRetryAt.isBefore(OffsetDateTime.now().plusSeconds(BASE_SECONDS + 10)));
+    }
+
+    @Test
+    void reportFailureParksJobWhenAttemptsExhausted() {
+        var repo = new FakeRepository(runningJob(5, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", failed());
+
+        assertEquals(JobState.FAILED, repo.reportedState);
+        assertNull(repo.reportedNextRetryAt);
+    }
+
+    @Test
+    void reportNonRetryableFailureParksImmediately() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", new ReportJobRequest("w", "FAILED", "bad config", false));
+
+        assertEquals(JobState.FAILED, repo.reportedState);
+    }
+
+    @Test
+    void reportSkippedClosesJobAsSucceeded() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", new ReportJobRequest("w", "SKIPPED", "already delivered", null));
+
+        assertEquals(JobState.SUCCEEDED, repo.reportedState);
+        assertNull(repo.reportedNextRetryAt);
+    }
+
+    @Test
+    void reportRejectsJobsThatAreNotRunning() {
+        var repo = new FakeRepository(jobInState(JobState.PENDING, 0, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.report("t", "job-1", failed()));
+    }
+
+    @Test
+    void retryRejectsSucceededJobs() {
+        var repo = new FakeRepository(jobInState(JobState.SUCCEEDED, 1, 5));
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        assertThrows(IllegalStateException.class, () -> service.retry("t", "job-1", "actor"));
+    }
+
+    @Test
+    void enqueueValidatesRequiredFields() {
+        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.enqueue("t", new EnqueueJobsRequest(null, "listener", List.of(spec()))));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.enqueue("t", new EnqueueJobsRequest("ecm-1", "listener", List.of())));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.enqueue("t", new EnqueueJobsRequest("ecm-1", "bogus", List.of(spec()))));
+    }
+
+    @Test
+    void enqueueCountsDuplicates() {
+        var repo = new FakeRepository(null) {
+            private int calls = 0;
+
+            @Override
+            public AsyncJob insert(AsyncJob job) {
+                // first insert wins, second hits the dedupe key
+                return ++calls == 1 ? job : null;
+            }
+        };
+        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+
+        var response = service.enqueue("t",
+                new EnqueueJobsRequest("ecm-1", "reconciler", List.of(spec(), spec())));
+
+        assertEquals(1, response.created().size());
+        assertEquals(1, response.duplicates());
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static ReportJobRequest failed() {
+        return new ReportJobRequest("worker-1", "FAILED", "Alerce 500", null);
+    }
+
+    private static AsyncJobSpec spec() {
+        return new AsyncJobSpec("alerce_arrival", "ecm", "v1", "chain-1", 0, "dk-1", Map.of(), null);
+    }
+
+    private static AsyncJob runningJob(int attempts, int maxAttempts) {
+        return jobInState(JobState.RUNNING, attempts, maxAttempts);
+    }
+
+    private static AsyncJob jobInState(JobState state, int attempts, int maxAttempts) {
+        return new AsyncJob("job-1", "t", "ecm-1", "ecm", "alerce_arrival", "v1",
+                "chain-1", 0, "dk-1", Map.of(), state, attempts, maxAttempts,
+                null, null, null, null, List.of(), "listener", null, null);
+    }
+
+    /** Repository stub capturing the state transition computed by the service. */
+    private static class FakeRepository extends AsyncJobRepository {
+
+        private final AsyncJob existing;
+        JobState reportedState;
+        OffsetDateTime reportedNextRetryAt;
+
+        FakeRepository(AsyncJob existing) {
+            super(null);
+            this.existing = existing;
+        }
+
+        @Override
+        public AsyncJob findByTenantAndId(String tenantCode, String jobId) {
+            return existing;
+        }
+
+        @Override
+        public AsyncJob report(String jobId, JobState newState, OffsetDateTime nextRetryAt,
+                String lastError, Map<String, Object> attemptEntry) {
+            this.reportedState = newState;
+            this.reportedNextRetryAt = nextRetryAt;
+            return existing;
+        }
+
+        @Override
+        public AsyncJob insert(AsyncJob job) {
+            return job;
+        }
+
+        @Override
+        public AsyncJob retry(String jobId, Map<String, Object> attemptEntry) {
+            return existing;
+        }
+    }
+}


### PR DESCRIPTION
Closes #643. Companion PR: microboxlabs/ecm-coordinator#288 (integration outbox Phase 1, issue microboxlabs/ecm-coordinator#287) — ECM is the first worker/enqueuer of this ledger.

## What

`miot_integrations.async_jobs` — a tenant-scoped, auditable ledger + control plane for jobs executed by external workers (ECM delivery integrations first). quarkus-srv never executes jobs; it owns state, retry policy, audit, and (Phase 2) the babysitter UI.

- **`V0.6.1__create_async_jobs.sql`** — generic schema: `job_type` + `executor` + `correlation_key` + JSONB `payload`; `tenant_code` + `source_instance` (multi-instance ready); `chain_key`/`chain_sequence` for ordered fail-fast-resume chains; `dedupe_key` UNIQUE for idempotent enqueue; lease columns; `attempt_history` JSONB; `enqueued_by` (`listener|reconciler|manual`) — reconciler-created rows are the backfill alarm signal.
- **`AsyncJobRepository`** — single-statement claim: CTE + `FOR UPDATE SKIP LOCKED`, chain-head gate (only the lowest unfinished sequence is claimable), expired-lease reclaim, attempts increment **at claim** (a crashed worker's attempt still counts — poison-pill protection).
- **`AsyncJobService`** — state machine: `SUCCEEDED`/`SKIPPED` close; `FAILED` → `PENDING` with exponential backoff (`base·2^(n−1)`, default 60 s base / 1 h cap) until attempts exhausted or non-retryable → parked `FAILED` awaiting manual retry; reconciler backfills logged at WARN.
- **`OrgAsyncJobsResource`** — OIDC org-scoped REST under `/api/v1/orgs/{org}/integrations/jobs`: `POST /enqueue` (batch, idempotent), `POST /claim`, `POST /{id}/report`, `POST /{id}/retry` (the future *Reenviar* button), `GET` list/detail.

Deliberately a **generic schema, not a generic job framework** — one executor, five job types today.

## Tests

`AsyncJobServiceTest` (8) — backoff scheduling, attempts-exhausted parking, non-retryable parking, SKIPPED→SUCCEEDED, RUNNING-only reports, retry guards, enqueue validation, duplicate counting. Full `miot-integrations` suite: 18/18 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds integrated async job management (enqueue, claim, report, retry) with protected tenant-scoped endpoints
  * Persistent job ledger with lifecycle states, attempt history, error tracking, and searchable filters (state, correlation key, type) with bounded limits
  * Automatic retry with configurable exponential backoff and manual retry controls

* **Tests**
  * New unit tests covering report transitions, retry/backoff behavior, enqueue validation, dedupe handling, and claim/report validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->