### PR TITLE
feat(ci): refactor Quarkus image promotion

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -208,11 +208,11 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: |
           cat > release-pr-body.md <<'EOF'
-          Prepares ${{ steps.version.outputs.app_tag }} and ${{ steps.version.outputs.modulith_tag }} from the same commit, with release notes v${{ steps.version.outputs.release_notes_version }}.
+          Prepares ${{ steps.version.outputs.app_tag }} and ${{ steps.version.outputs.modulith_tag }} from the same release commit, with release notes v${{ steps.version.outputs.release_notes_version }}.
 
           Milestones: ${{ steps.version.outputs.private_milestone }}, ${{ steps.version.outputs.oss_milestone }}.
 
-          Approve and merge this PR, then approve the protected release job to tag, build both images, and deploy the stack.
+          Approve and merge this PR, then approve the protected release job to tag, build the app image, promote the Quarkus CI modulith image, and deploy the stack.
           EOF
 
           url="$(gh pr create \
@@ -241,6 +241,7 @@ jobs:
     needs: [prepare, approve]
     outputs:
       sha: ${{ steps.release_pr.outputs.sha }}
+      short_sha: ${{ steps.release_pr.outputs.short_sha }}
     steps:
       - name: Wait for release PR merge
         id: release_pr
@@ -262,6 +263,7 @@ jobs:
             if [[ "$merged_at" != "null" && -n "$merge_sha" ]]; then
               echo "Release PR #$PR_NUMBER merged at $merged_at ($merge_sha)."
               echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
+              echo "short_sha=${merge_sha::7}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -387,7 +389,7 @@ jobs:
           tags: |
             ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}
             ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:app-v${{ needs.prepare.outputs.release_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
           build-args: |
             APP_NAME=app
           provenance: true
@@ -399,29 +401,12 @@ jobs:
           echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
   build-modulith:
-    name: Build and publish modulith image
+    name: Promote modulith image
     runs-on: ubuntu-latest
     needs: [prepare, tag]
     outputs:
       image: ${{ steps.image.outputs.image }}
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.tag.outputs.sha }}
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-          cache-dependency-path: quarkus-srv/pom.xml
-
-      - name: Build and test modulith
-        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true -Dmiot.component.integrations.enabled=true
-        working-directory: quarkus-srv
-
-      - uses: docker/setup-qemu-action@v3
-
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -430,27 +415,48 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
-        id: docker
-        uses: docker/build-push-action@v6
-        with:
-          context: quarkus-srv
-          file: quarkus-srv/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:modulith-v${{ needs.prepare.outputs.release_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
+      - name: Wait for release modulith image
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+          SOURCE_NATIVE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}-native
+        run: |
+          for attempt in {1..60}; do
+            if docker buildx imagetools inspect "$SOURCE_IMAGE" >/dev/null &&
+               docker buildx imagetools inspect "$SOURCE_NATIVE_IMAGE" >/dev/null; then
+              echo "Promoting release modulith images $SOURCE_IMAGE and $SOURCE_NATIVE_IMAGE."
+              exit 0
+            fi
+
+            echo "Waiting for Quarkus trunk CI to publish release images... ($attempt/60)"
+            sleep 60
+          done
+
+          echo "::error::Timed out waiting for Quarkus trunk CI to publish release modulith images."
+          exit 1
+
+      - name: Promote image tags
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+          SOURCE_NATIVE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}-native
+          RELEASE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}
+          COMPONENT_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:modulith-v${{ needs.prepare.outputs.release_version }}
+          RELEASE_NATIVE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}-native
+          COMPONENT_NATIVE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:modulith-v${{ needs.prepare.outputs.release_version }}-native
+        run: |
+          docker buildx imagetools create \
+            --tag "$RELEASE_IMAGE" \
+            --tag "$COMPONENT_IMAGE" \
+            "$SOURCE_IMAGE"
+          docker buildx imagetools create \
+            --tag "$RELEASE_NATIVE_IMAGE" \
+            --tag "$COMPONENT_NATIVE_IMAGE" \
+            "$SOURCE_NATIVE_IMAGE"
 
       - name: Export image ref
         id: image
         run: |
-          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:${{ needs.prepare.outputs.release_version }}" | awk '/^Digest:/ { print $2; exit }')"
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Dispatch configured environment deploys

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -8,10 +8,15 @@
 #   - GitHub Container Registry (GHCR) — Primary registry
 #   - Docker Hub — Secondary mirror (non-PR only)
 #
+# Build Modes:
+#   - JVM: Standard Quarkus fast-jar image
+#   - Native: Mandrel/GraalVM native executable image
+#
 # Tagging Strategy:
 #   - PRs:        ghcr.io/<org>/miot-srv:pr-<number>
 #   - main/trunk: ghcr.io/<org>/miot-srv:latest
-#   - Tags:       ghcr.io/<org>/miot-srv:<version>
+#   - SHA:        ghcr.io/<org>/miot-srv:sha-<short_sha>
+#   - Native:     same tags with -native suffix
 #
 # Required Secrets:
 #   - DOCKERHUB_USERNAME:              Docker Hub username
@@ -26,8 +31,6 @@ on:
     paths:
       - 'quarkus-srv/**'
     branches: [trunk, main]
-    tags:
-      - 'v*'
   pull_request:
     paths:
       - 'quarkus-srv/**'
@@ -40,6 +43,7 @@ env:
   IMAGE_NAME: microboxlabs/miot-srv
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
+  MANDREL_IMAGE: quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21
 
 jobs:
   # ===========================================================================
@@ -56,6 +60,7 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.version }}
+      short_sha: ${{ steps.version.outputs.short_sha }}
 
     steps:
       - name: Checkout repository
@@ -75,12 +80,9 @@ jobs:
         id: version
         working-directory: quarkus-srv
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          fi
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
       - name: Build & Test
@@ -110,6 +112,48 @@ jobs:
           path: |
             quarkus-srv/miot-cli/target/quarkus-app/
             quarkus-srv/Dockerfile
+          retention-days: 1
+
+  # ===========================================================================
+  # Build Native — GraalVM/Mandrel Native Executable
+  # ===========================================================================
+  build-native:
+    name: Build Native
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    container:
+      image: ${{ env.MANDREL_IMAGE }}
+      options: --user root
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Maven cache
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.m2/repository
+          key: ${{ runner.os }}-maven-native-${{ hashFiles('quarkus-srv/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-native-
+
+      - name: Build native executable
+        run: ./mvnw package -Pnative -DskipTests
+        working-directory: quarkus-srv
+        env:
+          MAVEN_OPTS: -Dmaven.repo.local=/github/home/.m2/repository
+
+      - name: Upload native artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-build
+          path: |
+            quarkus-srv/miot-cli/target/*-runner
+            quarkus-srv/Dockerfile.native
           retention-days: 1
 
   # ===========================================================================
@@ -166,9 +210,7 @@ jobs:
           tags: |
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-,format=short
+            type=raw,value=sha-${{ needs.build-jvm.outputs.short_sha }}
           labels: |
             org.opencontainers.image.title=ModularIoT Server
             org.opencontainers.image.description=Quarkus modulith backend for ModularIoT — fleet, driver and resource management
@@ -201,12 +243,98 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   # ===========================================================================
+  # Docker Native — Build and Publish Native Image
+  # ===========================================================================
+  docker-native:
+    name: Docker Native Image
+    runs-on: ubuntu-latest
+    needs: [build-jvm, build-native]
+
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    outputs:
+      image-digest: ${{ steps.build-push.outputs.digest }}
+
+    steps:
+      - name: Download native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: native-build
+          path: quarkus-srv
+
+      - name: Prepare native executable
+        run: |
+          chmod +x quarkus-srv/miot-cli/target/*-runner
+          ls -la quarkus-srv/miot-cli/target/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ github.event_name != 'pull_request' && format('{0}/{1}', env.DOCKERHUB_REGISTRY, env.IMAGE_NAME) || '' }}
+          flavor: |
+            suffix=-native
+          tags: |
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=sha-${{ needs.build-jvm.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.title=ModularIoT Server (Native)
+            org.opencontainers.image.description=Quarkus native modulith backend for ModularIoT
+            org.opencontainers.image.vendor=MicroboxLabs
+
+      - name: Build and push native Docker image
+        id: build-push
+        uses: docker/build-push-action@v6
+        with:
+          context: quarkus-srv
+          file: quarkus-srv/Dockerfile.native
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image summary
+        run: |
+          echo "## Docker Native Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  # ===========================================================================
   # Security Scan — Trivy (non-PR only)
   # ===========================================================================
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
-    needs: docker-jvm
+    needs: [build-jvm, docker-jvm]
     if: github.event_name != 'pull_request'
 
     permissions:
@@ -220,7 +348,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}'
+          image-ref: '${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ needs.build-jvm.outputs.short_sha }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
         continue-on-error: true

--- a/quarkus-srv/Dockerfile.native
+++ b/quarkus-srv/Dockerfile.native
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
+
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+
+COPY --chown=1001:root --chmod=0755 miot-cli/target/*-runner /work/application
+
+EXPOSE 8180
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["miot", "all"]


### PR DESCRIPTION
## Summary
- Refactors Quarkus CI so it owns backend JVM image builds with short-SHA tags.
- Adds a Mandrel/GraalVM native backend build and `-native` image publishing path.
- Updates the release train to promote Quarkus CI-built JVM and native images instead of rebuilding the modulith.
- Keeps release tags aligned with the release merge commit and Maven POM version checks.

## Details
- Adds `quarkus-srv/Dockerfile.native` for native runtime images.
- Publishes native image variants such as `sha-<short_sha>-native` and `latest-native`.
- Release train waits for both release merge images to exist before promoting official JVM/native tags.
- Deployment payload remains compatible by continuing to send the JVM immutable digest.

Closes #678

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/quarkus.yml .github/workflows/app-release-train.yml`
- `git diff --check -- .github/workflows/quarkus.yml .github/workflows/app-release-train.yml quarkus-srv/Dockerfile.native`
