### PR TITLE
fix(data-sources): test a source provider before saving it

### DIFF
--- a/turbo-repo/apps/app/src/app/api/data-sources/[dataSourceId]/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/[dataSourceId]/test/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveSiteForRequest } from "@/app/api/utils/org-resolver";
-import { validateTargetUrl } from "@/app/api/utils/url-validator";
 import {
   getDataSource,
   updateDataSource,
 } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import type { AlfrescoDataSourceConfig } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
-import { resolveBearerToken, buildAuthHeader } from "@/app/api/data-sources/resolve-credentials";
+import { resolveBearerToken } from "@/app/api/data-sources/resolve-credentials";
 import type { BearerResult } from "@/app/api/data-sources/resolve-credentials";
+import { testPostgrestConnection } from "@/app/api/data-sources/test-connection";
 import { logger } from "@/lib/logger";
 
 type RouteContext = { params: Promise<{ dataSourceId: string }> };
@@ -27,42 +27,6 @@ function buildBearerLogFields(dataSourceId: string, result: BearerResult) {
     return { dataSourceId, ok: true, authMethod: result.authMethod };
   }
   return { dataSourceId, ok: false, error: result.error };
-}
-
-async function testPostgrestConnection(
-  url: string,
-  token: string,
-  authMethod: "TOKEN" | "OAUTH",
-  dataSourceId: string
-): Promise<{ success: boolean; errorMessage?: string }> {
-  const specUrl = `${url}/`;
-
-  const urlCheck = await validateTargetUrl(specUrl);
-  if (!urlCheck.valid) {
-    return { success: false, errorMessage: urlCheck.reason };
-  }
-
-  try {
-    const res = await fetch(specUrl, {
-      headers: {
-        Accept: "application/openapi+json",
-        Authorization: buildAuthHeader(token, authMethod),
-      },
-      signal: AbortSignal.timeout(10000),
-    });
-
-    if (res.ok) {
-      await res.json();
-      return { success: true };
-    }
-    return { success: false, errorMessage: `HTTP ${res.status}: ${res.statusText}` };
-  } catch (err) {
-    logger.error({ err, dataSourceId }, "Data source connection test failed");
-    return {
-      success: false,
-      errorMessage: err instanceof Error ? err.message : "Connection test failed",
-    };
-  }
 }
 
 export async function POST(request: NextRequest, ctx: RouteContext) {

--- a/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
@@ -1,0 +1,45 @@
+import { validateTargetUrl } from "@/app/api/utils/url-validator";
+import { buildAuthHeader } from "@/app/api/data-sources/resolve-credentials";
+import type { AuthMethod } from "@/app/api/data-sources/resolve-credentials";
+import { logger } from "@/lib/logger";
+
+/**
+ * Probe a PostgREST data source by fetching its OpenAPI spec with the supplied
+ * bearer token. Shared by the persisted (by-id) test route and the stateless
+ * (inline form data) test route so both behave identically.
+ */
+export async function testPostgrestConnection(
+  url: string,
+  token: string,
+  authMethod: AuthMethod,
+  dataSourceId?: string
+): Promise<{ success: boolean; errorMessage?: string }> {
+  const specUrl = `${url}/`;
+
+  const urlCheck = await validateTargetUrl(specUrl);
+  if (!urlCheck.valid) {
+    return { success: false, errorMessage: urlCheck.reason };
+  }
+
+  try {
+    const res = await fetch(specUrl, {
+      headers: {
+        Accept: "application/openapi+json",
+        Authorization: buildAuthHeader(token, authMethod),
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (res.ok) {
+      await res.json();
+      return { success: true };
+    }
+    return { success: false, errorMessage: `HTTP ${res.status}: ${res.statusText}` };
+  } catch (err) {
+    logger.error({ err, dataSourceId }, "Data source connection test failed");
+    return {
+      success: false,
+      errorMessage: err instanceof Error ? err.message : "Connection test failed",
+    };
+  }
+}

--- a/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
@@ -14,7 +14,9 @@ export async function testPostgrestConnection(
   authMethod: AuthMethod,
   dataSourceId?: string
 ): Promise<{ success: boolean; errorMessage?: string }> {
-  const specUrl = `${url}/`;
+  // Strip any trailing slash before appending one so a url that already ends
+  // in "/" doesn't produce a double slash (which breaks the upstream probe).
+  const specUrl = `${url.replace(/\/+$/, "")}/`;
 
   const urlCheck = await validateTargetUrl(specUrl);
   if (!urlCheck.valid) {

--- a/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts
@@ -16,7 +16,13 @@ export async function testPostgrestConnection(
 ): Promise<{ success: boolean; errorMessage?: string }> {
   // Strip any trailing slash before appending one so a url that already ends
   // in "/" doesn't produce a double slash (which breaks the upstream probe).
-  const specUrl = `${url.replace(/\/+$/, "")}/`;
+  // Done with a linear scan rather than a /\/+$/ regex, which can backtrack
+  // super-linearly on a long run of trailing slashes (ReDoS / DoS).
+  let trimmedEnd = url.length;
+  while (trimmedEnd > 0 && url[trimmedEnd - 1] === "/") {
+    trimmedEnd--;
+  }
+  const specUrl = `${url.slice(0, trimmedEnd)}/`;
 
   const urlCheck = await validateTargetUrl(specUrl);
   if (!urlCheck.valid) {

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
@@ -218,6 +218,32 @@ describe("POST /api/data-sources/test (stateless)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("validates the OAuth tokenUrl against SSRF before exchanging the token", async () => {
+    // First validateTargetUrl call (the tokenUrl check) fails.
+    validateTargetUrlMock.mockResolvedValueOnce({ valid: false, reason: "blocked private address" });
+    exchangeOAuthTokenMock.mockResolvedValue({ accessToken: "minted", detectedFormat: "form", expiresAt: 0 });
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({
+        type: "POSTGREST",
+        url: "https://db.example.com",
+        authMethod: "OAUTH",
+        clientId: "cid",
+        clientSecret: "csecret",
+        tokenUrl: "https://169.254.169.254/token",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("blocked private address");
+    // Must not attempt the token exchange (or any upstream fetch) on SSRF rejection.
+    expect(exchangeOAuthTokenMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("reports success:false when the target URL fails SSRF validation", async () => {
     validateTargetUrlMock.mockResolvedValue({ valid: false, reason: "blocked private address" });
     const { POST } = await loadRoute();

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
@@ -105,6 +105,20 @@ describe("POST /api/data-sources/test (stateless)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("returns 400 (not 500) for a malformed JSON body", async () => {
+    const { POST } = await loadRoute();
+
+    const req = new Request("https://app.example.com/api/data-sources/test?siteId=site-1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{ not valid json",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("tests a TOKEN connection using the inline token from the body", async () => {
     fetchMock.mockResolvedValue(makeResponse({ ok: true, status: 200, jsonData: {} }));
     const { POST } = await loadRoute();

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
@@ -123,6 +123,18 @@ describe("POST /api/data-sources/test (stateless)", () => {
     expect(init.headers.Authorization).toBe("Bearer form-token");
   });
 
+  it("normalizes a trailing slash in the url so the probe URL has no double slash", async () => {
+    fetchMock.mockResolvedValue(makeResponse({ ok: true, status: 200, jsonData: {} }));
+    const { POST } = await loadRoute();
+
+    await POST(
+      makeRequest({ type: "POSTGREST", url: "https://db.example.com/", authMethod: "TOKEN", token: "t" })
+    );
+
+    const [calledUrl] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("https://db.example.com/");
+  });
+
   it("reports success:false when the TOKEN probe gets a non-OK response", async () => {
     fetchMock.mockResolvedValue(makeResponse({ ok: false, status: 401, statusText: "Unauthorized" }));
     const { POST } = await loadRoute();

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Coverage for the stateless connection-test endpoint.
+ *
+ * Unlike POST /api/data-sources/{id}/test (which loads the persisted, encrypted
+ * config by id), this route tests the connection using the *inline* form data in
+ * the request body. It performs NO persistence — it never touches the data-source
+ * store, so a user can validate a provider before saving it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const resolveSiteMock = vi.fn();
+const validateTargetUrlMock = vi.fn();
+const exchangeOAuthTokenMock = vi.fn();
+
+vi.mock("@/app/api/utils/org-resolver", () => ({
+  resolveSiteForRequest: (...args: unknown[]) => resolveSiteMock(...args),
+}));
+
+vi.mock("@/app/api/utils/url-validator", () => ({
+  validateTargetUrl: (...args: unknown[]) => validateTargetUrlMock(...args),
+}));
+
+vi.mock("@/app/api/data-sources/resolve-credentials", () => ({
+  exchangeOAuthToken: (...args: unknown[]) => exchangeOAuthTokenMock(...args),
+  buildAuthHeader: (token: string) => `Bearer ${token}`,
+}));
+
+function makeResponse({
+  ok,
+  status,
+  statusText = "",
+  jsonData,
+}: {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  jsonData?: unknown;
+}) {
+  return {
+    ok,
+    status,
+    statusText,
+    json: async () => jsonData,
+  };
+}
+
+function makeRequest(body: unknown, siteId = "site-1") {
+  return new Request(`https://app.example.com/api/data-sources/test?siteId=${siteId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const fetchMock = vi.fn();
+
+async function loadRoute() {
+  vi.resetModules();
+  return import("./route");
+}
+
+describe("POST /api/data-sources/test (stateless)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    resolveSiteMock.mockReset();
+    validateTargetUrlMock.mockReset();
+    exchangeOAuthTokenMock.mockReset();
+
+    // Default: authenticated + member of the site.
+    resolveSiteMock.mockResolvedValue({
+      resolved: true,
+      data: { siteId: "site-1", session: { user: { id: "u1" } } },
+    });
+    // Default: target URL passes SSRF validation.
+    validateTargetUrlMock.mockResolvedValue({ valid: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the auth failure response when the site cannot be resolved", async () => {
+    const { NextResponse } = await import("next/server");
+    resolveSiteMock.mockResolvedValue({
+      resolved: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    const { POST } = await loadRoute();
+
+    const res = await POST(makeRequest({ type: "POSTGREST", url: "https://db.example.com", authMethod: "TOKEN", token: "secret" }));
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid body with 400 and does not probe the upstream", async () => {
+    const { POST } = await loadRoute();
+
+    // TOKEN auth without a token is invalid.
+    const res = await POST(makeRequest({ type: "POSTGREST", url: "https://db.example.com", authMethod: "TOKEN" }));
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("tests a TOKEN connection using the inline token from the body", async () => {
+    fetchMock.mockResolvedValue(makeResponse({ ok: true, status: 200, jsonData: {} }));
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({ type: "POSTGREST", url: "https://db.example.com", authMethod: "TOKEN", token: "form-token" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // The probe must use the token from the request body, not any stored credential.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("https://db.example.com/");
+    expect(init.headers.Authorization).toBe("Bearer form-token");
+  });
+
+  it("reports success:false when the TOKEN probe gets a non-OK response", async () => {
+    fetchMock.mockResolvedValue(makeResponse({ ok: false, status: 401, statusText: "Unauthorized" }));
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({ type: "POSTGREST", url: "https://db.example.com", authMethod: "TOKEN", token: "bad" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("401");
+  });
+
+  it("exchanges OAuth credentials inline, then probes with the resulting token", async () => {
+    exchangeOAuthTokenMock.mockResolvedValue({ accessToken: "minted", detectedFormat: "form", expiresAt: 0 });
+    fetchMock.mockResolvedValue(makeResponse({ ok: true, status: 200, jsonData: {} }));
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({
+        type: "POSTGREST",
+        url: "https://db.example.com",
+        authMethod: "OAUTH",
+        clientId: "cid",
+        clientSecret: "csecret",
+        tokenUrl: "https://auth.example.com/token",
+        scope: "read",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // Exchange must use the raw secret from the body (no decryption, no dataSourceId/cache).
+    expect(exchangeOAuthTokenMock).toHaveBeenCalledWith(
+      "https://auth.example.com/token",
+      "cid",
+      "csecret",
+      "read",
+      undefined, // audience
+      undefined // tokenRequestFormat
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer minted");
+  });
+
+  it("reports success:false when the OAuth exchange fails", async () => {
+    exchangeOAuthTokenMock.mockRejectedValue(new Error("OAuth token exchange failed: HTTP 401 — bad client"));
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({
+        type: "POSTGREST",
+        url: "https://db.example.com",
+        authMethod: "OAUTH",
+        clientId: "cid",
+        clientSecret: "csecret",
+        tokenUrl: "https://auth.example.com/token",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("OAuth token exchange failed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports success:false when the target URL fails SSRF validation", async () => {
+    validateTargetUrlMock.mockResolvedValue({ valid: false, reason: "blocked private address" });
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({ type: "POSTGREST", url: "https://169.254.169.254", authMethod: "TOKEN", token: "x" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("blocked private address");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
@@ -4,7 +4,57 @@ import { validateTargetUrl } from "@/app/api/utils/url-validator";
 import { exchangeOAuthToken } from "@/app/api/data-sources/resolve-credentials";
 import { testPostgrestConnection } from "@/app/api/data-sources/test-connection";
 import { TestConnectionSchema } from "@/features/data-sources/types";
+import type { TestConnectionInput } from "@/features/data-sources/types";
 import { logger } from "@/lib/logger";
+
+type TokenResolution =
+  | { ok: true; token: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Resolve the bearer token straight from the submitted form data. TOKEN auth
+ * uses the raw token; OAUTH exchanges the raw client secret with no cache
+ * (there is no dataSourceId yet). Returns an error response instead of a token
+ * when the SSRF guard fails or the exchange throws.
+ */
+async function resolveToken(data: TestConnectionInput): Promise<TokenResolution> {
+  if (data.authMethod === "TOKEN") {
+    return { ok: true, token: data.token };
+  }
+
+  // SSRF guard: validate the token URL before the exchange, mirroring the
+  // by-id path (resolveOAuthToken). data.url is validated in the probe.
+  const tokenUrlCheck = await validateTargetUrl(data.tokenUrl);
+  if (!tokenUrlCheck.valid) {
+    return {
+      ok: false,
+      response: NextResponse.json({
+        success: false,
+        error: tokenUrlCheck.reason ?? "Invalid token URL",
+      }),
+    };
+  }
+
+  try {
+    const oauth = await exchangeOAuthToken(
+      data.tokenUrl,
+      data.clientId,
+      data.clientSecret,
+      data.scope,
+      data.audience,
+      data.tokenRequestFormat
+    );
+    return { ok: true, token: oauth.accessToken };
+  } catch (err) {
+    return {
+      ok: false,
+      response: NextResponse.json({
+        success: false,
+        error: err instanceof Error ? err.message : "OAuth token exchange failed",
+      }),
+    };
+  }
+}
 
 /**
  * Stateless connection test. Tests the connection using the inline form data in
@@ -34,43 +84,12 @@ export async function POST(request: Request) {
 
     const data = parsed.data;
 
-    // Resolve the bearer token straight from the submitted form data. TOKEN auth
-    // uses the raw token; OAUTH exchanges the raw client secret with no cache
-    // (there is no dataSourceId yet).
-    let token: string;
-    if (data.authMethod === "TOKEN") {
-      token = data.token;
-    } else {
-      // SSRF guard: validate the token URL before the exchange, mirroring the
-      // by-id path (resolveOAuthToken). data.url is validated in the probe.
-      const tokenUrlCheck = await validateTargetUrl(data.tokenUrl);
-      if (!tokenUrlCheck.valid) {
-        return NextResponse.json({
-          success: false,
-          error: tokenUrlCheck.reason ?? "Invalid token URL",
-        });
-      }
-      try {
-        const oauth = await exchangeOAuthToken(
-          data.tokenUrl,
-          data.clientId,
-          data.clientSecret,
-          data.scope,
-          data.audience,
-          data.tokenRequestFormat
-        );
-        token = oauth.accessToken;
-      } catch (err) {
-        return NextResponse.json({
-          success: false,
-          error: err instanceof Error ? err.message : "OAuth token exchange failed",
-        });
-      }
-    }
+    const tokenResult = await resolveToken(data);
+    if (!tokenResult.ok) return tokenResult.response;
 
     const { success, errorMessage } = await testPostgrestConnection(
       data.url,
-      token,
+      tokenResult.token,
       data.authMethod
     );
 

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
@@ -16,7 +16,12 @@ export async function POST(request: Request) {
   if (!result.resolved) return result.response;
 
   try {
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const parsed = TestConnectionSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { resolveSiteForRequest } from "@/app/api/utils/org-resolver";
+import { exchangeOAuthToken } from "@/app/api/data-sources/resolve-credentials";
+import { testPostgrestConnection } from "@/app/api/data-sources/test-connection";
+import { TestConnectionSchema } from "@/features/data-sources/types";
+import { logger } from "@/lib/logger";
+
+/**
+ * Stateless connection test. Tests the connection using the inline form data in
+ * the request body, WITHOUT persisting anything — this lets a user validate a
+ * provider before saving it. Compare with POST /api/data-sources/{id}/test,
+ * which tests the already-persisted (encrypted) config by id.
+ */
+export async function POST(request: Request) {
+  const result = await resolveSiteForRequest(request);
+  if (!result.resolved) return result.response;
+
+  try {
+    const body = await request.json();
+    const parsed = TestConnectionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const data = parsed.data;
+
+    // Resolve the bearer token straight from the submitted form data. TOKEN auth
+    // uses the raw token; OAUTH exchanges the raw client secret with no cache
+    // (there is no dataSourceId yet).
+    let token: string;
+    if (data.authMethod === "TOKEN") {
+      token = data.token;
+    } else {
+      try {
+        const oauth = await exchangeOAuthToken(
+          data.tokenUrl,
+          data.clientId,
+          data.clientSecret,
+          data.scope,
+          data.audience,
+          data.tokenRequestFormat
+        );
+        token = oauth.accessToken;
+      } catch (err) {
+        return NextResponse.json({
+          success: false,
+          error: err instanceof Error ? err.message : "OAuth token exchange failed",
+        });
+      }
+    }
+
+    const { success, errorMessage } = await testPostgrestConnection(
+      data.url,
+      token,
+      data.authMethod
+    );
+
+    return NextResponse.json({
+      success,
+      ...(errorMessage ? { error: errorMessage } : {}),
+    });
+  } catch (err) {
+    logger.error({ err }, "Stateless data source test route error");
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/data-sources/test/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveSiteForRequest } from "@/app/api/utils/org-resolver";
+import { validateTargetUrl } from "@/app/api/utils/url-validator";
 import { exchangeOAuthToken } from "@/app/api/data-sources/resolve-credentials";
 import { testPostgrestConnection } from "@/app/api/data-sources/test-connection";
 import { TestConnectionSchema } from "@/features/data-sources/types";
@@ -40,6 +41,15 @@ export async function POST(request: Request) {
     if (data.authMethod === "TOKEN") {
       token = data.token;
     } else {
+      // SSRF guard: validate the token URL before the exchange, mirroring the
+      // by-id path (resolveOAuthToken). data.url is validated in the probe.
+      const tokenUrlCheck = await validateTargetUrl(data.tokenUrl);
+      if (!tokenUrlCheck.valid) {
+        return NextResponse.json({
+          success: false,
+          error: tokenUrlCheck.reason ?? "Invalid token URL",
+        });
+      }
       try {
         const oauth = await exchangeOAuthToken(
           data.tokenUrl,

--- a/turbo-repo/apps/app/src/features/data-sources/components/data-source-modal.tsx
+++ b/turbo-repo/apps/app/src/features/data-sources/components/data-source-modal.tsx
@@ -18,7 +18,7 @@ interface DataSourceModalProps {
   readonly show: boolean;
   readonly onClose: () => void;
   readonly onSubmit: (data: DataSourceFormData) => void;
-  readonly onTest?: (id: string) => void;
+  readonly onTest?: (data: DataSourceFormData) => void;
   readonly editingSource?: DataSourceListItem | null;
   readonly loading?: boolean;
   readonly dict: I18nRecord;
@@ -291,11 +291,12 @@ export function DataSourceModal({
           </>
         )}
 
-        {editingSource && onTest && (
+        {onTest && (
           <div>
             <Button
+              type="button"
               color="light"
-              onClick={() => onTest(editingSource.id)}
+              onClick={handleSubmit(onTest)}
               disabled={loading}
             >
               {tr("modal.testConnection", dict)}

--- a/turbo-repo/apps/app/src/features/data-sources/components/data-sources-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/data-sources/components/data-sources-page-content.tsx
@@ -11,6 +11,7 @@ import { DataSourceTable } from "./data-source-table";
 import { DataSourceModal } from "./data-source-modal";
 import { DataSourceDeleteDialog } from "./data-source-delete-dialog";
 import type { DataSourceListItem, DataSourceFormData } from "../types";
+import { shouldTestStoredCredential } from "../test-decision";
 import { toast } from "sonner";
 
 interface DataSourcesPageContentProps {
@@ -31,6 +32,7 @@ export default function DataSourcesPageContent({
     update,
     remove,
     testConnection,
+    testInline,
     toggleActive,
     refetch,
   } = useDataSources(siteId);
@@ -109,14 +111,33 @@ export default function DataSourcesPageContent({
     }
   };
 
+  const showTestResult = (result: { success: boolean; error?: string }) => {
+    if (result.success) {
+      toast.success(tr("toast.testSuccess", dsDict));
+    } else {
+      toast.error(result.error || tr("toast.testFailed", dsDict));
+    }
+  };
+
+  // Table rows test the persisted provider by id.
   const handleTest = async (id: string) => {
     try {
-      const result = await testConnection(id);
-      if (result.success) {
-        toast.success(tr("toast.testSuccess", dsDict));
-      } else {
-        toast.error(result.error || tr("toast.testFailed", dsDict));
-      }
+      showTestResult(await testConnection(id));
+    } catch {
+      toast.error(tr("toast.testFailed", dsDict));
+    }
+  };
+
+  // Modal tests the data currently in the form (validate-before-save). When
+  // editing with the credential left blank, fall back to testing the stored
+  // config by id.
+  const handleTestForm = async (data: DataSourceFormData) => {
+    try {
+      const result =
+        shouldTestStoredCredential(!!editingSource, data) && editingSource
+          ? await testConnection(editingSource.id)
+          : await testInline(data);
+      showTestResult(result);
     } catch {
       toast.error(tr("toast.testFailed", dsDict));
     }
@@ -187,7 +208,7 @@ export default function DataSourcesPageContent({
           setEditingSource(null);
         }}
         onSubmit={handleSubmit}
-        onTest={handleTest}
+        onTest={handleTestForm}
         editingSource={editingSource}
         loading={actionLoading}
         dict={dsDict}

--- a/turbo-repo/apps/app/src/features/data-sources/hooks/use-data-sources.ts
+++ b/turbo-repo/apps/app/src/features/data-sources/hooks/use-data-sources.ts
@@ -98,6 +98,23 @@ export function useDataSources(siteId: string | undefined) {
     }
   }
 
+  async function testInline(input: DataSourceFormData) {
+    requireSiteId();
+    setActionLoading(true);
+    try {
+      return await fetcher<{ success: boolean; error?: string }>(
+        `/app/api/data-sources/test?siteId=${siteId}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        }
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
   async function toggleActive(id: string, isActive: boolean) {
     requireSiteId();
     setActionLoading(true);
@@ -125,6 +142,7 @@ export function useDataSources(siteId: string | undefined) {
     update,
     remove,
     testConnection,
+    testInline,
     toggleActive,
     refetch: mutate,
   };

--- a/turbo-repo/apps/app/src/features/data-sources/test-decision.test.ts
+++ b/turbo-repo/apps/app/src/features/data-sources/test-decision.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { shouldTestStoredCredential } from "./test-decision";
+import type { DataSourceFormData } from "./types";
+
+const tokenForm = (token?: string): DataSourceFormData => ({
+  name: "ds",
+  type: "POSTGREST",
+  url: "https://db.example.com",
+  authMethod: "TOKEN",
+  token,
+});
+
+const oauthForm = (clientSecret?: string): DataSourceFormData => ({
+  name: "ds",
+  type: "POSTGREST",
+  url: "https://db.example.com",
+  authMethod: "OAUTH",
+  clientId: "cid",
+  clientSecret,
+  tokenUrl: "https://auth.example.com/token",
+});
+
+describe("shouldTestStoredCredential", () => {
+  it("is false when creating (not editing), even with a blank credential", () => {
+    expect(shouldTestStoredCredential(false, tokenForm(""))).toBe(false);
+    expect(shouldTestStoredCredential(false, oauthForm(""))).toBe(false);
+  });
+
+  it("is true when editing and the TOKEN credential is left blank (keep existing)", () => {
+    expect(shouldTestStoredCredential(true, tokenForm(""))).toBe(true);
+    expect(shouldTestStoredCredential(true, tokenForm(undefined))).toBe(true);
+  });
+
+  it("is false when editing but a new TOKEN credential was typed", () => {
+    expect(shouldTestStoredCredential(true, tokenForm("new-token"))).toBe(false);
+  });
+
+  it("is true when editing and the OAuth client secret is left blank", () => {
+    expect(shouldTestStoredCredential(true, oauthForm(""))).toBe(true);
+  });
+
+  it("is false when editing and a new OAuth client secret was typed", () => {
+    expect(shouldTestStoredCredential(true, oauthForm("new-secret"))).toBe(false);
+  });
+});

--- a/turbo-repo/apps/app/src/features/data-sources/test-decision.ts
+++ b/turbo-repo/apps/app/src/features/data-sources/test-decision.ts
@@ -1,0 +1,18 @@
+import type { DataSourceFormData } from "./types";
+
+/**
+ * In edit mode the secret fields start blank, meaning "keep the existing
+ * credential". A stateless test needs the actual credential, so when editing
+ * with a blank credential we fall back to testing the persisted (stored) config
+ * by id. Otherwise we test the typed form data statelessly.
+ */
+export function credentialIsBlank(data: DataSourceFormData): boolean {
+  return data.authMethod === "TOKEN" ? !data.token : !data.clientSecret;
+}
+
+export function shouldTestStoredCredential(
+  isEditing: boolean,
+  data: DataSourceFormData
+): boolean {
+  return isEditing && credentialIsBlank(data);
+}

--- a/turbo-repo/apps/app/src/features/data-sources/types.ts
+++ b/turbo-repo/apps/app/src/features/data-sources/types.ts
@@ -73,6 +73,32 @@ export const CreateDataSourceSchema = z.discriminatedUnion("authMethod", [
   oauthCreateFields,
 ]);
 
+// Connection-only fields for a stateless "test before save" probe. No name /
+// description — only what is needed to attempt the upstream connection.
+const tokenTestFields = z.object({
+  type: z.enum(["POSTGREST"]),
+  url: z.string().url("validation.urlInvalid"),
+  authMethod: z.literal("TOKEN"),
+  token: z.string().min(1, "validation.tokenRequired"),
+});
+
+const oauthTestFields = z.object({
+  type: z.enum(["POSTGREST"]),
+  url: z.string().url("validation.urlInvalid"),
+  authMethod: z.literal("OAUTH"),
+  clientId: z.string().min(1, "validation.clientIdRequired"),
+  clientSecret: z.string().min(1, "validation.clientSecretRequired"),
+  tokenUrl: z.string().url("validation.tokenUrlInvalid"),
+  scope: z.string().max(500).optional(),
+  audience: z.string().max(500).optional(),
+  tokenRequestFormat: z.enum(["form", "json"]).optional(),
+});
+
+export const TestConnectionSchema = z.discriminatedUnion("authMethod", [
+  tokenTestFields,
+  oauthTestFields,
+]);
+
 export const UpdateDataSourceSchema = z.object({
   name: z.string().min(1, "validation.nameRequired").max(100).optional(),
   type: z.enum(["POSTGREST"]).optional(),

--- a/turbo-repo/apps/app/src/features/data-sources/types.ts
+++ b/turbo-repo/apps/app/src/features/data-sources/types.ts
@@ -119,3 +119,4 @@ export const UpdateDataSourceSchema = z.object({
 
 export type CreateDataSourceInput = z.infer<typeof CreateDataSourceSchema>;
 export type UpdateDataSourceInput = z.infer<typeof UpdateDataSourceSchema>;
+export type TestConnectionInput = z.infer<typeof TestConnectionSchema>;


### PR DESCRIPTION
Closes #713

## Problem

When creating a data source provider, the **Test Connection** button only worked *after* saving. Testing before save failed (and for a brand-new provider the button wasn't even shown), because the test always read the **persisted, encrypted** config by id (`POST /api/data-sources/{id}/test`) and never looked at the form. Editing a provider and clicking Test before saving likewise tested the stale stored config.

## Fix

Add a stateless test path that validates the data currently in the form, without persisting anything.

- **New `POST /api/data-sources/test`** — tests inline form data: raw token for `TOKEN`, inline OAuth client-credentials exchange for `OAUTH`, then the PostgREST probe. Returns `{ success, error? }`, no DB writes.
- **Shared probe** — `testPostgrestConnection` extracted into `test-connection.ts` so the by-id route and the new route share identical SSRF-check + fetch logic (no drift).
- **`TestConnectionSchema`** — connection-only discriminated union for the request body.
- **UI** — the modal's Test button is now always visible (not only when editing) and validates the form before testing the typed data.
- **Edit-mode fallback** — when editing with the credential field left blank ("keep existing"), the test falls back to the persisted by-id endpoint; otherwise it tests the typed data. Encapsulated in the pure, unit-tested `shouldTestStoredCredential` helper. The per-row Test button keeps testing the saved provider by id.

## Testing

- 12 tests passing: 7 for the stateless route (auth, validation, TOKEN/OAUTH success+failure, SSRF rejection), 5 for the decision helper.
- `tsc` clean on all changed files; eslint clean.
- Verified manually in the running app: creating a provider and clicking **Test Connection** before saving now tests the on-screen data and reports success/failure without persisting.

## Notes

Built test-first (TDD). Commits are small and ordered to mirror the build (refactor → schema → endpoint → decision helper → UI wiring); each commit compiles and passes its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stateless “Test connection” for data sources before saving, supporting **TOKEN** and **OAUTH** authentication.
  * When testing from the modal, the app selects the correct credential source automatically (stored vs current form values) and tests accordingly.
* **Bug Fixes**
  * Improved validation and error handling for invalid JSON, schema validation, blocked URLs, OAuth token exchange failures, and upstream probe failures.
* **Tests**
  * Expanded automated coverage for validation paths and correct request/auth header construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->