### PR TITLE
feat(auth): route integration-jobs API to HS256/M2M verification

### DIFF
--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanism.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanism.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.jose4j.jwk.HttpsJwks;
@@ -47,6 +49,9 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String NOT_CONFIGURED = "not-configured";
 
+    /** A JAX-RS path-template variable, e.g. {organizationId} or {id:\\d+}. */
+    private static final Pattern PATH_TEMPLATE_VAR = Pattern.compile("\\{[^/}]+}");
+
     private final String hs256Issuer;
     private final String rs256Issuer;
     private final String jwksUrl;
@@ -56,7 +61,7 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
 
     private JwtConsumer hs256Consumer;
     private JwtConsumer rs256Consumer;
-    private List<String> m2mPathPrefixes;
+    private List<Pattern> m2mPathPatterns;
 
     DualJwtAuthMechanism(
             @ConfigProperty(name = "miot.auth.hs256-issuer", defaultValue = "https://placeholder.auth0.com/")
@@ -81,7 +86,7 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
 
     @PostConstruct
     void init() {
-        m2mPathPrefixes = discoverM2mPaths();
+        m2mPathPatterns = discoverM2mPaths();
 
         if (!NOT_CONFIGURED.equals(hs256Secret)) {
             var hs256Builder = new JwtConsumerBuilder()
@@ -94,8 +99,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
                 hs256Builder.setSkipDefaultAudienceValidation();
             }
             hs256Consumer = hs256Builder.build();
-            LOG.infof("HS256 verification configured for @M2MAuth paths: %s issuer=%s",
-                    m2mPathPrefixes, hs256Issuer);
+            LOG.infof("HS256 verification configured for %d @M2MAuth path pattern(s) issuer=%s",
+                    m2mPathPatterns.size(), hs256Issuer);
         }
 
         if (!NOT_CONFIGURED.equals(jwksUrl)) {
@@ -115,8 +120,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
         }
     }
 
-    private List<String> discoverM2mPaths() {
-        List<String> paths = new ArrayList<>();
+    private List<Pattern> discoverM2mPaths() {
+        List<Pattern> patterns = new ArrayList<>();
         for (var bean : io.quarkus.arc.Arc.container().beanManager().getBeans(Object.class)) {
             Class<?> beanClass = bean.getBeanClass();
             if (beanClass.isAnnotationPresent(M2MAuth.class)
@@ -125,12 +130,34 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
                 if (!path.startsWith("/")) {
                     path = "/" + path;
                 }
-                paths.add(path);
+                patterns.add(templateToPattern(path));
                 LOG.infof("Discovered @M2MAuth resource: %s -> %s",
                         beanClass.getSimpleName(), path);
             }
         }
-        return paths;
+        return patterns;
+    }
+
+    /**
+     * Compiles a JAX-RS {@code @Path} value into a matcher for the runtime
+     * request path. Template variables ({@code {organizationId}}) become
+     * single-segment wildcards, so an org-scoped resource path like
+     * {@code /api/v1/orgs/{organizationId}/integrations/jobs} matches the real
+     * {@code /api/v1/orgs/mintral/integrations/jobs} and any sub-path under it.
+     * Static paths keep the original "exact or prefix-with-slash" semantics.
+     */
+    static Pattern templateToPattern(String pathTemplate) {
+        StringBuilder regex = new StringBuilder("^");
+        Matcher vars = PATH_TEMPLATE_VAR.matcher(pathTemplate);
+        int last = 0;
+        while (vars.find()) {
+            regex.append(Pattern.quote(pathTemplate.substring(last, vars.start())));
+            regex.append("[^/]+");
+            last = vars.end();
+        }
+        regex.append(Pattern.quote(pathTemplate.substring(last)));
+        regex.append("(/.*)?$");
+        return Pattern.compile(regex.toString());
     }
 
     @Override
@@ -168,8 +195,8 @@ public class DualJwtAuthMechanism implements HttpAuthenticationMechanism {
     }
 
     private boolean isM2mPath(String path) {
-        for (String prefix : m2mPathPrefixes) {
-            if (path.equals(prefix) || path.startsWith(prefix + "/")) {
+        for (Pattern pattern : m2mPathPatterns) {
+            if (pattern.matcher(path).matches()) {
                 return true;
             }
         }

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanismPathTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/DualJwtAuthMechanismPathTest.java
@@ -1,0 +1,49 @@
+package com.microboxlabs.miot.core.auth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link DualJwtAuthMechanism#templateToPattern} must match org-scoped resource
+ * paths whose {@code @Path} contains a template variable in the middle — the
+ * case that routes the integration-jobs API to HS256/M2M verification.
+ */
+class DualJwtAuthMechanismPathTest {
+
+    @Test
+    void templatedOrgPathMatchesRealPathAndSubPaths() {
+        Pattern p = DualJwtAuthMechanism.templateToPattern(
+                "/api/v1/orgs/{organizationId}/integrations/jobs");
+
+        assertTrue(p.matcher("/api/v1/orgs/mintral/integrations/jobs").matches());
+        assertTrue(p.matcher("/api/v1/orgs/mintral/integrations/jobs/enqueue").matches());
+        assertTrue(p.matcher("/api/v1/orgs/acme-corp/integrations/jobs/claim").matches());
+        assertTrue(p.matcher("/api/v1/orgs/acme/integrations/jobs/abc-123/report").matches());
+    }
+
+    @Test
+    void templatedOrgPathRejectsOtherOrgEndpointsAndPartialSegments() {
+        Pattern p = DualJwtAuthMechanism.templateToPattern(
+                "/api/v1/orgs/{organizationId}/integrations/jobs");
+
+        // A different org-scoped resource must stay on the RS256 (web) branch.
+        assertFalse(p.matcher("/api/v1/orgs/mintral/calendar").matches());
+        assertFalse(p.matcher("/api/v1/orgs/mintral/integrations/connections").matches());
+        // The org segment is a single path segment, not a wildcard across slashes.
+        assertFalse(p.matcher("/api/v1/orgs/a/b/integrations/jobs").matches());
+        // No false prefix match without a slash boundary.
+        assertFalse(p.matcher("/api/v1/orgs/mintral/integrations/jobsX").matches());
+    }
+
+    @Test
+    void staticPathKeepsExactOrPrefixSemantics() {
+        Pattern p = DualJwtAuthMechanism.templateToPattern("/api/v1/asset/track");
+
+        assertTrue(p.matcher("/api/v1/asset/track").matches());
+        assertTrue(p.matcher("/api/v1/asset/track/batch").matches());
+        assertFalse(p.matcher("/api/v1/asset/tracking").matches());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.integrations.api;
 
+import com.microboxlabs.miot.core.auth.M2MAuth;
 import com.microboxlabs.miot.core.auth.OrganizationContext;
 import com.microboxlabs.miot.core.auth.TenantContext;
 import com.microboxlabs.miot.integrations.domain.AsyncJob;
@@ -33,6 +34,10 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 @Tag(name = "Async Jobs", description = "Durable ledger and control plane for externally-executed integration jobs")
 @SecurityRequirement(name = "oidc")
 @Authenticated
+// The caller is a machine (ECM) using an Auth0 client-credentials token →
+// HS256/M2M verification. Org membership for M2M is validated by
+// OrganizationRequestFilter (token azp/aud == org.tenantClientId), no Alfresco.
+@M2MAuth
 @IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
 public class OrgAsyncJobsResource {
 


### PR DESCRIPTION
Follow-up to #644 (merged). This commit was pushed to the branch *after* #644 merged, so it never reached trunk — re-submitting it.

## Why
The ECM calls the async-jobs API with an Auth0 client-credentials (HS256 M2M) token, but `OrgAsyncJobsResource` defaulted to the RS256 (web/JWKS) branch of `DualJwtAuthMechanism` and rejected it (401). Discovered during dev auth-seam testing.

## Change
- `@M2MAuth` on `OrgAsyncJobsResource` → HS256/M2M verification.
- `DualJwtAuthMechanism` made **template-aware**: it matched M2M paths as literal prefixes, which works for static paths (`/api/v1/asset/track`) but not for an org-scoped template (`/api/v1/orgs/{organizationId}/integrations/jobs`). `{seg}` now becomes a single-segment wildcard. Covered by `DualJwtAuthMechanismPathTest` (3 tests). Existing static `@M2MAuth` routing unchanged.
- Org membership for M2M is already handled by `OrganizationRequestFilter` (token `azp`/`aud` == `org.tenantClientId`, no Alfresco).

## Deploy prerequisites
- miot HS256 configured: `AUTH0_HS256_SECRET/ISSUER/AUDIENCE`.
- `mintral` org row's `tenantClientId` = the ECM's Auth0 client id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)