### PR TITLE
chore(release): prepare MIOT stack v0.5.18

### DIFF
--- a/releases/notes/v1.31.17.mdx
+++ b/releases/notes/v1.31.17.mdx
@@ -1,0 +1,28 @@
+# 🔔 Release Notes v1.31.17 — ModularIoT
+
+### Fecha: 18/06/2026
+
+**Objetivo**: Unificar la autenticación de la app para reducir diferencias entre proveedores sociales y usuario/contraseña, y mejorar la portabilidad entre tenants de Auth0. Esta versión también preserva continuidad operativa en entornos sin Auth0 configurado.
+
+## 🚀 Evolutivos
+
+- **📍 Inicio de sesión unificado con Auth0 y conexiones configurables** *(Integración OSS — MIOT-0.5.18)*
+  - **Key point**: Se unificó el flujo de login de usuario/contraseña con el de OAuth para que, cuando Auth0 está configurado, ambos generen una sesión con forma JWT (`rawJWT`, refresh token y expiración), evitando depender de ticket de Alfresco como credencial de sesión.
+  - **Technical detail**: Los IDs de conexiones de Auth0 dejaron de estar acoplados al código y pasan a ser configurables por variables de entorno (con valores por defecto para compatibilidad), manteniendo fallback a autenticación contra Alfresco cuando no hay configuración `AUTH_AUTH0_*` y sin cambios en el comportamiento de Google y Entra ID.
+
+## 📊 Beneficios
+
+- Experiencia de autenticación más consistente entre login social y login con credenciales.
+- Menor complejidad en servicios consumidores al reducir la bifurcación de formatos de sesión.
+- Mayor cobertura de políticas de Auth0 para usuarios con email/contraseña (por ejemplo, controles de seguridad centralizados).
+- Mejor continuidad en desarrollo local y CI gracias al fallback a Alfresco cuando Auth0 no está activo.
+- Despliegues más flexibles entre tenants al parametrizar IDs de conexión por entorno.
+- Menor acoplamiento operativo a nombres de conexión específicos definidos en código fuente.
+
+## 📌 Conclusión
+
+La versión 1.31.17 consolida una mejora clave en autenticación: el acceso con usuario/contraseña se alinea con el modelo JWT ya utilizado por los proveedores OAuth cuando Auth0 está disponible. Esto simplifica la integración aguas abajo y estandariza el manejo de sesiones.
+
+Al mismo tiempo, la release mantiene compatibilidad con escenarios donde Auth0 no está configurado, preservando el ingreso vía Alfresco. Este equilibrio entre unificación y fallback reduce riesgo operativo durante adopción incremental.
+
+Finalmente, mover los IDs de conexión a configuración de entorno mejora la mantenibilidad y acelera la adaptación de la plataforma a distintos contextos de despliegue sin cambios de código.

--- a/releases/stacks/v0.5.18.plan.json
+++ b/releases/stacks/v0.5.18.plan.json
@@ -1,0 +1,41 @@
+{
+  "stack_version": "0.5.18",
+  "stack_tag": "miot-stack@v0.5.18",
+  "milestone": "MIOT-0.5.18",
+  "pull_requests": [
+    {
+      "number": 634,
+      "title": "feat(auth): validate username/password against Auth0, env-driven conn…",
+      "source_issues": [
+        {
+          "number": 635,
+          "title": "feat: unify username/password sign-in through Auth0 and make Auth0 connection IDs configurable"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    "turbo-repo/apps/app/.env.example",
+    "turbo-repo/apps/app/src/auth.config.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth.service.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.ts",
+    "turbo-repo/apps/app/src/test/server-only-stub.ts",
+    "turbo-repo/apps/app/src/types/next-auth.d.ts",
+    "turbo-repo/apps/app/vitest.config.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.17",
+      "tag": "app@v0.5.17"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.15",
+      "tag": "modulith@v0.5.15"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.16",
+      "version": "0.5.17",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.18 from milestone MIOT-0.5.18, with release notes v1.31.17.

Components:
- App: app@v0.5.17 (changed: true)
- Modulith: modulith@v0.5.15 (changed: false)

Milestones: Release 1.31.17, MIOT-0.5.18.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified authentication flow seamlessly integrating traditional and OAuth login methods.
  * Enhanced session management with JWT tokens and automatic refresh capabilities.
  * Configurable OAuth provider support with automatic fallback to standard authentication.
  * Existing authentication methods remain fully compatible.

* **Documentation**
  * Added comprehensive release notes for v1.31.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->