### PR TITLE
fix(app): make /api/map resilient to upstream 429 spike-arrest (#645)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/map/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression coverage for the map-positions BFF.
+ *
+ * The upstream gateway rate-limits this RPC by concurrency and rejects bursts
+ * with `429 "Spike arrest: too many concurrent requests"`. The route must:
+ *   - never surface that retryable backpressure as a hard 500,
+ *   - collapse concurrent callers into a single upstream request, and
+ *   - fall back to the last-known payload when the upstream is spiking.
+ *
+ * The route keeps module-level single-flight + cache state, so each test loads
+ * a fresh copy via `vi.resetModules()` + dynamic import.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const authMock = vi.fn();
+
+vi.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => authMock(...args),
+}));
+
+// Stub the M2M token client so the route does not hit the real login endpoint.
+vi.mock("@/features/common/providers/sreamhub-api/streamhub-api.provider", () => ({
+  AuthToken: class {
+    async getToken(): Promise<string> {
+      return "test-token";
+    }
+  },
+}));
+
+type ResponseInit = {
+  ok: boolean;
+  status: number;
+  jsonData?: unknown;
+  text?: string;
+  headers?: Record<string, string>;
+};
+
+function makeResponse({
+  ok,
+  status,
+  jsonData,
+  text = "",
+  headers = {},
+}: ResponseInit) {
+  const lower = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return {
+    ok,
+    status,
+    json: async () => jsonData,
+    text: async () => text,
+    headers: { get: (name: string) => lower[name.toLowerCase()] ?? null },
+  };
+}
+
+async function loadRoute() {
+  vi.resetModules();
+  return import("./route");
+}
+
+const fetchMock = vi.fn();
+
+describe("GET /api/map", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    authMock.mockReset();
+    authMock.mockResolvedValue({ user: { email: "u@example.com" } });
+    process.env.STREAMHUB_URL = "https://gateway.example.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without surfacing upstream when unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+    const { GET } = await loadRoute();
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the upstream positions on success", async () => {
+    const positions = [{ id: "asset-1", location: "0101000000" }];
+    fetchMock.mockResolvedValue(
+      makeResponse({ ok: true, status: 200, jsonData: { data: positions } })
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(positions);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT turn a 429 spike-arrest into a 500 (regression)", async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse({
+        ok: false,
+        status: 429,
+        text: "Spike arrest: too many concurrent requests, slow down.",
+      })
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET();
+
+    // The bug: any non-OK upstream became a hard 500. A 429 is retryable
+    // backpressure and must surface as a retryable status instead.
+    expect(response.status).not.toBe(500);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("retries a 429 with backoff before giving up", async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeResponse({ ok: false, status: 429, text: "slow down" }))
+      .mockResolvedValueOnce(makeResponse({ ok: false, status: 429, text: "slow down" }))
+      .mockResolvedValueOnce(
+        makeResponse({ ok: true, status: 200, jsonData: { data: [{ id: "a" }] } })
+      );
+    const { GET } = await loadRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual([{ id: "a" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("coalesces concurrent callers into a single upstream request", async () => {
+    // A single pending upstream response both callers must share.
+    let resolveFetch: (value: unknown) => void = () => {};
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    fetchMock.mockReturnValue(pending);
+    const { GET } = await loadRoute();
+
+    const first = GET();
+    const second = GET();
+    // Wait until the single upstream call is actually in flight before settling.
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    resolveFetch(
+      makeResponse({ ok: true, status: 200, jsonData: { data: [{ id: "x" }] } })
+    );
+
+    const [r1, r2] = await Promise.all([first, second]);
+
+    expect(await r1.json()).toEqual([{ id: "x" }]);
+    expect(await r2.json()).toEqual([{ id: "x" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the last-known positions when the upstream starts spiking", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    let clock = 1_000_000;
+    nowSpy.mockImplementation(() => clock);
+
+    const positions = [{ id: "asset-1" }];
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ ok: true, status: 200, jsonData: { data: positions } })
+    );
+    const { GET } = await loadRoute();
+
+    // Warm the cache.
+    const ok = await GET();
+    expect(await ok.json()).toEqual(positions);
+
+    // Advance past the TTL so the next call revalidates, but now the gateway
+    // is rejecting with 429. The map keeps its last-known positions.
+    clock += 60_000;
+    fetchMock.mockResolvedValue(
+      makeResponse({ ok: false, status: 429, text: "Spike arrest" })
+    );
+
+    const stale = await GET();
+
+    expect(stale.status).toBe(200);
+    expect(await stale.json()).toEqual(positions);
+    expect(stale.headers.get("x-map-stale")).toBe("1");
+  });
+});

--- a/turbo-repo/apps/app/src/app/api/map/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.test.ts
@@ -188,4 +188,64 @@ describe("GET /api/map", () => {
     expect(await stale.json()).toEqual(positions);
     expect(stale.headers.get("x-map-stale")).toBe("1");
   });
+
+  it("does NOT serve stale cache for a non-retryable (4xx) upstream error", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    let clock = 2_000_000;
+    nowSpy.mockImplementation(() => clock);
+
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ ok: true, status: 200, jsonData: { data: [{ id: "warm" }] } })
+    );
+    const { GET } = await loadRoute();
+    const warm = await GET();
+    expect(await warm.json()).toEqual([{ id: "warm" }]);
+
+    // Past the TTL, the upstream now fails with a non-retryable 400. A hard
+    // contract/auth break must surface, not be masked by stale data.
+    clock += 60_000;
+    fetchMock.mockResolvedValue(
+      makeResponse({ ok: false, status: 400, text: "bad request" })
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("x-map-stale")).toBeNull();
+  });
+
+  it("treats a malformed 200 (no data field) as a fault, not a cached success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ ok: true, status: 200, jsonData: { unexpected: "shape" } })
+    );
+    const { GET } = await loadRoute();
+
+    const bad = await GET();
+    expect(bad.status).toBe(503); // 502 upstream fault -> retryable, no cache
+
+    // The malformed payload must not have been cached: the next call hits the
+    // upstream again and returns the real data.
+    fetchMock.mockResolvedValue(
+      makeResponse({ ok: true, status: 200, jsonData: { data: [{ id: "real" }] } })
+    );
+    const good = await GET();
+    expect(await good.json()).toEqual([{ id: "real" }]);
+  });
+
+  it("does not leak the upstream error body to the client", async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse({
+        ok: false,
+        status: 500,
+        text: "SECRET pg error: relation private_table does not exist",
+      })
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(JSON.stringify(body)).not.toContain("SECRET");
+    expect(body.errorMessage).toBe("Map positions are temporarily unavailable");
+  });
 });

--- a/turbo-repo/apps/app/src/app/api/map/route.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.ts
@@ -35,10 +35,8 @@ const CACHE_TTL_MS = 5_000;
 const MAX_RETRIES = 2;
 const BASE_BACKOFF_MS = 250;
 
-type MapPayload = unknown;
-
-let cachedPayload: { data: MapPayload; ts: number } | null = null;
-let inFlight: Promise<MapPayload> | null = null;
+let cachedPayload: { data: unknown; ts: number } | null = null;
+let inFlight: Promise<unknown> | null = null;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -49,7 +47,7 @@ const isRetryableStatus = (status: number) => status === 429 || status >= 500;
  * exponential backoff (honoring `Retry-After` when present). Throws a tagged
  * error carrying the final upstream status on persistent failure.
  */
-async function fetchPositions(): Promise<MapPayload> {
+async function fetchPositions(): Promise<unknown> {
   const token = await authToken.getToken();
   const url = `${SYMPTOMS_API_URL}?p_is_dev=true`;
 
@@ -67,7 +65,8 @@ async function fetchPositions(): Promise<MapPayload> {
 
     if (response.ok) {
       const json = await response.json();
-      return json.data; //TODO: ask to standardize the response
+      // Upstream wraps the rows as { data: [...] }; unwrap to the array.
+      return json.data;
     }
 
     lastStatus = response.status;

--- a/turbo-repo/apps/app/src/app/api/map/route.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.ts
@@ -68,7 +68,7 @@ async function fetchPositions(): Promise<unknown> {
       const json: unknown = await response.json();
       // Upstream wraps the rows as { data: [...] }; unwrap to the array.
       if (json && typeof json === "object" && "data" in json) {
-        return (json as { data: unknown }).data;
+        return json.data;
       }
       // Malformed 200 (missing `data`): treat as an upstream fault instead of
       // caching `undefined` as a successful, empty map.

--- a/turbo-repo/apps/app/src/app/api/map/route.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.ts
@@ -17,47 +17,120 @@ const config: AuthTokenConfig = {
 
 const authToken = new AuthToken(config);
 
+/**
+ * The upstream gateway (APISIX) rate-limits this RPC by concurrency and rejects
+ * bursts with `429 "Spike arrest: too many concurrent requests"`. A 429 is
+ * backpressure, not a server fault, so we must not surface it as a 500.
+ *
+ * Three things keep a transient spike from breaking the map:
+ *   1. Single-flight: simultaneous requests (map page + sidebar count + dashlet
+ *      + focus/reconnect revalidations across tabs) share ONE upstream call,
+ *      so the FE stops generating the concurrency the limiter is rejecting.
+ *   2. Short TTL cache: identical bursts within the window are served without
+ *      touching the upstream at all.
+ *   3. Bounded backoff retry on 429/5xx, then fall back to the last-known
+ *      payload (or a retryable 503) instead of a hard 500.
+ */
+const CACHE_TTL_MS = 5_000;
+const MAX_RETRIES = 2;
+const BASE_BACKOFF_MS = 250;
+
+type MapPayload = unknown;
+
+let cachedPayload: { data: MapPayload; ts: number } | null = null;
+let inFlight: Promise<MapPayload> | null = null;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isRetryableStatus = (status: number) => status === 429 || status >= 500;
+
+/**
+ * Fetch the last-known positions, retrying transient gateway backpressure with
+ * exponential backoff (honoring `Retry-After` when present). Throws a tagged
+ * error carrying the final upstream status on persistent failure.
+ */
+async function fetchPositions(): Promise<MapPayload> {
+  const token = await authToken.getToken();
+  const url = `${SYMPTOMS_API_URL}?p_is_dev=true`;
+
+  let lastStatus = 0;
+  let lastBody = "";
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        accept: "application/json",
+        Authorization: ` Bearer ${token}`,
+      },
+      cache: "no-store",
+    });
+
+    if (response.ok) {
+      const json = await response.json();
+      return json.data; //TODO: ask to standardize the response
+    }
+
+    lastStatus = response.status;
+    lastBody = await response.text();
+
+    if (!isRetryableStatus(response.status) || attempt === MAX_RETRIES) {
+      break;
+    }
+
+    const retryAfter = Number(response.headers.get("retry-after"));
+    const backoff =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1_000
+        : BASE_BACKOFF_MS * 2 ** attempt;
+    await sleep(backoff);
+  }
+
+  console.error("API Error Details:", {
+    responseUrl: url,
+    status: lastStatus,
+    body: lastBody,
+  });
+  const error = new Error(
+    `HTTP error! status: ${lastStatus}, body: ${lastBody}`
+  ) as Error & { status?: number };
+  error.status = lastStatus;
+  throw error;
+}
+
 export async function GET() {
   const session = await auth();
   if (!session) {
-    return NextResponse.json({
-      status: 401,
-    });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Serve a recent payload to collapse request bursts before they reach the
+  // concurrency-limited gateway.
+  if (cachedPayload && Date.now() - cachedPayload.ts < CACHE_TTL_MS) {
+    return NextResponse.json(cachedPayload.data);
+  }
+
   try {
-    const token = await authToken.getToken();
-    const params = new URLSearchParams();
-    //params.set("lastUpdatedSince", new Date().toISOString());
-    params.set("p_is_dev", "true");
+    // Single-flight: concurrent callers await the same upstream request.
+    inFlight ??= fetchPositions().finally(() => {
+      inFlight = null;
+    });
+    const data = await inFlight;
+    cachedPayload = { data, ts: Date.now() };
+    return NextResponse.json(data);
+  } catch (error) {
+    const status = (error as { status?: number }).status ?? 500;
 
-    const response = await fetch(
-      SYMPTOMS_API_URL + "?" + params.toString(),
-      {
-        headers: {
-          accept: "application/json",
-          Authorization: ` Bearer ${token}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      console.error("API Error Details:", {
-        responseUrl: response.url,
-        status: response.status,
-        statusText: response.statusText,
-        headers: Object.fromEntries(response.headers.entries()),
-        body: errorBody,
+    // A transient gateway spike should not blank the map: prefer the last-known
+    // positions when we have them, even if slightly stale.
+    if (cachedPayload) {
+      return NextResponse.json(cachedPayload.data, {
+        headers: { "x-map-stale": "1" },
       });
-      throw new Error(
-        `HTTP error! status: ${response.status}, body: ${errorBody}`
-      );
     }
 
-    const data = await response.json();
-
-    return NextResponse.json(data.data); //TODO: ask to standardize the response
-  } catch (error) {
+    // No cache to fall back on. Return a *retryable* status for backpressure so
+    // the client backs off and retries instead of treating it as a hard 500.
+    const retryable = isRetryableStatus(status);
     return NextResponse.json(
       {
         error: "Failed to fetch map positions",
@@ -66,7 +139,10 @@ export async function GET() {
             ? (error as { message: string }).message
             : String(error),
       },
-      { status: 500 }
+      {
+        status: retryable ? 503 : 500,
+        headers: retryable ? { "Retry-After": "5" } : undefined,
+      }
     );
   }
 }

--- a/turbo-repo/apps/app/src/app/api/map/route.ts
+++ b/turbo-repo/apps/app/src/app/api/map/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
+import { mapLogger } from "@/lib/logger";
 
 const SYMPTOMS_API_URL = `${process.env.STREAMHUB_URL}/rpc/api_modular_map_positions`;
 
@@ -64,9 +65,16 @@ async function fetchPositions(): Promise<unknown> {
     });
 
     if (response.ok) {
-      const json = await response.json();
+      const json: unknown = await response.json();
       // Upstream wraps the rows as { data: [...] }; unwrap to the array.
-      return json.data;
+      if (json && typeof json === "object" && "data" in json) {
+        return (json as { data: unknown }).data;
+      }
+      // Malformed 200 (missing `data`): treat as an upstream fault instead of
+      // caching `undefined` as a successful, empty map.
+      lastStatus = 502;
+      lastBody = "unexpected upstream payload shape";
+      break;
     }
 
     lastStatus = response.status;
@@ -84,13 +92,14 @@ async function fetchPositions(): Promise<unknown> {
     await sleep(backoff);
   }
 
-  console.error("API Error Details:", {
-    responseUrl: url,
-    status: lastStatus,
-    body: lastBody,
-  });
+  // Log the full upstream detail server-side only; never echo the raw body to
+  // the client (it can carry internal gateway/db error text).
+  mapLogger.error(
+    { responseUrl: url, status: lastStatus, body: lastBody },
+    "Map upstream request failed"
+  );
   const error = new Error(
-    `HTTP error! status: ${lastStatus}, body: ${lastBody}`
+    `Map upstream request failed with status ${lastStatus}`
   ) as Error & { status?: number };
   error.status = lastStatus;
   throw error;
@@ -118,25 +127,25 @@ export async function GET() {
     return NextResponse.json(data);
   } catch (error) {
     const status = (error as { status?: number }).status ?? 500;
+    const retryable = isRetryableStatus(status);
 
     // A transient gateway spike should not blank the map: prefer the last-known
-    // positions when we have them, even if slightly stale.
-    if (cachedPayload) {
+    // positions when we have them, even if slightly stale. Only for *retryable*
+    // faults — a non-retryable error (e.g. a 4xx contract/auth break) must
+    // surface, not hide behind stale data indefinitely.
+    if (retryable && cachedPayload) {
       return NextResponse.json(cachedPayload.data, {
         headers: { "x-map-stale": "1" },
       });
     }
 
-    // No cache to fall back on. Return a *retryable* status for backpressure so
-    // the client backs off and retries instead of treating it as a hard 500.
-    const retryable = isRetryableStatus(status);
+    // Return a *retryable* status for backpressure so the client backs off and
+    // retries instead of treating it as a hard 500. Keep the client message
+    // generic; the upstream detail is logged server-side only.
     return NextResponse.json(
       {
         error: "Failed to fetch map positions",
-        errorMessage:
-          typeof error === "object" && error !== null && "message" in error
-            ? (error as { message: string }).message
-            : String(error),
+        errorMessage: "Map positions are temporarily unavailable",
       },
       {
         status: retryable ? 503 : 500,

--- a/turbo-repo/apps/app/src/app/sign-in/page.tsx
+++ b/turbo-repo/apps/app/src/app/sign-in/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { defaultLocale } from "@/features/i18n/tr.service";
+
+/**
+ * Lang-less sign-in shim.
+ *
+ * NextAuth's `pages.signIn`/`pages.error` are static strings ("/app/sign-in"),
+ * and a few call sites redirect to "/sign-in" without a locale. The real
+ * sign-in page lives under `[lang]/sign-in`, so "/app/sign-in" would otherwise
+ * match `[lang]` with `lang="sign-in"` and render the Next.js boilerplate page.
+ *
+ * This static route takes precedence over the dynamic `[lang]` segment for the
+ * exact "/sign-in" path and forwards to the localized sign-in page, preserving
+ * query params (e.g. `error=AccessDenied`, `callbackUrl`).
+ */
+export default async function SignInLocaleRedirect({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === "string") qs.set(key, value);
+    else if (Array.isArray(value) && value[0]) qs.set(key, value[0]);
+  }
+  const query = qs.toString();
+  redirect(`/${defaultLocale}/sign-in${query ? `?${query}` : ""}`);
+}

--- a/turbo-repo/apps/app/src/app/sign-in/page.tsx
+++ b/turbo-repo/apps/app/src/app/sign-in/page.tsx
@@ -25,5 +25,6 @@ export default async function SignInLocaleRedirect({
     else if (Array.isArray(value) && value[0]) qs.set(key, value[0]);
   }
   const query = qs.toString();
-  redirect(`/${defaultLocale}/sign-in${query ? `?${query}` : ""}`);
+  const suffix = query ? `?${query}` : "";
+  redirect(`/${defaultLocale}/sign-in${suffix}`);
 }

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -462,6 +462,10 @@ export function useMapPositions() {
     {
       revalidateOnFocus: true,
       revalidateOnReconnect: true,
+      // Collapse focus/reconnect-driven refetches into one call within the
+      // window — this endpoint is concurrency-limited upstream (429 spike
+      // arrest), so duplicate bursts must not reach it.
+      dedupingInterval: 10_000,
     }
   );
 

--- a/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { SidebarProvider } from "@/features/sidebar/context/sidebar-context";
 import { LayoutContent } from "@/features/layout/components/layout-content";
@@ -22,6 +23,12 @@ export default async function SecuredLayout({
   const [dict, dictionary] = await getDictionary(lang);
   const navBarMessages = buildNavBarMessages({ messages: dict });
   const session = await auth();
+  // No session (signed out, or an OAuth sign-in denied by the email-domain
+  // allowlist): redirect to sign-in instead of dereferencing a null session
+  // below, which would throw and crash the whole secured render.
+  if (!session?.user) {
+    redirect(`/${lang}/sign-in`);
+  }
   const initialOrgLogo = await getPublicOrgLogo();
   return (
     <RuntimeConfigProvider>
@@ -29,7 +36,7 @@ export default async function SecuredLayout({
         <KioskShell>
           <SseListener
             dictionary={dictionary}
-            tenantId={session!.user!.email}
+            tenantId={session.user.email}
           />
           <SecuredNavbar
             messages={navBarMessages}


### PR DESCRIPTION
Closes #645

## Problem

The map BFF (`turbo-repo/apps/app/src/app/api/map/route.ts`) turned a **transient upstream `429`** into a hard **HTTP 500**, breaking the geographic map page.

The APISIX gateway rate-limits `rpc/api_modular_map_positions` by **concurrency**:

```
429  {"error_msg":"Spike arrest: too many concurrent requests, slow down."}
```

Two compounding defects:
1. **Backpressure treated as fatal** — any non-OK upstream (incl. a retryable `429 "slow down"`) was thrown and returned as `500`.
2. **No concurrency damping** — map page + sidebar count + dashboard dashlet (all via `useMapPositions`) plus SWR `revalidateOnFocus`/`reconnect` each opened their own upstream connection and tripped the limiter; SWR's default error-retry then amplified it (feedback loop).

## Fix

`src/app/api/map/route.ts`:
- **Single-flight** — concurrent callers share one upstream request.
- **Short TTL cache (5s)** — identical bursts skip the upstream.
- **Bounded 429/5xx retry** with exponential backoff (honors `Retry-After`).
- **Stale fallback** — on a persistent spike, serve last-known positions (`200` + `x-map-stale`); only when there is no cache, return a **retryable `503`** (+ `Retry-After`) instead of a `500`.
- Proper `401` when unauthenticated (was `200` + `{status:401}`, which broke the client's `.map()`).

`src/features/common/providers/client-api.provider.ts`:
- `dedupingInterval: 10_000` on `useMapPositions` so focus/reconnect refetches don't burst the concurrency-limited endpoint.

## Tests

`src/app/api/map/route.test.ts` (9 tests): `429→503` (not 500), retry-with-backoff, concurrent-call coalescing, stale fallback, success, unauthenticated 401, **plus** non-retryable-error → no stale, malformed-`200` → not cached, and no upstream body leaked to the client.

Proven meaningful: the 429 / coalescing / stale tests **fail** against the old route (return 500) and **pass** with the fix. `check-types` clean; `sidebar-navigation-context` consumer tests green.

## Also in this PR (bundled — see scope note)

Two follow-on changes ride along with the map fix:

**Signed-out crash + sign-in routing** (`secured-layout.tsx`, new `app/sign-in/page.tsx`)
- `SecuredLayout` dereferenced `session!.user!.email` while rendering, so any signed-out request to a secured route — or an OAuth sign-in denied by the new `AUTH_ALLOWED_EMAIL_DOMAINS` allowlist — **crashed the whole secured render** instead of redirecting. Now guards the null session and redirects to `/<lang>/sign-in`.
- Adds a lang-less `/sign-in` shim that forwards to the localized sign-in page (preserving `error`/`callbackUrl`), so NextAuth's `pages.signIn`/`pages.error` (`/app/sign-in`, no locale) no longer land on the Next.js boilerplate page.

**Review hardening** (`route.ts`, addressing CodeRabbit)
- Upstream error bodies no longer reach the client (logged via `mapLogger`/Pino server-side; generic client message).
- Stale cache served only for retryable faults; a non-retryable 4xx surfaces.
- 200 payload shape validated before unwrapping `.data`.

> **Scope note:** CodeRabbit flagged the sign-in / secured-layout changes as out-of-scope for the 429 objective — correct, they're a separate signed-out-handling fix. They're bundled here intentionally rather than force-pushed into a split PR. Reviewable as distinct commits: `2af4fa083` (auth), `775d9a80e` (SonarCloud), `4a63d5844` (hardening).

Still **not** addressed: allowlisted-domain logins being denied (suspected empty `user.email` from Auth0 when an audience is set) — pending denial-log confirmation.

## Out of scope / follow-up

- Consolidate `/api/map` onto the canonical `pgrest-client.fetchLastPositions()` and drop the duplicate `AuthToken` singleton.
- Confirm the APISIX `limit-conn` threshold for `p_is_dev=true` is reasonable.
- Allowlisted-domain sign-in denial (Auth0 `user.email` extraction) — see note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized sign-in redirect that preserves query parameters.

* **Bug Fixes**
  * Map endpoint better handles upstream backpressure: retries transient errors, coalesces concurrent callers, and returns last-known positions with a stale indicator when appropriate.
  * Added null-safe session guard to prevent runtime redirect errors.

* **Improvements**
  * Reduced duplicate map fetches by collapsing rapid refetches.

* **Tests**
  * Added regression tests for map endpoint behaviors (retries, coalescing, fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
