### PR TITLE
[codex] Checkout release branch before generating release files

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -132,6 +132,18 @@ jobs:
             echo "oss_milestone=MIOT-$version"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Create release branch
+        id: branch
+        run: |
+          branch="release/miot-v${{ steps.version.outputs.release_version }}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+            git fetch origin "$branch"
+            git switch -C "$branch" "origin/$branch"
+          else
+            git switch -c "$branch"
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
       - name: Collect release issues
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
@@ -149,18 +161,6 @@ jobs:
           STACK_VERSION: ${{ steps.version.outputs.release_version }}
           OSS_MILESTONE: ${{ steps.version.outputs.oss_milestone }}
         run: node .github/scripts/resolve-stack-release-plan.js
-
-      - name: Create release branch
-        id: branch
-        run: |
-          branch="release/miot-v${{ steps.version.outputs.release_version }}"
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
-            git fetch origin "$branch"
-            git switch -C "$branch" "origin/$branch"
-          else
-            git switch -c "$branch"
-          fi
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Bump app package version
         if: steps.plan.outputs.app_changed == 'true'


### PR DESCRIPTION
## Summary

- checkout or create the `release/miot-v*` branch immediately after resolving the version
- generate release issues, stack plan, and release notes after the workflow is already on the release branch

## Why

Reruns can have generated files like `releases/stacks/v0.5.19.plan.json` in the workspace before the workflow switches to an existing remote release branch. Git refuses the checkout because that untracked file would be overwritten.

## Validation

- YAML parsed for `.github/workflows/app-release-train.yml`
- `git diff --check`
