### PR TITLE
fix(app): prevent task-edit crash when a media node has no content stream

### DIFF
--- a/turbo-repo/apps/app/src/features/common/components/error-boundary/error-boundary.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/error-boundary/error-boundary.tsx
@@ -1,15 +1,31 @@
 "use client";
 
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import {
+  Component,
+  cloneElement,
+  isValidElement,
+  type ErrorInfo,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+// Props the boundary injects into the fallback element when a child throws.
+// Both are optional so callers can construct the element with only its own
+// props (e.g. an i18n dictionary); the boundary fills these in via cloneElement.
+export type ErrorFallbackProps = {
+  error?: Error;
+  reset?: () => void;
+};
 
 type ErrorBoundaryProps = Readonly<{
   children: ReactNode;
-  // Rendered in place of `children` when a descendant throws during render or in
-  // a lifecycle method. `reset` clears the captured error so the subtree
-  // re-mounts — wire it to a "retry" control in the fallback.
-  fallback: (error: Error, reset: () => void) => ReactNode;
-  // Optional hook for logging/telemetry. React still logs the error to the
-  // console; this is for sending it somewhere durable.
+  // A React element rendered in place of `children` when a descendant throws.
+  // The boundary injects `error` and a `reset` callback (which clears the error
+  // so the subtree re-mounts) into it via cloneElement. Passing an element —
+  // not an inline render function — keeps call sites free of nested component
+  // definitions (sonar typescript:S6478).
+  fallback: ReactElement<ErrorFallbackProps>;
+  // Optional hook for logging/telemetry. React still logs to the console.
   onError?: (error: Error, info: ErrorInfo) => void;
 }>;
 
@@ -37,7 +53,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   render(): ReactNode {
     const { error } = this.state;
     if (error) {
-      return this.props.fallback(error, this.reset);
+      const { fallback } = this.props;
+      return isValidElement(fallback)
+        ? cloneElement(fallback, { error, reset: this.reset })
+        : fallback;
     }
     return this.props.children;
   }

--- a/turbo-repo/apps/app/src/features/common/components/error-boundary/error-boundary.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/error-boundary/error-boundary.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ErrorBoundaryProps = Readonly<{
+  children: ReactNode;
+  // Rendered in place of `children` when a descendant throws during render or in
+  // a lifecycle method. `reset` clears the captured error so the subtree
+  // re-mounts — wire it to a "retry" control in the fallback.
+  fallback: (error: Error, reset: () => void) => ReactNode;
+  // Optional hook for logging/telemetry. React still logs the error to the
+  // console; this is for sending it somewhere durable.
+  onError?: (error: Error, info: ErrorInfo) => void;
+}>;
+
+type ErrorBoundaryState = { error: Error | null };
+
+// React error boundaries must be class components — there is no hook equivalent
+// for componentDidCatch. This contains a render-time crash to the wrapped
+// subtree instead of letting it unmount the whole route (Next.js otherwise
+// surfaces a full-page "This page couldn't load" fallback).
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      return this.props.fallback(error, this.reset);
+    }
+    return this.props.children;
+  }
+}

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
@@ -5,9 +5,41 @@ import { HiExclamationTriangle } from "react-icons/hi2";
 import { TaskResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
 import { I18nDictionary } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
-import { ErrorBoundary } from "@/features/common/components/error-boundary/error-boundary";
+import {
+  ErrorBoundary,
+  ErrorFallbackProps,
+} from "@/features/common/components/error-boundary/error-boundary";
 import Geographic from "@/features/shipping/components/geographic";
 import FileImages from "./components/side-data/multimedia-manager.tsx/gallery/file-images";
+
+// Contained fallback for the media panel. Defined at module scope (not inline in
+// the parent) so it is a stable component — sonar typescript:S6478. `reset` is
+// injected by ErrorBoundary; `dict` is supplied at the call site.
+function MediaPanelErrorFallback({
+  reset,
+  dict,
+}: ErrorFallbackProps & Readonly<{ dict: I18nDictionary }>) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <HiExclamationTriangle className="h-8 w-8 text-amber-500" />
+      <div>
+        <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+          {tr("bento.multimedia.panel_error_title", dict)}
+        </p>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {tr("bento.multimedia.panel_error_description", dict)}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+      >
+        {tr("bento.multimedia.panel_error_retry", dict)}
+      </button>
+    </div>
+  );
+}
 
 export default function BentoMediaSection({
   task,
@@ -53,28 +85,7 @@ export default function BentoMediaSection({
         className="flex-1 overflow-hidden rounded-lg border scroll-p-6 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-500 ease-in-out"
         style={{ minWidth: 0 }}
       >
-        <ErrorBoundary
-          fallback={(_error, reset) => (
-            <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
-              <HiExclamationTriangle className="h-8 w-8 text-amber-500" />
-              <div>
-                <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
-                  {tr("bento.multimedia.panel_error_title", dict)}
-                </p>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  {tr("bento.multimedia.panel_error_description", dict)}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={reset}
-                className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
-              >
-                {tr("bento.multimedia.panel_error_retry", dict)}
-              </button>
-            </div>
-          )}
-        >
+        <ErrorBoundary fallback={<MediaPanelErrorFallback dict={dict} />}>
           <FileImages
             task={task}
             dictionary={dict}

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { HiExclamationTriangle } from "react-icons/hi2";
 import { TaskResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
 import { I18nDictionary } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { ErrorBoundary } from "@/features/common/components/error-boundary/error-boundary";
 import Geographic from "@/features/shipping/components/geographic";
 import FileImages from "./components/side-data/multimedia-manager.tsx/gallery/file-images";
 
@@ -50,13 +53,36 @@ export default function BentoMediaSection({
         className="flex-1 overflow-hidden rounded-lg border scroll-p-6 border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-500 ease-in-out"
         style={{ minWidth: 0 }}
       >
-        <FileImages
-          task={task}
-          dictionary={dict}
-          isExpanded={isMediaExpanded}
-          onRequestExpand={() => setIsMediaExpanded(true)}
-          onRequestCollapse={() => setIsMediaExpanded(false)}
-        />
+        <ErrorBoundary
+          fallback={(_error, reset) => (
+            <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
+              <HiExclamationTriangle className="h-8 w-8 text-amber-500" />
+              <div>
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
+                  {tr("bento.multimedia.panel_error_title", dict)}
+                </p>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {tr("bento.multimedia.panel_error_description", dict)}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={reset}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+              >
+                {tr("bento.multimedia.panel_error_retry", dict)}
+              </button>
+            </div>
+          )}
+        >
+          <FileImages
+            task={task}
+            dictionary={dict}
+            isExpanded={isMediaExpanded}
+            onRequestExpand={() => setIsMediaExpanded(true)}
+            onRequestCollapse={() => setIsMediaExpanded(false)}
+          />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-media-section.tsx
@@ -21,7 +21,7 @@ function MediaPanelErrorFallback({
 }: ErrorFallbackProps & Readonly<{ dict: I18nDictionary }>) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
-      <HiExclamationTriangle className="h-8 w-8 text-amber-500" />
+      <HiExclamationTriangle aria-hidden="true" className="h-8 w-8 text-amber-500" />
       <div>
         <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
           {tr("bento.multimedia.panel_error_title", dict)}

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.test.ts
@@ -276,6 +276,12 @@ describe("isImageEntry", () => {
       // Mislabeled name but image content → still an image.
       expect(isImageEntry(makeEntry("scan.pdf", "image/png"))).toBe(true);
     });
+
+    it("should not match non-image MIME types that merely contain 'image'", () => {
+      // Strict image/ family check — a substring match would misclassify these.
+      expect(isImageEntry(makeEntry("a.bin", "application/vnd.fake-image"))).toBe(false);
+      expect(isImageEntry(makeEntry("b.txt", "text/x-image-description"))).toBe(false);
+    });
   });
 
   describe("falls back to the file extension when content is missing", () => {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.test.ts
@@ -3,9 +3,28 @@ import {
   extractImageUrlFromDrop,
   isValidImageUrl,
   fetchImageAsFile,
+  isImageEntry,
   ALLOWED_FILE_TYPES,
   ALLOWED_IMAGE_EXTENSIONS,
 } from "./file-images";
+import { AlfrescoFileEntry } from "../image.types";
+
+// Build a minimal AlfrescoFileEntry for classification tests. `content` is
+// intentionally omittable — Alfresco drops it for nodes with no content stream.
+function makeEntry(
+  name: string,
+  mimeType?: string
+): AlfrescoFileEntry {
+  return {
+    entry: {
+      id: "node-1",
+      name,
+      ...(mimeType
+        ? { content: { mimeType, mimeTypeName: mimeType, sizeInBytes: 1, encoding: "UTF-8" } }
+        : {}),
+    } as AlfrescoFileEntry["entry"],
+  };
+}
 
 // Helper to create a mock DataTransfer object
 function createMockDataTransfer(data: Record<string, string>): DataTransfer {
@@ -239,6 +258,43 @@ describe("isValidImageUrl", () => {
   describe("ALLOWED_IMAGE_EXTENSIONS constant", () => {
     it("should contain exactly jpg, jpeg, png", () => {
       expect(ALLOWED_IMAGE_EXTENSIONS).toEqual(new Set(["jpg", "jpeg", "png"]));
+    });
+  });
+});
+
+describe("isImageEntry", () => {
+  describe("classifies by mimeType when content is present", () => {
+    it("should return true for an image mimeType", () => {
+      expect(isImageEntry(makeEntry("photo.jpg", "image/jpeg"))).toBe(true);
+    });
+
+    it("should return false for a non-image mimeType", () => {
+      expect(isImageEntry(makeEntry("doc.pdf", "application/pdf"))).toBe(false);
+    });
+
+    it("should trust the mimeType over the extension", () => {
+      // Mislabeled name but image content → still an image.
+      expect(isImageEntry(makeEntry("scan.pdf", "image/png"))).toBe(true);
+    });
+  });
+
+  describe("falls back to the file extension when content is missing", () => {
+    // Reproduces the incident: a full disk left a cm:content node with a name
+    // but no `content` block. It must still classify as an image, not crash.
+    it("should return true for a .jpg name with no content", () => {
+      expect(isImageEntry(makeEntry("polf-image-1.jpg"))).toBe(true);
+    });
+
+    it("should be case-insensitive on the extension", () => {
+      expect(isImageEntry(makeEntry("PHOTO.JPG"))).toBe(true);
+    });
+
+    it("should return false for a .pdf name with no content", () => {
+      expect(isImageEntry(makeEntry("contract.pdf"))).toBe(false);
+    });
+
+    it("should return false when there is no extension and no content", () => {
+      expect(isImageEntry(makeEntry("folder-node"))).toBe(false);
     });
   });
 });

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -262,7 +262,7 @@ export const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png"]);
 // gallery (with its missing-thumbnail icon) instead of being misfiled as a PDF.
 export function isImageEntry(entry: AlfrescoFileEntry): boolean {
   const mimeType = entry.entry.content?.mimeType;
-  if (mimeType) return mimeType.includes("image");
+  if (mimeType) return mimeType.startsWith("image/");
   const ext = entry.entry.name?.split(".").pop()?.toLowerCase();
   return ext ? ALLOWED_IMAGE_EXTENSIONS.has(ext) : false;
 }

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -254,6 +254,19 @@ export const ALLOWED_FILE_TYPES = new Set([
 
 export const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png"]);
 
+// Decide whether an entry belongs in the image gallery vs. the document list.
+// Prefer the server-reported mimeType, but Alfresco omits the `content` block
+// entirely when a node has no content stream — e.g. an upload interrupted by a
+// full disk leaves a `cm:content` node with a name but no bytes. In that case
+// fall back to the filename extension so a broken image still shows in the
+// gallery (with its missing-thumbnail icon) instead of being misfiled as a PDF.
+export function isImageEntry(entry: AlfrescoFileEntry): boolean {
+  const mimeType = entry.entry.content?.mimeType;
+  if (mimeType) return mimeType.includes("image");
+  const ext = entry.entry.name?.split(".").pop()?.toLowerCase();
+  return ext ? ALLOWED_IMAGE_EXTENSIONS.has(ext) : false;
+}
+
 function filterValidFiles(files: File[], dictionary: I18nRecord): File[] | null {
   const validFiles = files.filter((file) => ALLOWED_FILE_TYPES.has(file.type));
   if (validFiles.length !== files.length) {
@@ -801,7 +814,7 @@ export default function FileImages({
           if (reviewedAt) loadedTimestamps.set(entry.entry.id, new Date(reviewedAt));
           const reviewedBy = entry.entry.properties?.["mintral:reviewedBy"];
           if (reviewedBy) loadedUsers.set(entry.entry.id, reviewedBy);
-          if (entry.entry.content.mimeType.includes("image")) {
+          if (isImageEntry(entry)) {
             newImages.push({ file: entry, data: document });
           } else {
             newDocuments.push({ file: entry, data: document });

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image.types.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/image.types.ts
@@ -2,7 +2,10 @@ export interface AlfrescoFileEntry {
   entry: {
     id: string;
     name: string;
-    content: {
+    // Alfresco omits `content` entirely for nodes that have no content stream
+    // (e.g. folder nodes, or entries returned before an upload finishes), so this
+    // is optional — every read must guard with `?.` or it crashes at runtime.
+    content?: {
       mimeType: string;
       mimeTypeName: string;
       sizeInBytes: number;

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
@@ -47,10 +47,10 @@ export function PropertiesGrid({ entry, categoryLabel, onRename, dictionary }: P
         <MetaRow label={tr("bento.multimedia.sidebar_prop_version", dictionary)} value={`v${entry.properties?.["cm:versionLabel"]}`} />
       )}
       {entry.content && (
-        <MetaRow label={tr("bento.multimedia.sidebar_prop_format", dictionary)} value={entry.content.mimeTypeName ?? entry.content.mimeType} />
-      )}
-      {entry.content && (
-        <MetaRow label={tr("bento.multimedia.sidebar_prop_size", dictionary)} value={formatBytes(entry.content.sizeInBytes)} />
+        <>
+          <MetaRow label={tr("bento.multimedia.sidebar_prop_format", dictionary)} value={entry.content.mimeTypeName ?? entry.content.mimeType} />
+          <MetaRow label={tr("bento.multimedia.sidebar_prop_size", dictionary)} value={formatBytes(entry.content.sizeInBytes)} />
+        </>
       )}
       {entry.properties?.["exif:pixelXDimension"] != null && entry.properties?.["exif:pixelYDimension"] != null && (
         <MetaRow label="Resolution" value={`${entry.properties?.["exif:pixelXDimension"]} × ${entry.properties?.["exif:pixelYDimension"]}`} />

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/properties-grid.tsx
@@ -46,8 +46,12 @@ export function PropertiesGrid({ entry, categoryLabel, onRename, dictionary }: P
       {entry.properties?.["cm:versionLabel"] && (
         <MetaRow label={tr("bento.multimedia.sidebar_prop_version", dictionary)} value={`v${entry.properties?.["cm:versionLabel"]}`} />
       )}
-      <MetaRow label={tr("bento.multimedia.sidebar_prop_format", dictionary)} value={entry.content.mimeTypeName ?? entry.content.mimeType} />
-      <MetaRow label={tr("bento.multimedia.sidebar_prop_size", dictionary)} value={formatBytes(entry.content.sizeInBytes)} />
+      {entry.content && (
+        <MetaRow label={tr("bento.multimedia.sidebar_prop_format", dictionary)} value={entry.content.mimeTypeName ?? entry.content.mimeType} />
+      )}
+      {entry.content && (
+        <MetaRow label={tr("bento.multimedia.sidebar_prop_size", dictionary)} value={formatBytes(entry.content.sizeInBytes)} />
+      )}
       {entry.properties?.["exif:pixelXDimension"] != null && entry.properties?.["exif:pixelYDimension"] != null && (
         <MetaRow label="Resolution" value={`${entry.properties?.["exif:pixelXDimension"]} × ${entry.properties?.["exif:pixelYDimension"]}`} />
       )}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2768,6 +2768,9 @@
       "only_jpg_jpeg_png_allowed": "Only JPG, JPEG or PNG files are allowed.",
       "fetch_image_error": "Could not fetch the image from the URL. Please try downloading it first.",
       "fetching_image": "Fetching image...",
+      "panel_error_title": "The media panel couldn't be displayed",
+      "panel_error_description": "Something went wrong loading this content. The rest of the page is unaffected.",
+      "panel_error_retry": "Retry",
       "select_document_type": "Select a document type",
       "select_document_type_error": "You must select a document type",
       "categories": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2768,6 +2768,9 @@
       "only_jpg_jpeg_png_allowed": "Solo se permiten archivos JPG, JPEG o PNG.",
       "fetch_image_error": "No se pudo obtener la imagen desde la URL. Por favor, intente descargarla primero.",
       "fetching_image": "Obteniendo imagen...",
+      "panel_error_title": "No se pudo mostrar el panel multimedia",
+      "panel_error_description": "Ocurrió un error al cargar este contenido. El resto de la página no se ve afectado.",
+      "panel_error_retry": "Reintentar",
       "select_document_type": "Selecciona un Tipo de Documento",
       "select_document_type_error": "Debe seleccionar un tipo de documento",
       "categories": {


### PR DESCRIPTION
## What

Fixes a full-page crash on the task edit screen (`/app/<locale>/task/edit/<id>`) — the Next.js **"This page couldn't load"** fallback — triggered when the bento multimedia panel contains a media node with **no content stream**.

Closes #668

## Root cause

`FileImages` read `entry.entry.content.mimeType` unconditionally. Alfresco **omits the `content` block entirely** for a node whose content stream was never written. In this incident a full disk left a `cm:content` node (`polf-image-1.jpg`) with a name but no `content`, so the read threw `TypeError: Cannot read properties of undefined (reading 'mimeType')` during render and unmounted the whole route.

## Changes

- **Type honesty** — `content` is now optional on `AlfrescoFileEntry` (Alfresco can omit it), with a comment mirroring the existing one on `properties?`.
- **Guard the reads** — `file-images.tsx` and `viewer/sidebar/properties-grid.tsx`.
- **Correct classification** — new exported `isImageEntry()` prefers `content.mimeType` but falls back to the filename extension, so a contentless image still lands in the gallery (with its missing-thumbnail icon) instead of being misfiled as a PDF/document.
- **Containment** — new reusable `ErrorBoundary` (`features/common/components/error-boundary/`) wraps `<FileImages>`; any future render error in the media panel now shows a small localized fallback with a retry button instead of crashing the page.
- **i18n** — `panel_error_title` / `panel_error_description` / `panel_error_retry` in `en.json` and `es.json`.
- **Tests** — `isImageEntry()` unit tests, including the exact contentless-`.jpg` incident case.

## Verification

- `vitest run` on the affected suite: **59 passed** (52 existing + 7 new).
- `tsc --noEmit`: **0 errors**.

## Note

The `ErrorBoundary` catches render-time errors. The original crash was on a render path so it's covered; the `content` guard removes the cause directly, and the boundary is the safety net for the next unforeseen failure. A backend follow-up to clean up the orphaned `cm:content` node left by the disk-full event may be worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media uploads now show a clearer, localized error state for the multimedia panel, including a retry action
  * Improved image detection to better classify partially processed or incomplete uploads
  * Added multilingual (EN/ES) media panel error messaging for a more consistent experience
* **Bug Fixes**
  * Prevented potential runtime crashes by safely handling cases where file content metadata is missing
  * Updated image/file partitioning to use the improved classification logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->