### PR TITLE
chore(release): prepare MIOT v0.5.14

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.13</version>
+        <version>0.5.14</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.13</version>
+    <version>0.5.14</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.13.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.13.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.13 — ModularIoT
+
+### Fecha: 17/06/2026
+
+**Objetivo**: Esta versión mejora la experiencia de planificación y dashboards en la app, y fortalece el flujo de entrega de servicios Quarkus en CI/CD. El foco es aumentar consistencia funcional, trazabilidad de artefactos y confiabilidad operativa entre app y backend.
+
+## 🚀 Evolutivos
+
+- **📍 Planner de calendario con flags alineados al algoritmo de priorización** *(Integración OSS — MIOT-0.5.14)*
+  - **Key point**: En sidebar y chips de grilla ahora se muestran solo los códigos de incidentes relevantes para el ordenamiento de planificación, eliminando elementos secundarios y controles de “+N más / Show less”.
+  - **Technical detail**: La UI queda alineada con la jerarquía usada por `mintral_calendarPlanningPriority`, manteniendo coherencia entre lógica de priorización y representación visual.
+
+- **📍 Mejoras UX del dashboard: navegación interna, autocompletado unificado y ajustes de localización** *(Integración OSS — MIOT-0.5.14)*
+  - **Key point**: Se eliminan recargas completas al navegar desde tarjetas de estadísticas en rutas internas y se unifica el autocompletado de expresiones para múltiples tipos de dashlets.
+  - **Technical detail**: Se estandarizan sugerencias `row`/`filter` mediante hooks compartidos y se corrige la clave i18n de `data_table_v2` para resolver el nombre mostrado en el modal de alta de widgets.
+
+## 🔧 Integraciones
+
+- **🔌 Promoción de imágenes Quarkus desde CI hacia release train** *(Integración OSS — MIOT-0.5.14)*
+  - **Scope**: El pipeline se refactoriza para publicar imágenes JVM y nativas desde Quarkus CI (tags por short SHA), validar versión Maven vs release y promover artefactos en release sin recompilar en el train, preservando compatibilidad con despliegues por digest inmutable.
+
+## 📊 Beneficios
+
+- Menor ruido visual en planificación y foco directo en señales que afectan prioridad operativa.
+- Mayor consistencia entre backend de ordenamiento y frontend de calendario.
+- Navegación más fluida en dashboards al evitar recargas completas en rutas internas.
+- Configuración de widgets más uniforme con autocompletado compartido entre dashlets.
+- Mejor calidad funcional en internacionalización del catálogo de widgets.
+- Proceso de release más trazable al promover imágenes ya construidas en CI.
+- Reducción de riesgo en despliegues al mantener referencias inmutables por digest.
+
+## 📌 Conclusión
+
+La release 1.31.13 consolida una mejora transversal: experiencia de usuario más consistente en la app y un circuito de entrega backend más robusto en Quarkus. Esto reduce fricción tanto para equipos operativos como para equipos de plataforma.
+
+También fortalece la continuidad entre desarrollo, integración OSS y release productivo, alineando criterios funcionales (priorización y UX) con prácticas técnicas de promoción de artefactos.
+
+En conjunto, es una versión orientada a confiabilidad y claridad: menos ambigüedad en la operación diaria y mayor previsibilidad en los ciclos de entrega.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares app@v0.5.14 and modulith@v0.5.14 from the same release commit, with release notes v1.31.13.

Milestones: Release-1.31.13, MIOT-0.5.14.

Approve and merge this PR, then approve the protected release job to tag, build the app image, promote the Quarkus CI modulith image, and deploy the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.5.14 across all modules and packages.

* **Documentation**
  * Added release notes for v1.31.13, documenting planner/calendar UI refinements, dashboard navigation enhancements, autocompletion improvements, and CI/CD integration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->