### PR TITLE
[codex] Reuse release branch on release train reruns

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -154,7 +154,12 @@ jobs:
         id: branch
         run: |
           branch="release/miot-v${{ steps.version.outputs.release_version }}"
-          git switch -c "$branch"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            git fetch origin "$branch"
+            git switch -C "$branch" "origin/$branch"
+          else
+            git switch -c "$branch"
+          fi
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Bump app package version
@@ -251,8 +256,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml
-          git commit -m "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}"
-          git push origin "${{ steps.branch.outputs.branch }}"
+          if git diff --cached --quiet; then
+            echo "No release prep changes to commit."
+          else
+            git commit -m "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}"
+            git push origin "${{ steps.branch.outputs.branch }}"
+          fi
 
       - name: Open release PR
         id: pr
@@ -272,11 +281,19 @@ jobs:
           Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
           EOF
 
-          url="$(gh pr create \
+          url="$(gh pr list \
             --base trunk \
             --head "${{ steps.branch.outputs.branch }}" \
-            --title "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}" \
-            --body-file release-pr-body.md)"
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [[ -z "$url" ]]; then
+            url="$(gh pr create \
+              --base trunk \
+              --head "${{ steps.branch.outputs.branch }}" \
+              --title "chore(release): prepare MIOT stack v${{ steps.version.outputs.release_version }}" \
+              --body-file release-pr-body.md)"
+          fi
           number="${url##*/}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
           echo "url=$url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- fetch and reuse an existing `release/miot-v*` branch when the release train is rerun
- skip the release-prep commit when the rerun produces no staged changes
- reuse an existing open release PR instead of failing on duplicate PR creation

## Why

The v0.5.19 release train failed because `release/miot-v0.5.19` already existed remotely. The workflow created a fresh local branch and attempted a normal push, which Git rejected as non-fast-forward.

## Validation

- YAML parsed for `.github/workflows/app-release-train.yml`
- `git diff --check`
