### PR TITLE
fix(release): seed stack version from component tags

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -71,6 +71,14 @@ jobs:
           else
             latest="$(git tag --list 'miot-stack@v*' | sed 's/^miot-stack@v//' | sort -V | tail -1)"
             if [[ -z "$latest" ]]; then
+              latest="$(
+                {
+                  git tag --list 'app@v*' | sed 's/^app@v//'
+                  git tag --list 'modulith@v*' | sed 's/^modulith@v//'
+                } | sort -V | tail -1
+              )"
+            fi
+            if [[ -z "$latest" ]]; then
               version="0.1.0"
             else
               IFS=. read -r major minor patch <<< "$latest"
@@ -115,7 +123,7 @@ jobs:
           {
             echo "release_version=$version"
             echo "release_notes_version=$release_notes_version"
-            echo "private_milestone=Release-$release_notes_version"
+            echo "private_milestone=Release $release_notes_version"
             echo "oss_milestone=MIOT-$version"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fixes the first stack-release default version after the milestone-driven release refactor.
- Seeds the stack version from existing component tags when no `miot-stack@v*` tags exist yet.
- Changes private release milestone output from `Release-<version>` to `Release <version>`.

## Why
PR #696 showed the stack workflow preparing `miot-stack@v0.1.0` / `MIOT-0.1.0` even though the current MIOT release should continue as `MIOT-0.5.16`. The default only looked for prior stack tags, and there are none yet.

With this change, current tags compute:

```text
latest=0.5.15
next=0.5.16
```

Closes #697

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-release-train.yml"); puts "ok workflow"'`
- `git diff --check -- .github/workflows/app-release-train.yml`
- Verified current default computes `0.5.16` from `app@v*` / `modulith@v*` tags.
- Verified org milestone lookup finds `Release 1.31.15` naming.
