### PR TITLE
feat(calendar): un-gate accredited-resource selection from clientRut (pass null)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts
@@ -21,8 +21,8 @@ const MAX_LIMIT = 200;
 
 /**
  * GET /app/api/calendar/accredited-resources
- *   ?rutMandante=<rut>
- *   &delegacion=<code>
+ *   ?delegacion=<code>
+ *   [&rutMandante=<rut>]  optional; omitted/blank → upstream p_rut_mandante=null
  *   [&resourceType=DRIVER|TRUCK|TRAILER|CARRIER]
  *   [&carrierId=<resource_id>]
  *   [&q=<search>]
@@ -52,7 +52,10 @@ export async function GET(request: Request) {
   if (!authResult.authenticated) return authResult.response;
 
   const { searchParams } = new URL(request.url);
-  const rutMandante = searchParams.get("rutMandante")?.trim();
+  // clientRut is optional now: a service may have no client assigned. Keep the
+  // contract (still forwarded as p_rut_mandante) but coalesce absent/blank to
+  // null so the resource picker is no longer gated on it.
+  const rutMandante = searchParams.get("rutMandante")?.trim() || null;
   const delegacion = searchParams.get("delegacion")?.trim();
   const resourceTypeRaw = searchParams.get("resourceType")?.trim().toUpperCase();
   const carrierId = searchParams.get("carrierId")?.trim() || undefined;
@@ -68,9 +71,9 @@ export async function GET(request: Request) {
   const limitRaw = searchParams.get("limit");
   const refresh = searchParams.get("refresh") === "1";
 
-  if (!rutMandante || !delegacion) {
+  if (!delegacion) {
     return NextResponse.json(
-      { error: "rutMandante and delegacion are required" },
+      { error: "delegacion is required" },
       { status: 400 }
     );
   }

--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -558,13 +558,13 @@ interface AccreditedCacheEntry {
 const accreditedResourcesCache = new Map<string, AccreditedCacheEntry>();
 
 function accreditedCacheKey(opts: {
-  rutMandante: string;
+  rutMandante: string | null;
   delegacion: string;
   resourceType?: AccreditedResourceType;
   carrierId?: string;
 }): string {
   return [
-    opts.rutMandante,
+    opts.rutMandante ?? "*",
     opts.delegacion,
     opts.resourceType ?? "*",
     opts.carrierId ?? "*",
@@ -586,7 +586,7 @@ function accreditedCacheKey(opts: {
  * this feature expects.
  */
 export async function fetchAccreditedResources(opts: {
-  rutMandante: string;
+  rutMandante: string | null;
   delegacion: string;
   resourceType?: AccreditedResourceType;
   /**
@@ -605,6 +605,9 @@ export async function fetchAccreditedResources(opts: {
   const url = `${amsRouteBaseUrl()}/rpc/fn_rd_accredited_resources`;
   const body: Record<string, unknown> = {
     p_client_id: "mintral",
+    // Contract preserved: `p_rut_mandante` is always sent. It is `null` when
+    // the service carries no client RUT — the upstream function must treat
+    // null as "no mandante filter" (return the full delegacion scope).
     p_rut_mandante: opts.rutMandante,
     p_delegacion: opts.delegacion,
   };
@@ -638,7 +641,7 @@ export async function fetchAccreditedResources(opts: {
 
 /** Drop the cached entry — used when the route wants to bypass TTL on demand. */
 export function invalidateAccreditedResourcesCache(opts?: {
-  rutMandante: string;
+  rutMandante: string | null;
   delegacion: string;
   resourceType?: AccreditedResourceType;
   carrierId?: string;

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -96,9 +96,10 @@ interface UseAccreditedResourcesOpts {
 /**
  * Paginated accredited-resources feed, backed by
  * `/app/api/calendar/accredited-resources` (which in turn caches the upstream
- * pgrest function for 5 min). Stays idle until both `rutMandante` and
- * `delegacion` are set — matches the calendar UX where the combobox only
- * activates once a service is selected.
+ * pgrest function for 5 min). Stays idle until `delegacion` is set — matches
+ * the calendar UX where the combobox only activates once a service is
+ * selected. `rutMandante` (the service's client RUT) is optional: when absent
+ * it is forwarded as `null`, so resource selection no longer depends on it.
  *
  * Each change to `query` resets the feed to page 0 (SWR key is query-scoped).
  * `loadMore` fetches the next page; `hasMore` tracks whether the server still
@@ -116,7 +117,8 @@ export function useAccreditedResources(opts: UseAccreditedResourcesOpts) {
     enabled = true,
   } = opts;
 
-  const canFetch = Boolean(enabled && rutMandante && delegacion);
+  // clientRut (rutMandante) is no longer a gate — only delegacion is required.
+  const canFetch = Boolean(enabled && delegacion);
 
   // Stable, comma-joined form of the pin set so it can sit in the SWR key and
   // the `getKey` dependency list without churning on every render.


### PR DESCRIPTION
## What

During the assignment step, the planner's accredited-resource picker (carriers/drivers/trucks/trailers) no longer depends on the service's **client RUT**. The contract is preserved — `p_rut_mandante` is still always sent to PostgREST — but it is passed as `null` when the service has no client.

Closes #702.

## Why

The picker fetched `ams.fn_rd_accredited_resources` gated on `mintralClientRut → rutMandante → p_rut_mandante`. A service with no client assigned could not load resources at all (the hook stayed idle, the route 400'd).

## How (3 layers)

| Layer | Before | After |
|---|---|---|
| `useAccreditedResources` (`accredited-resources.service.ts`) | `canFetch = enabled && rutMandante && delegacion` | `canFetch = enabled && delegacion` |
| `/api/calendar/accredited-resources` route | `if (!rutMandante \|\| !delegacion) → 400` | `if (!delegacion) → 400`; `rutMandante` absent/blank → `null` |
| `pgrest-client` | `rutMandante: string`; body `p_rut_mandante` | `rutMandante: string \| null` (fetch + cache key + invalidator); `p_rut_mandante` **still always sent**, now nullable |

No FE component change — `assignment-form` already passes the optional `mintralClientRut`; `null` now flows cleanly end-to-end. `turbo check-types` passes.

## ✅ Verified against deployed pgrest (delegación ANF)

Ran the RPC directly (read-only) against `pgrest.streamhub.cl`. The **deployed** `fn_rd_accredited_resources` already handles `p_rut_mandante = null` — no DB change required:

| `p_resource_type` | `p_rut_mandante` | `p_carrier_id` | rows |
|---|---|---|---|
| CARRIER | `null` | — | **792** (full ANF set, incl. `TRANSPORTES MICHEA SPA`) |
| DRIVER | `null` | Michea `76662759-5` | **99** |
| TRUCK | `null` | Michea | **78** |
| DRIVER / TRUCK | `null` | *none* | 0 — never hit by the app (child queries are `enabled: Boolean(value.carrier)`) |

Carriers load unfiltered when the service has no client; drivers/trucks/trailers scope by the chosen carrier exactly as before. (The `db-scripts/outputs/erick/…v2.sql` draft, which filters strictly on `= p_rut_mandante`, is **not** what's deployed — the live function returns extra fields like `proximity_status`.)

## Test plan

- ✅ `turbo run check-types --filter=@modulariot/app` passes.
- ✅ Live pgrest RPC confirms `null` returns resources (counts above).
- Manual UI: open the assignment tab on a service **with no client** → carriers load for the delegación; pick one → drivers/trucks load; a service **with** a client is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
