### PR TITLE
feat(integrations): WhatsApp Cloud API connection provider + live test

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ProviderType.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/ProviderType.java
@@ -6,5 +6,6 @@ public enum ProviderType {
     N8N,
     AUTH0,
     ECM,
-    CUSTOM_HTTP
+    CUSTOM_HTTP,
+    WHATSAPP
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
@@ -24,6 +24,13 @@ public class CredentialProfileRepository {
             ORDER BY display_name
             """;
 
+    private static final String SELECT_BY_ID = """
+            SELECT id, tenant_code, display_name, auth_type, public_config, encrypted_secret_json,
+                   secret_preview, secret_version, created_at, updated_at
+            FROM miot_integrations.credential_profiles
+            WHERE tenant_code = $1 AND id = $2 AND active
+            """;
+
     private static final String INSERT = """
             INSERT INTO miot_integrations.credential_profiles (
                 id, tenant_code, display_name, auth_type, public_config, encrypted_secret_json,
@@ -46,6 +53,23 @@ public class CredentialProfileRepository {
                 .stream()
                 .map(this::mapRow)
                 .toList();
+    }
+
+    public CredentialProfile findByTenantAndId(String tenantCode, String id) {
+        if (id == null || id.isBlank()) {
+            return null;
+        }
+        UUID profileId;
+        try {
+            profileId = UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        var rows = client().preparedQuery(SELECT_BY_ID)
+                .execute(Tuple.of(tenantCode, profileId))
+                .await().indefinitely();
+        var iterator = rows.iterator();
+        return iterator.hasNext() ? mapRow(iterator.next()) : null;
     }
 
     public CredentialProfile create(CredentialProfile profile) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -15,6 +15,7 @@ import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepos
 import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
 import com.microboxlabs.miot.integrations.secret.IntegrationSecretCipher;
 import com.microboxlabs.miot.integrations.secret.IntegrationSecretEncryptionException;
+import com.microboxlabs.miot.integrations.tester.ConnectionTesterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
@@ -33,17 +34,20 @@ public class IntegrationConnectionService {
     private final IntegrationConnectionRepository connectionRepository;
     private final IntegrationOperationRepository operationRepository;
     private final IntegrationSecretCipher secretCipher;
+    private final ConnectionTesterRegistry testerRegistry;
 
     @Inject
     public IntegrationConnectionService(
             CredentialProfileRepository credentialProfileRepository,
             IntegrationConnectionRepository connectionRepository,
             IntegrationOperationRepository operationRepository,
-            IntegrationSecretCipher secretCipher) {
+            IntegrationSecretCipher secretCipher,
+            ConnectionTesterRegistry testerRegistry) {
         this.credentialProfileRepository = credentialProfileRepository;
         this.connectionRepository = connectionRepository;
         this.operationRepository = operationRepository;
         this.secretCipher = secretCipher;
+        this.testerRegistry = testerRegistry;
     }
 
     public List<CredentialProfileResponse> listCredentialProfiles(String tenantCode) {
@@ -137,17 +141,17 @@ public class IntegrationConnectionService {
             return new ConnectionTestResponse(false, OffsetDateTime.now(), "Connection not found");
         }
 
-        OffsetDateTime now = OffsetDateTime.now();
-        connectionRepository.updateTestResult(connection.tenantCode(), connection.id(), ConnectionStatus.ACTIVE, now, true);
-        return new ConnectionTestResponse(true, now, testMessage(req));
-    }
+        CredentialProfile credential = connection.credentialProfileId() == null
+                ? null
+                : credentialProfileRepository.findByTenantAndId(tenantCode, connection.credentialProfileId());
 
-    private String testMessage(ConnectionTestRequest req) {
-        if (req == null || req.path() == null || req.path().isBlank()) {
-            return "Connection contract is valid; runtime probe pending";
-        }
-        String method = req.method() == null || req.method().isBlank() ? "GET" : req.method();
-        return "Connection contract is valid for " + method + " " + req.path() + "; runtime probe pending";
+        ConnectionTestResponse response = testerRegistry.testerFor(connection.providerType())
+                .test(connection, credential, req);
+
+        ConnectionStatus status = response.success() ? ConnectionStatus.ACTIVE : ConnectionStatus.TEST_FAILED;
+        connectionRepository.updateTestResult(
+                connection.tenantCode(), connection.id(), status, response.testedAt(), response.success());
+        return response;
     }
 
     private CredentialProfileResponse toResponse(CredentialProfile profile) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/ConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/ConnectionTester.java
@@ -1,0 +1,25 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+
+/**
+ * Provider-specific connectivity check for an integration connection. Implementations
+ * declare which {@link ProviderType}s they handle; the {@link ConnectionTesterRegistry}
+ * routes a connection to the right one (falling back to a generic contract check).
+ */
+public interface ConnectionTester {
+
+    boolean supports(ProviderType providerType);
+
+    /**
+     * @param credential the connection's linked credential profile, or {@code null} if none is set
+     */
+    ConnectionTestResponse test(
+            IntegrationConnection connection,
+            CredentialProfile credential,
+            ConnectionTestRequest request);
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/ConnectionTesterRegistry.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/ConnectionTesterRegistry.java
@@ -1,0 +1,33 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Routes a connection to the {@link ConnectionTester} that handles its provider type,
+ * falling back to {@link GenericConnectionTester} (contract-only check) when no live
+ * probe is registered.
+ */
+@ApplicationScoped
+public class ConnectionTesterRegistry {
+
+    private final Instance<ConnectionTester> testers;
+    private final GenericConnectionTester fallback;
+
+    @Inject
+    public ConnectionTesterRegistry(Instance<ConnectionTester> testers, GenericConnectionTester fallback) {
+        this.testers = testers;
+        this.fallback = fallback;
+    }
+
+    public ConnectionTester testerFor(ProviderType providerType) {
+        for (ConnectionTester tester : testers) {
+            if (tester.supports(providerType)) {
+                return tester;
+            }
+        }
+        return fallback;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
@@ -7,6 +7,7 @@ import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 /**
  * Fallback tester for providers without a live probe. Validates the connection
@@ -26,7 +27,7 @@ public class GenericConnectionTester implements ConnectionTester {
             IntegrationConnection connection,
             CredentialProfile credential,
             ConnectionTestRequest request) {
-        return new ConnectionTestResponse(true, OffsetDateTime.now(), message(request));
+        return new ConnectionTestResponse(true, OffsetDateTime.now(ZoneOffset.UTC), message(request));
     }
 
     private String message(ConnectionTestRequest request) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
@@ -1,0 +1,39 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.OffsetDateTime;
+
+/**
+ * Fallback tester for providers without a live probe. Validates the connection
+ * contract only (preserves the original pre-probe behaviour). Never matches a
+ * specific provider; the registry uses it as the default.
+ */
+@ApplicationScoped
+public class GenericConnectionTester implements ConnectionTester {
+
+    @Override
+    public boolean supports(ProviderType providerType) {
+        return false;
+    }
+
+    @Override
+    public ConnectionTestResponse test(
+            IntegrationConnection connection,
+            CredentialProfile credential,
+            ConnectionTestRequest request) {
+        return new ConnectionTestResponse(true, OffsetDateTime.now(), message(request));
+    }
+
+    private String message(ConnectionTestRequest request) {
+        if (request == null || request.path() == null || request.path().isBlank()) {
+            return "Connection contract is valid; runtime probe pending";
+        }
+        String method = request.method() == null || request.method().isBlank() ? "GET" : request.method();
+        return "Connection contract is valid for " + method + " " + request.path() + "; runtime probe pending";
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTester.java
@@ -15,6 +15,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 /**
@@ -52,7 +53,7 @@ public class WhatsAppConnectionTester implements ConnectionTester {
             IntegrationConnection connection,
             CredentialProfile credential,
             ConnectionTestRequest request) {
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
         if (connection.baseUrl() == null) {
             return fail(now, "Connection base URL is not set (expected https://graph.facebook.com/<version>)");

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTester.java
@@ -1,0 +1,122 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import com.microboxlabs.miot.integrations.secret.IntegrationSecretCipher;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+/**
+ * Live connectivity check for a WHATSAPP connection. Calls
+ * {@code GET {baseUrl}/{phone_number_id}} on the Meta Graph API with the connection's
+ * bearer access token (resolved from the linked credential profile). A 2xx response
+ * means the token + phone-number-id are valid.
+ */
+@ApplicationScoped
+public class WhatsAppConnectionTester implements ConnectionTester {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final String PHONE_NUMBER_ID = "phone_number_id";
+
+    private final HttpClient httpClient;
+    private final IntegrationSecretCipher secretCipher;
+
+    @Inject
+    public WhatsAppConnectionTester(IntegrationSecretCipher secretCipher) {
+        this(HttpClient.newHttpClient(), secretCipher);
+    }
+
+    WhatsAppConnectionTester(HttpClient httpClient, IntegrationSecretCipher secretCipher) {
+        this.httpClient = httpClient;
+        this.secretCipher = secretCipher;
+    }
+
+    @Override
+    public boolean supports(ProviderType providerType) {
+        return providerType == ProviderType.WHATSAPP;
+    }
+
+    @Override
+    public ConnectionTestResponse test(
+            IntegrationConnection connection,
+            CredentialProfile credential,
+            ConnectionTestRequest request) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (connection.baseUrl() == null) {
+            return fail(now, "Connection base URL is not set (expected https://graph.facebook.com/<version>)");
+        }
+        String phoneNumberId = metadataString(connection, PHONE_NUMBER_ID);
+        if (phoneNumberId == null || phoneNumberId.isBlank()) {
+            return fail(now, "metadata.phone_number_id is required for a WhatsApp connection");
+        }
+        if (credential == null) {
+            return fail(now, "No credential profile is linked to this connection");
+        }
+
+        String token;
+        try {
+            Map<String, Object> secret = secretCipher.decrypt(credential.encryptedSecretJson());
+            Object value = secret.get("token");
+            token = value == null ? null : value.toString();
+        } catch (RuntimeException e) {
+            return fail(now, "Could not read the access token from the credential profile");
+        }
+        if (token == null || token.isBlank()) {
+            return fail(now, "Credential profile does not contain a 'token' secret");
+        }
+
+        URI uri = URI.create(trimTrailingSlash(connection.baseUrl().toString()) + "/" + phoneNumberId);
+        HttpRequest httpRequest = HttpRequest.newBuilder(uri)
+                .timeout(REQUEST_TIMEOUT)
+                .header("Authorization", "Bearer " + token)
+                .GET()
+                .build();
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            return fail(now, "Could not reach Meta Graph API: " + e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return fail(now, "WhatsApp connection test was interrupted");
+        }
+
+        int status = response.statusCode();
+        if (status >= 200 && status < 300) {
+            return new ConnectionTestResponse(true, now,
+                    "WhatsApp connection OK — Meta returned HTTP " + status + " for phone number " + phoneNumberId);
+        }
+        return fail(now,
+                "Meta Graph API returned HTTP " + status + " — check the access token and phone_number_id");
+    }
+
+    private static String metadataString(IntegrationConnection connection, String key) {
+        Map<String, Object> metadata = connection.metadata();
+        if (metadata == null) {
+            return null;
+        }
+        Object value = metadata.get(key);
+        return value == null ? null : value.toString();
+    }
+
+    private static String trimTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static ConnectionTestResponse fail(OffsetDateTime testedAt, String message) {
+        return new ConnectionTestResponse(false, testedAt, message);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__add_whatsapp_provider_type.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.1__add_whatsapp_provider_type.sql
@@ -1,0 +1,18 @@
+-- Extend the integration_connections provider_type allow-list with WHATSAPP
+-- (Meta WhatsApp Cloud API channel). New migration on purpose — never mutate the
+-- already-applied V0.6.0 (Flyway checksum).
+ALTER TABLE miot_integrations.integration_connections
+    DROP CONSTRAINT chk_integration_connections_provider_type;
+
+ALTER TABLE miot_integrations.integration_connections
+    ADD CONSTRAINT chk_integration_connections_provider_type CHECK (
+        provider_type IN (
+            'POSTGREST',
+            'ALERCE_TMS',
+            'N8N',
+            'AUTH0',
+            'ECM',
+            'CUSTOM_HTTP',
+            'WHATSAPP'
+        )
+    );

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
@@ -24,6 +24,6 @@ class IntegrationConnectionServiceTest {
     }
 
     private IntegrationConnectionService serviceWithoutDependencies() {
-        return new IntegrationConnectionService(null, null, null, null);
+        return new IntegrationConnectionService(null, null, null, null, null);
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
@@ -1,0 +1,151 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
+import com.microboxlabs.miot.integrations.domain.CredentialProfile;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import com.microboxlabs.miot.integrations.secret.IntegrationSecretCipher;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WhatsAppConnectionTesterTest {
+
+    private static final String PHONE_NUMBER_ID = "1188646904321987";
+    private static final String TOKEN = "EAAtest-token";
+
+    private final IntegrationSecretCipher cipher =
+            new IntegrationSecretCipher(new ObjectMapper(), "unit-test-key");
+    private final WhatsAppConnectionTester tester =
+            new WhatsAppConnectionTester(HttpClient.newHttpClient(), cipher);
+
+    private HttpServer server;
+    private final AtomicReference<String> seenAuthHeader = new AtomicReference<>();
+    private final AtomicReference<String> seenPath = new AtomicReference<>();
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void returnsSuccessWhenMetaReturns2xx() throws IOException {
+        startServer(200, "{\"id\":\"" + PHONE_NUMBER_ID + "\",\"display_phone_number\":\"+56 9 6231 1587\"}");
+        IntegrationConnection connection = connection(URI.create(baseUrl()), Map.of("phone_number_id", PHONE_NUMBER_ID));
+
+        ConnectionTestResponse response = tester.test(connection, bearerCredential(TOKEN), new ConnectionTestRequest("GET", null));
+
+        assertTrue(response.success());
+        assertTrue(response.message().contains("OK"));
+        assertEquals("Bearer " + TOKEN, seenAuthHeader.get());
+        assertEquals("/" + PHONE_NUMBER_ID, seenPath.get());
+    }
+
+    @Test
+    void returnsFailureWhenMetaRejectsToken() throws IOException {
+        startServer(401, "{\"error\":{\"message\":\"Invalid OAuth access token\"}}");
+        IntegrationConnection connection = connection(URI.create(baseUrl()), Map.of("phone_number_id", PHONE_NUMBER_ID));
+
+        ConnectionTestResponse response = tester.test(connection, bearerCredential(TOKEN), new ConnectionTestRequest("GET", null));
+
+        assertFalse(response.success());
+        assertTrue(response.message().contains("401"));
+    }
+
+    @Test
+    void failsFastWhenPhoneNumberIdMissing() {
+        IntegrationConnection connection = connection(URI.create("https://graph.facebook.com/v25.0"), Map.of());
+
+        ConnectionTestResponse response = tester.test(connection, bearerCredential(TOKEN), new ConnectionTestRequest("GET", null));
+
+        assertFalse(response.success());
+        assertTrue(response.message().contains("phone_number_id"));
+    }
+
+    @Test
+    void failsWhenNoCredentialLinked() {
+        IntegrationConnection connection =
+                connection(URI.create("https://graph.facebook.com/v25.0"), Map.of("phone_number_id", PHONE_NUMBER_ID));
+
+        ConnectionTestResponse response = tester.test(connection, null, new ConnectionTestRequest("GET", null));
+
+        assertFalse(response.success());
+        assertTrue(response.message().contains("credential"));
+    }
+
+    @Test
+    void supportsOnlyWhatsApp() {
+        assertTrue(tester.supports(ProviderType.WHATSAPP));
+        assertFalse(tester.supports(ProviderType.N8N));
+    }
+
+    private void startServer(int status, String body) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            seenAuthHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            seenPath.set(exchange.getRequestURI().getPath());
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, payload.length);
+            exchange.getResponseBody().write(payload);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    private String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    private CredentialProfile bearerCredential(String token) {
+        String encrypted = cipher.encrypt(Map.of("token", token));
+        assertNotNull(encrypted);
+        OffsetDateTime now = OffsetDateTime.now();
+        return new CredentialProfile(
+                UUID.randomUUID().toString(),
+                "tenant-1",
+                "WhatsApp Cloud Token",
+                AuthType.BEARER_TOKEN,
+                Map.of(),
+                encrypted,
+                "****",
+                1,
+                now,
+                now);
+    }
+
+    private IntegrationConnection connection(URI baseUrl, Map<String, Object> metadata) {
+        return new IntegrationConnection(
+                UUID.randomUUID().toString(),
+                "tenant-1",
+                "WhatsApp Prod",
+                ProviderType.WHATSAPP,
+                baseUrl,
+                UUID.randomUUID().toString(),
+                ConnectionStatus.DRAFT,
+                null,
+                null,
+                metadata);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class WhatsAppConnectionTesterTest {


### PR DESCRIPTION
## Summary
First foundation slice of the **WhatsApp communication-channel** capability (roadmap / **demo-first — not production rollout**). Adds `WHATSAPP` as a per-org integration provider so a WhatsApp Cloud API channel can be configured and validated through the existing `miot-integrations` connections + credential-profile machinery. No new service, no public wiring — just the provider + a real connectivity test.

Part of the phased plan, **Phase 0 — Foundations** (slice 1 of 3).

## What's in it (`quarkus-srv/miot-integrations`)
- `ProviderType.WHATSAPP`
- Flyway **`V0.6.1`** — extends the `provider_type` CHECK constraint (new migration; the applied `V0.6.0` is left untouched)
- **`ConnectionTester` SPI**
  - `WhatsAppConnectionTester` — live probe `GET {baseUrl}/{phone_number_id}` with the bearer token (2xx ⇒ OK; clear failure messages for missing phone-id / missing credential / non-2xx)
  - `GenericConnectionTester` — contract-only fallback; **preserves the prior behaviour for the other 6 providers**
  - `ConnectionTesterRegistry` — routes a connection to the right tester
- `CredentialProfileRepository.findByTenantAndId`
- `IntegrationConnectionService.testConnection` now runs the provider probe and persists **ACTIVE / TEST_FAILED**

## Connection shape
- Bearer System-User token in a credential profile (`secretConfig.token`)
- Non-secret `metadata{ phone_number_id, waba_id, graph_version }`
- `baseUrl = https://graph.facebook.com/v25.0`

## Test plan
```
./mvnw -pl miot-integrations test \
  -Dtest='WhatsAppConnectionTesterTest,IntegrationConnectionServiceTest' \
  -Dsurefire.failIfNoSpecifiedTests=false
```
→ **6 tests, 0 failures** (5 new in `WhatsAppConnectionTesterTest`: success / 401 / missing phone-id / no credential / supports-only-WhatsApp).

## Out of scope (later phases)
- `miot-conversational` module + message-pool tables
- Settings UI to create/test the connection
- Webhook, send, harness mediation

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WhatsApp as a connection provider.
  * Added live connection testing for WhatsApp integrations.

* **Bug Fixes**
  * Connection tests now return clearer success/failure results and record the latest test outcome correctly.
  * Improved validation for missing connection details and credentials during testing.

* **Improvements**
  * Connection profile lookup now supports direct access by tenant and profile ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->