### PR TITLE
feat(calendar): show only sort-relevant flags in planner sidebar and chips

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Coverage for the planner's flag filtering (issue #677): only incident
+ * codes that participate in the calendar planning sort
+ * (ecm-coordinator `MintralModel.INCIDENT_TIER_BY_CODE`) are shown, in tier
+ * order. Everything else is dropped.
+ */
+import { describe, it, expect } from "vitest";
+import { isSortingRelevant, getDisplayIncidencias } from "./incidencias.types";
+
+const TIERED_CODES = [
+  "C309",
+  "C307",
+  "C314",
+  "C319",
+  "C320",
+  "C326",
+  "C329",
+  "C308",
+];
+
+describe("isSortingRelevant", () => {
+  it("returns true for every tiered sort code", () => {
+    for (const code of TIERED_CODES) {
+      expect(isSortingRelevant(code)).toBe(true);
+    }
+  });
+
+  it("resolves dictionary keys and labels, not just codes", () => {
+    expect(isSortingRelevant("urgencia")).toBe(true);
+    expect(isSortingRelevant("DESPACHO URGENTE")).toBe(true);
+  });
+
+  it("returns false for codes outside the sort hierarchy", () => {
+    expect(isSortingRelevant("C999")).toBe(false);
+    expect(isSortingRelevant("FOO")).toBe(false);
+    expect(isSortingRelevant("")).toBe(false);
+  });
+});
+
+describe("getDisplayIncidencias", () => {
+  it("drops non-sort codes and keeps only the tiered ones", () => {
+    const result = getDisplayIncidencias(["C314", "FOO", "C309", "C999"]);
+    expect(result.map((i) => i.key)).toEqual(["C309", "C314"]);
+  });
+
+  it("orders the kept codes by tier (priority ascending)", () => {
+    const result = getDisplayIncidencias(["C308", "C309", "C307"]);
+    expect(result.map((i) => i.key)).toEqual(["C309", "C307", "C308"]);
+  });
+
+  it("returns an empty array when no code is sort-relevant", () => {
+    expect(getDisplayIncidencias(["FOO", "BAR"])).toEqual([]);
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/incidencias.types.ts
@@ -117,24 +117,32 @@ export function getIncidenciaConfig(keyOrLabel: string): Required<IncidenciaConf
 }
 
 /**
- * Sort incidencias by priority and split into primary/secondary groups
+ * Whether an incident code participates in the calendar planning sort.
+ *
+ * Mirrors ecm-coordinator `MintralModel.INCIDENT_TIER_BY_CODE`: only codes
+ * with an explicit tier — C309 (1); C307/C314/C319/C320/C326/C329 (2);
+ * C308 (3) — are sort-relevant. Everything else falls to the default tier
+ * and is intentionally hidden in the planner (issue #677).
  */
-export function categorizeIncidencias(incidencias: string[]): {
-  primary: Array<{ key: string; config: Required<IncidenciaConfig> }>;
-  secondary: Array<{ key: string; config: Required<IncidenciaConfig> }>;
-} {
-  const withConfig = incidencias.map((key) => ({
-    key,
-    config: getIncidenciaConfig(key),
-  }));
-
-  // Sort by priority
-  withConfig.sort((a, b) => a.config.priority - b.config.priority);
-
-  const primary = withConfig.filter((i) => i.config.visibility === "primary");
-  const secondary = withConfig.filter(
-    (i) => i.config.visibility === "secondary"
+export function isSortingRelevant(keyOrLabel: string): boolean {
+  return (
+    getIncidenciaConfig(keyOrLabel).priority !==
+    DEFAULT_INCIDENCIA_CONFIG.priority
   );
+}
 
-  return { primary, secondary };
+/**
+ * The incidencias to render in the planner, in sort (tier) order.
+ *
+ * Only sort-relevant codes are returned, so the sidebar and grid chips show
+ * exactly the flags the backend sort ranks on — and nothing else. Non-tiered
+ * incident codes carried by a service are dropped here.
+ */
+export function getDisplayIncidencias(
+  incidencias: string[]
+): Array<{ key: string; config: Required<IncidenciaConfig> }> {
+  return incidencias
+    .filter(isSortingRelevant)
+    .map((key) => ({ key, config: getIncidenciaConfig(key) }))
+    .sort((a, b) => a.config.priority - b.config.priority);
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -496,7 +496,7 @@ export function PlanningSelectionProvider({
       // canonical item's raw service. The package's generic SidebarShell calls
       // this seam (falling back to its default ItemCard when unset).
       renderItemCard: (item) => (
-        <ServiceEvent service={item.raw as SelectedService} dict={dict} />
+        <ServiceEvent service={item.raw as SelectedService} />
       ),
       bookingApi: {
         createBooking,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -20,7 +20,7 @@ import {
 } from "./planning-selection-context";
 import { useServiceTypes } from "@/features/common/providers/client-api.provider";
 import { HiCalendar, HiExclamation, HiUserAdd } from "react-icons/hi";
-import { categorizeIncidencias } from "./incidencias.types";
+import { getDisplayIncidencias } from "./incidencias.types";
 import {
   formatPercent,
   SidebarFormShell,
@@ -128,7 +128,6 @@ export function PlanningSidebarForm({
   isSlotsLoading = false,
   liveTaskStage,
 }: PlanningSidebarFormProps) {
-  const [showAllIncidencias, setShowAllIncidencias] = useState(false);
   const [selectedTime, setSelectedTime] = useState<string>("");
   const [selectedAnden, setSelectedAnden] = useState<number>(1);
   const [selectedServiceCategory, setSelectedServiceCategory] =
@@ -443,18 +442,9 @@ export function PlanningSidebarForm({
     }
   );
 
-  // Categorize incidencias into primary (always visible) and secondary (expandable)
-  const { primary, secondary } = categorizeIncidencias(incidentCodes);
-  const hasIncidencias = primary.length > 0 || secondary.length > 0;
-  // Always reserve up to INLINE_BUDGET inline slots: primary first, then top up with secondary.
-  const INLINE_BUDGET = 2;
-  const inlineSecondaryCount = Math.max(
-    0,
-    Math.min(secondary.length, INLINE_BUDGET - primary.length)
-  );
-  const inlineSecondary = secondary.slice(0, inlineSecondaryCount);
-  const collapsedSecondary = secondary.slice(inlineSecondaryCount);
-  const hasCollapsed = collapsedSecondary.length > 0;
+  // Show only sort-relevant incidencias, in tier order (issue #677).
+  const displayIncidencias = getDisplayIncidencias(incidentCodes);
+  const hasIncidencias = displayIncidencias.length > 0;
 
   // Use real data from selectedService
   const id = selectedService.id;
@@ -523,8 +513,7 @@ export function PlanningSidebarForm({
         {hasIncidencias && (
           <FormSection title={tr("pages.planning.sidebar.form.flags", dict)}>
             <div className="flex flex-wrap gap-2 max-h-24 overflow-y-auto">
-              {/* Primary incidencias - always visible */}
-              {primary.map(({ key, config }) => {
+              {displayIncidencias.map(({ key, config }) => {
                 const tooltip =
                   codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
                 return (
@@ -542,66 +531,6 @@ export function PlanningSidebarForm({
                   </Badge>
                 );
               })}
-
-              {/* Inline secondary incidencias - always visible */}
-              {inlineSecondary.map(({ key, config }) => {
-                const tooltip =
-                  codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
-                return (
-                  <Badge
-                    key={key}
-                    size="xs"
-                    color="gray"
-                    className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5"
-                    title={tooltip}
-                  >
-                    {config.label}
-                  </Badge>
-                );
-              })}
-
-              {/* Collapsed secondary incidencias - revealed when expanded */}
-              {hasCollapsed &&
-                showAllIncidencias &&
-                collapsedSecondary.map(({ key, config }) => {
-                  const tooltip =
-                    codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
-                  return (
-                    <Badge
-                      key={key}
-                      size="xs"
-                      color="gray"
-                      className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5"
-                      title={tooltip}
-                    >
-                      {config.label}
-                    </Badge>
-                  );
-                })}
-
-              {/* "+N more" button to expand collapsed secondary incidencias */}
-              {hasCollapsed && !showAllIncidencias && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllIncidencias(true)}
-                  className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 cursor-pointer transition-colors"
-                >
-                  {tr("pages.planning.sidebar.form.showMore", dict, {
-                    count: String(collapsedSecondary.length),
-                  })}
-                </button>
-              )}
-
-              {/* "Show less" button when expanded */}
-              {hasCollapsed && showAllIncidencias && (
-                <button
-                  type="button"
-                  onClick={() => setShowAllIncidencias(false)}
-                  className="inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 cursor-pointer transition-colors"
-                >
-                  {tr("pages.planning.sidebar.form.showLess", dict)}
-                </button>
-              )}
             </div>
           </FormSection>
         )}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -11,9 +11,7 @@ import {
   type LeadTimeData,
   getLeadTimeStatus,
 } from "./planning-selection-types";
-import { categorizeIncidencias } from "./incidencias.types";
-import { I18nRecord } from "@/features/i18n/i18n.service.types";
-import { tr } from "@/features/i18n/tr.service";
+import { getDisplayIncidencias } from "./incidencias.types";
 import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 // Set Spanish locale for dayjs
@@ -21,7 +19,6 @@ dayjs.locale("es");
 
 export interface ServiceEventProps {
   readonly service: SelectedService;
-  readonly dict: I18nRecord;
   readonly className?: string;
 }
 
@@ -76,7 +73,7 @@ function getOccupancyColor(percentage: number): string {
  * 2. KPIs (Lead Time, Ocupación)
  * 3. Static (Cliente, Origen → Destino)
  */
-export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
+export function ServiceEvent({ service, className }: ServiceEventProps) {
   const { selectedService, selectService } =
     usePlanningSelection<SelectedService>();
 
@@ -96,17 +93,9 @@ export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
       })
     : [];
 
-  // Categorize using the codes - the dictionary will map C307/C309 to their configs
-  const { primary, secondary } = categorizeIncidencias(incidentCodes);
-  const hasFlags = primary.length > 0 || secondary.length > 0;
-  // Always reserve up to INLINE_BUDGET inline slots: primary first, then top up with secondary.
-  const INLINE_BUDGET = 2;
-  const inlineSecondaryCount = Math.max(
-    0,
-    Math.min(secondary.length, INLINE_BUDGET - primary.length)
-  );
-  const inlineSecondary = secondary.slice(0, inlineSecondaryCount);
-  const collapsedSecondaryCount = secondary.length - inlineSecondaryCount;
+  // Show only sort-relevant incidencias, in tier order (issue #677).
+  const displayIncidencias = getDisplayIncidencias(incidentCodes);
+  const hasFlags = displayIncidencias.length > 0;
 
   const handleClick = () => {
     selectService(service);
@@ -161,11 +150,11 @@ export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
               className="px-2 py-0.5 text-xs cursor-help"
             />
 
-            {/* Primary incidencias - always visible */}
-            {primary.map(({ key, config }) => {
+            {/* Sort-relevant incidencias, in tier order */}
+            {displayIncidencias.map(({ key, config }) => {
               const tooltip =
                 codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
-              // Use the config color, with special handling for urgencia/C309 (purple with icon)
+              // Special handling for urgencia/C309 (purple with icon)
               if (
                 config.color === "purple" ||
                 key === "urgencia" ||
@@ -196,32 +185,6 @@ export function ServiceEvent({ service, dict, className }: ServiceEventProps) {
                 </Badge>
               );
             })}
-
-            {/* Inline secondary incidencias - always visible */}
-            {inlineSecondary.map(({ key, config }) => {
-              const tooltip =
-                codeToLabelMap.get(key) || codeToLabelMap.get(config.label);
-              return (
-                <Badge
-                  key={key}
-                  className="flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 cursor-help"
-                  color="gray"
-                  size="xs"
-                  title={tooltip}
-                >
-                  {config.label}
-                </Badge>
-              );
-            })}
-
-            {/* Collapsed count for remaining secondary incidencias */}
-            {collapsedSecondaryCount > 0 && (
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                {tr("pages.planning.sidebar.form.showMore", dict, {
-                  count: String(collapsedSecondaryCount),
-                })}
-              </span>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
## What

In the calendar planner, show **only** the incident flags that are relevant to the planning **sort algorithm**, on both the right sidebar and the service grid chips. Everything else is hidden.

Closes #677.

## Why

Client (Mintral) request: the planner was rendering **every** incident code a service carried. Non-sorting codes were merely demoted into a "secondary" bucket shown inline or behind a **"+N más"** toggle — so they were still visible and added noise.

"Relevant to the sort" is defined by `MintralModel.INCIDENT_TIER_BY_CODE` in ecm-coordinator (the `mintral_calendarPlanningPriority` preset), which matches the client's reference table:

| Jerarquía | Códigos |
|---|---|
| 1 | C309 |
| 2 | C307, C314, C319, C320, C326, C329 |
| 3 | C308 |
| 4 (default) | everything else → **not shown** |

## How

- **`incidencias.types.ts`** — replace `categorizeIncidencias` (primary/secondary split) with `isSortingRelevant()` + `getDisplayIncidencias()`: filter to the tiered codes and order by tier. The dictionary already mirrors `INCIDENT_TIER_BY_CODE`; a comment now cross-references it.
- **`planning-sidebar-form.tsx`** / **`service-event.tsx`** — render the filtered list directly; remove the inline/collapsed **"+N más" / "Show less"** machinery (and the `showAllIncidencias` state), plus the now-unused `dict`/`tr` wiring on `ServiceEvent`.
- **`planning-selection-wrapper.tsx`** — drop the `dict` prop from the `ServiceEvent` call site.

**Filter only — badge colors/styling are unchanged** (C309 keeps its purple+icon treatment). **No backend / API / contract change**; the sort itself was already correct.

## Test plan

- ✅ New unit test `incidencias.types.test.ts` (6 cases): tiered codes are sort-relevant; keys/labels resolve; non-tiered codes are dropped; output is tier-ordered.
- ✅ `turbo run check-types --filter=@modulariot/app` passes.
- A service carrying a non-sorting incident code now shows no badge for it (sidebar + grid chip); the "+N más" control is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified incident badge display in the planning view by removing the "show more/show less" expansion interface.

* **Chores**
  * Refactored incident filtering and ordering logic to prioritize display of relevant incidents by tier.
  * Added comprehensive test coverage for incident filtering and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->