### PR TITLE
chore(release): prepare MIOT v0.5.15

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.14</version>
+        <version>0.5.15</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.14</version>
+    <version>0.5.15</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.14.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.14.mdx
@@ -1,0 +1,34 @@
+# 🔔 Release Notes v1.31.14 — ModularIoT
+
+### Fecha: 17/06/2026
+
+**Objetivo**: Esta versión mejora la adaptabilidad del ASK MIOT Harness por entorno y tenant sin depender de rebuilds de imagen, y corrige un bloqueo crítico en dashboards con fuentes PostgREST. El foco está en acelerar operación, reducir fricción de configuración y aumentar resiliencia ante entradas inválidas.
+
+## 🚀 Evolutivos
+
+- **📍 Contexto y Skills configurables externamente para ASK MIOT Harness** *(Integración OSS — MIOT-0.5.15)*
+  - **Key point**: Se habilitó la carga de contexto y skills desde archivos externos, con capas globales y overlays por tenant, manteniendo contenido por defecto para arranque sin configuración montada.
+  - **Technical detail**: Se incorpora un modelo declarativo para playbook skills y connector skills HTTP, con controles de permisos/aprobación, resolución de secretos vía variables de entorno, diagnósticos en `health` y modo estricto para readiness.
+
+## 🐛 Correcciones
+
+- **🐛 Falla HTTP 400 en dashboards PostgREST cuando parámetros tipados quedan vacíos** *(Integración OSS — MIOT-0.5.15)*
+  - **Impacto**: Dashlets del Planificador de Solicitudes no cargaban datos al enviar RPC con argumentos tipados opcionales en blanco.
+  - **Solución**: Los parámetros vacíos dejan de propagarse como valores vacíos hacia PostgREST y se alinea el comportamiento con Swagger: si están en blanco, se omiten; si tienen valor, se envían sin cambios.
+
+## 📊 Beneficios
+
+- Mayor velocidad para adaptar ASK MIOT por ambiente y tenant sin ciclos de build/deploy.
+- Menor riesgo operativo gracias a carga resiliente ante manifiestos malformados.
+- Mejor gobernanza de capacidades con skills declarativas y controles de aprobación.
+- Reducción de errores de integración en dashboards con RPC tipadas y filtros opcionales.
+- Mejor continuidad del servicio al preservar arranque con defaults empaquetados.
+- Base preparada para evolucionar de archivos a fuentes runtime (API/DB) sin rediseño.
+
+## 📌 Conclusión
+
+La v1.31.14 fortalece dos frentes clave del producto: extensibilidad del harness y confiabilidad en visualización de datos. Esto mejora tanto la experiencia operativa de equipos técnicos como la estabilidad funcional para usuarios de dashboards.
+
+En términos de arquitectura, se consolida un enfoque más configurable y seguro para incorporar contexto y capacidades sin tocar imagen base. Al mismo tiempo, se corrige un comportamiento que afectaba casos reales de uso con parámetros opcionales en PostgREST.
+
+El resultado es una plataforma más flexible para despliegues heterogéneos, con menor fricción para evolucionar integraciones y menor probabilidad de interrupciones por configuración.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares app@v0.5.15 and modulith@v0.5.15 from the same release commit, with release notes v1.31.14.

Milestones: Release-1.31.14, MIOT-0.5.15.

Approve and merge this PR, then approve the protected release job to tag, build the app image, promote the Quarkus CI modulith image, and deploy the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable loading of context and skills from external files with global layers and tenant overlays
  * Declarative model for playbook and connector HTTP skills
  * Support for permissions and approval workflows
  * Secret resolution via environment variables
  * Enhanced health diagnostics and strict readiness mode

* **Bug Fixes**
  * Fixed HTTP 400 errors in dashboards with PostgREST sources when typed parameters are empty; blank parameters are now omitted while valued parameters are sent unchanged

* **Chores**
  * Released version 0.5.15

<!-- end of auto-generated comment: release notes by coderabbit.ai -->