### PR TITLE
feat(release): add harness to stack train

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -104,8 +104,11 @@ const appChanged = true;
 const modulithChanged = pathStarts(["quarkus-srv/"]);
 
 const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
+const latestHarnessVersion = latestVersion("harness@v*", "harness@v");
+const harnessChanged = pathStarts(["miot-harness/"]) || !latestHarnessVersion;
 const appVersion = stackVersion;
 const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : latestModulithVersion;
+const harnessVersion = harnessChanged ? bumpPatch(latestHarnessVersion) : latestHarnessVersion;
 
 if (!appVersion) {
   throw new Error("No app@v* tag exists and the app did not change in this milestone.");
@@ -113,7 +116,6 @@ if (!appVersion) {
 if (!modulithVersion) {
   throw new Error("No modulith@v* tag exists and the modulith did not change in this milestone.");
 }
-
 const plan = {
   stack_version: stackVersion,
   stack_tag: `miot-stack@v${stackVersion}`,
@@ -131,6 +133,11 @@ const plan = {
       version: modulithVersion,
       tag: `modulith@v${modulithVersion}`,
     },
+    harness: {
+      changed: harnessChanged,
+      version: harnessVersion,
+      tag: `harness@v${harnessVersion}`,
+    },
   },
 };
 
@@ -145,6 +152,9 @@ const outputs = {
   modulith_changed: String(modulithChanged),
   modulith_version: modulithVersion,
   modulith_tag: plan.components.modulith.tag,
+  harness_changed: String(harnessChanged),
+  harness_version: harnessVersion,
+  harness_tag: plan.components.harness.tag,
   stack_tag: plan.stack_tag,
   stack_plan_file: planFile,
 };

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -13,6 +13,7 @@ on:
       - 'turbo-repo/package-lock.json'
       - 'turbo-repo/docker/**'
       - 'quarkus-srv/**'
+      - 'miot-harness/**'
   schedule:
     - cron: '0 7 * * *'
   workflow_dispatch:
@@ -30,6 +31,7 @@ env:
   IMAGE_OWNER: microboxlabs
   APP_IMAGE_NAME: miot-app
   MODULITH_IMAGE_NAME: miot-srv
+  HARNESS_IMAGE_NAME: miot-harness
 
 jobs:
   metadata:
@@ -204,10 +206,81 @@ jobs:
             echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  resolve-harness:
+    name: Resolve nightly harness image
+    runs-on: ubuntu-latest
+    needs: metadata
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+      source_tag: ${{ steps.resolve.outputs.source_tag }}
+    steps:
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve source image
+        id: resolve
+        env:
+          SHA_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:sha-${{ needs.metadata.outputs.short_sha }}
+          LATEST_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:latest
+        run: |
+          if docker buildx imagetools inspect "$SHA_IMAGE" >/dev/null; then
+            source_image="$SHA_IMAGE"
+            source_tag="sha-${{ needs.metadata.outputs.short_sha }}"
+          else
+            source_image="$LATEST_IMAGE"
+            source_tag="latest"
+          fi
+
+          docker buildx imagetools inspect "$source_image" >/dev/null
+          {
+            echo "source_image=$source_image"
+            echo "source_tag=$source_tag"
+            echo "image_tag=nightly-${{ needs.metadata.outputs.nightly_date }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Promote nightly tags
+        env:
+          SOURCE_IMAGE: ${{ steps.resolve.outputs.source_image }}
+          NIGHTLY_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:nightly
+          DATED_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}
+          SHA_NIGHTLY_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$NIGHTLY_IMAGE" \
+            --tag "$DATED_IMAGE" \
+            --tag "$SHA_NIGHTLY_IMAGE" \
+            "$SOURCE_IMAGE"
+
+      - name: Resolve immutable image reference
+        id: image
+        run: |
+          digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}" | awk '/^Digest:/ { print $2; exit }')"
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Nightly summary
+        run: |
+          {
+            echo "# MIOT Harness Nightly"
+            echo ""
+            echo "- Image: \`${{ steps.image.outputs.image }}\`"
+            echo "- Source tag: \`${{ steps.resolve.outputs.source_tag }}\`"
+            echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   deploy:
     name: Dispatch development environment deploys
     runs-on: ubuntu-latest
-    needs: [metadata, build-app, resolve-modulith]
+    needs: [metadata, build-app, resolve-modulith, resolve-harness]
     permissions:
       contents: read
     environment:
@@ -222,6 +295,7 @@ jobs:
           RELEASE_VERSION: nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           APP_TAG: app@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           MODULITH_TAG: modulith@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+          HARNESS_TAG: harness@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           APP_IMAGE_REF: ${{ needs.build-app.outputs.image }}
@@ -229,6 +303,10 @@ jobs:
           MODULITH_IMAGE_TAG: ${{ needs.resolve-modulith.outputs.image_tag }}
           MODULITH_IMAGE_REF: ${{ needs.resolve-modulith.outputs.image }}
           MODULITH_SOURCE_TAG: ${{ needs.resolve-modulith.outputs.source_tag }}
+          HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
+          HARNESS_IMAGE_TAG: ${{ needs.resolve-harness.outputs.image_tag }}
+          HARNESS_IMAGE_REF: ${{ needs.resolve-harness.outputs.image }}
+          HARNESS_SOURCE_TAG: ${{ needs.resolve-harness.outputs.source_tag }}
         run: |
           DEPLOY_DISPATCH_REPO="${DEPLOY_DISPATCH_REPO:-microboxlabs/miot-deployments}"
 
@@ -241,6 +319,7 @@ jobs:
             --arg release_version "$RELEASE_VERSION" \
             --arg app_tag "$APP_TAG" \
             --arg modulith_tag "$MODULITH_TAG" \
+            --arg harness_tag "$HARNESS_TAG" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
             --arg app_image_ref "$APP_IMAGE_REF" \
@@ -248,18 +327,26 @@ jobs:
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
             --arg modulith_source_tag "$MODULITH_SOURCE_TAG" \
+            --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
+            --arg harness_image_tag "$HARNESS_IMAGE_TAG" \
+            --arg harness_image_ref "$HARNESS_IMAGE_REF" \
+            --arg harness_source_tag "$HARNESS_SOURCE_TAG" \
             '{
               event_type: "miot-stack-nightly",
               client_payload: {
                 release_version: $release_version,
                 app_tag: $app_tag,
                 modulith_tag: $modulith_tag,
+                harness_tag: $harness_tag,
                 app_image_repository: $app_image_repository,
                 app_image_tag: $app_image_tag,
                 app_image_ref: $app_image_ref,
                 modulith_image_repository: $modulith_image_repository,
                 modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref
+                modulith_image_ref: $modulith_image_ref,
+                harness_image_repository: $harness_image_repository,
+                harness_image_tag: $harness_image_tag,
+                harness_image_ref: $harness_image_ref
               }
             }' |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -23,6 +23,7 @@ env:
   IMAGE_OWNER: microboxlabs
   APP_IMAGE_NAME: miot-app
   MODULITH_IMAGE_NAME: miot-srv
+  HARNESS_IMAGE_NAME: miot-harness
   JAVA_VERSION: "21"
   RELEASE_NOTES_MODEL: auto
   RELEASE_NOTES_CONTEXT: long_context
@@ -41,6 +42,9 @@ jobs:
       modulith_changed: ${{ steps.plan.outputs.modulith_changed }}
       modulith_version: ${{ steps.plan.outputs.modulith_version }}
       modulith_tag: ${{ steps.plan.outputs.modulith_tag }}
+      harness_changed: ${{ steps.plan.outputs.harness_changed }}
+      harness_version: ${{ steps.plan.outputs.harness_version }}
+      harness_tag: ${{ steps.plan.outputs.harness_tag }}
       release_notes_version: ${{ steps.version.outputs.release_notes_version }}
       private_milestone: ${{ steps.version.outputs.private_milestone }}
       oss_milestone: ${{ steps.version.outputs.oss_milestone }}
@@ -75,6 +79,7 @@ jobs:
                 {
                   git tag --list 'app@v*' | sed 's/^app@v//'
                   git tag --list 'modulith@v*' | sed 's/^modulith@v//'
+                  git tag --list 'harness@v*' | sed 's/^harness@v//'
                 } | sort -V | tail -1
               )"
             fi
@@ -161,6 +166,23 @@ jobs:
         run: ./mvnw versions:set -DnewVersion="${{ steps.plan.outputs.modulith_version }}" -DgenerateBackupPoms=false -DprocessAllModules=true
         working-directory: quarkus-srv
 
+      - name: Bump harness package version
+        if: steps.plan.outputs.harness_changed == 'true'
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const path = "miot-harness/pyproject.toml";
+          const version = "${{ steps.plan.outputs.harness_version }}";
+          const content = fs.readFileSync(path, "utf8");
+          const match = content.match(/^version = "([^"]+)"$/m);
+          if (!match) {
+            throw new Error(`Could not update project.version in ${path}`);
+          }
+          if (match[1] !== version) {
+            fs.writeFileSync(path, content.replace(/^version = ".*"$/m, `version = "${version}"`));
+          }
+          NODE
+
       - name: Resolve release date
         id: release_date
         run: echo "date=$(date +'%d/%m/%Y')" >> "$GITHUB_OUTPUT"
@@ -228,7 +250,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv
+          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml
           git commit -m "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}"
           git push origin "${{ steps.branch.outputs.branch }}"
 
@@ -243,6 +265,7 @@ jobs:
           Components:
           - App: ${{ steps.plan.outputs.app_tag }} (changed: ${{ steps.plan.outputs.app_changed }})
           - Modulith: ${{ steps.plan.outputs.modulith_tag }} (changed: ${{ steps.plan.outputs.modulith_changed }})
+          - Harness: ${{ steps.plan.outputs.harness_tag }} (changed: ${{ steps.plan.outputs.harness_changed }})
 
           Milestones: ${{ steps.version.outputs.private_milestone }}, ${{ steps.version.outputs.oss_milestone }}.
 
@@ -350,6 +373,15 @@ jobs:
             fi
           fi
 
+          if [[ "${{ needs.prepare.outputs.harness_changed }}" == "true" ]]; then
+            harness_version="$(node -p "require('fs').readFileSync('miot-harness/pyproject.toml', 'utf8').match(/^version = \\\"([^\\\"]+)\\\"$/m)?.[1] || process.exit(1)")"
+            if [[ "$harness_version" != "${{ needs.prepare.outputs.harness_version }}" ]]; then
+              echo "trunk harness version is $harness_version, expected ${{ needs.prepare.outputs.harness_version }}." >&2
+              echo "Merge the release PR before approving/tagging." >&2
+              exit 1
+            fi
+          fi
+
           if [[ ! -f "$release_file" ]]; then
             echo "Missing release notes file on trunk: $release_file" >&2
             echo "Merge the release PR before approving/tagging." >&2
@@ -385,6 +417,11 @@ jobs:
             tags+=("${{ needs.prepare.outputs.modulith_tag }}")
           fi
 
+          if [[ "${{ needs.prepare.outputs.harness_changed }}" == "true" ]]; then
+            git tag -a "${{ needs.prepare.outputs.harness_tag }}" -m "${{ needs.prepare.outputs.harness_tag }}"
+            tags+=("${{ needs.prepare.outputs.harness_tag }}")
+          fi
+
           git push origin "${tags[@]}"
 
       - name: Create GitHub releases
@@ -403,6 +440,11 @@ jobs:
           if [[ "${{ needs.prepare.outputs.modulith_changed }}" == "true" ]]; then
             gh release create "${{ needs.prepare.outputs.modulith_tag }}" \
               --title "${{ needs.prepare.outputs.modulith_tag }}" \
+              --generate-notes
+          fi
+          if [[ "${{ needs.prepare.outputs.harness_changed }}" == "true" ]]; then
+            gh release create "${{ needs.prepare.outputs.harness_tag }}" \
+              --title "${{ needs.prepare.outputs.harness_tag }}" \
               --generate-notes
           fi
 
@@ -540,10 +582,61 @@ jobs:
           digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}:modulith-v${{ needs.prepare.outputs.modulith_version }}" | awk '/^Digest:/ { print $2; exit }')"
           echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
 
+  build-harness:
+    name: Resolve harness image
+    runs-on: ubuntu-latest
+    needs: [prepare, tag]
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for release harness image
+        if: needs.prepare.outputs.harness_changed == 'true'
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+        run: |
+          for attempt in {1..60}; do
+            if docker buildx imagetools inspect "$SOURCE_IMAGE" >/dev/null; then
+              echo "Promoting release harness image $SOURCE_IMAGE."
+              exit 0
+            fi
+
+            echo "Waiting for Harness CI to publish release image... ($attempt/60)"
+            sleep 60
+          done
+
+          echo "::error::Timed out waiting for Harness CI to publish release image."
+          exit 1
+
+      - name: Promote image tags
+        if: needs.prepare.outputs.harness_changed == 'true'
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+          RELEASE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:${{ needs.prepare.outputs.harness_version }}
+          COMPONENT_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:harness-v${{ needs.prepare.outputs.harness_version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$RELEASE_IMAGE" \
+            --tag "$COMPONENT_IMAGE" \
+            "$SOURCE_IMAGE"
+
+      - name: Export image ref
+        id: image
+        run: |
+          digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}:harness-v${{ needs.prepare.outputs.harness_version }}" | awk '/^Digest:/ { print $2; exit }')"
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: Dispatch configured environment deploys
     runs-on: ubuntu-latest
-    needs: [prepare, tag, build-app, build-modulith]
+    needs: [prepare, tag, build-app, build-modulith, build-harness]
     environment:
       name: app-deploy
     steps:
@@ -565,6 +658,12 @@ jobs:
           MODULITH_IMAGE_REF: ${{ needs.build-modulith.outputs.image }}
           MODULITH_CHANGED: ${{ needs.prepare.outputs.modulith_changed }}
           MODULITH_VERSION: ${{ needs.prepare.outputs.modulith_version }}
+          HARNESS_TAG: ${{ needs.prepare.outputs.harness_tag }}
+          HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
+          HARNESS_IMAGE_TAG: harness-v${{ needs.prepare.outputs.harness_version }}
+          HARNESS_IMAGE_REF: ${{ needs.build-harness.outputs.image }}
+          HARNESS_CHANGED: ${{ needs.prepare.outputs.harness_changed }}
+          HARNESS_VERSION: ${{ needs.prepare.outputs.harness_version }}
         run: |
           DEPLOY_DISPATCH_REPO="${DEPLOY_DISPATCH_REPO:-microboxlabs/miot-deployments}"
 
@@ -588,18 +687,26 @@ jobs:
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
+            --arg harness_tag "$HARNESS_TAG" \
+            --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
+            --arg harness_image_tag "$HARNESS_IMAGE_TAG" \
+            --arg harness_image_ref "$HARNESS_IMAGE_REF" \
             '{
               event_type: "miot-stack-release",
               client_payload: {
                 release_version: $release_version,
                 app_tag: $app_tag,
                 modulith_tag: $modulith_tag,
+                harness_tag: $harness_tag,
                 app_image_repository: $app_image_repository,
                 app_image_tag: $app_image_tag,
                 app_image_ref: $app_image_ref,
                 modulith_image_repository: $modulith_image_repository,
                 modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref
+                modulith_image_ref: $modulith_image_ref,
+                harness_image_repository: $harness_image_repository,
+                harness_image_tag: $harness_image_tag,
+                harness_image_ref: $harness_image_ref
               }
             }' > stack-dispatch-payload.json
 
@@ -618,6 +725,12 @@ jobs:
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
+            --arg harness_tag "$HARNESS_TAG" \
+            --arg harness_changed "$HARNESS_CHANGED" \
+            --arg harness_version "$HARNESS_VERSION" \
+            --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
+            --arg harness_image_tag "$HARNESS_IMAGE_TAG" \
+            --arg harness_image_ref "$HARNESS_IMAGE_REF" \
             '{
               release_version: $release_version,
               stack_version: $release_version,
@@ -625,12 +738,16 @@ jobs:
               manifest_version: 1,
               app_tag: $app_tag,
               modulith_tag: $modulith_tag,
+              harness_tag: $harness_tag,
               app_image_repository: $app_image_repository,
               app_image_tag: $app_image_tag,
               app_image_ref: $app_image_ref,
               modulith_image_repository: $modulith_image_repository,
               modulith_image_tag: $modulith_image_tag,
               modulith_image_ref: $modulith_image_ref,
+              harness_image_repository: $harness_image_repository,
+              harness_image_tag: $harness_image_tag,
+              harness_image_ref: $harness_image_ref,
               components: {
                 app: {
                   changed: ($app_changed == "true"),
@@ -647,6 +764,14 @@ jobs:
                   image_repository: $modulith_image_repository,
                   image_tag: $modulith_image_tag,
                   image_ref: $modulith_image_ref
+                },
+                harness: {
+                  changed: ($harness_changed == "true"),
+                  version: $harness_version,
+                  tag: $harness_tag,
+                  image_repository: $harness_image_repository,
+                  image_tag: $harness_image_tag,
+                  image_ref: $harness_image_ref
                 }
               }
             }' > stack-manifest.json


### PR DESCRIPTION
## Summary
- add `miot-harness` as a first-class MIOT stack release component
- create/reuse scoped `harness@v*` metadata in the stack release plan
- promote harness images into release/nightly tags and include harness image coordinates in deployment dispatch payloads

## Why
The harness should ship with the MIOT stack using the same release-train contract as app and modulith, instead of floating outside the stack manifest.

## Validation
- `node --check .github/scripts/resolve-stack-release-plan.js`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml`

Closes #731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added harness component to the release train and nightly deployment pipelines.
  * Implemented automatic harness versioning, Docker image tagging, and inclusion in deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->