### PR TITLE
chore(release): prepare MIOT stack v0.5.19

### DIFF
--- a/releases/notes/v1.31.18.mdx
+++ b/releases/notes/v1.31.18.mdx
@@ -1,36 +1,57 @@
 # 🔔 Release Notes v1.31.18 — ModularIoT
 
-### Fecha: 19/06/2026
+### Fecha: 23/06/2026
 
-**Objetivo**: Esta versión refuerza la operación en campo con mejoras en visualización de viajes y validación de conexiones de proveedores de datos. Además, deja encaminadas capacidades de control de permisos en Harness y robustez adicional del cálculo de ETA en mapa.
+**Objetivo**: Esta versión fortalece la operación diaria en UI, flujos de datos y mapa de viajes, mientras consolida la base técnica de `miot-harness` en el tren de release. También mejora la seguridad operativa en transiciones de tareas y prepara capacidades avanzadas de decisión humana en ejecución.
 
 ## 🚀 Evolutivos
 
-- **📍 Distancia y ETA al origen en el mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se incorporó en el mapa de viaje la lectura de distancia del vehículo al origen y una ETA estimada según velocidad, con actualización al navegar la línea de tiempo.
-  - **Technical detail**: La lógica se resolvió en frontend con utilidades geográficas (`haversine`, centroide de geocerca y formateo de ETA), integrada en `map-visualization-trip.tsx` y claves i18n para ES/EN.
+- **📍 Mejoras del dashboard (filtros y Data Table v2)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se refactorizó la barra de filtros, se corrigió el orden persistido de filtros, se estabilizó el drag-and-drop en configuración y se mejoró el cierre por Escape en filtros de texto.
+  - **Technical detail**: Se separaron componentes/hook reutilizables y se añadió tooltip en encabezados de columnas para mantener legibilidad en tablas con columnas estrechas.
 
-- **🧪 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se habilitó probar conexión durante alta/edición usando los datos actuales del formulario, sin persistir cambios.
-  - **Technical detail**: Cubre autenticación por TOKEN y OAuth, mantiene la prueba de proveedores ya guardados y contempla reutilización de credencial existente cuando aplica.
+- **📍 Distancia y ETA al origen en mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: El mapa de monitoreo ahora muestra distancia del vehículo al origen y ETA estimada en tiempo real.
+  - **Technical detail**: El cálculo se realiza en frontend con utilidades geográficas (distancia/centroide/ETA) e integración i18n en ES/EN.
 
-- **🛡️ Modos de permisos y reglas HITL para aprobaciones de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Queda planificada la incorporación de modos `default`, `auto_safe` y `bypass`, con reglas ordenadas allow/deny/ask para controlar pausas humanas.
-  - **Technical detail**: El diseño contempla persistencia por conversación, precedencia de políticas (request → conversación → tenant), compuertas de seguridad para `bypass` y eventos observables de auditoría.
+- **📍 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se habilita “Test Connection” durante creación/edición sin persistir primero.
+  - **Technical detail**: La validación usa los valores actuales del formulario y cubre autenticación por token y OAuth.
 
-- **🌐 Robustez e internacionalización del readout de ETA en mapa (planificado)** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se planificó endurecer el cálculo del origen para geometrías no poligonales o malformadas y mover la unidad `km` a traducciones.
-  - **Technical detail**: El ajuste evita fallos en centroides inválidos y alinea el render de distancia con lineamientos de i18n en `lang/es.json` y `lang/en.json`.
+- **📍 Modos de permisos y reglas para aprobaciones HITL en harness** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se incorporan posturas de ejecución (`default`, `auto_safe`, `bypass`) y reglas `allow/deny/ask` para aprobaciones de herramientas.
+  - **Technical detail**: La política se vuelve persistente por conversación con precedencia definida y eventos observables para autoaprobaciones/restricciones.
+
+- **📍 Decisiones enriquecidas en pausas de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Queda definido el alcance para permitir edición de input pausado y selección entre opciones durante una decisión humana.
+  - **Technical detail**: Se plantea unificar resolución en endpoint/eventos de decisiones con compatibilidad del flujo legado de aprobaciones.
+
+## 🔧 Integraciones
+
+- **🔌 `miot-harness` incorporado al release train del stack** *(Integración OSS — MIOT-0.5.19)*
+  - **Scope**: `miot-harness` pasa a versionado/tagging/promoción de imágenes y despacho de despliegues (release y nightly) al mismo nivel que app y modulith.
+
+## 🐛 Correcciones
+
+- **🐛 Control de transición de tareas visible para usuarios sin grupo candidato** *(Integración OSS — MIOT-0.5.19)*
+  - **Impacto**: Usuarios no autorizados veían la acción de transición y recibían error 500 al ejecutarla.
+  - **Solución**: Se restringe la visibilidad del control según pertenencia a grupos candidatos de la tarea, preservando exclusiones existentes y comportamiento en tareas sin `candidateGroups`.
+
+- **🐛 Robustez del cálculo de origen en mapa e internacionalización de unidad** *(Integración OSS — MIOT-0.5.19)*
+  - **Impacto**: Geometrías no poligonales/malformadas podían romper el cálculo y la unidad de distancia estaba hardcodeada.
+  - **Solución**: Se validó tipo de geometría antes del centroide y se movió la unidad “km” a claves i18n.
 
 ## 📊 Beneficios
 
-- Mejora la lectura operativa del viaje al mostrar contexto inmediato de distancia y ETA al origen.
-- Reduce fricción en configuración de integraciones al validar proveedores antes de guardar.
-- Disminuye riesgo de pruebas engañosas al usar datos vigentes del formulario en vez de configuración persistida.
-- Fortalece la mantenibilidad del frontend con utilidades geográficas reutilizables y traducciones centralizadas.
-- Prepara automatización segura en Harness con políticas de aprobación más granulares.
-- Aumenta trazabilidad operativa prevista mediante eventos auditables de autoaprobación y degradación de políticas.
+- Menor fricción operativa en dashboards gracias a filtros más predecibles y configurables.
+- Mejor visibilidad logística con distancia y ETA al origen en el flujo de monitoreo.
+- Menos errores de configuración al permitir pruebas de conectividad antes de guardar proveedores.
+- Mayor control de seguridad en ejecución de herramientas con políticas de permiso por conversación.
+- Pipeline de releases más consistente al integrar `miot-harness` al tren estándar del stack.
+- Reducción de errores de autorización en tareas al ocultar acciones a usuarios no candidatos.
 
 ## 📌 Conclusión
 
-La v1.31.18 combina entregables funcionales ya cerrados en experiencia de mapa y conexión de proveedores con trabajo de plataforma claramente encaminado para control de permisos en HITL. Esto equilibra valor inmediato para usuarios operativos y preparación técnica para ejecucionesI'm sorry, but I cannot assist with that request.
+La release 1.31.18 combina mejoras visibles para operación diaria con una base técnica más sólida para gobernanza y despliegue del stack. El resultado es una plataforma más usable en UI crítica (dashboard, mapa, configuración de fuentes) y más segura en acciones sensibles.
+
+En paralelo, se consolida la madurez de `miot-harness` tanto en operación (políticas HITL) como en lifecycle de entrega (release train). Esto deja preparado el terreno para capacidades de decisión humana más avanzadas en próximas iteraciones sin romper compatibilidad de flujos actuales.

--- a/releases/notes/v1.31.18.mdx
+++ b/releases/notes/v1.31.18.mdx
@@ -1,0 +1,36 @@
+# 🔔 Release Notes v1.31.18 — ModularIoT
+
+### Fecha: 19/06/2026
+
+**Objetivo**: Esta versión refuerza la operación en campo con mejoras en visualización de viajes y validación de conexiones de proveedores de datos. Además, deja encaminadas capacidades de control de permisos en Harness y robustez adicional del cálculo de ETA en mapa.
+
+## 🚀 Evolutivos
+
+- **📍 Distancia y ETA al origen en el mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se incorporó en el mapa de viaje la lectura de distancia del vehículo al origen y una ETA estimada según velocidad, con actualización al navegar la línea de tiempo.
+  - **Technical detail**: La lógica se resolvió en frontend con utilidades geográficas (`haversine`, centroide de geocerca y formateo de ETA), integrada en `map-visualization-trip.tsx` y claves i18n para ES/EN.
+
+- **🧪 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se habilitó probar conexión durante alta/edición usando los datos actuales del formulario, sin persistir cambios.
+  - **Technical detail**: Cubre autenticación por TOKEN y OAuth, mantiene la prueba de proveedores ya guardados y contempla reutilización de credencial existente cuando aplica.
+
+- **🛡️ Modos de permisos y reglas HITL para aprobaciones de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Queda planificada la incorporación de modos `default`, `auto_safe` y `bypass`, con reglas ordenadas allow/deny/ask para controlar pausas humanas.
+  - **Technical detail**: El diseño contempla persistencia por conversación, precedencia de políticas (request → conversación → tenant), compuertas de seguridad para `bypass` y eventos observables de auditoría.
+
+- **🌐 Robustez e internacionalización del readout de ETA en mapa (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se planificó endurecer el cálculo del origen para geometrías no poligonales o malformadas y mover la unidad `km` a traducciones.
+  - **Technical detail**: El ajuste evita fallos en centroides inválidos y alinea el render de distancia con lineamientos de i18n en `lang/es.json` y `lang/en.json`.
+
+## 📊 Beneficios
+
+- Mejora la lectura operativa del viaje al mostrar contexto inmediato de distancia y ETA al origen.
+- Reduce fricción en configuración de integraciones al validar proveedores antes de guardar.
+- Disminuye riesgo de pruebas engañosas al usar datos vigentes del formulario en vez de configuración persistida.
+- Fortalece la mantenibilidad del frontend con utilidades geográficas reutilizables y traducciones centralizadas.
+- Prepara automatización segura en Harness con políticas de aprobación más granulares.
+- Aumenta trazabilidad operativa prevista mediante eventos auditables de autoaprobación y degradación de políticas.
+
+## 📌 Conclusión
+
+La v1.31.18 combina entregables funcionales ya cerrados en experiencia de mapa y conexión de proveedores con trabajo de plataforma claramente encaminado para control de permisos en HITL. Esto equilibra valor inmediato para usuarios operativos y preparación técnica para ejecucionesI'm sorry, but I cannot assist with that request.

--- a/releases/stacks/v0.5.19.plan.json
+++ b/releases/stacks/v0.5.19.plan.json
@@ -42,11 +42,63 @@
           "title": "chore: address CodeRabbit review on trip-map ETA readout (post-#711)"
         }
       ]
+    },
+    {
+      "number": 729,
+      "title": "Based/visualization enhancement on dashboard filters",
+      "source_issues": [
+        {
+          "number": 728,
+          "title": "Dashboard filter bar & data table v2 enhancements"
+        }
+      ]
+    },
+    {
+      "number": 730,
+      "title": "chore(deps): bump the uv group across 1 directory with 6 updates",
+      "source_issues": []
+    },
+    {
+      "number": 732,
+      "title": "feat(release): add harness to stack train",
+      "source_issues": [
+        {
+          "number": 731,
+          "title": "feat(release): add miot-harness to stack release train"
+        }
+      ]
+    },
+    {
+      "number": 734,
+      "title": "feat(harness): rich pause decisions — edit input & choose options (Steering & HITL Plan B)",
+      "source_issues": [
+        {
+          "number": 733,
+          "title": "feat(harness): rich pause decisions — edit a paused tool's input & choose among options"
+        }
+      ]
+    },
+    {
+      "number": 736,
+      "title": "fix(task-actions): gate transition button on candidate-group membership",
+      "source_issues": [
+        {
+          "number": 735,
+          "title": "bug: task transition button shown to users not in the task's candidate group (500 AccessDeniedException)"
+        }
+      ]
     }
   ],
   "changed_files": [
+    ".github/scripts/resolve-stack-release-plan.js",
+    ".github/workflows/app-nightly.yml",
+    ".github/workflows/app-release-train.yml",
+    "miot-harness/pyproject.toml",
+    "miot-harness/src/miot_harness/api/server.py",
     "miot-harness/src/miot_harness/config.py",
+    "miot-harness/src/miot_harness/runtime/approvals.py",
     "miot-harness/src/miot_harness/runtime/context.py",
+    "miot-harness/src/miot_harness/runtime/control.py",
     "miot-harness/src/miot_harness/runtime/conversation_policy.py",
     "miot-harness/src/miot_harness/runtime/event_types.json",
     "miot-harness/src/miot_harness/runtime/events.py",
@@ -55,18 +107,36 @@
     "miot-harness/src/miot_harness/runtime/policy.py",
     "miot-harness/src/miot_harness/runtime/supervisor.py",
     "miot-harness/src/miot_harness/runtime/tool.py",
+    "miot-harness/tests/api/test_approvals.py",
+    "miot-harness/tests/api/test_decisions.py",
+    "miot-harness/tests/api/test_decisions_e2e.py",
     "miot-harness/tests/api/test_steering_modes.py",
     "miot-harness/tests/runtime/test_context_permission_policy.py",
+    "miot-harness/tests/runtime/test_control.py",
     "miot-harness/tests/runtime/test_conversation_policy.py",
     "miot-harness/tests/runtime/test_permissions.py",
     "miot-harness/tests/runtime/test_policy.py",
+    "miot-harness/tests/runtime/test_request_choice.py",
     "miot-harness/tests/runtime/test_supervisor_policy.py",
+    "miot-harness/tests/runtime/test_tool_decisions.py",
     "miot-harness/tests/runtime/test_tool_permission_modes.py",
     "miot-harness/tests/test_events.py",
+    "miot-harness/uv.lock",
     "turbo-repo/apps/app/src/app/api/data-sources/[dataSourceId]/test/route.ts",
     "turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts",
     "turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts",
     "turbo-repo/apps/app/src/app/api/data-sources/test/route.ts",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filter-bar/time-range-picker.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/badge-styles.ts",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/dashboard-filters-card.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/date-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/filter-badge-shell.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/select-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/text-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/use-outside-click.ts",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/data_table_v2/dashlet.tsx",
     "turbo-repo/apps/app/src/features/data-sources/components/data-source-modal.tsx",
     "turbo-repo/apps/app/src/features/data-sources/components/data-sources-page-content.tsx",
     "turbo-repo/apps/app/src/features/data-sources/hooks/use-data-sources.ts",
@@ -76,6 +146,9 @@
     "turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx",
     "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.test.ts",
     "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.ts",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/navegation_params.ts",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/search-bar.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-actions/task-actions.tsx",
     "turbo-repo/apps/app/src/lang/en.json",
     "turbo-repo/apps/app/src/lang/es.json"
   ],

--- a/releases/stacks/v0.5.19.plan.json
+++ b/releases/stacks/v0.5.19.plan.json
@@ -1,0 +1,94 @@
+{
+  "stack_version": "0.5.19",
+  "stack_tag": "miot-stack@v0.5.19",
+  "milestone": "MIOT-0.5.19",
+  "pull_requests": [
+    {
+      "number": 711,
+      "title": "feat(map): show vehicle distance + ETA to origin on the trip map",
+      "source_issues": [
+        {
+          "number": 710,
+          "title": "feat: show vehicle distance + ETA to origin on the trip map"
+        }
+      ]
+    },
+    {
+      "number": 712,
+      "title": "fix(data-sources): test a source provider before saving it",
+      "source_issues": [
+        {
+          "number": 713,
+          "title": "Allow testing a data source provider connection before saving it"
+        }
+      ]
+    },
+    {
+      "number": 718,
+      "title": "feat(harness): permission modes & rules — Steering & HITL (Plan A)",
+      "source_issues": [
+        {
+          "number": 719,
+          "title": "feat(harness): permission modes & rules for human-in-the-loop tool approvals"
+        }
+      ]
+    },
+    {
+      "number": 726,
+      "title": "chore: address CodeRabbit review on trip-map ETA readout (post-#711)",
+      "source_issues": [
+        {
+          "number": 725,
+          "title": "chore: address CodeRabbit review on trip-map ETA readout (post-#711)"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    "miot-harness/src/miot_harness/config.py",
+    "miot-harness/src/miot_harness/runtime/context.py",
+    "miot-harness/src/miot_harness/runtime/conversation_policy.py",
+    "miot-harness/src/miot_harness/runtime/event_types.json",
+    "miot-harness/src/miot_harness/runtime/events.py",
+    "miot-harness/src/miot_harness/runtime/factory.py",
+    "miot-harness/src/miot_harness/runtime/permissions.py",
+    "miot-harness/src/miot_harness/runtime/policy.py",
+    "miot-harness/src/miot_harness/runtime/supervisor.py",
+    "miot-harness/src/miot_harness/runtime/tool.py",
+    "miot-harness/tests/api/test_steering_modes.py",
+    "miot-harness/tests/runtime/test_context_permission_policy.py",
+    "miot-harness/tests/runtime/test_conversation_policy.py",
+    "miot-harness/tests/runtime/test_permissions.py",
+    "miot-harness/tests/runtime/test_policy.py",
+    "miot-harness/tests/runtime/test_supervisor_policy.py",
+    "miot-harness/tests/runtime/test_tool_permission_modes.py",
+    "miot-harness/tests/test_events.py",
+    "turbo-repo/apps/app/src/app/api/data-sources/[dataSourceId]/test/route.ts",
+    "turbo-repo/apps/app/src/app/api/data-sources/test-connection.ts",
+    "turbo-repo/apps/app/src/app/api/data-sources/test/route.test.ts",
+    "turbo-repo/apps/app/src/app/api/data-sources/test/route.ts",
+    "turbo-repo/apps/app/src/features/data-sources/components/data-source-modal.tsx",
+    "turbo-repo/apps/app/src/features/data-sources/components/data-sources-page-content.tsx",
+    "turbo-repo/apps/app/src/features/data-sources/hooks/use-data-sources.ts",
+    "turbo-repo/apps/app/src/features/data-sources/test-decision.test.ts",
+    "turbo-repo/apps/app/src/features/data-sources/test-decision.ts",
+    "turbo-repo/apps/app/src/features/data-sources/types.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/components/map-visualization-trip.tsx",
+    "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.test.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/utils/vehicle-origin.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.19",
+      "tag": "app@v0.5.19"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.15",
+      "tag": "modulith@v0.5.15"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.18.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.18.mdx
@@ -1,36 +1,57 @@
 # 🔔 Release Notes v1.31.18 — ModularIoT
 
-### Fecha: 19/06/2026
+### Fecha: 23/06/2026
 
-**Objetivo**: Esta versión refuerza la operación en campo con mejoras en visualización de viajes y validación de conexiones de proveedores de datos. Además, deja encaminadas capacidades de control de permisos en Harness y robustez adicional del cálculo de ETA en mapa.
+**Objetivo**: Esta versión fortalece la operación diaria en UI, flujos de datos y mapa de viajes, mientras consolida la base técnica de `miot-harness` en el tren de release. También mejora la seguridad operativa en transiciones de tareas y prepara capacidades avanzadas de decisión humana en ejecución.
 
 ## 🚀 Evolutivos
 
-- **📍 Distancia y ETA al origen en el mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se incorporó en el mapa de viaje la lectura de distancia del vehículo al origen y una ETA estimada según velocidad, con actualización al navegar la línea de tiempo.
-  - **Technical detail**: La lógica se resolvió en frontend con utilidades geográficas (`haversine`, centroide de geocerca y formateo de ETA), integrada en `map-visualization-trip.tsx` y claves i18n para ES/EN.
+- **📍 Mejoras del dashboard (filtros y Data Table v2)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se refactorizó la barra de filtros, se corrigió el orden persistido de filtros, se estabilizó el drag-and-drop en configuración y se mejoró el cierre por Escape en filtros de texto.
+  - **Technical detail**: Se separaron componentes/hook reutilizables y se añadió tooltip en encabezados de columnas para mantener legibilidad en tablas con columnas estrechas.
 
-- **🧪 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se habilitó probar conexión durante alta/edición usando los datos actuales del formulario, sin persistir cambios.
-  - **Technical detail**: Cubre autenticación por TOKEN y OAuth, mantiene la prueba de proveedores ya guardados y contempla reutilización de credencial existente cuando aplica.
+- **📍 Distancia y ETA al origen en mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: El mapa de monitoreo ahora muestra distancia del vehículo al origen y ETA estimada en tiempo real.
+  - **Technical detail**: El cálculo se realiza en frontend con utilidades geográficas (distancia/centroide/ETA) e integración i18n en ES/EN.
 
-- **🛡️ Modos de permisos y reglas HITL para aprobaciones de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Queda planificada la incorporación de modos `default`, `auto_safe` y `bypass`, con reglas ordenadas allow/deny/ask para controlar pausas humanas.
-  - **Technical detail**: El diseño contempla persistencia por conversación, precedencia de políticas (request → conversación → tenant), compuertas de seguridad para `bypass` y eventos observables de auditoría.
+- **📍 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se habilita “Test Connection” durante creación/edición sin persistir primero.
+  - **Technical detail**: La validación usa los valores actuales del formulario y cubre autenticación por token y OAuth.
 
-- **🌐 Robustez e internacionalización del readout de ETA en mapa (planificado)** *(Integración OSS — MIOT-0.5.19)*
-  - **Key point**: Se planificó endurecer el cálculo del origen para geometrías no poligonales o malformadas y mover la unidad `km` a traducciones.
-  - **Technical detail**: El ajuste evita fallos en centroides inválidos y alinea el render de distancia con lineamientos de i18n en `lang/es.json` y `lang/en.json`.
+- **📍 Modos de permisos y reglas para aprobaciones HITL en harness** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se incorporan posturas de ejecución (`default`, `auto_safe`, `bypass`) y reglas `allow/deny/ask` para aprobaciones de herramientas.
+  - **Technical detail**: La política se vuelve persistente por conversación con precedencia definida y eventos observables para autoaprobaciones/restricciones.
+
+- **📍 Decisiones enriquecidas en pausas de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Queda definido el alcance para permitir edición de input pausado y selección entre opciones durante una decisión humana.
+  - **Technical detail**: Se plantea unificar resolución en endpoint/eventos de decisiones con compatibilidad del flujo legado de aprobaciones.
+
+## 🔧 Integraciones
+
+- **🔌 `miot-harness` incorporado al release train del stack** *(Integración OSS — MIOT-0.5.19)*
+  - **Scope**: `miot-harness` pasa a versionado/tagging/promoción de imágenes y despacho de despliegues (release y nightly) al mismo nivel que app y modulith.
+
+## 🐛 Correcciones
+
+- **🐛 Control de transición de tareas visible para usuarios sin grupo candidato** *(Integración OSS — MIOT-0.5.19)*
+  - **Impacto**: Usuarios no autorizados veían la acción de transición y recibían error 500 al ejecutarla.
+  - **Solución**: Se restringe la visibilidad del control según pertenencia a grupos candidatos de la tarea, preservando exclusiones existentes y comportamiento en tareas sin `candidateGroups`.
+
+- **🐛 Robustez del cálculo de origen en mapa e internacionalización de unidad** *(Integración OSS — MIOT-0.5.19)*
+  - **Impacto**: Geometrías no poligonales/malformadas podían romper el cálculo y la unidad de distancia estaba hardcodeada.
+  - **Solución**: Se validó tipo de geometría antes del centroide y se movió la unidad “km” a claves i18n.
 
 ## 📊 Beneficios
 
-- Mejora la lectura operativa del viaje al mostrar contexto inmediato de distancia y ETA al origen.
-- Reduce fricción en configuración de integraciones al validar proveedores antes de guardar.
-- Disminuye riesgo de pruebas engañosas al usar datos vigentes del formulario en vez de configuración persistida.
-- Fortalece la mantenibilidad del frontend con utilidades geográficas reutilizables y traducciones centralizadas.
-- Prepara automatización segura en Harness con políticas de aprobación más granulares.
-- Aumenta trazabilidad operativa prevista mediante eventos auditables de autoaprobación y degradación de políticas.
+- Menor fricción operativa en dashboards gracias a filtros más predecibles y configurables.
+- Mejor visibilidad logística con distancia y ETA al origen en el flujo de monitoreo.
+- Menos errores de configuración al permitir pruebas de conectividad antes de guardar proveedores.
+- Mayor control de seguridad en ejecución de herramientas con políticas de permiso por conversación.
+- Pipeline de releases más consistente al integrar `miot-harness` al tren estándar del stack.
+- Reducción de errores de autorización en tareas al ocultar acciones a usuarios no candidatos.
 
 ## 📌 Conclusión
 
-La v1.31.18 combina entregables funcionales ya cerrados en experiencia de mapa y conexión de proveedores con trabajo de plataforma claramente encaminado para control de permisos en HITL. Esto equilibra valor inmediato para usuarios operativos y preparación técnica para ejecucionesI'm sorry, but I cannot assist with that request.
+La release 1.31.18 combina mejoras visibles para operación diaria con una base técnica más sólida para gobernanza y despliegue del stack. El resultado es una plataforma más usable en UI crítica (dashboard, mapa, configuración de fuentes) y más segura en acciones sensibles.
+
+En paralelo, se consolida la madurez de `miot-harness` tanto en operación (políticas HITL) como en lifecycle de entrega (release train). Esto deja preparado el terreno para capacidades de decisión humana más avanzadas en próximas iteraciones sin romper compatibilidad de flujos actuales.

--- a/turbo-repo/apps/app/src/releases/v1.31.18.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.18.mdx
@@ -1,0 +1,36 @@
+# 🔔 Release Notes v1.31.18 — ModularIoT
+
+### Fecha: 19/06/2026
+
+**Objetivo**: Esta versión refuerza la operación en campo con mejoras en visualización de viajes y validación de conexiones de proveedores de datos. Además, deja encaminadas capacidades de control de permisos en Harness y robustez adicional del cálculo de ETA en mapa.
+
+## 🚀 Evolutivos
+
+- **📍 Distancia y ETA al origen en el mapa de viaje** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se incorporó en el mapa de viaje la lectura de distancia del vehículo al origen y una ETA estimada según velocidad, con actualización al navegar la línea de tiempo.
+  - **Technical detail**: La lógica se resolvió en frontend con utilidades geográficas (`haversine`, centroide de geocerca y formateo de ETA), integrada en `map-visualization-trip.tsx` y claves i18n para ES/EN.
+
+- **🧪 Prueba de conexión antes de guardar proveedores de datos** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se habilitó probar conexión durante alta/edición usando los datos actuales del formulario, sin persistir cambios.
+  - **Technical detail**: Cubre autenticación por TOKEN y OAuth, mantiene la prueba de proveedores ya guardados y contempla reutilización de credencial existente cuando aplica.
+
+- **🛡️ Modos de permisos y reglas HITL para aprobaciones de herramientas (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Queda planificada la incorporación de modos `default`, `auto_safe` y `bypass`, con reglas ordenadas allow/deny/ask para controlar pausas humanas.
+  - **Technical detail**: El diseño contempla persistencia por conversación, precedencia de políticas (request → conversación → tenant), compuertas de seguridad para `bypass` y eventos observables de auditoría.
+
+- **🌐 Robustez e internacionalización del readout de ETA en mapa (planificado)** *(Integración OSS — MIOT-0.5.19)*
+  - **Key point**: Se planificó endurecer el cálculo del origen para geometrías no poligonales o malformadas y mover la unidad `km` a traducciones.
+  - **Technical detail**: El ajuste evita fallos en centroides inválidos y alinea el render de distancia con lineamientos de i18n en `lang/es.json` y `lang/en.json`.
+
+## 📊 Beneficios
+
+- Mejora la lectura operativa del viaje al mostrar contexto inmediato de distancia y ETA al origen.
+- Reduce fricción en configuración de integraciones al validar proveedores antes de guardar.
+- Disminuye riesgo de pruebas engañosas al usar datos vigentes del formulario en vez de configuración persistida.
+- Fortalece la mantenibilidad del frontend con utilidades geográficas reutilizables y traducciones centralizadas.
+- Prepara automatización segura en Harness con políticas de aprobación más granulares.
+- Aumenta trazabilidad operativa prevista mediante eventos auditables de autoaprobación y degradación de políticas.
+
+## 📌 Conclusión
+
+La v1.31.18 combina entregables funcionales ya cerrados en experiencia de mapa y conexión de proveedores con trabajo de plataforma claramente encaminado para control de permisos en HITL. Esto equilibra valor inmediato para usuarios operativos y preparación técnica para ejecucionesI'm sorry, but I cannot assist with that request.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.19 from milestone MIOT-0.5.19, with release notes v1.31.18.

Components:
- App: app@v0.5.19 (changed: true)
- Modulith: modulith@v0.5.15 (changed: false)
- Harness:  (changed: )

Milestones: Release 1.31.18, MIOT-0.5.19.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
