### PR TITLE
[codex] Release app and modulith together

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -1,10 +1,10 @@
-name: App Release Train
+name: MIOT Release Train
 
 on:
   workflow_dispatch:
     inputs:
-      app_version:
-        description: "App semver without v prefix. Leave blank to bump the latest app@v* patch."
+      release_version:
+        description: "Shared app and modulith semver without v prefix. Leave blank to bump the latest app@v* patch."
         required: false
         type: string
       release_notes_version:
@@ -21,7 +21,9 @@ env:
   NODE_VERSION: "22"
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
-  IMAGE_NAME: miot-app
+  APP_IMAGE_NAME: miot-app
+  MODULITH_IMAGE_NAME: miot-srv
+  JAVA_VERSION: "21"
   RELEASE_NOTES_MODEL: claude-opus-4.8
   RELEASE_NOTES_CONTEXT: long_context
 
@@ -30,8 +32,9 @@ jobs:
     name: Prepare release
     runs-on: ubuntu-latest
     outputs:
-      app_version: ${{ steps.version.outputs.app_version }}
-      tag: ${{ steps.version.outputs.tag }}
+      release_version: ${{ steps.version.outputs.release_version }}
+      app_tag: ${{ steps.version.outputs.app_tag }}
+      modulith_tag: ${{ steps.version.outputs.modulith_tag }}
       release_notes_version: ${{ steps.version.outputs.release_notes_version }}
       private_milestone: ${{ steps.version.outputs.private_milestone }}
       oss_milestone: ${{ steps.version.outputs.oss_milestone }}
@@ -47,11 +50,18 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+          cache-dependency-path: quarkus-srv/pom.xml
+
       - name: Determine release metadata
         id: version
         run: |
-          if [[ -n "${{ inputs.app_version }}" ]]; then
-            version="${{ inputs.app_version }}"
+          if [[ -n "${{ inputs.release_version }}" ]]; then
+            version="${{ inputs.release_version }}"
           else
             latest="$(git tag --list 'app@v*' | sed 's/^app@v//' | sort -V | tail -1)"
             if [[ -z "$latest" ]]; then
@@ -63,7 +73,7 @@ jobs:
           fi
 
           if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid app version: $version" >&2
+            echo "Invalid release version: $version" >&2
             exit 1
           fi
 
@@ -92,21 +102,28 @@ jobs:
             exit 1
           fi
 
-          echo "app_version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=app@v$version" >> "$GITHUB_OUTPUT"
-          echo "release_notes_version=$release_notes_version" >> "$GITHUB_OUTPUT"
-          echo "private_milestone=Release-$release_notes_version" >> "$GITHUB_OUTPUT"
-          echo "oss_milestone=MIOT-$version" >> "$GITHUB_OUTPUT"
+          {
+            echo "release_version=$version"
+            echo "app_tag=app@v$version"
+            echo "modulith_tag=modulith@v$version"
+            echo "release_notes_version=$release_notes_version"
+            echo "private_milestone=Release-$release_notes_version"
+            echo "oss_milestone=MIOT-$version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create release branch
         id: branch
         run: |
-          branch="release/app-v${{ steps.version.outputs.app_version }}"
+          branch="release/miot-v${{ steps.version.outputs.release_version }}"
           git switch -c "$branch"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Bump app package version
-        run: bash turbo-repo/generative_ai/tools/sh/bump-app-version.sh "${{ steps.version.outputs.app_version }}"
+        run: bash turbo-repo/generative_ai/tools/sh/bump-app-version.sh "${{ steps.version.outputs.release_version }}"
+
+      - name: Bump modulith Maven version
+        run: ./mvnw versions:set -DnewVersion="${{ steps.version.outputs.release_version }}" -DgenerateBackupPoms=false -DprocessAllModules=true
+        working-directory: quarkus-srv
 
       - name: Collect release issues
         env:
@@ -181,8 +198,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add turbo-repo/apps/app/package.json turbo-repo/package-lock.json turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx
-          git commit -m "chore(app): prepare v${{ steps.version.outputs.app_version }} release"
+          git add turbo-repo/apps/app/package.json turbo-repo/package-lock.json turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx quarkus-srv
+          git commit -m "chore(release): prepare MIOT v${{ steps.version.outputs.release_version }}"
           git push origin "${{ steps.branch.outputs.branch }}"
 
       - name: Open release PR
@@ -190,11 +207,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: |
+          cat > release-pr-body.md <<'EOF'
+          Prepares ${{ steps.version.outputs.app_tag }} and ${{ steps.version.outputs.modulith_tag }} from the same commit, with release notes v${{ steps.version.outputs.release_notes_version }}.
+
+          Milestones: ${{ steps.version.outputs.private_milestone }}, ${{ steps.version.outputs.oss_milestone }}.
+
+          Approve and merge this PR, then approve the protected release job to tag, build both images, and deploy the stack.
+          EOF
+
           url="$(gh pr create \
             --base trunk \
             --head "${{ steps.branch.outputs.branch }}" \
-            --title "chore(app): prepare v${{ steps.version.outputs.app_version }} release" \
-            --body "Prepares app release ${{ steps.version.outputs.tag }} with release notes v${{ steps.version.outputs.release_notes_version }}.\n\nMilestones: ${{ steps.version.outputs.private_milestone }}, ${{ steps.version.outputs.oss_milestone }}.\n\nApprove and merge this PR, then approve the protected release job to tag, build, and deploy.")"
+            --title "chore(release): prepare MIOT v${{ steps.version.outputs.release_version }}" \
+            --body-file release-pr-body.md)"
           number="${url##*/}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
           echo "url=$url" >> "$GITHUB_OUTPUT"
@@ -208,7 +233,7 @@ jobs:
       url: ${{ needs.prepare.outputs.pr_url }}
     steps:
       - name: Approval acknowledged
-        run: echo "Release approval granted for ${{ needs.prepare.outputs.tag }}"
+        run: echo "Release approval granted for MIOT v${{ needs.prepare.outputs.release_version }}"
 
   tag:
     name: Tag trunk
@@ -252,20 +277,34 @@ jobs:
           ref: ${{ steps.release_pr.outputs.sha }}
           fetch-depth: 0
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+          cache-dependency-path: quarkus-srv/pom.xml
+
       - name: Verify release prep landed on trunk
         run: |
           package_version="$(node -p "require('./turbo-repo/apps/app/package.json').version")"
           lock_version="$(node -p "require('./turbo-repo/package-lock.json').packages['apps/app'].version")"
+          modulith_version="$(cd quarkus-srv && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
           release_file="turbo-repo/apps/app/src/releases/v${{ needs.prepare.outputs.release_notes_version }}.mdx"
 
-          if [[ "$package_version" != "${{ needs.prepare.outputs.app_version }}" ]]; then
-            echo "trunk package.json is $package_version, expected ${{ needs.prepare.outputs.app_version }}." >&2
+          if [[ "$package_version" != "${{ needs.prepare.outputs.release_version }}" ]]; then
+            echo "trunk package.json is $package_version, expected ${{ needs.prepare.outputs.release_version }}." >&2
             echo "Merge the release PR before approving/tagging." >&2
             exit 1
           fi
 
-          if [[ "$lock_version" != "${{ needs.prepare.outputs.app_version }}" ]]; then
-            echo "trunk package-lock.json is $lock_version, expected ${{ needs.prepare.outputs.app_version }}." >&2
+          if [[ "$lock_version" != "${{ needs.prepare.outputs.release_version }}" ]]; then
+            echo "trunk package-lock.json is $lock_version, expected ${{ needs.prepare.outputs.release_version }}." >&2
+            echo "Merge the release PR before approving/tagging." >&2
+            exit 1
+          fi
+
+          if [[ "$modulith_version" != "${{ needs.prepare.outputs.release_version }}" ]]; then
+            echo "trunk modulith version is $modulith_version, expected ${{ needs.prepare.outputs.release_version }}." >&2
             echo "Merge the release PR before approving/tagging." >&2
             exit 1
           fi
@@ -276,23 +315,27 @@ jobs:
             exit 1
           fi
 
-      - name: Create and push annotated app tag
+      - name: Create and push component tags
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ needs.prepare.outputs.tag }}" -m "${{ needs.prepare.outputs.tag }}"
-          git push origin "${{ needs.prepare.outputs.tag }}"
+          git tag -a "${{ needs.prepare.outputs.app_tag }}" -m "${{ needs.prepare.outputs.app_tag }}"
+          git tag -a "${{ needs.prepare.outputs.modulith_tag }}" -m "${{ needs.prepare.outputs.modulith_tag }}"
+          git push origin "${{ needs.prepare.outputs.app_tag }}" "${{ needs.prepare.outputs.modulith_tag }}"
 
-      - name: Create GitHub release
+      - name: Create GitHub releases
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ needs.prepare.outputs.tag }}" \
-            --title "${{ needs.prepare.outputs.tag }}" \
+          gh release create "${{ needs.prepare.outputs.app_tag }}" \
+            --title "${{ needs.prepare.outputs.app_tag }}" \
             --generate-notes \
             --latest
+          gh release create "${{ needs.prepare.outputs.modulith_tag }}" \
+            --title "${{ needs.prepare.outputs.modulith_tag }}" \
+            --generate-notes
 
-  build:
+  build-app:
     name: Build and publish app image
     runs-on: ubuntu-latest
     needs: [prepare, tag]
@@ -342,9 +385,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.app_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:app-v${{ needs.prepare.outputs.app_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:app-v${{ needs.prepare.outputs.release_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
           build-args: |
             APP_NAME=app
           provenance: true
@@ -353,12 +396,66 @@ jobs:
       - name: Export image ref
         id: image
         run: |
-          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+  build-modulith:
+    name: Build and publish modulith image
+    runs-on: ubuntu-latest
+    needs: [prepare, tag]
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+          cache-dependency-path: quarkus-srv/pom.xml
+
+      - name: Build and test modulith
+        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true -Dmiot.component.integrations.enabled=true
+        working-directory: quarkus-srv
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: docker
+        uses: docker/build-push-action@v6
+        with:
+          context: quarkus-srv
+          file: quarkus-srv/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:modulith-v${{ needs.prepare.outputs.release_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Export image ref
+        id: image
+        run: |
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Dispatch configured environment deploys
     runs-on: ubuntu-latest
-    needs: [prepare, tag, build]
+    needs: [prepare, tag, build-app, build-modulith]
     environment:
       name: app-deploy
     steps:
@@ -366,11 +463,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
           DEPLOY_DISPATCH_REPO: ${{ secrets.DEPLOY_DISPATCH_REPO }}
-          APP_VERSION: ${{ needs.prepare.outputs.app_version }}
-          APP_TAG: ${{ needs.prepare.outputs.tag }}
-          IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}
-          IMAGE_TAG: ${{ needs.prepare.outputs.app_version }}
-          IMAGE_REF: ${{ needs.build.outputs.image }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          APP_TAG: ${{ needs.prepare.outputs.app_tag }}
+          MODULITH_TAG: ${{ needs.prepare.outputs.modulith_tag }}
+          APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
+          APP_IMAGE_TAG: ${{ needs.prepare.outputs.release_version }}
+          APP_IMAGE_REF: ${{ needs.build-app.outputs.image }}
+          MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
+          MODULITH_IMAGE_TAG: ${{ needs.prepare.outputs.release_version }}
+          MODULITH_IMAGE_REF: ${{ needs.build-modulith.outputs.image }}
         run: |
           DEPLOY_DISPATCH_REPO="${DEPLOY_DISPATCH_REPO:-microboxlabs/miot-deployments}"
 
@@ -380,26 +481,34 @@ jobs:
           fi
 
           jq -n \
-            --arg app_version "$APP_VERSION" \
+            --arg release_version "$RELEASE_VERSION" \
             --arg app_tag "$APP_TAG" \
-            --arg image_repository "$IMAGE_REPOSITORY" \
-            --arg image_tag "$IMAGE_TAG" \
-            --arg image_ref "$IMAGE_REF" \
+            --arg modulith_tag "$MODULITH_TAG" \
+            --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
+            --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg app_image_ref "$APP_IMAGE_REF" \
+            --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
+            --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
+            --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
             '{
-              event_type: "miot-app-release",
+              event_type: "miot-stack-release",
               client_payload: {
-                app_version: $app_version,
+                release_version: $release_version,
                 app_tag: $app_tag,
-                image_repository: $image_repository,
-                image_tag: $image_tag,
-                image_ref: $image_ref
+                modulith_tag: $modulith_tag,
+                app_image_repository: $app_image_repository,
+                app_image_tag: $app_image_tag,
+                app_image_ref: $app_image_ref,
+                modulith_image_repository: $modulith_image_repository,
+                modulith_image_tag: $modulith_image_tag,
+                modulith_image_ref: $modulith_image_ref
               }
             }' |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \
               --method POST \
               --input -
 
-          echo "Dispatched ${APP_TAG} deployment to ${DEPLOY_DISPATCH_REPO}."
+          echo "Dispatched MIOT v${RELEASE_VERSION} deployment to ${DEPLOY_DISPATCH_REPO}."
 
   close-milestones:
     name: Close release milestones


### PR DESCRIPTION
## Summary

- use one shared semantic version for the app package and modulith Maven reactor
- create `app@vX.Y.Z` and `modulith@vX.Y.Z` from the same merged commit
- build and publish both GHCR images with matching semantic and SHA tags
- dispatch both immutable image refs to the private `miot-stack-release` workflow
- keep release notes and milestones on the existing automated approval flow

## Why

The release train should represent one deployable MIOT version while retaining component-specific source tags and images.

## Validation

- Actionlint
- Ruby YAML parse
- Maven `versions:set`, project version verification, and reactor validation
- `git diff --check`

## Dependency

Merge after the Helm chart and private deployment PRs are available.