### PR TITLE
chore: address CodeRabbit review on trip-map ETA readout (post-#711)

### DIFF
--- a/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
@@ -314,12 +314,12 @@ export default function MapVisualizationTrip({
       (f) => (f.properties as { location_type?: number }).location_type === 1
     );
     const geometry = origin?.geometry as
-      | { type?: string; coordinates?: unknown }
+      | { type?: string; coordinates?: LngLat[][] }
       | undefined;
     // Only a Polygon's outer ring is a list of [lng,lat] tuples; a Point or
     // MultiPolygon (or malformed payload) would make ringCentroid throw.
     if (geometry?.type !== "Polygon") return null;
-    const ring = (geometry.coordinates as LngLat[][] | undefined)?.[0];
+    const ring = geometry.coordinates?.[0];
     if (!Array.isArray(ring)) return null;
     return ringCentroid(ring);
   }, [processedGeofence]);

--- a/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
+++ b/turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx
@@ -313,9 +313,15 @@ export default function MapVisualizationTrip({
     const origin = processedGeofence?.features.find(
       (f) => (f.properties as { location_type?: number }).location_type === 1
     );
-    const ring = (origin?.geometry as { coordinates?: LngLat[][] } | undefined)
-      ?.coordinates?.[0];
-    return ring ? ringCentroid(ring) : null;
+    const geometry = origin?.geometry as
+      | { type?: string; coordinates?: unknown }
+      | undefined;
+    // Only a Polygon's outer ring is a list of [lng,lat] tuples; a Point or
+    // MultiPolygon (or malformed payload) would make ringCentroid throw.
+    if (geometry?.type !== "Polygon") return null;
+    const ring = (geometry.coordinates as LngLat[][] | undefined)?.[0];
+    if (!Array.isArray(ring)) return null;
+    return ringCentroid(ring);
   }, [processedGeofence]);
 
   const vehicle =
@@ -588,7 +594,9 @@ export default function MapVisualizationTrip({
             <span className="font-semibold">
               {tr("geographic_view.distance_to_origin", dict)}:
             </span>
-            <span>{distanceToOriginKm.toFixed(1)} km</span>
+            <span>
+              {distanceToOriginKm.toFixed(1)} {tr("geographic_view.km", dict)}
+            </span>
           </span>
           <span className="h-3 w-px bg-gray-300 dark:bg-gray-600" />
           <span className="flex items-center gap-1">

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2624,6 +2624,7 @@
     "no_data_found": "No data found",
     "distance_to_origin": "Distance to origin",
     "eta_to_origin": "ETA to origin",
+    "km": "km",
     "last_reported_speed": "Last reported speed",
     "last_reported_engine_status": "Last reported engine status",
     "on": "On",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2624,6 +2624,7 @@
     "no_data_found": "No se encontraron datos",
     "distance_to_origin": "Distancia al origen",
     "eta_to_origin": "ETA al origen",
+    "km": "km",
     "last_reported_speed": "Velocidad reportada",
     "last_reported_engine_status": "Estado del motor reportado",
     "on": "Encendido",


### PR DESCRIPTION
## What

Follow-up to merged **#711** — addresses the 2 CodeRabbit comments that came in around merge time, on the trip-map vehicle-distance/ETA readout.

Closes #725.

## Changes (`map-visualization-trip.tsx` + lang)

1. **🟠 Guard origin geometry before `ringCentroid`** — `originCentroid` only proceeds when `geometry.type === "Polygon"` and the outer ring is an array; otherwise returns `null`. A `Point` geometry would previously make `ringCentroid` iterate a number and throw; `MultiPolygon`/malformed would yield `NaN`. (In practice these geofences are polygons, so this is defensive hardening.)
2. **🟡 i18n the distance unit** — `" km"` → `tr("geographic_view.km", dict)` (`km` added to es + en).

## Test plan

- ✅ `turbo run check-types --filter=@modulariot/app` passes.
- ✅ Both `lang/*.json` valid.
- The util math (`ringCentroid` etc.) is unchanged and still covered by `vehicle-origin.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of geofence geometry handling in the geographic view to gracefully process non-polygon data.

* **Localization**
  * Distance units in the geographic view are now properly translated based on user language preference.
  * Added Spanish translation support for distance units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->