### PR TITLE
fix(flyway): tolerate applied-but-future component migrations in FlywayMigrator

### DIFF
--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -86,7 +86,15 @@ public class FlywayMigrator {
                 .schemas("miot_core")
                 .defaultSchema("miot_core")
                 .outOfOrder(true)
-                .ignoreMigrationPatterns("*:missing")
+                // Tolerate applied component migrations this run can't resolve
+                // locally because the component is disabled (its location isn't
+                // added above). Both buckets matter — mirrors the extension config
+                // from #536 (quarkus.flyway.ignore-migration-patterns=*:missing,*:future):
+                //   *:missing → applied version BELOW the resolved max (e.g. fleet 0.2.x)
+                //   *:future  → applied version ABOVE the resolved max (e.g. integrations 0.6.x)
+                // Without *:future, disabling a component whose migrations are already
+                // applied aborts boot with "applied migration not resolved locally".
+                .ignoreMigrationPatterns("*:missing", "*:future")
                 .load();
 
         flyway.migrate();


### PR DESCRIPTION
## Problem

The GKE dev modulith crash-looped on boot after the umbrella `miot-stack` deploy ran it with the **integrations component disabled**:

```
FlywayValidateException: Validate failed: Migrations have failed validation
Detected applied migration not resolved locally: 0.6.0
Detected applied migration not resolved locally: 0.6.1
```

`FlywayMigrator` only adds `db/migration/<component>` to its scan locations for **enabled** components. With integrations off, the already-applied `0.6.x` rows in `miot_core.flyway_schema_history` are unresolved locally and — being above the enabled set's max version (`0.5.6`) — classified as `future`. The call site ignored only `*:missing`, **not** `*:future`, so `validate()` aborted boot.

## Why this is the right fix

This is the exact gap #536 closed for the **Quarkus extension** (`quarkus.flyway.ignore-migration-patterns=*:missing,*:future`). That PR's body even notes the programmatic `FlywayMigrator` works around the case via `.ignoreMigrationPatterns("*:missing")` — but `*:missing` alone leaves `future` rows failing (which is precisely what we just hit when a *higher-versioned* component was disabled). Back then fleet/driver were enabled, so the migrator never saw a `future` row; disabling integrations exposed it.

## Change

One line (+ explanatory comment) mirroring #536:

```java
.ignoreMigrationPatterns("*:missing", "*:future")
```

So any component subset boots cleanly against a DB carrying the full migration set — which is exactly the umbrella chart's per-deployment component-toggle model.

## Notes
- Dev was unblocked immediately by enabling integrations in the deploy values (microboxlabs/miot-deployments#14). This PR is the durable fix so components can be turned off without a boot crash.
- Also recommended (separate): add a first-class `components.integrations.enabled` toggle to the `miot-modulith` helm subchart (currently only fleet/driver/tracking/gateway are modeled).

## Test plan
- [ ] CI: `cd quarkus-srv && ./mvnw -pl miot-cli -am test`
- [ ] Boot a modulith with integrations disabled against a DB that has `0.6.x` applied → starts cleanly (previously crashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where application startup would fail when disabling components with previously-applied database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->