### PR TITLE
fix: resolve release components from milestone issues

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -47,12 +47,50 @@ const prListJson = run("gh", [
   "200",
 ]);
 
-const prs = JSON.parse(prListJson);
+const issueListJson = run("gh", [
+  "issue",
+  "list",
+  "--repo",
+  repo,
+  "--milestone",
+  milestone,
+  "--state",
+  "all",
+  "--json",
+  "number,title,closedByPullRequestsReferences",
+  "--limit",
+  "200",
+]);
+
+const prByNumber = new Map();
+for (const pr of JSON.parse(prListJson)) {
+  prByNumber.set(pr.number, { ...pr, source_issues: [] });
+}
+
+for (const issue of JSON.parse(issueListJson)) {
+  for (const pr of issue.closedByPullRequestsReferences ?? []) {
+    if (pr.repository?.owner?.login !== repo.split("/")[0] || pr.repository?.name !== repo.split("/")[1]) {
+      continue;
+    }
+
+    const existing = prByNumber.get(pr.number) ?? {
+      number: pr.number,
+      title: "",
+      source_issues: [],
+    };
+    existing.source_issues.push({ number: issue.number, title: issue.title });
+    prByNumber.set(pr.number, existing);
+  }
+}
+
+const prs = [...prByNumber.values()].sort((a, b) => a.number - b.number);
 const changedFiles = new Set();
 
 for (const pr of prs) {
-  const prJson = run("gh", ["pr", "view", String(pr.number), "--repo", repo, "--json", "files"]);
-  const files = JSON.parse(prJson).files ?? [];
+  const prJson = run("gh", ["pr", "view", String(pr.number), "--repo", repo, "--json", "title,files"]);
+  const prData = JSON.parse(prJson);
+  pr.title = pr.title || prData.title;
+  const files = prData.files ?? [];
   for (const file of files) {
     if (file.path) changedFiles.add(file.path);
   }

--- a/releases/stacks/v0.5.16.plan.json
+++ b/releases/stacks/v0.5.16.plan.json
@@ -2,13 +2,75 @@
   "stack_version": "0.5.16",
   "stack_tag": "miot-stack@v0.5.16",
   "milestone": "MIOT-0.5.16",
-  "pull_requests": [],
-  "changed_files": [],
+  "pull_requests": [
+    {
+      "number": 690,
+      "title": "Based/fixing bentobox modal",
+      "source_issues": [
+        {
+          "number": 689,
+          "title": "fix(bento): consolidate task modals, fix viewer dropdown tooltip & full-width reject item"
+        }
+      ]
+    },
+    {
+      "number": 693,
+      "title": "feat(release): make train milestone driven",
+      "source_issues": [
+        {
+          "number": 692,
+          "title": "feat: make release train milestone-driven"
+        }
+      ]
+    },
+    {
+      "number": 695,
+      "title": "feat(release): align nightly stack assembly",
+      "source_issues": [
+        {
+          "number": 694,
+          "title": "feat: align nightly stack assembly"
+        }
+      ]
+    },
+    {
+      "number": 698,
+      "title": "fix(release): seed stack version from component tags",
+      "source_issues": [
+        {
+          "number": 697,
+          "title": "fix: seed stack release version from component tags"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    ".github/scripts/resolve-stack-release-plan.js",
+    ".github/workflows/app-nightly.yml",
+    ".github/workflows/app-release-train.yml",
+    "turbo-repo/.claude/settings.json",
+    "turbo-repo/apps/app/src/features/dynamic-forms/components/live-form-field.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/go-back-modal.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/go-forward-modal.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/review-items.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.types.ts",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-head.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/sidebar-section.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/viewer-toolbar.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.types.ts",
+    "turbo-repo/apps/app/src/features/task-forms/services/form.service.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/package-lock.json"
+  ],
   "components": {
     "app": {
-      "changed": false,
-      "version": "0.5.15",
-      "tag": "app@v0.5.15"
+      "changed": true,
+      "version": "0.5.16",
+      "tag": "app@v0.5.16"
     },
     "modulith": {
       "changed": false,

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.15.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.15.mdx
@@ -1,0 +1,47 @@
+# 🔔 Release Notes v1.31.15 — ModularIoT
+
+### Fecha: 17/06/2026
+
+**Objetivo**: Esta versión mejora la priorización operativa en planificación y consolida el modelo de releases por milestone para que los despliegues sean más consistentes entre app y modulith. Además, corrige fricciones en flujos de tareas y visualización documental para estabilizar la operación diaria.
+
+## 🚀 Evolutivos
+
+- **📍 Priorización de servicios sin cliente en planificación de calendario**
+  - **Key point**: Se ajustó el orden del preset de planificación para que los servicios sin cliente asignado queden siempre al final.
+  - **Technical detail**: El criterio de orden ahora evalúa primero ausencia de cliente (considerando valores vacíos o con espacios) y luego conserva la prioridad existente por incidencia, compliance y recencia.
+
+## 🔧 Integraciones
+
+- **🔌 Release train guiado por milestones con ensamblado por componentes** *(Integración OSS — MIOT-0.5.16)*
+  - **Scope**: El release pasa a usar una versión umbrella de stack y detecta qué componentes cambiaron por paths de PR para versionar/promover solo app o modulith cuando corresponde, reutilizando artefactos ya liberados para lo no modificado y publicando manifiesto con `components.app` y `components.modulith` (manteniendo campos legacy durante migración).
+
+- **🔌 Alineación del flujo nightly con el modelo de release por componentes** *(Integración OSS — MIOT-0.5.16)*
+  - **Scope**: Nightly deja de recompilar Quarkus, resuelve imagen existente (priorizando `sha-<short_sha>` y fallback a `latest`), promueve esa imagen a tags nightly y despacha payload con estructura por componentes sin romper compatibilidad de campos actuales.
+
+## 🐛 Correcciones
+
+- **🐛 Versionado por defecto del stack y nomenclatura de milestone privada en release train** *(Integración OSS — MIOT-0.5.16)*
+  - **Impacto**: Cuando no existía tag `miot-stack@v*`, el flujo arrancaba en `0.1.0` en lugar de continuar la línea vigente, y el milestone privado salía con formato inconsistente.
+  - **Solución**: El seed de versión ahora toma como base los tags más recientes de `app`/`modulith` y hace bump patch; además, el milestone privado se emite como `Release <version>`.
+
+- **🐛 Consolidación de modales de tareas y correcciones en viewer multimedia/bento** *(Integración OSS — MIOT-0.5.16)*
+  - **Impacto**: Había inconsistencias entre modales de acción, problemas de scroll/layout en el modal, tooltip de rechazo recortado en dropdown y comportamiento de ancho en ítems; también se observaba carga duplicada PDF+PNG en iOS en ciertos casos.
+  - **Solución**: Se unificó en `TaskConfirmModal` con reglas de supresión de motivos según acción, se estabilizó layout scrollable con header/footer fijos, se mejoró `SidebarSection`, se reemplazó el tooltip interno por `PortalTooltip` para evitar clipping y se añadió deduplicación por nombre base para descartar PNGs duplicados de previsualización.
+
+## 📊 Beneficios
+
+- Mejora la lectura operativa del planificador al priorizar primero servicios con cliente identificado.
+- Reduce acoplamiento artificial entre versiones de app y backend en releases de milestone.
+- Disminuye trabajo innecesario en nightly al reutilizar imágenes existentes de modulith.
+- Mantiene compatibilidad hacia atrás en payloads de despliegue durante la transición de contrato.
+- Hace más predecible el versionado del stack y evita saltos a versiones base incorrectas.
+- Simplifica y homogeneiza la experiencia de confirmación/rechazo en tareas de entrega/recepción.
+- Mitiga fricciones de UX en viewer y reduce duplicados de archivos en flujos móviles iOS.
+
+## 📌 Conclusión
+
+La v1.31.15 combina mejoras funcionales visibles para operación con ajustes estructurales del pipeline de releases. El resultado es una planificación más útil en campo y un tren de liberación más alineado con cambios reales por componente.
+
+En paralelo, las correcciones de UX en bento/viewer atacan puntos de fricción concretos del flujo documental y de validación de tareas, reforzando consistencia en interacción y legibilidad en modal.
+
+En conjunto, esta entrega fortalece la continuidad operativa, la gobernanza de versiones y la estabilidad del ciclo de despliegue de ModularIoT.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.15",
+      "version": "0.5.16",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
## Summary
- make the stack release planner collect PRs from milestone issues via `closedByPullRequestsReferences`
- preserve the previous direct PR milestone search for compatibility
- repair `releases/stacks/v0.5.16.plan.json` so app is marked changed and points to `app@v0.5.16`
- bump `@modulariot/app` to `0.5.16`
- add app-visible release notes `turbo-repo/apps/app/src/releases/v1.31.15.mdx`

## Root cause
MIOT-0.5.16 tracked issue #689, and issue #689 was closed by PR #690. PR #690 touched `turbo-repo/apps/app/**`, but the PR itself had no milestone. The release planner only searched merged PRs with `milestone:"MIOT-0.5.16"`, so it generated an empty plan and reused `app@v0.5.15` for stack `miot-stack@v0.5.16`.

## Validation
- `GITHUB_REPOSITORY=microboxlabs/modulariot OSS_MILESTONE=MIOT-0.5.16 STACK_VERSION=0.5.16 GITHUB_OUTPUT=$(mktemp) node .github/scripts/resolve-stack-release-plan.js`
- `node --check .github/scripts/resolve-stack-release-plan.js`
- `git diff --check`
- `npx turbo run build --filter=@modulariot/app`

## Post-merge release repair
Do not rerun the full MIOT release train. After this merges to trunk:

1. Create/push `app@v0.5.16` on the merged repair commit.
2. Build and push `ghcr.io/microboxlabs/miot-app:0.5.16` and `ghcr.io/microboxlabs/miot-app:app-v0.5.16` from that commit.
3. Dispatch `miot-stack-release` manually to `microboxlabs/miot-deployments` with stack `0.5.16`, app `app@v0.5.16`, and modulith `modulith@v0.5.15`.

Closes #706
