### PR TITLE
fix(task-actions): gate transition button on candidate-group membership

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx
@@ -89,6 +89,20 @@ export default function TaskActions({
   const [outcomeLabel, setOutcomeLabel] = useState<string | undefined>();
   const { data: userGroups } = useUserGroups();
   const bpmPackage = typeof extraData?.bpm_package === "string" ? extraData.bpm_package : undefined;
+  // Pooled tasks are offered to Alfresco candidate groups; a user who is not a
+  // member cannot complete the task (the backend rejects endTask with an
+  // AccessDeniedException). Hide the action when the current user is not a
+  // candidate. Stay backwards-compatible: only restrict once the user's groups
+  // are loaded and the task actually exposes candidate groups — otherwise defer
+  // to the backend check so non-pooled / unannotated tasks are unaffected.
+  const rawCandidateGroups = extraData?.candidateGroups;
+  const taskCandidateGroups = Array.isArray(rawCandidateGroups)
+    ? (rawCandidateGroups as string[])
+    : [];
+  const isTaskCandidate =
+    userGroups.length === 0 ||
+    taskCandidateGroups.length === 0 ||
+    taskCandidateGroups.some((group) => userGroups.includes(group));
   const {
     isValid: documentsValid,
     isLoading: documentsLoading,
@@ -245,6 +259,10 @@ export default function TaskActions({
       }))}
     />
   );
+
+  if (!isTaskCandidate) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col-reverse lg:flex-row w-full gap-2 items-center">

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx
@@ -87,20 +87,21 @@ export default function TaskActions({
     | undefined
   >();
   const [outcomeLabel, setOutcomeLabel] = useState<string | undefined>();
-  const { data: userGroups } = useUserGroups();
+  const { data: userGroups, isLoading: userGroupsLoading } = useUserGroups();
   const bpmPackage = typeof extraData?.bpm_package === "string" ? extraData.bpm_package : undefined;
   // Pooled tasks are offered to Alfresco candidate groups; a user who is not a
   // member cannot complete the task (the backend rejects endTask with an
   // AccessDeniedException). Hide the action when the current user is not a
-  // candidate. Stay backwards-compatible: only restrict once the user's groups
-  // are loaded and the task actually exposes candidate groups — otherwise defer
-  // to the backend check so non-pooled / unannotated tasks are unaffected.
+  // candidate. While the user's groups are still loading we defer (show) to
+  // avoid a flash; once loaded, an empty or failed group list fails closed
+  // (hidden) for pooled tasks. Tasks that expose no candidate groups are left
+  // unaffected so non-pooled / unannotated tasks behave exactly as before.
   const rawCandidateGroups = extraData?.candidateGroups;
   const taskCandidateGroups = Array.isArray(rawCandidateGroups)
     ? (rawCandidateGroups as string[])
     : [];
   const isTaskCandidate =
-    userGroups.length === 0 ||
+    userGroupsLoading ||
     taskCandidateGroups.length === 0 ||
     taskCandidateGroups.some((group) => userGroups.includes(group));
   const {


### PR DESCRIPTION
## What & why

Closes #735.

Pooled shipping-coordination tasks are offered to Alfresco **candidate groups**. The task action control (the "Continuar" split button + "Confirmar mover a …" modal) was shown to **any** non-`REVISOR` user who could see the task — it only excluded `GROUP_MINTRAL_REVISOR` and never checked candidate-group membership. A user who is not a candidate (e.g. a TORRE_CONTROL exec viewing a delivery task that was reassigned to TRANSPORTE) would click the button and hit a raw 500:

```
org.alfresco.repo.security.permissions.AccessDeniedException: 05233756
Accessing task with id='activiti$48954347' is not allowed for user 'x'
```

The backend (`workflowService.endTask`) runs as the current user with no `runAsSystem`, so the only real authorization happened server-side — the UI presented an action it knew (or could know) the user couldn't perform.

## Change

`task-actions.tsx`: hide the action control when the current user is not a member of any of the task's candidate groups.

```ts
const rawCandidateGroups = extraData?.candidateGroups;
const taskCandidateGroups = Array.isArray(rawCandidateGroups) ? (rawCandidateGroups as string[]) : [];
const isTaskCandidate =
  userGroups.length === 0 ||          // groups not loaded yet → defer to backend (no flash)
  taskCandidateGroups.length === 0 || // task not pooled / no info → unchanged behaviour
  taskCandidateGroups.some((group) => userGroups.includes(group));
// …
if (!isTaskCandidate) return null;
```

The data was already wired end-to-end: `FastTaskServiceSqlImpl.getTaskDetails` (ecm-coordinator) surfaces `candidateGroups` from `act_ru_identitylink` (raw `GROUP_`-prefixed authorities), the FE `TaskResponse` carries it, and it's passed into `TaskActions` via `extraData`. Until now it was only consumed for a display badge. `userGroups` are `GROUP_`-prefixed too, so the comparison is direct.

## Backwards-compatibility / safety

- Only restricts once `userGroups` is loaded **and** the task exposes `candidateGroups` — otherwise behaviour is unchanged (avoids hiding the button during the groups-loading flash and leaves non-pooled / unannotated tasks alone).
- `REVISOR` exclusion preserved.
- The candidate-group badge already rendered in the bento header still communicates which group the task is assigned to, so a hidden action reads correctly.

## Test plan

- [ ] User **in** the task's candidate group: button shows and completes as before.
- [ ] User **not** in any candidate group (but can see the task via KANBAN/OVERLORD): button is hidden; no 500.
- [ ] Task with no `candidateGroups`: unchanged.
- [ ] `REVISOR`: still excluded.

## Notes / follow-ups (out of scope)

- Defense-in-depth: friendlier toast instead of a raw 500 if a non-candidate action ever slips through.
- Product question: the delivery reassignment job is one-directional/"sticky" (`deliveryReassignedGroup`); decide whether TORRE_CONTROL should retain access to reassigned delivery tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refined access controls for task actions. Users can now only interact with pooled tasks if they are members of designated candidate groups, ensuring appropriate task ownership and visibility.
  * Includes backwards-compatible support for seamless transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->