### PR TITLE
chore(release): prepare MIOT stack v0.5.18

### DIFF
--- a/releases/notes/v1.31.17.mdx
+++ b/releases/notes/v1.31.17.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.17 — ModularIoT
+
+### Fecha: 18/06/2026
+
+**Objetivo**: Mejorar la visibilidad operativa en mapas de viaje/asignación y consolidar la autenticación para reducir fricción entre flujos de acceso. Esta versión combina mejoras funcionales de monitoreo con una integración de identidad más consistente para despliegues multi-entorno.
+
+## 🚀 Evolutivos
+
+- **📍 Señalización de origen/destino y contexto operativo en mapa de asignación**
+  - **Key point**: En el paso `Asignar viaje` se incorporan bandera de origen, bandera de destino, distancia del vehículo al origen y ETA del trayecto en el mapa.
+  - **Technical detail**: Se resolvieron centroides desde `geofences` vía pgrest (nueva ruta BFF `/api/calendar/geofence-coords` y hook `useGeofenceCoords`), con cálculo de distancia por haversine y manejo robusto cuando un geofence no se resuelve. *(Integración OSS — MIOT-0.5.18)*
+
+- **📍 Distancia y ETA al origen en mapa de viaje (alcance preparado)**
+  - **Key point**: Se definió el trabajo para mostrar en el mapa de viaje la distancia del vehículo al origen y una ETA estimada al origen basada en velocidad reportada.
+  - **Technical detail**: El enfoque usa cálculo cliente (haversine + centroides de geocerca) y muestra `—` cuando no hay velocidad válida; este ítem permanece abierto dentro del alcance de la release. *(Integración OSS — MIOT-0.5.18)*
+
+## 🔧 Integraciones
+
+- **🔌 Autenticación unificada con Auth0 y conexiones configurables por entorno**
+  - **Scope**: El inicio de sesión con usuario/contraseña se unifica con Auth0 para obtener sesión tipo JWT como en OAuth, se mantiene fallback a Alfresco cuando Auth0 no está configurado y se eliminan IDs de conexiones hardcodeados en favor de variables de entorno con valores por defecto compatibles. *(Integración OSS — MIOT-0.5.18)*
+
+## 📊 Beneficios
+
+- Mayor contexto visual para planificación y asignación de viajes con origen/destino y distancia operativa en mapa.
+- Menor ambigüedad para operación al combinar posición del vehículo y ETA del recorrido en un mismo flujo.
+- Autenticación más homogénea entre login social y credenciales, simplificando consumo downstream de JWT.
+- Mejor postura de seguridad al centralizar políticas de Auth0 (cuando está configurado).
+- Despliegues más portables entre tenants gracias a IDs de conexión configurables por entorno.
+- Continuidad operativa preservada mediante fallback de autenticación contra Alfresco en entornos sin Auth0.
+- Comportamiento más resiliente ante datos incompletos (geocercas no resolubles o velocidad desconocida).
+
+## 📌 Conclusión
+
+La versión 1.31.17 refuerza dos ejes clave del producto: visibilidad operativa en mapas y consistencia de identidad. En conjunto, reduce fricción en decisiones de despacho y mejora la coherencia técnica de autenticación entre flujos.
+
+También deja encaminado trabajo de monitoreo en mapa de viaje que aún está abierto dentro del milestone OSS, manteniendo transparencia sobre estado de avance y alcance real de entrega.
+
+Con esta base, ModularIoT queda mejor preparado para escalar operación multi-cliente con configuraciones de autenticación más flexibles y una experiencia de planificación más informada.

--- a/releases/stacks/v0.5.18.plan.json
+++ b/releases/stacks/v0.5.18.plan.json
@@ -1,0 +1,75 @@
+{
+  "stack_version": "0.5.18",
+  "stack_tag": "miot-stack@v0.5.18",
+  "milestone": "MIOT-0.5.18",
+  "pull_requests": [
+    {
+      "number": 634,
+      "title": "feat(auth): validate username/password against Auth0, env-driven conn…",
+      "source_issues": [
+        {
+          "number": 635,
+          "title": "feat: unify username/password sign-in through Auth0 and make Auth0 connection IDs configurable"
+        }
+      ]
+    },
+    {
+      "number": 711,
+      "title": "feat(map): show vehicle distance + ETA to origin on the trip map",
+      "source_issues": [
+        {
+          "number": 710,
+          "title": "feat: show vehicle distance + ETA to origin on the trip map"
+        }
+      ]
+    },
+    {
+      "number": 715,
+      "title": "feat(calendar): origin/destination flags + vehicle distance/ETA on assignment map",
+      "source_issues": [
+        {
+          "number": 714,
+          "title": "feat: origin/destination flags + vehicle distance/ETA on the assignment map"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    "turbo-repo/apps/app/.env.example",
+    "turbo-repo/apps/app/src/app/api/calendar/geofence-coords/route.ts",
+    "turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts",
+    "turbo-repo/apps/app/src/auth.config.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.test.ts",
+    "turbo-repo/apps/app/src/features/auth/config/auth0-connections.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth.service.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.test.ts",
+    "turbo-repo/apps/app/src/features/auth/services/auth0-password.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/services/geofence-coords.service.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/geofence-coords.service.types.ts",
+    "turbo-repo/apps/app/src/features/calendar/utils/distance.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/utils/distance.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/components/geofence_pin.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx",
+    "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.test.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/apps/app/src/test/server-only-stub.ts",
+    "turbo-repo/apps/app/src/types/next-auth.d.ts",
+    "turbo-repo/apps/app/vitest.config.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.18",
+      "tag": "app@v0.5.18"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.15",
+      "tag": "modulith@v0.5.15"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.16",
+  "version": "0.5.18",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.17.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.17.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.17 — ModularIoT
+
+### Fecha: 18/06/2026
+
+**Objetivo**: Mejorar la visibilidad operativa en mapas de viaje/asignación y consolidar la autenticación para reducir fricción entre flujos de acceso. Esta versión combina mejoras funcionales de monitoreo con una integración de identidad más consistente para despliegues multi-entorno.
+
+## 🚀 Evolutivos
+
+- **📍 Señalización de origen/destino y contexto operativo en mapa de asignación**
+  - **Key point**: En el paso `Asignar viaje` se incorporan bandera de origen, bandera de destino, distancia del vehículo al origen y ETA del trayecto en el mapa.
+  - **Technical detail**: Se resolvieron centroides desde `geofences` vía pgrest (nueva ruta BFF `/api/calendar/geofence-coords` y hook `useGeofenceCoords`), con cálculo de distancia por haversine y manejo robusto cuando un geofence no se resuelve. *(Integración OSS — MIOT-0.5.18)*
+
+- **📍 Distancia y ETA al origen en mapa de viaje (alcance preparado)**
+  - **Key point**: Se definió el trabajo para mostrar en el mapa de viaje la distancia del vehículo al origen y una ETA estimada al origen basada en velocidad reportada.
+  - **Technical detail**: El enfoque usa cálculo cliente (haversine + centroides de geocerca) y muestra `—` cuando no hay velocidad válida; este ítem permanece abierto dentro del alcance de la release. *(Integración OSS — MIOT-0.5.18)*
+
+## 🔧 Integraciones
+
+- **🔌 Autenticación unificada con Auth0 y conexiones configurables por entorno**
+  - **Scope**: El inicio de sesión con usuario/contraseña se unifica con Auth0 para obtener sesión tipo JWT como en OAuth, se mantiene fallback a Alfresco cuando Auth0 no está configurado y se eliminan IDs de conexiones hardcodeados en favor de variables de entorno con valores por defecto compatibles. *(Integración OSS — MIOT-0.5.18)*
+
+## 📊 Beneficios
+
+- Mayor contexto visual para planificación y asignación de viajes con origen/destino y distancia operativa en mapa.
+- Menor ambigüedad para operación al combinar posición del vehículo y ETA del recorrido en un mismo flujo.
+- Autenticación más homogénea entre login social y credenciales, simplificando consumo downstream de JWT.
+- Mejor postura de seguridad al centralizar políticas de Auth0 (cuando está configurado).
+- Despliegues más portables entre tenants gracias a IDs de conexión configurables por entorno.
+- Continuidad operativa preservada mediante fallback de autenticación contra Alfresco en entornos sin Auth0.
+- Comportamiento más resiliente ante datos incompletos (geocercas no resolubles o velocidad desconocida).
+
+## 📌 Conclusión
+
+La versión 1.31.17 refuerza dos ejes clave del producto: visibilidad operativa en mapas y consistencia de identidad. En conjunto, reduce fricción en decisiones de despacho y mejora la coherencia técnica de autenticación entre flujos.
+
+También deja encaminado trabajo de monitoreo en mapa de viaje que aún está abierto dentro del milestone OSS, manteniendo transparencia sobre estado de avance y alcance real de entrega.
+
+Con esta base, ModularIoT queda mejor preparado para escalar operación multi-cliente con configuraciones de autenticación más flexibles y una experiencia de planificación más informada.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.16",
+      "version": "0.5.18",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.18 from milestone MIOT-0.5.18, with release notes v1.31.17.

Components:
- App: app@v0.5.18 (changed: true)
- Modulith: modulith@v0.5.15 (changed: false)

Milestones: Release 1.31.17, MIOT-0.5.18.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced assignment maps with origin/destination signaling, vehicle distance, and ETA display
  * Unified authentication via Auth0 with Alfresco fallback option
  
* **Chores**
  * Released v0.5.18 and v1.31.17; upcoming travel map enhancements for distance and ETA visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->