### PR TITLE
[codex] Use current release planner on reruns

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -116,6 +116,9 @@ if (!appVersion) {
 if (!modulithVersion) {
   throw new Error("No modulith@v* tag exists and the modulith did not change in this milestone.");
 }
+if (!harnessVersion) {
+  throw new Error("No harness@v* tag exists and the harness did not change in this milestone.");
+}
 const plan = {
   stack_version: stackVersion,
   stack_tag: `miot-stack@v${stackVersion}`,

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -144,6 +144,14 @@ jobs:
           fi
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
+      - name: Restore release automation from workflow ref
+        run: |
+          git checkout "$GITHUB_SHA" -- \
+            .github/scripts/resolve-stack-release-plan.js \
+            .github/prompts/app-release-notes.prompt.yml \
+            turbo-repo/generative_ai/tools/sh/fetch-release-issues.sh \
+            turbo-repo/generative_ai/tools/sh/bump-app-version.sh
+
       - name: Collect release issues
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- restore the release-train helper scripts from the triggering workflow ref after switching to an existing release branch
- keep reruns from using stale `.github/scripts/resolve-stack-release-plan.js` from the release branch
- fail early if the resolved harness version is empty

## Why

The v0.5.19 deployment received an empty harness tag/image because the rerun switched to the existing `release/miot-v0.5.19` branch before resolving the stack plan. That branch was created before the harness-aware planner existed, so the old planner emitted no harness outputs.

Failing deployment: https://github.com/microboxlabs/miot-deployments/actions/runs/28000192722/job/82870768520

## Validation

- YAML parsed for `.github/workflows/app-release-train.yml`
- `node --check .github/scripts/resolve-stack-release-plan.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release automation with validation checks to ensure proper version detection.
  * Improved release branch preparation to restore automation files from the current workflow commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->