### PR TITLE
fix: expose deploy dispatch credentials to nightlies

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -211,7 +211,9 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: app-nightly-development
+      # Dispatch credentials are shared with tagged releases. The private
+      # deployment repository still restricts nightly targets to development.
+      name: app-deploy
     steps:
       - name: Dispatch private deployment workflow
         env:


### PR DESCRIPTION
## Summary

- run the nightly dispatch job through the existing `app-deploy` protected environment
- reuse the configured `DEPLOY_DISPATCH_TOKEN` and `DEPLOY_DISPATCH_REPO` secrets
- keep nightly target selection restricted to GKE development in `miot-deployments`

## Root cause

The secrets exist only on the `app-deploy` GitHub Environment. The nightly job selected `app-nightly-development`, which has no secrets, so `GH_TOKEN` was empty.

The linked failed run used commit `b2a10d1f`, before the full-stack nightly workflow merged, but the same environment mismatch remained in the merged workflow.

## Validation

- Actionlint
- Ruby YAML parsing
- verified both dispatch secrets exist on `app-deploy`
- verified `app-nightly-development` has no secrets
- `git diff --check`