### PR TITLE
fix: include Quarkus artifacts in Docker context

### DIFF
--- a/quarkus-srv/.dockerignore
+++ b/quarkus-srv/.dockerignore
@@ -1,5 +1,8 @@
 *
-!target/*-runner
-!target/*-runner.jar
-!target/lib/*
-!target/quarkus-app/*
+!Dockerfile
+!miot-cli/
+miot-cli/*
+!miot-cli/target/
+miot-cli/target/*
+!miot-cli/target/quarkus-app/
+!miot-cli/target/quarkus-app/**


### PR DESCRIPTION
## Summary

- fix `quarkus-srv/.dockerignore` to include the executable module's `quarkus-app` directory recursively
- keep unrelated Maven outputs excluded from the Docker context
- include the Dockerfile explicitly

## Root cause

The Dockerfile copies from `miot-cli/target/quarkus-app`, but `.dockerignore` only allowed root-level `target` paths. BuildKit received a 2-byte context, so `lib`, `app`, and `quarkus` were all absent even though Maven packaged them successfully.

## Validation

- reproduced the Quarkus fast-jar package locally
- Docker context increased from 2 bytes to the expected artifact payload
- built the complete `linux/amd64` image successfully
- verified `/deployments/quarkus-run.jar`, `lib`, `app`, and `quarkus` exist in the image
- `git diff --check`

This shared fix covers nightly, tagged release, and standalone Quarkus image builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to optimize image generation and ensure necessary application artifacts are included in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->