### PR TITLE
chore(release): prepare MIOT stack v0.5.17

### DIFF
--- a/releases/notes/v1.31.16.mdx
+++ b/releases/notes/v1.31.16.mdx
@@ -1,0 +1,46 @@
+# 🔔 Release Notes v1.31.16 — ModularIoT
+
+### Fecha: 18/06/2026
+
+**Objetivo**: Esta versión fortalece la confiabilidad del ciclo de release/despliegue y mejora flujos funcionales clave de la app. El foco estuvo en reducir errores operativos de pipeline y asegurar una evolución más consistente entre app, stack y despliegues.
+
+## 🚀 Evolutivos
+
+- **📍 Redirección raíz en ingress de `miot-app` y pin de stack en coordinador** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: Se incorporó una opción para redirigir `/` hacia una ruta de aplicación configurada y se fijó el stack chart compatible en despliegues de coordinador.
+  - **Technical detail**: Se añadió superficie de configuración en charts/workflows para soportar `redirectRoot` y versionado de stack, incluyendo sincronización de manifiestos de entorno.
+
+- **📍 Selección de recursos acreditados sin dependencia de client RUT** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: La selección de recursos (transportistas, conductores, camiones y ramplas) dejó de bloquearse cuando el servicio no tiene cliente asociado.
+  - **Technical detail**: El flujo de app/BFF ahora acepta `rutMandante` nulo y mantiene el contrato RPC enviando `p_rut_mandante` (con `null` cuando corresponde), preservando compatibilidad para casos con cliente.
+
+- **📍 Unificación de login usuario/clave vía Auth0 y conexión configurable** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: Se dejó definido el trabajo para unificar el sign-in de usuario/clave con sesiones JWT homogéneas y mantener fallback a Alfresco cuando Auth0 no esté configurado.
+  - **Technical detail**: El alcance contempla parametrizar IDs de conexiones Auth0 por variables de entorno y eliminar dependencias hardcodeadas. *(Trabajo planificado; issue abierto).*
+
+## 🐛 Correcciones
+
+- **🐛 El release planner no detectaba cambios de app cuando el milestone estaba en issues** *(Integración OSS — MIOT-0.5.17)*
+  - **Impacto**: Podía marcar componentes como “sin cambios” y reutilizar versiones incorrectas en planes de stack.
+  - **Solución**: Se corrigió la resolución para tomar issues del milestone y sus PRs vinculados/cerradores, manteniendo soporte de milestones en PRs.
+
+- **🐛 Incompatibilidades del `repository_dispatch` de stack por límite/forma del payload** *(Integración OSS — MIOT-0.5.17)*
+  - **Impacto**: Se producían fallas en despliegues release/nightly por exceso de propiedades top-level o por desalineación con workflows que esperaban campos planos.
+  - **Solución**: Se aplicó compatibilidad enviando payload plano acotado para despliegue y moviendo metadatos al manifiesto; además quedó trabajo planificado para tolerar formas anidadas y reforzar compatibilidad en transición. *(Incluye issues abiertos en curso).*
+
+## 📊 Beneficios
+
+- Menos riesgo de fallas en pipelines de release y nightly por contratos de payload.
+- Mayor trazabilidad de cambios reales de app dentro de planes de release.
+- Mejor experiencia operativa al soportar redirección raíz en ingress de forma configurable.
+- Despliegues de coordinador más predecibles al fijar versión de chart compatible.
+- Menor bloqueo funcional en planificación/asignación cuando no existe client RUT.
+- Base preparada para autenticación más uniforme y gobernada por Auth0 en distintos entornos.
+
+## 📌 Conclusión
+
+La versión 1.31.16 consolida estabilidad en puntos críticos de entrega continua y despliegue, corrigiendo brechas que impactaban la consistencia entre milestones, planes de stack y ejecución operativa.
+
+Al mismo tiempo, introduce mejoras funcionales concretas en app e infraestructura (ingress y selección de recursos), con impacto directo en continuidad de operación y mantenibilidad técnica.
+
+También deja encaminadas iniciativas abiertas relevantes —especialmente en autenticación y compatibilidad de payloads durante transición— para sostener una evolución segura en próximas iteraciones.

--- a/releases/stacks/v0.5.17.plan.json
+++ b/releases/stacks/v0.5.17.plan.json
@@ -1,0 +1,86 @@
+{
+  "stack_version": "0.5.17",
+  "stack_tag": "miot-stack@v0.5.17",
+  "milestone": "MIOT-0.5.17",
+  "pull_requests": [
+    {
+      "number": 634,
+      "title": "feat(auth): validate username/password against Auth0, env-driven conn…",
+      "source_issues": [
+        {
+          "number": 635,
+          "title": "feat: unify username/password sign-in through Auth0 and make Auth0 connection IDs configurable"
+        }
+      ]
+    },
+    {
+      "number": 701,
+      "title": "fix: keep stack dispatch payload under GitHub limit",
+      "source_issues": []
+    },
+    {
+      "number": 703,
+      "title": "feat(calendar): un-gate accredited-resource selection from clientRut (pass null)",
+      "source_issues": [
+        {
+          "number": 702,
+          "title": "feat: don't gate accredited-resource selection on clientRut (pass null)"
+        }
+      ]
+    },
+    {
+      "number": 705,
+      "title": "fix: keep stack dispatch compatible with deployments",
+      "source_issues": [
+        {
+          "number": 704,
+          "title": "bug: stack dispatch payload is incompatible with deployment workflow"
+        }
+      ]
+    },
+    {
+      "number": 707,
+      "title": "fix: resolve release components from milestone issues",
+      "source_issues": [
+        {
+          "number": 706,
+          "title": "bug: release planner misses app changes from milestone issues"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    ".github/scripts/resolve-stack-release-plan.js",
+    ".github/workflows/app-nightly.yml",
+    ".github/workflows/app-release-train.yml",
+    "releases/stacks/v0.5.16.plan.json",
+    "turbo-repo/apps/app/.env.example",
+    "turbo-repo/apps/app/package.json",
+    "turbo-repo/apps/app/src/app/api/calendar/accredited-resources/route.ts",
+    "turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts",
+    "turbo-repo/apps/app/src/auth.config.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth.service.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts",
+    "turbo-repo/apps/app/src/releases/v1.31.15.mdx",
+    "turbo-repo/apps/app/src/test/server-only-stub.ts",
+    "turbo-repo/apps/app/src/types/next-auth.d.ts",
+    "turbo-repo/apps/app/vitest.config.ts",
+    "turbo-repo/package-lock.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.16",
+      "tag": "app@v0.5.16"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.15",
+      "tag": "modulith@v0.5.15"
+    }
+  }
+}

--- a/turbo-repo/apps/app/src/releases/v1.31.16.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.16.mdx
@@ -1,0 +1,46 @@
+# 🔔 Release Notes v1.31.16 — ModularIoT
+
+### Fecha: 18/06/2026
+
+**Objetivo**: Esta versión fortalece la confiabilidad del ciclo de release/despliegue y mejora flujos funcionales clave de la app. El foco estuvo en reducir errores operativos de pipeline y asegurar una evolución más consistente entre app, stack y despliegues.
+
+## 🚀 Evolutivos
+
+- **📍 Redirección raíz en ingress de `miot-app` y pin de stack en coordinador** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: Se incorporó una opción para redirigir `/` hacia una ruta de aplicación configurada y se fijó el stack chart compatible en despliegues de coordinador.
+  - **Technical detail**: Se añadió superficie de configuración en charts/workflows para soportar `redirectRoot` y versionado de stack, incluyendo sincronización de manifiestos de entorno.
+
+- **📍 Selección de recursos acreditados sin dependencia de client RUT** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: La selección de recursos (transportistas, conductores, camiones y ramplas) dejó de bloquearse cuando el servicio no tiene cliente asociado.
+  - **Technical detail**: El flujo de app/BFF ahora acepta `rutMandante` nulo y mantiene el contrato RPC enviando `p_rut_mandante` (con `null` cuando corresponde), preservando compatibilidad para casos con cliente.
+
+- **📍 Unificación de login usuario/clave vía Auth0 y conexión configurable** *(Integración OSS — MIOT-0.5.17)*
+  - **Key point**: Se dejó definido el trabajo para unificar el sign-in de usuario/clave con sesiones JWT homogéneas y mantener fallback a Alfresco cuando Auth0 no esté configurado.
+  - **Technical detail**: El alcance contempla parametrizar IDs de conexiones Auth0 por variables de entorno y eliminar dependencias hardcodeadas. *(Trabajo planificado; issue abierto).*
+
+## 🐛 Correcciones
+
+- **🐛 El release planner no detectaba cambios de app cuando el milestone estaba en issues** *(Integración OSS — MIOT-0.5.17)*
+  - **Impacto**: Podía marcar componentes como “sin cambios” y reutilizar versiones incorrectas en planes de stack.
+  - **Solución**: Se corrigió la resolución para tomar issues del milestone y sus PRs vinculados/cerradores, manteniendo soporte de milestones en PRs.
+
+- **🐛 Incompatibilidades del `repository_dispatch` de stack por límite/forma del payload** *(Integración OSS — MIOT-0.5.17)*
+  - **Impacto**: Se producían fallas en despliegues release/nightly por exceso de propiedades top-level o por desalineación con workflows que esperaban campos planos.
+  - **Solución**: Se aplicó compatibilidad enviando payload plano acotado para despliegue y moviendo metadatos al manifiesto; además quedó trabajo planificado para tolerar formas anidadas y reforzar compatibilidad en transición. *(Incluye issues abiertos en curso).*
+
+## 📊 Beneficios
+
+- Menos riesgo de fallas en pipelines de release y nightly por contratos de payload.
+- Mayor trazabilidad de cambios reales de app dentro de planes de release.
+- Mejor experiencia operativa al soportar redirección raíz en ingress de forma configurable.
+- Despliegues de coordinador más predecibles al fijar versión de chart compatible.
+- Menor bloqueo funcional en planificación/asignación cuando no existe client RUT.
+- Base preparada para autenticación más uniforme y gobernada por Auth0 en distintos entornos.
+
+## 📌 Conclusión
+
+La versión 1.31.16 consolida estabilidad en puntos críticos de entrega continua y despliegue, corrigiendo brechas que impactaban la consistencia entre milestones, planes de stack y ejecución operativa.
+
+Al mismo tiempo, introduce mejoras funcionales concretas en app e infraestructura (ingress y selección de recursos), con impacto directo en continuidad de operación y mantenibilidad técnica.
+
+También deja encaminadas iniciativas abiertas relevantes —especialmente en autenticación y compatibilidad de payloads durante transición— para sostener una evolución segura en próximas iteraciones.


### PR DESCRIPTION
Prepares miot-stack@v0.5.17 from milestone MIOT-0.5.17, with release notes v1.31.16.

Components:
- App: app@v0.5.16 (changed: true)
- Modulith: modulith@v0.5.15 (changed: false)

Milestones: Release 1.31.16, MIOT-0.5.17.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
