### PR TITLE
fix(dashboard): omit blank PgREST params so typed RPC args don't 400

### DIFF
--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/pgrest-utils.test.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/pgrest-utils.test.ts
@@ -139,6 +139,15 @@ describe("buildPgrestFetch", () => {
     expect(JSON.parse(result.init!.body as string)).toEqual({ p_name: "test" });
   });
 
+  it("POST: filters out params with empty-string value", () => {
+    const params = [
+      makePgrestParam({ key: "p_etapa_max", value: "" }),
+      makePgrestParam({ key: "p_name", value: "test" }),
+    ];
+    const result = buildPgrestFetch("my_func", "POST", params);
+    expect(JSON.parse(result.init!.body as string)).toEqual({ p_name: "test" });
+  });
+
   it("POST: appends dataSourceId to query string", () => {
     const result = buildPgrestFetch("my_func", "POST", [], "ds-99");
     expect(result.url).toBe("/app/api/dashboard/pgrest/my_func?dataSourceId=ds-99");
@@ -149,6 +158,16 @@ describe("buildPgrestFetch", () => {
     const result = buildPgrestFetch("my_func", "GET", params);
     expect(result.url).toBe("/app/api/dashboard/pgrest/my_func?p_id=123");
     expect(result.init).toBeUndefined();
+  });
+
+  it("GET: omits params with empty-string value from query string", () => {
+    const params = [
+      makePgrestParam({ key: "p_id", value: "123" }),
+      makePgrestParam({ key: "p_etapa_max", value: "" }),
+      makePgrestParam({ key: "p_solo_criticos", value: "" }),
+    ];
+    const result = buildPgrestFetch("my_func", "GET", params);
+    expect(result.url).toBe("/app/api/dashboard/pgrest/my_func?p_id=123");
   });
 
   it("GET: includes dataSourceId in query params", () => {

--- a/turbo-repo/apps/app/src/features/dashboard/dashlets/common/pgrest-utils.ts
+++ b/turbo-repo/apps/app/src/features/dashboard/dashlets/common/pgrest-utils.ts
@@ -70,7 +70,10 @@ export function buildPgrestFetch(
   params: PgrestParam[],
   dataSourceId?: string,
 ): { url: string; init?: RequestInit } {
-  const validParams = params.filter((p) => p.key && p.value != null);
+  // Drop blank values so the request mirrors Swagger: a blank param is omitted
+  // entirely, letting the RPC's defaults/NULLs apply. Forwarding `p_x=` sends an
+  // empty string, which PostgREST rejects for typed args (integer/boolean) with 400.
+  const validParams = params.filter((p) => p.key && p.value != null && p.value !== "");
   const baseUrl = `/app/api/dashboard/pgrest/${encodeURIComponent(functionName.trim())}`;
 
   const dsParams = buildDataSourceParams(dataSourceId);


### PR DESCRIPTION
buildPgrestFetch kept any param whose value was not null, so blank planner fields were sent as empty strings (e.g. p_etapa_max=, p_solo_criticos=). PostgREST rejects an empty string for typed args (integer/boolean) with 400, which the proxy relays back to the dashlet.

Drop empty-string values too, mirroring Swagger: a blank param is omitted entirely so the RPC's defaults/NULLs apply. Covers GET (query string) and POST (JSON body) since both share validParams.

<!-- Provide a clear, concise description of your change. -->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->
Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI / tooling

## Affected workspace(s)

- [ ] `quarkus-srv/` (Integration)
- [ ] `ecm-srv/` (Coordinator)
- [ ] `turbo-repo/` (Frontend)
- [ ] `miot-harness/` (AI harness)

## How was this tested?

<!-- Commands run, manual steps, screenshots, etc. -->

## Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat(app): ...`, `fix(bff): ...`)
- [ ] Lint and tests pass locally
- [ ] Documentation updated where needed
- [ ] I have read the [Contributing guidelines](../CONTRIBUTING.md)
