### PR TITLE
fix: keep stack dispatch payload under GitHub limit

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -253,14 +253,17 @@ jobs:
               client_payload: {
                 deploy_kind: "nightly",
                 release_version: $release_version,
-                app_tag: $app_tag,
-                modulith_tag: $modulith_tag,
-                app_image_repository: $app_image_repository,
-                app_image_tag: $app_image_tag,
-                app_image_ref: $app_image_ref,
-                modulith_image_repository: $modulith_image_repository,
-                modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref,
+                manifest_version: 1,
+                legacy: {
+                  app_tag: $app_tag,
+                  modulith_tag: $modulith_tag,
+                  app_image_repository: $app_image_repository,
+                  app_image_tag: $app_image_tag,
+                  app_image_ref: $app_image_ref,
+                  modulith_image_repository: $modulith_image_repository,
+                  modulith_image_tag: $modulith_image_tag,
+                  modulith_image_ref: $modulith_image_ref
+                },
                 components: {
                   app: {
                     changed: true,

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -584,14 +584,17 @@ jobs:
                 release_version: $release_version,
                 stack_version: $release_version,
                 stack_tag: $stack_tag,
-                app_tag: $app_tag,
-                modulith_tag: $modulith_tag,
-                app_image_repository: $app_image_repository,
-                app_image_tag: $app_image_tag,
-                app_image_ref: $app_image_ref,
-                modulith_image_repository: $modulith_image_repository,
-                modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref,
+                manifest_version: 1,
+                legacy: {
+                  app_tag: $app_tag,
+                  modulith_tag: $modulith_tag,
+                  app_image_repository: $app_image_repository,
+                  app_image_tag: $app_image_tag,
+                  app_image_ref: $app_image_ref,
+                  modulith_image_repository: $modulith_image_repository,
+                  modulith_image_tag: $modulith_image_tag,
+                  modulith_image_ref: $modulith_image_ref
+                },
                 components: {
                   app: {
                     changed: ($app_changed == "true"),


### PR DESCRIPTION
## Summary
- nest legacy stack dispatch fields under `client_payload.legacy`
- keep `components` as the structured app/modulith manifest contract
- apply the same payload shape to release train and nightly dispatches

## Root cause
GitHub repository_dispatch rejects `client_payload` with more than 10 top-level properties. The release train payload had 12 top-level fields and nightly had 11, which caused HTTP 422 during the deploy dispatch step.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml`\n- `git diff --check -- .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml`\n\nCloses #700\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configurations to restructure internal payload organization for nightly and release deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->