### PR TITLE
fix: keep nightly dispatch payload within GitHub limit

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -228,9 +228,6 @@ jobs:
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           MODULITH_IMAGE_REF: ${{ needs.build-modulith.outputs.image }}
-          GIT_SHA: ${{ github.sha }}
-          SHORT_SHA: ${{ needs.metadata.outputs.short_sha }}
-          NIGHTLY_DATE: ${{ needs.metadata.outputs.nightly_date }}
         run: |
           DEPLOY_DISPATCH_REPO="${DEPLOY_DISPATCH_REPO:-microboxlabs/miot-deployments}"
 
@@ -249,9 +246,6 @@ jobs:
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
-            --arg git_sha "$GIT_SHA" \
-            --arg short_sha "$SHORT_SHA" \
-            --arg nightly_date "$NIGHTLY_DATE" \
             '{
               event_type: "miot-stack-nightly",
               client_payload: {
@@ -264,10 +258,7 @@ jobs:
                 app_image_ref: $app_image_ref,
                 modulith_image_repository: $modulith_image_repository,
                 modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref,
-                git_sha: $git_sha,
-                short_sha: $short_sha,
-                nightly_date: $nightly_date
+                modulith_image_ref: $modulith_image_ref
               }
             }' |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \


### PR DESCRIPTION
## Summary

- reduce `miot-stack-nightly` client payload from 13 to GitHub's maximum of 10 properties
- remove redundant `git_sha`, `short_sha`, and `nightly_date` fields
- preserve the complete deployment contract consumed by `miot-deployments`

## Root cause

GitHub repository dispatch rejects `client_payload` objects with more than 10 top-level properties. The nightly event supplied 13.

The removed metadata remains represented by `release_version`, semantic SHA image tags, and immutable image digest references.

## Validation

- Actionlint
- Ruby YAML parsing
- generated representative payload and asserted exactly 10 properties
- verified the private receiver does not consume the removed fields
- `git diff --check`

## Dependency

Merge `microboxlabs/miot-deployments#4` first so private trunk accepts `miot-stack-nightly`, then merge this PR and rerun the nightly workflow.