### PR TITLE
chore(release): prepare MIOT stack v0.5.20

### DIFF
--- a/releases/notes/v1.31.19.mdx
+++ b/releases/notes/v1.31.19.mdx
@@ -1,0 +1,19 @@
+# 🔔 Release Notes v1.31.19 — ModularIoT
+
+### Fecha: 24/06/2026
+
+**Objetivo**: Formalizar el corte de la versión `1.31.19` y mantener alineados los hitos **Release 1.31.19** (privado) y **MIOT-0.5.20** (OSS), sin cambios funcionales registrados en el listado de issues provisto.
+
+## 📊 Beneficios
+
+- Se conserva la trazabilidad del versionado entre el ciclo privado y la integración OSS.
+- Se mantiene un punto de referencia claro para auditoría técnica y operativa del release.
+- Se reduce ambigüedad para equipos de producto, soporte y operaciones al documentar explícitamente el alcance.
+- Se facilita la planificación de los siguientes incrementos al dejar explícito que no hay ítems detallados en esta entrega.
+- Se sostiene la disciplina de publicación y comunicación de releases en el ecosistema ModularIoT.
+
+## 📌 Conclusión
+
+La versión `1.31.19` queda documentada como un release de control y alineación, con foco en gobernanza de entrega más que en cambios funcionales reportados.
+
+Este registro aporta claridad para el seguimiento entre milestones privados y OSS, y prepara el terreno para que los próximos releases incorporen evolutivos, integraciones o correcciones con trazabilidad completa.

--- a/releases/stacks/v0.5.20.plan.json
+++ b/releases/stacks/v0.5.20.plan.json
@@ -1,0 +1,24 @@
+{
+  "stack_version": "0.5.20",
+  "stack_tag": "miot-stack@v0.5.20",
+  "milestone": "MIOT-0.5.20",
+  "pull_requests": [],
+  "changed_files": [],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.20",
+      "tag": "app@v0.5.20"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.15",
+      "tag": "modulith@v0.5.15"
+    },
+    "harness": {
+      "changed": true,
+      "version": "0.1.0",
+      "tag": "harness@v0.1.0"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.19.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.19.mdx
@@ -1,0 +1,19 @@
+# 🔔 Release Notes v1.31.19 — ModularIoT
+
+### Fecha: 24/06/2026
+
+**Objetivo**: Formalizar el corte de la versión `1.31.19` y mantener alineados los hitos **Release 1.31.19** (privado) y **MIOT-0.5.20** (OSS), sin cambios funcionales registrados en el listado de issues provisto.
+
+## 📊 Beneficios
+
+- Se conserva la trazabilidad del versionado entre el ciclo privado y la integración OSS.
+- Se mantiene un punto de referencia claro para auditoría técnica y operativa del release.
+- Se reduce ambigüedad para equipos de producto, soporte y operaciones al documentar explícitamente el alcance.
+- Se facilita la planificación de los siguientes incrementos al dejar explícito que no hay ítems detallados en esta entrega.
+- Se sostiene la disciplina de publicación y comunicación de releases en el ecosistema ModularIoT.
+
+## 📌 Conclusión
+
+La versión `1.31.19` queda documentada como un release de control y alineación, con foco en gobernanza de entrega más que en cambios funcionales reportados.
+
+Este registro aporta claridad para el seguimiento entre milestones privados y OSS, y prepara el terreno para que los próximos releases incorporen evolutivos, integraciones o correcciones con trazabilidad completa.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.20 from milestone MIOT-0.5.20, with release notes v1.31.19.

Components:
- App: app@v0.5.20 (changed: true)
- Modulith: modulith@v0.5.15 (changed: false)
- Harness: harness@v0.1.0 (changed: true)

Milestones: Release 1.31.19, MIOT-0.5.20.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
