### PR TITLE
fix: keep release train app artifact aligned

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -651,7 +651,7 @@ jobs:
       - name: Upload stack manifest to release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.prepare.outputs.stack_tag }}" stack-manifest.json --clobber
+        run: gh release upload "${{ needs.prepare.outputs.stack_tag }}" stack-manifest.json --clobber --repo "$GITHUB_REPOSITORY"
 
   close-milestones:
     name: Close release milestones


### PR DESCRIPTION
Closes #716

## Summary
- pass `--repo "$GITHUB_REPOSITORY"` to `gh release upload` so stack manifest upload works without a checkout
- assign the stack version to components that change in a stack release instead of bumping from the latest component tag
- force the app component to change while release notes are bundled into the Next.js app artifact
- write generated release notes to both `releases/notes` and `turbo-repo/apps/app/src/releases`, then verify both files landed before tagging

## Why
The failed `miot-stack@v0.5.17` run dispatched deployment with stack `0.5.17` but app `0.5.16`:

```
RELEASE_VERSION: 0.5.17
APP_CHANGED: true
APP_VERSION: 0.5.16
APP_IMAGE_TAG: app-v0.5.16
```

That happened because the release planner used independent component patch bumps, and the app-facing release note copy was added after the generated plan. Since release notes are currently compiled into the app, the app artifact must be versioned/tagged with the stack release whenever a new stack release note is produced.

## Validation
- `node --check .github/scripts/resolve-stack-release-plan.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-release-train.yml"); puts "ok"'`\n- `git diff --check -- .github/scripts/resolve-stack-release-plan.js .github/workflows/app-release-train.yml`\n- planner dry run for `MIOT-0.5.17` with `STACK_VERSION=0.5.18` produced `app_version=0.5.18`, `app_tag=app@v0.5.18`, and unchanged modulith `0.5.15`\n