### PR TITLE
fix: keep stack and app release versions in sync

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -25,13 +25,6 @@ const latestVersion = (pattern, prefix) => {
   return tags.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))[tags.length - 1];
 };
 
-const bumpPatch = (version) => {
-  if (!version) return "0.1.0";
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) throw new Error(`Invalid semver tag version: ${version}`);
-  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
-};
-
 const prListJson = run("gh", [
   "pr",
   "list",
@@ -99,7 +92,7 @@ for (const pr of prs) {
 const pathStarts = (prefixes) => [...changedFiles].some((file) => prefixes.some((prefix) => file.startsWith(prefix)));
 const pathEquals = (paths) => [...changedFiles].some((file) => paths.includes(file));
 
-const appChanged =
+const appSourceChanged =
   pathStarts([
     "turbo-repo/apps/app/",
     "turbo-repo/packages/ui/",
@@ -109,12 +102,16 @@ const appChanged =
     "turbo-repo/docker/",
   ]) || pathEquals(["turbo-repo/package-lock.json"]);
 
+// Release notes are still bundled into the Next.js app, so every stack release
+// changes the app artifact until notes are served from an external resource.
+const releaseNotesAreEmbeddedInApp = true;
+const appChanged = releaseNotesAreEmbeddedInApp || appSourceChanged;
 const modulithChanged = pathStarts(["quarkus-srv/"]);
 
 const latestAppVersion = latestVersion("app@v*", "app@v");
 const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
-const appVersion = appChanged ? bumpPatch(latestAppVersion) : latestAppVersion;
-const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : latestModulithVersion;
+const appVersion = appChanged ? stackVersion : latestAppVersion;
+const modulithVersion = modulithChanged ? stackVersion : latestModulithVersion;
 
 if (!appVersion) {
   throw new Error("No app@v* tag exists and the app did not change in this milestone.");

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -209,7 +209,9 @@ jobs:
       - name: Write release notes
         run: |
           release_file="releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx"
+          app_release_file="turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx"
           mkdir -p "$(dirname "$release_file")"
+          mkdir -p "$(dirname "$app_release_file")"
           node - "${{ steps.release_notes_ai.outputs['response-file'] }}" "$release_file" <<'NODE'
           const fs = require("fs");
           const [source, target] = process.argv.slice(2);
@@ -220,12 +222,13 @@ jobs:
           }
           fs.writeFileSync(target, `${content}\n`);
           NODE
+          cp "$release_file" "$app_release_file"
 
       - name: Commit release prep
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv
+          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv
           git commit -m "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}"
           git push origin "${{ steps.branch.outputs.branch }}"
 
@@ -320,6 +323,7 @@ jobs:
       - name: Verify release prep landed on trunk
         run: |
           release_file="releases/notes/v${{ needs.prepare.outputs.release_notes_version }}.mdx"
+          app_release_file="turbo-repo/apps/app/src/releases/v${{ needs.prepare.outputs.release_notes_version }}.mdx"
           plan_file="${{ needs.prepare.outputs.stack_plan_file }}"
 
           if [[ "${{ needs.prepare.outputs.app_changed }}" == "true" ]]; then
@@ -348,6 +352,12 @@ jobs:
 
           if [[ ! -f "$release_file" ]]; then
             echo "Missing release notes file on trunk: $release_file" >&2
+            echo "Merge the release PR before approving/tagging." >&2
+            exit 1
+          fi
+
+          if [[ ! -f "$app_release_file" ]]; then
+            echo "Missing app release notes file on trunk: $app_release_file" >&2
             echo "Merge the release PR before approving/tagging." >&2
             exit 1
           fi


### PR DESCRIPTION
Closes #721

## Rule
The stack release and app release are intentionally kept in sync while release notes live inside the app source.

For stack `0.5.18`, the release train must produce:
- app package version `0.5.18`
- app git tag `app@v0.5.18`
- app image tag `app-v0.5.18`
- stack tag `miot-stack@v0.5.18`

Modulith stays independently versioned unless Quarkus changes.

## Summary
- force the app component to participate in every stack release
- set the app component version directly to the stack version
- keep generated MDX release notes inside the app at `turbo-repo/apps/app/src/releases`
- also keep the stack copy in `releases/notes`
- verify both release-note files are present before tagging/building

## Why
The failed `miot-stack@v0.5.17` run dispatched deployment with stack `0.5.17` but app `0.5.16`:

```
RELEASE_VERSION: 0.5.17
APP_CHANGED: true
APP_VERSION: 0.5.16
APP_IMAGE_TAG: app-v0.5.16
```

That produced exactly the mismatch seen in prod: app image `app-v0.5.16`, but release notes for the current stack release.

## Validation
- `node --check .github/scripts/resolve-stack-release-plan.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-release-train.yml"); puts "ok"'`\n- `git diff --check -- .github/scripts/resolve-stack-release-plan.js .github/workflows/app-release-train.yml`\n- planner dry run for `MIOT-0.5.17` with `STACK_VERSION=0.5.18` produced `app_version=0.5.18`, `app_tag=app@v0.5.18`, and unchanged modulith `0.5.15`\n