### PR TITLE
feat(harness): virtual filesystem scratchpad tool

### DIFF
--- a/miot-harness/src/miot_harness/agents/filter_expert.py
+++ b/miot-harness/src/miot_harness/agents/filter_expert.py
@@ -40,6 +40,12 @@ logger = logging.getLogger(__name__)
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
 
+# Scratchpad tools (tools/filesystem.py) are datasource-agnostic working
+# memory, not datasource data tools. They're allowed past the
+# datasource-prefix guardrail below as a known-safe utility allowlist —
+# a hallucinated `fs_*` name still fails the registry-membership check.
+_SCRATCHPAD_PREFIX = "fs_"
+
 
 def _strip_fences(text: str) -> str:
     """Real Claude wraps structured output in ```json fences; strip them."""
@@ -66,6 +72,12 @@ Routing hints:
 - L3 tools drill into one service.
 - VT tools support shift-handoff narratives.
 
+Scratchpad (optional): you have a private virtual filesystem to keep
+working notes across turns. Use fs_write / fs_read / fs_ls / fs_edit to
+stash an intermediate finding or a running plan so it doesn't bloat the
+prompt on later turns. These are helpers — when the user is asking for
+data, prefer a {prefix_label} data tool.
+
 Output ONLY a JSON object with this exact shape:
 {{"intent": "...", "tool": "{tool_prefix}xxx", "args": {{}}, "rationale": "..."}}
 - intent: one short phrase describing what you're trying to learn.
@@ -79,19 +91,26 @@ Available tools:
 """
 
 
+def _catalog_line(registry: ToolRegistry, name: str) -> str:
+    tool = registry.get(name)
+    first_line = (tool.description or "").splitlines()[0].strip()
+    return f"- {name}: {first_line}"
+
+
 def build_tool_catalog(registry: ToolRegistry, *, profile: DataSourceProfile) -> str:
-    lines: list[str] = []
-    for name in registry.names():
-        if not name.startswith(profile.tool_prefix):
-            continue
-        tool = registry.get(name)
-        first_line = (tool.description or "").splitlines()[0].strip()
-        lines.append(f"- {name}: {first_line}")
-    return (
-        "\n".join(lines)
-        if lines
+    data_tools = [n for n in registry.names() if n.startswith(profile.tool_prefix)]
+    catalog = (
+        "\n".join(_catalog_line(registry, name) for name in data_tools)
+        if data_tools
         else f"(no {profile.display_name.lower()} tools registered)"
     )
+    # Scratchpad tools are listed in their own section so the model treats
+    # them as utilities, not datasource data tools.
+    scratchpad = [n for n in registry.names() if n.startswith(_SCRATCHPAD_PREFIX)]
+    if scratchpad:
+        catalog += "\n\nScratchpad tools (optional, for working notes):\n"
+        catalog += "\n".join(_catalog_line(registry, name) for name in scratchpad)
+    return catalog
 
 
 def _parse_step(text: str) -> DataStep | None:
@@ -159,7 +178,7 @@ async def filter_expert_node(
             "next_action": None,
         }
 
-    if not step.tool.startswith(profile.tool_prefix):
+    if not (step.tool.startswith(profile.tool_prefix) or step.tool.startswith(_SCRATCHPAD_PREFIX)):
         logger.error("filter_expert: model picked out-of-scope datasource tool %r", step.tool)
         return {
             "failure": f"filter_expert picked out-of-scope tool: {step.tool}",

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -72,6 +72,18 @@ class HarnessSettings(BaseSettings):
     # strictly positive; 0 or negative is meaningless as a budget.
     conversation_token_budget: int = Field(default=24_000, gt=0)
 
+    # Virtual filesystem scratchpad. An in-memory, per-conversation file
+    # store that lets agents offload notes/plans/intermediate findings out
+    # of the LLM context window across a multi-turn run (see
+    # tools/filesystem.py). On by default; flip `fs_enabled=False` to drop
+    # the four `fs_*` tools from the registry. Caps are per-conversation
+    # and bound a single scratchpad's memory footprint; exceeding any cap
+    # returns a typed `ok=False` tool result (no partial write).
+    fs_enabled: bool = True
+    fs_max_file_bytes: int = Field(default=65_536, gt=0)
+    fs_max_total_bytes: int = Field(default=1_048_576, gt=0)
+    fs_max_files: int = Field(default=64, gt=0)
+
     # Operations / observability
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
     request_id_header: str = "x-request-id"

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -76,13 +76,16 @@ class HarnessSettings(BaseSettings):
     # store that lets agents offload notes/plans/intermediate findings out
     # of the LLM context window across a multi-turn run (see
     # tools/filesystem.py). On by default; flip `fs_enabled=False` to drop
-    # the four `fs_*` tools from the registry. Caps are per-conversation
-    # and bound a single scratchpad's memory footprint; exceeding any cap
-    # returns a typed `ok=False` tool result (no partial write).
+    # the four `fs_*` tools from the registry. The per-conversation caps
+    # bound a single scratchpad's memory footprint (exceeding any returns a
+    # typed `ok=False` tool result, no partial write); `fs_max_conversations`
+    # is a global LRU bound on how many scratchpads stay in memory so the
+    # store can't grow without limit as new conversation/thread ids arrive.
     fs_enabled: bool = True
     fs_max_file_bytes: int = Field(default=65_536, gt=0)
     fs_max_total_bytes: int = Field(default=1_048_576, gt=0)
     fs_max_files: int = Field(default=64, gt=0)
+    fs_max_conversations: int = Field(default=512, gt=0)
 
     # Operations / observability
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"

--- a/miot-harness/src/miot_harness/tools/filesystem.py
+++ b/miot-harness/src/miot_harness/tools/filesystem.py
@@ -1,0 +1,394 @@
+"""Virtual filesystem scratchpad tools for the harness.
+
+An in-memory, per-conversation scratchpad so agents can offload notes,
+plans, and intermediate findings to files instead of carrying them in
+the LLM context window across a multi-turn run. Files never touch real
+disk and never cross conversation/tenant boundaries.
+
+The backing store mirrors `runtime/conversation.InMemoryConversationStore`:
+a process-local dict, lost on restart — acceptable for v1. A disk- or
+Redis-backed implementation can slot behind the same surface later.
+
+The four tools (`fs_write` / `fs_read` / `fs_ls` / `fs_edit`) follow the
+`HarnessTool` factory pattern (see `tools/dashboard.py`) and capture a
+shared `VirtualFileStore` via closure (the same way
+`integrations/nexo/tool_factory` captures `pool`/`tenant_lock`). The
+conversation key is derived from `HarnessContext` inside each call — no
+change to the `call(ctx, input, progress)` signature.
+
+Cap / validation violations raise `FileStoreError` inside the store; the
+tool wrappers catch it and return a typed `ok=False` output so the agent
+gets a structured result it can react to rather than an aborting
+exception. A missing read returns `found=False` (also not an error).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.permissions import PermissionResult
+from miot_harness.runtime.tool import HarnessTool, Progress
+
+# Defaults mirror config.py's fs_* settings so a bare VirtualFileStore()
+# (tests, evals) behaves like the wired-up one.
+_DEFAULT_MAX_FILE_BYTES = 65_536
+_DEFAULT_MAX_TOTAL_BYTES = 1_048_576
+_DEFAULT_MAX_FILES = 64
+
+
+class FileStoreError(Exception):
+    """Carries a stable `code` so callers can branch without string-matching."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class FileEntry:
+    content: str
+
+    @property
+    def bytes(self) -> int:
+        return len(self.content.encode("utf-8"))
+
+
+@dataclass(frozen=True, slots=True)
+class WriteResult:
+    path: str
+    bytes: int
+    created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class EditResult:
+    path: str
+    bytes: int
+    replacements: int
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize a virtual path into a clean key.
+
+    Even though the store is virtual, we keep the key namespace clean and
+    reject absolute paths and parent traversal so an agent can't construct
+    surprising keys (and so a future disk-backed impl inherits a safe rule).
+    """
+    raw = path.strip()
+    if not raw:
+        raise FileStoreError("invalid_path", "path must not be empty")
+    if raw.startswith("/") or raw.startswith("\\"):
+        raise FileStoreError("invalid_path", "absolute paths are not allowed")
+    parts = [seg for seg in raw.replace("\\", "/").split("/") if seg not in ("", ".")]
+    if any(seg == ".." for seg in parts):
+        raise FileStoreError("invalid_path", "parent traversal ('..') is not allowed")
+    if not parts:
+        raise FileStoreError("invalid_path", "path resolves to empty")
+    return "/".join(parts)
+
+
+class VirtualFileStore:
+    """Process-local, per-conversation virtual file store.
+
+    Concurrency: single event loop, no locks (same posture as
+    `InMemoryConversationStore`). If the harness ever runs multi-worker,
+    a shared backend becomes the seam.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_file_bytes: int = _DEFAULT_MAX_FILE_BYTES,
+        max_total_bytes: int = _DEFAULT_MAX_TOTAL_BYTES,
+        max_files: int = _DEFAULT_MAX_FILES,
+    ) -> None:
+        self._files: dict[str, dict[str, FileEntry]] = {}
+        self._max_file_bytes = max_file_bytes
+        self._max_total_bytes = max_total_bytes
+        self._max_files = max_files
+
+    def _total_bytes(self, conv_key: str) -> int:
+        return sum(entry.bytes for entry in self._files.get(conv_key, {}).values())
+
+    def write(self, conv_key: str, path: str, content: str) -> WriteResult:
+        norm = _normalize_path(path)
+        size = len(content.encode("utf-8"))
+        if size > self._max_file_bytes:
+            raise FileStoreError(
+                "file_too_large",
+                f"file is {size} bytes; per-file cap is {self._max_file_bytes}",
+            )
+        bucket = self._files.setdefault(conv_key, {})
+        existing = bucket.get(norm)
+        created = existing is None
+        if created and len(bucket) >= self._max_files:
+            raise FileStoreError(
+                "too_many_files",
+                f"scratchpad already holds {len(bucket)} files (cap {self._max_files})",
+            )
+        existing_bytes = existing.bytes if existing else 0
+        projected = self._total_bytes(conv_key) - existing_bytes + size
+        if projected > self._max_total_bytes:
+            raise FileStoreError(
+                "workspace_full",
+                f"write would use {projected} bytes; total cap is {self._max_total_bytes}",
+            )
+        bucket[norm] = FileEntry(content=content)
+        return WriteResult(path=norm, bytes=size, created=created)
+
+    def read(self, conv_key: str, path: str) -> str | None:
+        norm = _normalize_path(path)
+        entry = self._files.get(conv_key, {}).get(norm)
+        return entry.content if entry is not None else None
+
+    def ls(self, conv_key: str, prefix: str | None = None) -> list[tuple[str, int]]:
+        bucket = self._files.get(conv_key, {})
+        pfx = (prefix or "").strip().lstrip("/")
+        return [
+            (path, entry.bytes)
+            for path, entry in sorted(bucket.items())
+            if not pfx or path.startswith(pfx)
+        ]
+
+    def edit(
+        self,
+        conv_key: str,
+        path: str,
+        old_string: str,
+        new_string: str,
+        *,
+        replace_all: bool = False,
+    ) -> EditResult:
+        norm = _normalize_path(path)
+        if old_string == "":
+            raise FileStoreError("invalid_edit", "old_string must not be empty")
+        bucket = self._files.get(conv_key, {})
+        entry = bucket.get(norm)
+        if entry is None:
+            raise FileStoreError("not_found", f"no such file: {norm}")
+        count = entry.content.count(old_string)
+        if count == 0:
+            raise FileStoreError("not_found", "old_string not present in file")
+        if count > 1 and not replace_all:
+            raise FileStoreError(
+                "not_unique",
+                f"old_string occurs {count} times; pass replace_all=true to replace all",
+            )
+        if replace_all:
+            updated = entry.content.replace(old_string, new_string)
+            replacements = count
+        else:
+            updated = entry.content.replace(old_string, new_string, 1)
+            replacements = 1
+        size = len(updated.encode("utf-8"))
+        if size > self._max_file_bytes:
+            raise FileStoreError(
+                "file_too_large",
+                f"edit would make the file {size} bytes; per-file cap is {self._max_file_bytes}",
+            )
+        projected = self._total_bytes(conv_key) - entry.bytes + size
+        if projected > self._max_total_bytes:
+            raise FileStoreError(
+                "workspace_full",
+                f"edit would use {projected} bytes; total cap is {self._max_total_bytes}",
+            )
+        bucket[norm] = FileEntry(content=updated)
+        return EditResult(path=norm, bytes=size, replacements=replacements)
+
+
+def _conv_key(ctx: HarnessContext) -> str:
+    """Scratchpad partition key: the conversation if set, else the thread.
+
+    `thread_id` is always populated, so one-shot runs still get an isolated
+    partition; multi-turn conversations share one so a later turn can read
+    an earlier turn's note.
+    """
+    return ctx.conversation_id or ctx.thread_id
+
+
+# --- Pydantic I/O models -------------------------------------------------
+
+
+class FsWriteInput(BaseModel):
+    path: str
+    content: str
+
+
+class FsWriteOutput(BaseModel):
+    ok: bool
+    path: str
+    bytes: int = 0
+    created: bool = False
+    error: str | None = None
+
+
+class FsReadInput(BaseModel):
+    path: str
+
+
+class FsReadOutput(BaseModel):
+    ok: bool
+    path: str
+    found: bool = False
+    content: str | None = None
+    bytes: int = 0
+    error: str | None = None
+
+
+class FsFileInfo(BaseModel):
+    path: str
+    bytes: int
+
+
+class FsLsInput(BaseModel):
+    prefix: str | None = None
+
+
+class FsLsOutput(BaseModel):
+    ok: bool
+    files: list[FsFileInfo] = Field(default_factory=list)
+    error: str | None = None
+
+
+class FsEditInput(BaseModel):
+    path: str
+    old_string: str
+    new_string: str
+    replace_all: bool = False
+
+
+class FsEditOutput(BaseModel):
+    ok: bool
+    path: str
+    bytes: int = 0
+    replacements: int = 0
+    error: str | None = None
+
+
+async def _allow(_: HarnessContext, __: BaseModel) -> PermissionResult:
+    return PermissionResult.allow("Virtual scratchpad — sandboxed, no real disk.")
+
+
+def _error_text(exc: FileStoreError) -> str:
+    return f"{exc.code}: {exc.message}"
+
+
+# --- Tool factories ------------------------------------------------------
+
+
+def fs_write_tool(store: VirtualFileStore) -> HarnessTool[FsWriteInput, FsWriteOutput]:
+    async def call(ctx: HarnessContext, value: FsWriteInput, _: Progress) -> FsWriteOutput:
+        try:
+            res = store.write(_conv_key(ctx), value.path, value.content)
+        except FileStoreError as exc:
+            return FsWriteOutput(ok=False, path=value.path, error=_error_text(exc))
+        return FsWriteOutput(ok=True, path=res.path, bytes=res.bytes, created=res.created)
+
+    return HarnessTool(
+        name="fs_write",
+        description=(
+            "Write a note/plan/intermediate finding to a file in your private "
+            "scratchpad (create or overwrite). Use it to keep working memory "
+            "out of the prompt across turns."
+        ),
+        input_model=FsWriteInput,
+        output_model=FsWriteOutput,
+        read_only=False,
+        destructive=False,
+        source="scratchpad",
+        check_permission=_allow,
+        call=call,
+    )
+
+
+def fs_read_tool(store: VirtualFileStore) -> HarnessTool[FsReadInput, FsReadOutput]:
+    async def call(ctx: HarnessContext, value: FsReadInput, _: Progress) -> FsReadOutput:
+        try:
+            content = store.read(_conv_key(ctx), value.path)
+        except FileStoreError as exc:
+            return FsReadOutput(ok=False, path=value.path, error=_error_text(exc))
+        if content is None:
+            return FsReadOutput(ok=True, path=value.path, found=False)
+        return FsReadOutput(
+            ok=True,
+            path=value.path,
+            found=True,
+            content=content,
+            bytes=len(content.encode("utf-8")),
+        )
+
+    return HarnessTool(
+        name="fs_read",
+        description="Read a file back from your private scratchpad by path.",
+        input_model=FsReadInput,
+        output_model=FsReadOutput,
+        read_only=True,
+        source="scratchpad",
+        check_permission=_allow,
+        call=call,
+    )
+
+
+def fs_ls_tool(store: VirtualFileStore) -> HarnessTool[FsLsInput, FsLsOutput]:
+    async def call(ctx: HarnessContext, value: FsLsInput, _: Progress) -> FsLsOutput:
+        files = store.ls(_conv_key(ctx), value.prefix)
+        return FsLsOutput(
+            ok=True,
+            files=[FsFileInfo(path=path, bytes=size) for path, size in files],
+        )
+
+    return HarnessTool(
+        name="fs_ls",
+        description="List the files currently in your private scratchpad (optionally by prefix).",
+        input_model=FsLsInput,
+        output_model=FsLsOutput,
+        read_only=True,
+        source="scratchpad",
+        check_permission=_allow,
+        call=call,
+    )
+
+
+def fs_edit_tool(store: VirtualFileStore) -> HarnessTool[FsEditInput, FsEditOutput]:
+    async def call(ctx: HarnessContext, value: FsEditInput, _: Progress) -> FsEditOutput:
+        try:
+            res = store.edit(
+                _conv_key(ctx),
+                value.path,
+                value.old_string,
+                value.new_string,
+                replace_all=value.replace_all,
+            )
+        except FileStoreError as exc:
+            return FsEditOutput(ok=False, path=value.path, error=_error_text(exc))
+        return FsEditOutput(ok=True, path=res.path, bytes=res.bytes, replacements=res.replacements)
+
+    return HarnessTool(
+        name="fs_edit",
+        description=(
+            "Edit a scratchpad file by exact string replacement. Fails if "
+            "old_string is absent or non-unique (unless replace_all=true)."
+        ),
+        input_model=FsEditInput,
+        output_model=FsEditOutput,
+        read_only=False,
+        destructive=False,
+        source="scratchpad",
+        check_permission=_allow,
+        call=call,
+    )
+
+
+def build_filesystem_tools(store: VirtualFileStore) -> list[HarnessTool[Any, Any]]:
+    """All four scratchpad tools, sharing one `VirtualFileStore`."""
+    return [
+        fs_write_tool(store),
+        fs_read_tool(store),
+        fs_ls_tool(store),
+        fs_edit_tool(store),
+    ]

--- a/miot-harness/src/miot_harness/tools/filesystem.py
+++ b/miot-harness/src/miot_harness/tools/filesystem.py
@@ -24,6 +24,7 @@ exception. A missing read returns `found=False` (also not an error).
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,6 +39,12 @@ from miot_harness.runtime.tool import HarnessTool, Progress
 _DEFAULT_MAX_FILE_BYTES = 65_536
 _DEFAULT_MAX_TOTAL_BYTES = 1_048_576
 _DEFAULT_MAX_FILES = 64
+# Global bound on the number of distinct conversation partitions kept in
+# memory. The per-conversation caps above bound each partition's size; this
+# bounds how many partitions accumulate so a long-running process can't grow
+# without limit as new conversation/thread ids arrive. Least-recently-used
+# conversations are evicted first.
+_DEFAULT_MAX_CONVERSATIONS = 512
 
 
 class FileStoreError(Exception):
@@ -95,6 +102,13 @@ def _normalize_path(path: str) -> str:
 class VirtualFileStore:
     """Process-local, per-conversation virtual file store.
 
+    Two layers of bounds: per-conversation caps (file size, total bytes,
+    file count) bound a single scratchpad; a global `max_conversations`
+    LRU bound caps how many conversation partitions stay in memory so the
+    store can't grow without limit as new conversation/thread ids arrive.
+    Every access (write/read/ls/edit) marks its conversation most-recently
+    used; the oldest is evicted when a new conversation exceeds the cap.
+
     Concurrency: single event loop, no locks (same posture as
     `InMemoryConversationStore`). If the harness ever runs multi-worker,
     a shared backend becomes the seam.
@@ -106,14 +120,35 @@ class VirtualFileStore:
         max_file_bytes: int = _DEFAULT_MAX_FILE_BYTES,
         max_total_bytes: int = _DEFAULT_MAX_TOTAL_BYTES,
         max_files: int = _DEFAULT_MAX_FILES,
+        max_conversations: int = _DEFAULT_MAX_CONVERSATIONS,
     ) -> None:
-        self._files: dict[str, dict[str, FileEntry]] = {}
+        # OrderedDict so we can track recency: move_to_end on access,
+        # popitem(last=False) to evict the least-recently-used conversation.
+        self._files: OrderedDict[str, dict[str, FileEntry]] = OrderedDict()
         self._max_file_bytes = max_file_bytes
         self._max_total_bytes = max_total_bytes
         self._max_files = max_files
+        self._max_conversations = max_conversations
 
     def _total_bytes(self, conv_key: str) -> int:
         return sum(entry.bytes for entry in self._files.get(conv_key, {}).values())
+
+    def _bucket_for_write(self, conv_key: str) -> dict[str, FileEntry]:
+        """Return the conversation's bucket, creating it (and LRU-evicting
+        the oldest conversation when at the global cap) if it's new.
+
+        Only called after a write's per-conversation cap checks pass, so a
+        rejected write never evicts a victim or leaves an empty bucket.
+        """
+        bucket = self._files.get(conv_key)
+        if bucket is not None:
+            self._files.move_to_end(conv_key)
+            return bucket
+        while len(self._files) >= self._max_conversations:
+            self._files.popitem(last=False)
+        bucket = {}
+        self._files[conv_key] = bucket
+        return bucket
 
     def write(self, conv_key: str, path: str, content: str) -> WriteResult:
         norm = _normalize_path(path)
@@ -123,10 +158,10 @@ class VirtualFileStore:
                 "file_too_large",
                 f"file is {size} bytes; per-file cap is {self._max_file_bytes}",
             )
-        bucket = self._files.setdefault(conv_key, {})
-        existing = bucket.get(norm)
+        bucket = self._files.get(conv_key)
+        existing = bucket.get(norm) if bucket is not None else None
         created = existing is None
-        if created and len(bucket) >= self._max_files:
+        if created and bucket is not None and len(bucket) >= self._max_files:
             raise FileStoreError(
                 "too_many_files",
                 f"scratchpad already holds {len(bucket)} files (cap {self._max_files})",
@@ -138,16 +173,26 @@ class VirtualFileStore:
                 "workspace_full",
                 f"write would use {projected} bytes; total cap is {self._max_total_bytes}",
             )
+        # All per-conversation checks passed — now materialize the bucket
+        # (LRU-evicting if needed) and write.
+        bucket = self._bucket_for_write(conv_key)
         bucket[norm] = FileEntry(content=content)
         return WriteResult(path=norm, bytes=size, created=created)
 
     def read(self, conv_key: str, path: str) -> str | None:
         norm = _normalize_path(path)
-        entry = self._files.get(conv_key, {}).get(norm)
+        bucket = self._files.get(conv_key)
+        if bucket is None:
+            return None
+        self._files.move_to_end(conv_key)
+        entry = bucket.get(norm)
         return entry.content if entry is not None else None
 
     def ls(self, conv_key: str, prefix: str | None = None) -> list[tuple[str, int]]:
-        bucket = self._files.get(conv_key, {})
+        bucket = self._files.get(conv_key)
+        if bucket is None:
+            return []
+        self._files.move_to_end(conv_key)
         pfx = (prefix or "").strip().lstrip("/")
         return [
             (path, entry.bytes)
@@ -167,10 +212,10 @@ class VirtualFileStore:
         norm = _normalize_path(path)
         if old_string == "":
             raise FileStoreError("invalid_edit", "old_string must not be empty")
-        bucket = self._files.get(conv_key, {})
-        entry = bucket.get(norm)
-        if entry is None:
+        bucket = self._files.get(conv_key)
+        if bucket is None or norm not in bucket:
             raise FileStoreError("not_found", f"no such file: {norm}")
+        entry = bucket[norm]
         count = entry.content.count(old_string)
         if count == 0:
             raise FileStoreError("not_found", "old_string not present in file")
@@ -197,6 +242,7 @@ class VirtualFileStore:
                 "workspace_full",
                 f"edit would use {projected} bytes; total cap is {self._max_total_bytes}",
             )
+        self._files.move_to_end(conv_key)
         bucket[norm] = FileEntry(content=updated)
         return EditResult(path=norm, bytes=size, replacements=replacements)
 

--- a/miot-harness/src/miot_harness/tools/registry.py
+++ b/miot-harness/src/miot_harness/tools/registry.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.tool import HarnessTool, Progress
 from miot_harness.tools.dashboard import (
@@ -8,6 +9,7 @@ from miot_harness.tools.dashboard import (
     get_dashboard_context_tool,
 )
 from miot_harness.tools.delivery_metrics import get_delivery_compliance_metrics_tool
+from miot_harness.tools.filesystem import VirtualFileStore, build_filesystem_tools
 from miot_harness.tools.storytelling import create_story_draft_tool
 from miot_harness.tools.workflow_events import get_workflow_bottlenecks_tool
 
@@ -37,7 +39,8 @@ class ToolRegistry:
         return await self.get(name).invoke(ctx, raw_input, progress)
 
 
-def build_default_registry() -> ToolRegistry:
+def build_default_registry(settings: HarnessSettings | None = None) -> ToolRegistry:
+    settings = settings or get_settings()
     registry = ToolRegistry()
     registry.register(get_delivery_compliance_metrics_tool())
     registry.register(get_workflow_bottlenecks_tool())
@@ -45,4 +48,14 @@ def build_default_registry() -> ToolRegistry:
     registry.register(create_story_draft_tool())
     registry.register(create_dashboard_widget_draft_tool())
     registry.register(apply_dashboard_patch_tool())
+    if settings.fs_enabled:
+        # One process-local store shared by all four fs_* tools, partitioned
+        # internally by conversation key (ctx.conversation_id or thread_id).
+        store = VirtualFileStore(
+            max_file_bytes=settings.fs_max_file_bytes,
+            max_total_bytes=settings.fs_max_total_bytes,
+            max_files=settings.fs_max_files,
+        )
+        for tool in build_filesystem_tools(store):
+            registry.register(tool)
     return registry

--- a/miot-harness/src/miot_harness/tools/registry.py
+++ b/miot-harness/src/miot_harness/tools/registry.py
@@ -55,6 +55,7 @@ def build_default_registry(settings: HarnessSettings | None = None) -> ToolRegis
             max_file_bytes=settings.fs_max_file_bytes,
             max_total_bytes=settings.fs_max_total_bytes,
             max_files=settings.fs_max_files,
+            max_conversations=settings.fs_max_conversations,
         )
         for tool in build_filesystem_tools(store):
             registry.register(tool)

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -162,6 +162,7 @@ def test_fs_settings_defaults():
     assert settings.fs_max_file_bytes == 65_536
     assert settings.fs_max_total_bytes == 1_048_576
     assert settings.fs_max_files == 64
+    assert settings.fs_max_conversations == 512
 
 
 def test_fs_settings_read_from_env(monkeypatch):
@@ -169,11 +170,13 @@ def test_fs_settings_read_from_env(monkeypatch):
     monkeypatch.setenv("MIOT_HARNESS_FS_MAX_FILE_BYTES", "1024")
     monkeypatch.setenv("MIOT_HARNESS_FS_MAX_TOTAL_BYTES", "4096")
     monkeypatch.setenv("MIOT_HARNESS_FS_MAX_FILES", "8")
+    monkeypatch.setenv("MIOT_HARNESS_FS_MAX_CONVERSATIONS", "16")
     settings = HarnessSettings()
     assert settings.fs_enabled is False
     assert settings.fs_max_file_bytes == 1024
     assert settings.fs_max_total_bytes == 4096
     assert settings.fs_max_files == 8
+    assert settings.fs_max_conversations == 16
 
 
 def test_fs_caps_reject_non_positive(monkeypatch):

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -156,6 +156,32 @@ def test_conversation_token_budget_read_from_env(monkeypatch):
     assert settings.conversation_token_budget == 8_000
 
 
+def test_fs_settings_defaults():
+    settings = HarnessSettings()
+    assert settings.fs_enabled is True
+    assert settings.fs_max_file_bytes == 65_536
+    assert settings.fs_max_total_bytes == 1_048_576
+    assert settings.fs_max_files == 64
+
+
+def test_fs_settings_read_from_env(monkeypatch):
+    monkeypatch.setenv("MIOT_HARNESS_FS_ENABLED", "false")
+    monkeypatch.setenv("MIOT_HARNESS_FS_MAX_FILE_BYTES", "1024")
+    monkeypatch.setenv("MIOT_HARNESS_FS_MAX_TOTAL_BYTES", "4096")
+    monkeypatch.setenv("MIOT_HARNESS_FS_MAX_FILES", "8")
+    settings = HarnessSettings()
+    assert settings.fs_enabled is False
+    assert settings.fs_max_file_bytes == 1024
+    assert settings.fs_max_total_bytes == 4096
+    assert settings.fs_max_files == 8
+
+
+def test_fs_caps_reject_non_positive(monkeypatch):
+    monkeypatch.setenv("MIOT_HARNESS_FS_MAX_FILES", "0")
+    with pytest.raises(ValidationError):
+        HarnessSettings()
+
+
 def test_debug_tenant_allowed_trims_both_sides():
     """Both the allow-list entries AND the input tenant_id are trimmed
     so accidental whitespace on either side doesn't produce a silent

--- a/miot-harness/tests/test_filter_expert.py
+++ b/miot-harness/tests/test_filter_expert.py
@@ -71,6 +71,70 @@ def test_build_tool_catalog_includes_layer_hint():
     assert "KPI summary text" in catalog
 
 
+def test_build_tool_catalog_lists_scratchpad_tools_separately():
+    from miot_harness.tools.filesystem import VirtualFileStore, build_filesystem_tools
+
+    registry = ToolRegistry()
+    registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI summary"))
+    for tool in build_filesystem_tools(VirtualFileStore()):
+        registry.register(tool)
+
+    catalog = build_tool_catalog(registry, profile=NEXO_PROFILE)
+
+    assert "Scratchpad tools" in catalog
+    assert "fs_write" in catalog
+    assert "fs_read" in catalog
+    # Datasource tools still listed.
+    assert "coordinador_centro_control" in catalog
+
+
+@pytest.mark.asyncio
+async def test_filter_expert_allows_scratchpad_tool():
+    """The model may pick a scratchpad fs_* tool — it's a known-safe
+    utility, allowed past the datasource-prefix guardrail."""
+    from miot_harness.tools.filesystem import VirtualFileStore, build_filesystem_tools
+
+    registry = ToolRegistry()
+    registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
+    for tool in build_filesystem_tools(VirtualFileStore()):
+        registry.register(tool)
+
+    fake_response = json.dumps(
+        {
+            "intent": "stash a running note",
+            "tool": "fs_write",
+            "args": {"path": "notes.md", "content": "service 42 is late"},
+            "rationale": "keep working memory out of the prompt",
+        }
+    )
+    model = FakeListChatModel(responses=[fake_response])
+    state: dict[str, Any] = {
+        "user_message": "remember service 42 is late",
+        "ctx": _ctx(),
+        "evidence": [],
+        "turn_count": 0,
+    }
+
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
+
+    assert update.get("failure") is None
+    assert update["plan"].steps[0].tool == "fs_write"
+
+
+@pytest.mark.asyncio
+async def test_filter_expert_refuses_hallucinated_scratchpad_tool():
+    """A made-up fs_* name passes the prefix gate but must still fail the
+    registry-membership check (the allowlist is not a hole)."""
+    registry = ToolRegistry()
+    registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
+    fake_response = json.dumps({"intent": "x", "tool": "fs_bogus", "args": {}, "rationale": "r"})
+    model = FakeListChatModel(responses=[fake_response])
+    state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
+    assert update.get("failure")
+    assert "unknown tool" in update["failure"].lower()
+
+
 @pytest.mark.asyncio
 async def test_filter_expert_produces_single_step():
     """Given a user message and a tool catalog, filter_expert returns a
@@ -95,9 +159,7 @@ async def test_filter_expert_produces_single_step():
         "turn_count": 0,
     }
 
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
 
     plan = update["plan"]
     assert isinstance(plan, DataPlan)
@@ -141,9 +203,7 @@ async def test_filter_expert_appends_to_existing_plan():
         "turn_count": 1,
     }
 
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     new_plan = update["plan"]
 
     assert len(new_plan.steps) == 2
@@ -174,9 +234,7 @@ async def test_filter_expert_clears_next_action():
         "turn_count": 1,
         "next_action": "need_more_tools",
     }
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert update.get("next_action") is None
 
 
@@ -186,16 +244,14 @@ async def test_filter_expert_handles_json_fenced_response():
     registry = ToolRegistry()
     registry.register(_stub_tool("coordinador_centro_control", "[Layer L1] KPI"))
     fenced = (
-        '```json\n'
+        "```json\n"
         '{"intent": "x", "tool": "coordinador_centro_control", '
         '"args": {}, "rationale": "r"}\n'
-        '```'
+        "```"
     )
     model = FakeListChatModel(responses=[fenced])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert "plan" in update
     assert update["plan"].steps[0].tool == "coordinador_centro_control"
 
@@ -228,9 +284,7 @@ async def test_filter_expert_handles_plan_max_steps():
         "evidence": [],
         "turn_count": 4,
     }
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert update.get("failure")
     assert update.get("next_action") == "ready_to_synthesize"
 
@@ -251,9 +305,7 @@ async def test_filter_expert_refuses_non_coordinador_tool():
     )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert update.get("failure")
     assert "out-of-scope" in update["failure"] or "scope" in update["failure"].lower()
 
@@ -272,9 +324,7 @@ async def test_filter_expert_emits_plan_created_event_on_first_step():
     )
     model = FakeListChatModel(responses=[fake_response])
     state = {"user_message": "?", "ctx": _ctx(), "evidence": [], "turn_count": 0}
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     events = update.get("_events") or []
     assert any(e.type == "plan.created" for e in events)
 
@@ -303,9 +353,7 @@ async def test_filter_expert_refuses_unknown_tool():
         "turn_count": 0,
     }
 
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert update.get("failure")
 
 
@@ -323,7 +371,5 @@ async def test_filter_expert_non_object_json_is_malformed_step():
         "evidence": [],
         "turn_count": 0,
     }
-    update = await filter_expert_node(
-        state, registry=registry, model=model, profile=NEXO_PROFILE
-    )
+    update = await filter_expert_node(state, registry=registry, model=model, profile=NEXO_PROFILE)
     assert update.get("failure") == "filter_expert returned malformed step"

--- a/miot-harness/tests/test_tool_registry.py
+++ b/miot-harness/tests/test_tool_registry.py
@@ -1,8 +1,27 @@
+from miot_harness.config import HarnessSettings
 from miot_harness.tools.registry import build_default_registry
 
 
 def test_default_registry_contains_first_slice_tools() -> None:
+    # fs_* scratchpad tools are on by default (fs_enabled=True).
     registry = build_default_registry()
+
+    assert registry.names() == [
+        "apply_dashboard_patch",
+        "create_dashboard_widget_draft",
+        "create_story_draft",
+        "fs_edit",
+        "fs_ls",
+        "fs_read",
+        "fs_write",
+        "get_dashboard_context",
+        "get_delivery_compliance_metrics",
+        "get_workflow_bottlenecks",
+    ]
+
+
+def test_default_registry_omits_fs_tools_when_disabled() -> None:
+    registry = build_default_registry(HarnessSettings(fs_enabled=False))
 
     assert registry.names() == [
         "apply_dashboard_patch",

--- a/miot-harness/tests/tools/test_filesystem_store.py
+++ b/miot-harness/tests/tools/test_filesystem_store.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.tools.filesystem import FileStoreError, VirtualFileStore
+
+CONV = "conv-1"
+OTHER = "conv-2"
+
+
+def test_write_then_read_round_trip() -> None:
+    store = VirtualFileStore()
+    res = store.write(CONV, "notes.md", "hello")
+    assert res.path == "notes.md"
+    assert res.bytes == 5
+    assert res.created is True
+    assert store.read(CONV, "notes.md") == "hello"
+
+
+def test_overwrite_reports_not_created() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "a.txt", "one")
+    res = store.write(CONV, "a.txt", "two-longer")
+    assert res.created is False
+    assert store.read(CONV, "a.txt") == "two-longer"
+
+
+def test_read_missing_returns_none() -> None:
+    store = VirtualFileStore()
+    assert store.read(CONV, "nope.txt") is None
+
+
+def test_ls_returns_only_this_conversation_sorted() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "b.txt", "b")
+    store.write(CONV, "a.txt", "aa")
+    store.write(OTHER, "secret.txt", "x")
+    listing = store.ls(CONV)
+    assert listing == [("a.txt", 2), ("b.txt", 1)]
+
+
+def test_ls_prefix_filter() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "plans/p1.md", "1")
+    store.write(CONV, "plans/p2.md", "2")
+    store.write(CONV, "notes.md", "3")
+    assert [p for p, _ in store.ls(CONV, prefix="plans/")] == ["plans/p1.md", "plans/p2.md"]
+
+
+def test_cross_conversation_isolation() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "mine")
+    assert store.read(OTHER, "f.txt") is None
+    assert store.ls(OTHER) == []
+
+
+def test_edit_single_occurrence() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "the quick brown fox")
+    res = store.edit(CONV, "f.txt", "quick", "slow")
+    assert res.replacements == 1
+    assert store.read(CONV, "f.txt") == "the slow brown fox"
+
+
+def test_edit_replace_all() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "a a a")
+    res = store.edit(CONV, "f.txt", "a", "b", replace_all=True)
+    assert res.replacements == 3
+    assert store.read(CONV, "f.txt") == "b b b"
+
+
+def test_edit_not_unique_without_replace_all() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "x x")
+    with pytest.raises(FileStoreError) as exc:
+        store.edit(CONV, "f.txt", "x", "y")
+    assert exc.value.code == "not_unique"
+
+
+def test_edit_missing_file() -> None:
+    store = VirtualFileStore()
+    with pytest.raises(FileStoreError) as exc:
+        store.edit(CONV, "ghost.txt", "a", "b")
+    assert exc.value.code == "not_found"
+
+
+def test_edit_absent_old_string() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "hello")
+    with pytest.raises(FileStoreError) as exc:
+        store.edit(CONV, "f.txt", "zzz", "y")
+    assert exc.value.code == "not_found"
+
+
+def test_edit_empty_old_string_rejected() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "f.txt", "hello")
+    with pytest.raises(FileStoreError) as exc:
+        store.edit(CONV, "f.txt", "", "y")
+    assert exc.value.code == "invalid_edit"
+
+
+@pytest.mark.parametrize("bad", ["/abs/path", "../escape", "a/../b", "", "   ", "/"])
+def test_path_normalization_rejects_unsafe(bad: str) -> None:
+    store = VirtualFileStore()
+    with pytest.raises(FileStoreError) as exc:
+        store.write(CONV, bad, "x")
+    assert exc.value.code == "invalid_path"
+
+
+def test_path_normalization_strips_redundant_segments() -> None:
+    store = VirtualFileStore()
+    store.write(CONV, "./dir//file.txt", "x")
+    assert store.read(CONV, "dir/file.txt") == "x"
+
+
+def test_per_file_byte_cap() -> None:
+    store = VirtualFileStore(max_file_bytes=4)
+    with pytest.raises(FileStoreError) as exc:
+        store.write(CONV, "f.txt", "12345")
+    assert exc.value.code == "file_too_large"
+
+
+def test_total_byte_cap() -> None:
+    store = VirtualFileStore(max_total_bytes=6)
+    store.write(CONV, "a.txt", "abc")
+    with pytest.raises(FileStoreError) as exc:
+        store.write(CONV, "b.txt", "defg")
+    assert exc.value.code == "workspace_full"
+
+
+def test_overwrite_counts_against_total_minus_existing() -> None:
+    # Existing file's bytes are reclaimed when overwriting, so an
+    # overwrite that fits within the cap is allowed.
+    store = VirtualFileStore(max_total_bytes=5)
+    store.write(CONV, "a.txt", "abcde")
+    res = store.write(CONV, "a.txt", "xy")
+    assert res.bytes == 2
+
+
+def test_max_files_cap() -> None:
+    store = VirtualFileStore(max_files=2)
+    store.write(CONV, "a", "1")
+    store.write(CONV, "b", "2")
+    with pytest.raises(FileStoreError) as exc:
+        store.write(CONV, "c", "3")
+    assert exc.value.code == "too_many_files"
+
+
+def test_edit_total_cap_enforced() -> None:
+    store = VirtualFileStore(max_total_bytes=5)
+    store.write(CONV, "a.txt", "abcde")
+    with pytest.raises(FileStoreError) as exc:
+        store.edit(CONV, "a.txt", "abcde", "abcdefgh")
+    assert exc.value.code == "workspace_full"

--- a/miot-harness/tests/tools/test_filesystem_store.py
+++ b/miot-harness/tests/tools/test_filesystem_store.py
@@ -154,3 +154,37 @@ def test_edit_total_cap_enforced() -> None:
     with pytest.raises(FileStoreError) as exc:
         store.edit(CONV, "a.txt", "abcde", "abcdefgh")
     assert exc.value.code == "workspace_full"
+
+
+def test_global_conversation_lru_eviction() -> None:
+    store = VirtualFileStore(max_conversations=2)
+    store.write("c1", "f", "1")
+    store.write("c2", "f", "2")
+    store.write("c3", "f", "3")  # exceeds cap → evicts c1 (least recently used)
+    assert store.read("c1", "f") is None
+    assert store.read("c2", "f") == "2"
+    assert store.read("c3", "f") == "3"
+
+
+def test_access_marks_conversation_most_recently_used() -> None:
+    store = VirtualFileStore(max_conversations=2)
+    store.write("c1", "f", "1")
+    store.write("c2", "f", "2")
+    # Touch c1 so c2 becomes the LRU victim instead.
+    assert store.read("c1", "f") == "1"
+    store.write("c3", "f", "3")
+    assert store.read("c2", "f") is None
+    assert store.read("c1", "f") == "1"
+    assert store.read("c3", "f") == "3"
+
+
+def test_failed_write_does_not_evict_or_create_bucket() -> None:
+    # A write that violates a per-conversation cap must not evict an existing
+    # conversation or leave behind an empty bucket for the failed one.
+    store = VirtualFileStore(max_conversations=1, max_file_bytes=2)
+    store.write("c1", "f", "ok")
+    with pytest.raises(FileStoreError) as exc:
+        store.write("c2", "f", "toolong")
+    assert exc.value.code == "file_too_large"
+    assert store.read("c1", "f") == "ok"  # c1 not evicted
+    assert store.ls("c2") == []  # c2 never materialized

--- a/miot-harness/tests/tools/test_filesystem_tools.py
+++ b/miot-harness/tests/tools/test_filesystem_tools.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.config import HarnessSettings
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.events import HarnessEvent
+from miot_harness.tools.filesystem import (
+    FsReadOutput,
+    FsWriteOutput,
+    VirtualFileStore,
+    build_filesystem_tools,
+)
+from miot_harness.tools.registry import build_default_registry
+
+
+def _ctx(*, conversation_id: str | None = "conv-1", thread_id: str = "thread-1") -> HarnessContext:
+    return HarnessContext(
+        thread_id=thread_id,
+        tenant_id="acme",
+        user_id="u1",
+        conversation_id=conversation_id,
+    )
+
+
+def _tools() -> dict[str, object]:
+    store = VirtualFileStore()
+    return {t.name: t for t in build_filesystem_tools(store)}
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_through_tools() -> None:
+    tools = _tools()
+    ctx = _ctx()
+    events: list[HarnessEvent] = []
+
+    out = await tools["fs_write"].invoke(ctx, {"path": "n.md", "content": "hi"}, events.append)
+    assert isinstance(out, FsWriteOutput)
+    assert out.ok and out.created and out.bytes == 2
+
+    read = await tools["fs_read"].invoke(ctx, {"path": "n.md"}, events.append)
+    assert isinstance(read, FsReadOutput)
+    assert read.found and read.content == "hi"
+
+
+@pytest.mark.asyncio
+async def test_invoke_emits_started_and_completed_events() -> None:
+    tools = _tools()
+    events: list[HarnessEvent] = []
+    await tools["fs_write"].invoke(_ctx(), {"path": "n.md", "content": "x"}, events.append)
+    types = [e.type for e in events]
+    assert "tool.started" in types
+    assert "tool.completed" in types
+
+
+@pytest.mark.asyncio
+async def test_read_missing_returns_found_false_no_raise() -> None:
+    tools = _tools()
+    out = await tools["fs_read"].invoke(_ctx(), {"path": "ghost.md"}, lambda _e: None)
+    assert isinstance(out, FsReadOutput)
+    assert out.ok and out.found is False and out.content is None
+
+
+@pytest.mark.asyncio
+async def test_cap_violation_returns_typed_error_not_exception() -> None:
+    store = VirtualFileStore(max_file_bytes=2)
+    tools = {t.name: t for t in build_filesystem_tools(store)}
+    out = await tools["fs_write"].invoke(
+        _ctx(), {"path": "n.md", "content": "toolong"}, lambda _e: None
+    )
+    assert isinstance(out, FsWriteOutput)
+    assert out.ok is False
+    assert out.error is not None and out.error.startswith("file_too_large")
+
+
+@pytest.mark.asyncio
+async def test_tools_isolate_by_conversation() -> None:
+    # One shared store across both contexts (as in production), different
+    # conversation ids → isolated views.
+    store = VirtualFileStore()
+    tools = {t.name: t for t in build_filesystem_tools(store)}
+    a, b = _ctx(conversation_id="A"), _ctx(conversation_id="B")
+
+    await tools["fs_write"].invoke(a, {"path": "f.md", "content": "secret-a"}, lambda _e: None)
+    out_b = await tools["fs_read"].invoke(b, {"path": "f.md"}, lambda _e: None)
+    assert isinstance(out_b, FsReadOutput)
+    assert out_b.found is False
+
+
+@pytest.mark.asyncio
+async def test_edit_through_tool() -> None:
+    tools = _tools()
+    ctx = _ctx()
+    await tools["fs_write"].invoke(ctx, {"path": "f.md", "content": "alpha beta"}, lambda _e: None)
+    out = await tools["fs_edit"].invoke(
+        ctx, {"path": "f.md", "old_string": "beta", "new_string": "gamma"}, lambda _e: None
+    )
+    assert out.ok and out.replacements == 1
+    read = await tools["fs_read"].invoke(ctx, {"path": "f.md"}, lambda _e: None)
+    assert read.content == "alpha gamma"
+
+
+@pytest.mark.asyncio
+async def test_round_trip_through_registry_invoke() -> None:
+    # T4: prove the normal tool-invocation seam (used by data_fetcher in
+    # both data_graph and agentic_graph) reaches the scratchpad.
+    registry = build_default_registry()
+    ctx = _ctx()
+    await registry.invoke(
+        "fs_write", ctx, {"path": "plan.md", "content": "step 1"}, lambda _e: None
+    )
+    out = await registry.invoke("fs_read", ctx, {"path": "plan.md"}, lambda _e: None)
+    assert isinstance(out, FsReadOutput)
+    assert out.found and out.content == "step 1"
+
+
+def test_default_registry_excludes_fs_tools_when_disabled() -> None:
+    registry = build_default_registry(HarnessSettings(fs_enabled=False))
+    assert not any(n.startswith("fs_") for n in registry.names())


### PR DESCRIPTION
Closes #665

## Summary

Adds a **virtual, in-memory, per-conversation filesystem scratchpad** so harness agents can offload notes, plans, and intermediate findings to files instead of carrying them in the LLM context window across a multi-turn run. Files never touch real disk and never cross conversation/tenant boundaries.

This is the DeepAgents "virtual filesystem" pattern adapted to the harness's own `HarnessTool` / `ToolRegistry` model (no LangGraph `InjectedState`).

## What's included

- **`tools/filesystem.py`** — `VirtualFileStore`: a process-local store keyed by `conversation_id` (falling back to `thread_id`), mirroring `InMemoryConversationStore`'s durability semantics. Path normalization rejects absolute/`..` keys; per-file, total-bytes, and file-count caps raise `FileStoreError`.
- **Four tools** (`fs_write` / `fs_read` / `fs_ls` / `fs_edit`) via `HarnessTool` factories. Cap/validation failures return a typed `ok=false` output (structured result for the agent, not an abort); a missing read returns `found=false`.
- **Registry wiring** — registered in `build_default_registry()` behind `fs_enabled` (default on), so both `data_graph` (plan-execute) and `agentic_graph` reach them via the normal tool-invocation path.
- **Config** — `fs_enabled`, `fs_max_file_bytes` (64 KB), `fs_max_total_bytes` (1 MB), `fs_max_files` (64).
- **`filter_expert`** — surfaces scratchpad tools in their own catalog section and allows `fs_*` past the datasource-prefix guardrail as a **known-safe utility allowlist** (a hallucinated `fs_*` still fails the registry-membership check); prompt hint added so the planner knows the scratchpad exists.

## Backing store / scope (v1)

- **Virtual only** — no disk persistence; lost on restart (same as `ConversationStore`). A disk-/Redis-backed `FileStore` can slot behind the same surface later.
- Out of scope: `fs_delete`, glob/grep, binary files, user-facing file delivery, eviction/LRU (caps only).
- Files are **not** part of the serialized `HarnessRunRecord` snapshot, by design.

## Testing

- New: `tests/tools/test_filesystem_store.py` (store: round-trip, caps, path safety, cross-conversation isolation), `tests/tools/test_filesystem_tools.py` (invoke-path, event emission, registry round-trip, isolation), plus `filter_expert` scratchpad-acceptance + hallucination-refusal tests and config/registry-gating tests.
- `uv run pytest` → **546 passed, 2 skipped**; `mypy --strict` clean on new modules; `ruff` check + format clean.

## Follow-up note

The cleanest consumer of the scratchpad is the **agentic planner** (free multi-turn exploration), which is a stub on `trunk` and lands in PR #641. In the `data_graph` plan-execute loop a `fs_write` step executes via `data_fetcher` and flows through `freshness_judge`/`domain_analyst` — mechanically fine and green, but worth a live two-turn confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added virtual filesystem scratchpad with configurable storage limits (per-file size, total workspace size, maximum file count).
  * Filesystem operations available: write, read, list, and edit files with per-conversation data isolation.

* **Tests**
  * Comprehensive test coverage added for filesystem operations and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->