### PR TITLE
fix(harness): never fail a run when provenance log is unwritable

### DIFF
--- a/miot-harness/src/miot_harness/observability/provenance.py
+++ b/miot-harness/src/miot_harness/observability/provenance.py
@@ -17,9 +17,12 @@ by an external job).
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,17 +48,18 @@ class ProvenanceLog:
     def __init__(self, root: Path, *, enabled: bool = True) -> None:
         self._root = Path(root)
         self._enabled = enabled
+        # Latches True after the first unwritable-filesystem error so we
+        # don't retry the syscall (or re-log the warning) on every step.
+        self._write_disabled = False
 
     def append(self, entry: ProvenanceEntry, *, now: datetime | None = None) -> None:
-        if not self._enabled:
+        if not self._enabled or self._write_disabled:
             return
         when = now or datetime.now(UTC)
         if when.tzinfo is None:
             when = when.replace(tzinfo=UTC)
         else:
             when = when.astimezone(UTC)
-        self._root.mkdir(parents=True, exist_ok=True)
-        path = self._root / f"{when.date().isoformat()}.jsonl"
         payload = {
             "logged_at": when.isoformat(),
             "question": entry.question,
@@ -66,7 +70,26 @@ class ProvenanceLog:
             "run_id": entry.run_id,
             "tenant_id": entry.tenant_id,
         }
-        with path.open("a", encoding="utf-8") as fh:
-            # Single write so concurrent appends from other processes
-            # can't slip a record between the JSON body and its newline.
-            fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        try:
+            self._root.mkdir(parents=True, exist_ok=True)
+            path = self._root / f"{when.date().isoformat()}.jsonl"
+            with path.open("a", encoding="utf-8") as fh:
+                # Single write so concurrent appends from other processes
+                # can't slip a record between the JSON body and its newline.
+                fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            # Provenance is a best-effort telemetry side-channel — it must
+            # never break a user-facing run. In production the harness runs
+            # on a read-only filesystem (EROFS) or without write permission
+            # (EACCES); log once, latch off, and let the request return an
+            # answer. Point MIOT_HARNESS_PROVENANCE_LOG_DIR at a writable
+            # path, or set MIOT_HARNESS_PROVENANCE_LOG_ENABLED=false, to
+            # silence this.
+            self._write_disabled = True
+            logger.warning(
+                "Provenance log disabled: cannot write to %s (%s). "
+                "Set MIOT_HARNESS_PROVENANCE_LOG_DIR to a writable path or "
+                "MIOT_HARNESS_PROVENANCE_LOG_ENABLED=false to silence this.",
+                self._root,
+                exc,
+            )

--- a/miot-harness/tests/observability/test_provenance.py
+++ b/miot-harness/tests/observability/test_provenance.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import errno
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -150,3 +152,78 @@ def test_provenance_handles_missing_refreshed_at(
         assert payload["refreshed_at"] is None
     else:
         assert payload["refreshed_at"] == refreshed_at.isoformat()
+
+
+def _entry() -> ProvenanceEntry:
+    return ProvenanceEntry(
+        question="q",
+        sql="SELECT 1 FROM analytics.dx_servicios LIMIT 1",
+        plan_cost=1.0,
+        rows_returned=0,
+        refreshed_at=None,
+        run_id="r",
+        tenant_id="acme",
+    )
+
+
+def test_provenance_survives_read_only_filesystem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A read-only FS (EROFS) when creating the dir must never break the run.
+
+    Production runs the harness on a read-only filesystem; provenance is a
+    best-effort telemetry side-channel and must degrade to a no-op so the
+    user still gets an answer.
+    """
+
+    def _raise_erofs(*_args: object, **_kwargs: object) -> None:
+        raise OSError(errno.EROFS, "Read-only file system")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_erofs)
+    log = ProvenanceLog(root=tmp_path / "evals" / "provenance")
+
+    with caplog.at_level(logging.WARNING):
+        log.append(_entry(), now=datetime(2026, 5, 12, 9, 0, tzinfo=UTC))  # must not raise
+
+    assert not (tmp_path / "evals").exists()
+    assert any("provenance" in r.message.lower() for r in caplog.records)
+
+
+def test_provenance_survives_permission_error_on_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A permission error (EACCES) when opening the file must also degrade."""
+
+    def _raise_eacces(*_args: object, **_kwargs: object) -> None:
+        raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(Path, "open", _raise_eacces)
+    log = ProvenanceLog(root=tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        log.append(_entry(), now=datetime(2026, 5, 12, 9, 0, tzinfo=UTC))  # must not raise
+
+    assert any("provenance" in r.message.lower() for r in caplog.records)
+
+
+def test_provenance_disables_after_first_fs_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """After one FS failure the log latches off — no retries, no log spam."""
+
+    calls = {"mkdir": 0}
+
+    def _raise_erofs(*_args: object, **_kwargs: object) -> None:
+        calls["mkdir"] += 1
+        raise OSError(errno.EROFS, "Read-only file system")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_erofs)
+    log = ProvenanceLog(root=tmp_path / "evals")
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            log.append(_entry(), now=datetime(2026, 5, 12, 9, 0, tzinfo=UTC))
+
+    assert calls["mkdir"] == 1
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1


### PR DESCRIPTION
Closes #746

## Problem

The agentic executor crashes in production with:

```
route: data_agentic → agent: executor → run.failed
[Errno 30] Read-only file system: 'evals'
```

User-visible symptom in `miot-chat` / `miot chat`: any question routed to `data_agentic` returns **`(no answer recorded)`**.

Root cause: `ProvenanceLog.append()` (`observability/provenance.py`) does `mkdir`/`open` on the default relative `evals/provenance` dir. The prod harness container runs on a **read-only filesystem**, so the `mkdir` raises `OSError(EROFS)`, which propagates out of the executor (`runtime/agentic_graph.py`) and fails the entire run. Provenance is a best-effort telemetry side-channel, yet a write failure takes down the whole user-facing request.

Only the agentic route is affected — it's the sole caller of `ProvenanceLog`; the `nexo_query`/canned route is unaffected.

## Fix

Wrap the filesystem writes in `append()` in `try/except OSError`. On a read-only FS (EROFS) or missing permission (EACCES):

- log **one** warning (with the path + how to fix),
- latch the writer off (`_write_disabled`) so it doesn't retry the syscall or spam the log on every agentic turn,
- **return normally** so the run completes and the user gets an answer.

The `MIOT_HARNESS_PROVENANCE_LOG_ENABLED` flag and the default `evals/provenance` dir are intentionally **unchanged** — ops can still redirect (`MIOT_HARNESS_PROVENANCE_LOG_DIR`) or disable (`MIOT_HARNESS_PROVENANCE_LOG_ENABLED=false`). This change only converts the failure mode from "crash the run" to "log and continue."

## Tests

New tests in `tests/observability/test_provenance.py` (confirmed red before, green after):

- `test_provenance_survives_read_only_filesystem` — EROFS on `mkdir` → no raise, no file, warning logged
- `test_provenance_survives_permission_error_on_write` — EACCES on `open` → no raise, warning logged
- `test_provenance_disables_after_first_fs_error` — latches off: one `mkdir` attempt, one warning across repeated appends

Verification (matches CI):

```
uv run pytest -q  → 23 passed (provenance + agentic_graph)
uv run ruff check → All checks passed!
uv run mypy       → Success: no issues found
```

## Deploy note

This is the durable fix and unblocks prod once deployed. For an immediate unblock without waiting on a release, set `MIOT_HARNESS_PROVENANCE_LOG_ENABLED=false` on the prod harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provenance logging now handles filesystem write errors gracefully instead of failing the app.
  * After the first write error, further provenance writes are automatically skipped to avoid repeated failures.
  * Time values are normalized consistently before entries are recorded.
  * Added warning messages to help surface provenance logging issues and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->