### PR TITLE
fix: keep stack dispatch compatible with deployments

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -251,36 +251,15 @@ jobs:
             '{
               event_type: "miot-stack-nightly",
               client_payload: {
-                deploy_kind: "nightly",
                 release_version: $release_version,
-                manifest_version: 1,
-                legacy: {
-                  app_tag: $app_tag,
-                  modulith_tag: $modulith_tag,
-                  app_image_repository: $app_image_repository,
-                  app_image_tag: $app_image_tag,
-                  app_image_ref: $app_image_ref,
-                  modulith_image_repository: $modulith_image_repository,
-                  modulith_image_tag: $modulith_image_tag,
-                  modulith_image_ref: $modulith_image_ref
-                },
-                components: {
-                  app: {
-                    changed: true,
-                    tag: $app_tag,
-                    image_repository: $app_image_repository,
-                    image_tag: $app_image_tag,
-                    image_ref: $app_image_ref
-                  },
-                  modulith: {
-                    changed: false,
-                    tag: $modulith_tag,
-                    source_tag: $modulith_source_tag,
-                    image_repository: $modulith_image_repository,
-                    image_tag: $modulith_image_tag,
-                    image_ref: $modulith_image_ref
-                  }
-                }
+                app_tag: $app_tag,
+                modulith_tag: $modulith_tag,
+                app_image_repository: $app_image_repository,
+                app_image_tag: $app_image_tag,
+                app_image_ref: $app_image_ref,
+                modulith_image_repository: $modulith_image_repository,
+                modulith_image_tag: $modulith_image_tag,
+                modulith_image_ref: $modulith_image_ref
               }
             }' |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -582,41 +582,64 @@ jobs:
               event_type: "miot-stack-release",
               client_payload: {
                 release_version: $release_version,
-                stack_version: $release_version,
-                stack_tag: $stack_tag,
-                manifest_version: 1,
-                legacy: {
-                  app_tag: $app_tag,
-                  modulith_tag: $modulith_tag,
-                  app_image_repository: $app_image_repository,
-                  app_image_tag: $app_image_tag,
-                  app_image_ref: $app_image_ref,
-                  modulith_image_repository: $modulith_image_repository,
-                  modulith_image_tag: $modulith_image_tag,
-                  modulith_image_ref: $modulith_image_ref
-                },
-                components: {
-                  app: {
-                    changed: ($app_changed == "true"),
-                    version: $app_version,
-                    tag: $app_tag,
-                    image_repository: $app_image_repository,
-                    image_tag: $app_image_tag,
-                    image_ref: $app_image_ref
-                  },
-                  modulith: {
-                    changed: ($modulith_changed == "true"),
-                    version: $modulith_version,
-                    tag: $modulith_tag,
-                    image_repository: $modulith_image_repository,
-                    image_tag: $modulith_image_tag,
-                    image_ref: $modulith_image_ref
-                  }
-                }
+                app_tag: $app_tag,
+                modulith_tag: $modulith_tag,
+                app_image_repository: $app_image_repository,
+                app_image_tag: $app_image_tag,
+                app_image_ref: $app_image_ref,
+                modulith_image_repository: $modulith_image_repository,
+                modulith_image_tag: $modulith_image_tag,
+                modulith_image_ref: $modulith_image_ref
               }
             }' > stack-dispatch-payload.json
 
-          jq '.client_payload' stack-dispatch-payload.json > stack-manifest.json
+          jq -n \
+            --arg release_version "$RELEASE_VERSION" \
+            --arg stack_tag "$STACK_TAG" \
+            --arg app_tag "$APP_TAG" \
+            --arg app_changed "$APP_CHANGED" \
+            --arg app_version "$APP_VERSION" \
+            --arg modulith_tag "$MODULITH_TAG" \
+            --arg modulith_changed "$MODULITH_CHANGED" \
+            --arg modulith_version "$MODULITH_VERSION" \
+            --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
+            --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg app_image_ref "$APP_IMAGE_REF" \
+            --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
+            --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
+            --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
+            '{
+              release_version: $release_version,
+              stack_version: $release_version,
+              stack_tag: $stack_tag,
+              manifest_version: 1,
+              app_tag: $app_tag,
+              modulith_tag: $modulith_tag,
+              app_image_repository: $app_image_repository,
+              app_image_tag: $app_image_tag,
+              app_image_ref: $app_image_ref,
+              modulith_image_repository: $modulith_image_repository,
+              modulith_image_tag: $modulith_image_tag,
+              modulith_image_ref: $modulith_image_ref,
+              components: {
+                app: {
+                  changed: ($app_changed == "true"),
+                  version: $app_version,
+                  tag: $app_tag,
+                  image_repository: $app_image_repository,
+                  image_tag: $app_image_tag,
+                  image_ref: $app_image_ref
+                },
+                modulith: {
+                  changed: ($modulith_changed == "true"),
+                  version: $modulith_version,
+                  tag: $modulith_tag,
+                  image_repository: $modulith_image_repository,
+                  image_tag: $modulith_image_tag,
+                  image_ref: $modulith_image_ref
+                }
+              }
+            }' > stack-manifest.json
 
           cat stack-dispatch-payload.json |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \


### PR DESCRIPTION
## Summary
- restore stack repository_dispatch payloads to the flat fields currently consumed by `miot-deployments`
- keep both release and nightly dispatch payloads at nine top-level properties, below GitHub's 10-property limit
- write the richer release stack manifest separately instead of sending it through repository_dispatch

## Root cause
PR #701 nested deployment fields under `legacy`/`components` to avoid GitHub's repository_dispatch payload property limit. That fixed the API shape, but the private `miot-deployments` workflow still reads flat `github.event.client_payload` fields. The first nightly dispatch with the nested shape failed during payload normalization:

https://github.com/microboxlabs/miot-deployments/actions/runs/27760643944

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml`\n- `git diff --check -- .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml`\n\nCloses #704\n