### PR TITLE
[codex] Compact stack dispatch payload

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -335,18 +335,26 @@ jobs:
               event_type: "miot-stack-nightly",
               client_payload: {
                 release_version: $release_version,
-                app_tag: $app_tag,
-                modulith_tag: $modulith_tag,
-                harness_tag: $harness_tag,
-                app_image_repository: $app_image_repository,
-                app_image_tag: $app_image_tag,
-                app_image_ref: $app_image_ref,
-                modulith_image_repository: $modulith_image_repository,
-                modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref,
-                harness_image_repository: $harness_image_repository,
-                harness_image_tag: $harness_image_tag,
-                harness_image_ref: $harness_image_ref
+                components: {
+                  app: {
+                    tag: $app_tag,
+                    image_repository: $app_image_repository,
+                    image_tag: $app_image_tag,
+                    image_ref: $app_image_ref
+                  },
+                  modulith: {
+                    tag: $modulith_tag,
+                    image_repository: $modulith_image_repository,
+                    image_tag: $modulith_image_tag,
+                    image_ref: $modulith_image_ref
+                  },
+                  harness: {
+                    tag: $harness_tag,
+                    image_repository: $harness_image_repository,
+                    image_tag: $harness_image_tag,
+                    image_ref: $harness_image_ref
+                  }
+                }
               }
             }' |
             gh api "repos/${DEPLOY_DISPATCH_REPO}/dispatches" \

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -695,18 +695,26 @@ jobs:
               event_type: "miot-stack-release",
               client_payload: {
                 release_version: $release_version,
-                app_tag: $app_tag,
-                modulith_tag: $modulith_tag,
-                harness_tag: $harness_tag,
-                app_image_repository: $app_image_repository,
-                app_image_tag: $app_image_tag,
-                app_image_ref: $app_image_ref,
-                modulith_image_repository: $modulith_image_repository,
-                modulith_image_tag: $modulith_image_tag,
-                modulith_image_ref: $modulith_image_ref,
-                harness_image_repository: $harness_image_repository,
-                harness_image_tag: $harness_image_tag,
-                harness_image_ref: $harness_image_ref
+                components: {
+                  app: {
+                    tag: $app_tag,
+                    image_repository: $app_image_repository,
+                    image_tag: $app_image_tag,
+                    image_ref: $app_image_ref
+                  },
+                  modulith: {
+                    tag: $modulith_tag,
+                    image_repository: $modulith_image_repository,
+                    image_tag: $modulith_image_tag,
+                    image_ref: $modulith_image_ref
+                  },
+                  harness: {
+                    tag: $harness_tag,
+                    image_repository: $harness_image_repository,
+                    image_tag: $harness_image_tag,
+                    image_ref: $harness_image_ref
+                  }
+                }
               }
             }' > stack-dispatch-payload.json
 


### PR DESCRIPTION
## Summary

- compact the stack repository_dispatch payload to avoid GitHub's 10 top-level property limit
- send app, modulith, and harness metadata under the supported `components` object
- apply the same payload shape to release train and nightly stack dispatches

## Why

The release train failed while dispatching to `miot-deployments` because adding harness fields increased `client_payload` to 13 top-level properties. GitHub repository dispatch allows at most 10.

Failing run: https://github.com/microboxlabs/modulariot/actions/runs/27998801405/job/82866867485

## Validation

- YAML parsed for `.github/workflows/app-release-train.yml` and `.github/workflows/app-nightly.yml`
- `git diff --check`
