### PR TITLE
fix(ci): use literal Mandrel container image

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -43,7 +43,6 @@ env:
   IMAGE_NAME: microboxlabs/miot-srv
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
-  MANDREL_IMAGE: quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21
 
 jobs:
   # ===========================================================================
@@ -126,7 +125,7 @@ jobs:
       contents: read
 
     container:
-      image: ${{ env.MANDREL_IMAGE }}
+      image: quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21
       options: --user root
 
     steps:


### PR DESCRIPTION
## Summary
- Fixes the Quarkus native build job workflow syntax after #679 merged.
- Replaces unsupported `env.MANDREL_IMAGE` usage in `jobs.build-native.container.image` with the literal Mandrel builder image.
- Removes the now-unused top-level `MANDREL_IMAGE` env var.

## Why
GitHub Actions does not allow the top-level `env` context in `container.image`, causing workflow validation to fail before jobs can run.

Refs #678

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/quarkus.yml .github/workflows/app-release-train.yml`
- `git diff --check origin/trunk..HEAD -- .github/workflows/quarkus.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow configuration to use a hardcoded container image reference, removing an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->