### PR TITLE
feat(conversational): miot-conversational module skeleton + WhatsApp message-pool tables

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-conversational</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
             <artifactId>miot-driver</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
+++ b/quarkus-srv/miot-cli/src/main/java/com/microboxlabs/miot/cli/FlywayMigrator.java
@@ -35,6 +35,9 @@ public class FlywayMigrator {
     @ConfigProperty(name = "miot.component.integrations.enabled", defaultValue = "false")
     boolean integrationsEnabled;
 
+    @ConfigProperty(name = "miot.component.conversational.enabled", defaultValue = "false")
+    boolean conversationalEnabled;
+
     @ConfigProperty(name = "quarkus.datasource.active", defaultValue = "true")
     boolean dataSourceActive;
 
@@ -42,7 +45,8 @@ public class FlywayMigrator {
         // Gateway and other stateless components have no DB schema.
         // Skip migration entirely when no DB-dependent component is active
         // to avoid connecting to (or validating against) a database that isn't needed.
-        if (!fleetEnabled && !driverEnabled && !trackingEnabled && !integrationsEnabled) {
+        if (!fleetEnabled && !driverEnabled && !trackingEnabled && !integrationsEnabled
+                && !conversationalEnabled) {
             LOG.debug("No DB-dependent components enabled — skipping Flyway");
             return;
         }
@@ -70,6 +74,9 @@ public class FlywayMigrator {
         }
         if (integrationsEnabled) {
             locations.add("db/migration/integrations");
+        }
+        if (conversationalEnabled) {
+            locations.add("db/migration/conversational");
         }
 
         LOG.infof("Flyway locations: %s", locations);

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -13,6 +13,7 @@ miot.component.driver.enabled=${miot.component.all.enabled}
 miot.component.tracking.enabled=${miot.component.all.enabled}
 miot.component.gateway.enabled=${miot.component.all.enabled}
 miot.component.integrations.enabled=${miot.component.all.enabled}
+miot.component.conversational.enabled=${miot.component.all.enabled}
 miot.integrations.secret-key=${MIOT_INTEGRATIONS_SECRET_KEY:not-configured}
 
 # --- HTTP ---

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microboxlabs.miot</groupId>
+        <artifactId>miot-parent</artifactId>
+        <version>0.5.15</version>
+    </parent>
+
+    <artifactId>miot-conversational</artifactId>
+    <name>ModularIoT — Conversational</name>
+    <description>WhatsApp conversational channel: message pool, outbound send, inbound webhook</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microboxlabs.miot</groupId>
+            <artifactId>miot-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-pg-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/ConversationalComponent.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/ConversationalComponent.java
@@ -1,17 +1,20 @@
 package com.microboxlabs.miot.conversational;
 
-import com.microboxlabs.miot.core.config.IMiotComponent;
+import com.microboxlabs.miot.core.config.AbstractMiotComponent;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
 @LookupIfProperty(name = "miot.component.conversational.enabled", stringValue = "true")
-public class ConversationalComponent implements IMiotComponent {
+public class ConversationalComponent extends AbstractMiotComponent {
 
     private static final Logger LOG = Logger.getLogger(ConversationalComponent.class);
+
+    @Override
+    protected Logger log() {
+        return LOG;
+    }
 
     @Override
     public String name() {
@@ -21,20 +24,5 @@ public class ConversationalComponent implements IMiotComponent {
     @Override
     public int priority() {
         return 160;
-    }
-
-    @Override
-    public void onStart() {
-        LOG.info("Conversational component started");
-    }
-
-    @Override
-    public void onStop() {
-        LOG.info("Conversational component stopped");
-    }
-
-    @Override
-    public HealthCheck healthCheck() {
-        return () -> HealthCheckResponse.named("conversational").up().build();
     }
 }

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/ConversationalComponent.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/ConversationalComponent.java
@@ -1,0 +1,40 @@
+package com.microboxlabs.miot.conversational;
+
+import com.microboxlabs.miot.core.config.IMiotComponent;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@LookupIfProperty(name = "miot.component.conversational.enabled", stringValue = "true")
+public class ConversationalComponent implements IMiotComponent {
+
+    private static final Logger LOG = Logger.getLogger(ConversationalComponent.class);
+
+    @Override
+    public String name() {
+        return "conversational";
+    }
+
+    @Override
+    public int priority() {
+        return 160;
+    }
+
+    @Override
+    public void onStart() {
+        LOG.info("Conversational component started");
+    }
+
+    @Override
+    public void onStop() {
+        LOG.info("Conversational component stopped");
+    }
+
+    @Override
+    public HealthCheck healthCheck() {
+        return () -> HealthCheckResponse.named("conversational").up().build();
+    }
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/Conversation.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/Conversation.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.conversational.domain;
+
+import java.time.OffsetDateTime;
+
+/**
+ * One WhatsApp conversation per (tenant, phone). Holds the current trip context the
+ * conversation is about (anchored on outbound trip-tied sends) plus 24h-window state,
+ * so the whole interaction history per number / per driver is recoverable.
+ */
+public record Conversation(
+        String id,
+        String tenantCode,
+        String phoneE164,
+        String waContactName,
+        String driverId,
+        String contextServiceCode,
+        String contextProcessInstanceId,
+        String contextTaskId,
+        ConversationStatus status,
+        OffsetDateTime lastInboundAt,
+        OffsetDateTime lastOutboundAt,
+        OffsetDateTime lastMessageAt,
+        OffsetDateTime sessionExpiresAt,
+        String lastMessagePreview,
+        int unreadCount,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/ConversationStatus.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/ConversationStatus.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.conversational.domain;
+
+public enum ConversationStatus {
+    OPEN,
+    ARCHIVED
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/Message.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/Message.java
@@ -1,0 +1,33 @@
+package com.microboxlabs.miot.conversational.domain;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+/**
+ * A single message in the timeline of a {@link Conversation}. {@code serviceCode} /
+ * {@code processInstanceId} are snapshotted so the message stays attributable to a trip
+ * even after the conversation's current context moves on.
+ */
+public record Message(
+        String id,
+        String conversationId,
+        MessageDirection direction,
+        MessageRole role,
+        MessageType type,
+        String body,
+        String templateName,
+        String mediaRef,
+        String mediaMimeType,
+        String mediaFileName,
+        String metaMessageId,
+        MessageStatus status,
+        String errorMessage,
+        String sentByUserId,
+        String serviceCode,
+        String processInstanceId,
+        Map<String, Object> metadata,
+        OffsetDateTime sentAt,
+        OffsetDateTime deliveredAt,
+        OffsetDateTime readAt,
+        OffsetDateTime createdAt) {
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageDirection.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageDirection.java
@@ -1,0 +1,6 @@
+package com.microboxlabs.miot.conversational.domain;
+
+public enum MessageDirection {
+    INBOUND,
+    OUTBOUND
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageRole.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageRole.java
@@ -1,0 +1,8 @@
+package com.microboxlabs.miot.conversational.domain;
+
+public enum MessageRole {
+    DRIVER,
+    AGENT,
+    SYSTEM,
+    HARNESS
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageStatus.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageStatus.java
@@ -1,0 +1,10 @@
+package com.microboxlabs.miot.conversational.domain;
+
+public enum MessageStatus {
+    RECEIVED,
+    PENDING,
+    SENT,
+    DELIVERED,
+    READ,
+    FAILED
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageType.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/domain/MessageType.java
@@ -1,0 +1,12 @@
+package com.microboxlabs.miot.conversational.domain;
+
+public enum MessageType {
+    TEXT,
+    IMAGE,
+    DOCUMENT,
+    AUDIO,
+    VIDEO,
+    STICKER,
+    TEMPLATE,
+    UNKNOWN
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
@@ -1,0 +1,104 @@
+package com.microboxlabs.miot.conversational.persistence;
+
+import com.microboxlabs.miot.conversational.domain.Conversation;
+import com.microboxlabs.miot.conversational.domain.ConversationStatus;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.util.UUID;
+
+/**
+ * Persistence for {@link Conversation} (the WhatsApp message-pool head row). Thin
+ * skeleton for the channel foundation; send/webhook flows extend it in later slices.
+ */
+@ApplicationScoped
+public class ConversationRepository {
+
+    private static final String SELECT_BY_TENANT_AND_PHONE = """
+            SELECT id, tenant_code, phone_e164, wa_contact_name, driver_id,
+                   context_service_code, context_process_instance_id, context_task_id,
+                   status, last_inbound_at, last_outbound_at, last_message_at,
+                   session_expires_at, last_message_preview, unread_count, created_at, updated_at
+            FROM miot_conversational.wa_conversation
+            WHERE tenant_code = $1 AND phone_e164 = $2
+            """;
+
+    private static final String INSERT = """
+            INSERT INTO miot_conversational.wa_conversation (
+                id, tenant_code, phone_e164, wa_contact_name, driver_id,
+                context_service_code, context_process_instance_id, context_task_id,
+                status, last_inbound_at, last_outbound_at, last_message_at,
+                session_expires_at, last_message_preview, unread_count, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+            RETURNING id, tenant_code, phone_e164, wa_contact_name, driver_id,
+                      context_service_code, context_process_instance_id, context_task_id,
+                      status, last_inbound_at, last_outbound_at, last_message_at,
+                      session_expires_at, last_message_preview, unread_count, created_at, updated_at
+            """;
+
+    private final Instance<Pool> clientInstance;
+
+    ConversationRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public Conversation findByTenantAndPhone(String tenantCode, String phoneE164) {
+        var rows = client().preparedQuery(SELECT_BY_TENANT_AND_PHONE)
+                .execute(Tuple.of(tenantCode, phoneE164))
+                .await().indefinitely();
+        var iterator = rows.iterator();
+        return iterator.hasNext() ? mapRow(iterator.next()) : null;
+    }
+
+    public Conversation create(Conversation conversation) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(conversation.id()))
+                .addString(conversation.tenantCode())
+                .addString(conversation.phoneE164())
+                .addString(conversation.waContactName())
+                .addString(conversation.driverId())
+                .addString(conversation.contextServiceCode())
+                .addString(conversation.contextProcessInstanceId())
+                .addString(conversation.contextTaskId())
+                .addString(conversation.status().name())
+                .addOffsetDateTime(conversation.lastInboundAt())
+                .addOffsetDateTime(conversation.lastOutboundAt())
+                .addOffsetDateTime(conversation.lastMessageAt())
+                .addOffsetDateTime(conversation.sessionExpiresAt())
+                .addString(conversation.lastMessagePreview())
+                .addInteger(conversation.unreadCount())
+                .addOffsetDateTime(conversation.createdAt())
+                .addOffsetDateTime(conversation.updatedAt());
+        return mapRow(client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely()
+                .iterator().next());
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private Conversation mapRow(Row row) {
+        return new Conversation(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("phone_e164"),
+                row.getString("wa_contact_name"),
+                row.getString("driver_id"),
+                row.getString("context_service_code"),
+                row.getString("context_process_instance_id"),
+                row.getString("context_task_id"),
+                ConversationStatus.valueOf(row.getString("status")),
+                row.getOffsetDateTime("last_inbound_at"),
+                row.getOffsetDateTime("last_outbound_at"),
+                row.getOffsetDateTime("last_message_at"),
+                row.getOffsetDateTime("session_expires_at"),
+                row.getString("last_message_preview"),
+                row.getInteger("unread_count"),
+                row.getOffsetDateTime("created_at"),
+                row.getOffsetDateTime("updated_at"));
+    }
+}

--- a/quarkus-srv/miot-conversational/src/main/resources/db/migration/conversational/V0.7.0__create_conversational_schema.sql
+++ b/quarkus-srv/miot-conversational/src/main/resources/db/migration/conversational/V0.7.0__create_conversational_schema.sql
@@ -1,0 +1,87 @@
+-- WhatsApp conversational channel: message pool (per number / per driver history).
+-- Component-scoped migration applied by FlywayMigrator when
+-- miot.component.conversational.enabled=true. Owns its own schema; the shared
+-- Flyway history lives in miot_core.
+CREATE SCHEMA IF NOT EXISTS miot_conversational;
+
+-- One conversation per (tenant, phone). Carries the current trip context the
+-- conversation is about plus 24h-window state.
+CREATE TABLE miot_conversational.wa_conversation (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id                   BIGINT REFERENCES miot_core.tenants(id),
+    tenant_code                 VARCHAR(128) NOT NULL,
+    phone_e164                  VARCHAR(32)  NOT NULL,
+    wa_contact_name             VARCHAR(255),
+    driver_id                   VARCHAR(128),
+    context_service_code        VARCHAR(128),
+    context_process_instance_id VARCHAR(128),
+    context_task_id             VARCHAR(128),
+    status                      VARCHAR(32)  NOT NULL DEFAULT 'OPEN',
+    last_inbound_at             TIMESTAMPTZ,
+    last_outbound_at            TIMESTAMPTZ,
+    last_message_at             TIMESTAMPTZ,
+    session_expires_at          TIMESTAMPTZ,
+    last_message_preview        VARCHAR(280),
+    unread_count                INTEGER      NOT NULL DEFAULT 0,
+    created_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_wa_conversation_status CHECK (status IN ('OPEN', 'ARCHIVED'))
+);
+
+CREATE UNIQUE INDEX idx_wa_conversation_tenant_phone
+    ON miot_conversational.wa_conversation(tenant_code, phone_e164);
+CREATE INDEX idx_wa_conversation_tenant_last_message
+    ON miot_conversational.wa_conversation(tenant_code, last_message_at DESC);
+CREATE INDEX idx_wa_conversation_context_service
+    ON miot_conversational.wa_conversation(context_service_code);
+
+-- Message timeline. service_code / process_instance_id are snapshotted so a message
+-- stays attributable to a trip even after the conversation's context moves on.
+CREATE TABLE miot_conversational.wa_message (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id     UUID NOT NULL
+                            REFERENCES miot_conversational.wa_conversation(id) ON DELETE CASCADE,
+    direction           VARCHAR(16) NOT NULL,
+    role                VARCHAR(16) NOT NULL,
+    msg_type            VARCHAR(16) NOT NULL,
+    body                TEXT,
+    template_name       VARCHAR(255),
+    media_ref           TEXT,
+    media_mime_type     VARCHAR(128),
+    media_file_name     VARCHAR(255),
+    meta_message_id     VARCHAR(255),
+    status              VARCHAR(16) NOT NULL DEFAULT 'PENDING',
+    error_message       TEXT,
+    sent_by_user_id     VARCHAR(128),
+    service_code        VARCHAR(128),
+    process_instance_id VARCHAR(128),
+    metadata            JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    sent_at             TIMESTAMPTZ,
+    delivered_at        TIMESTAMPTZ,
+    read_at             TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_wa_message_direction CHECK (direction IN ('INBOUND', 'OUTBOUND')),
+    CONSTRAINT chk_wa_message_role CHECK (role IN ('DRIVER', 'AGENT', 'SYSTEM', 'HARNESS')),
+    CONSTRAINT chk_wa_message_type CHECK (
+        msg_type IN ('TEXT', 'IMAGE', 'DOCUMENT', 'AUDIO', 'VIDEO', 'STICKER', 'TEMPLATE', 'UNKNOWN')
+    ),
+    CONSTRAINT chk_wa_message_status CHECK (
+        status IN ('RECEIVED', 'PENDING', 'SENT', 'DELIVERED', 'READ', 'FAILED')
+    )
+);
+
+CREATE INDEX idx_wa_message_conversation_created
+    ON miot_conversational.wa_message(conversation_id, created_at);
+-- Dedup Meta's wamid (nullable for locally-originated rows before send completes).
+CREATE UNIQUE INDEX idx_wa_message_meta_message_id
+    ON miot_conversational.wa_message(meta_message_id)
+    WHERE meta_message_id IS NOT NULL;
+
+-- Webhook idempotency: one row per processed external event; survives Meta retries.
+CREATE TABLE miot_conversational.wa_webhook_idempotency (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source      VARCHAR(64)  NOT NULL,
+    external_id VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uq_wa_webhook_idempotency UNIQUE (source, external_id)
+);

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/config/AbstractMiotComponent.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/config/AbstractMiotComponent.java
@@ -1,0 +1,32 @@
+package com.microboxlabs.miot.core.config;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.logging.Logger;
+
+/**
+ * Base {@link IMiotComponent} that supplies the standard lifecycle boilerplate
+ * (start/stop logging + an UP health check named after the component). Concrete
+ * components only declare {@link #name()}, {@link #priority()} and a
+ * {@link #log() logger}. Existing components may migrate to this over time.
+ */
+public abstract class AbstractMiotComponent implements IMiotComponent {
+
+    /** Component-specific logger used for the lifecycle log lines. */
+    protected abstract Logger log();
+
+    @Override
+    public void onStart() {
+        log().infof("%s component started", name());
+    }
+
+    @Override
+    public void onStop() {
+        log().infof("%s component stopped", name());
+    }
+
+    @Override
+    public HealthCheck healthCheck() {
+        return () -> HealthCheckResponse.named(name()).up().build();
+    }
+}

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -17,6 +17,7 @@
         <module>miot-core</module>
         <module>miot-resource-core</module>
         <module>miot-integrations</module>
+        <module>miot-conversational</module>
         <module>miot-fleet</module>
         <module>miot-driver</module>
         <module>miot-tracking</module>
@@ -65,6 +66,11 @@
             <dependency>
                 <groupId>com.microboxlabs.miot</groupId>
                 <artifactId>miot-integrations</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microboxlabs.miot</groupId>
+                <artifactId>miot-conversational</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
Second foundation slice of the **WhatsApp communication-channel** capability (roadmap / **demo-first — not production**). Scaffolds a new modulith module that will own the WhatsApp **message pool**, outbound send, and the inbound webhook. This slice is the **module skeleton + Flyway message-pool tables** only — no send/webhook wiring yet. Independent of #751 (different module).

Part of the phased plan, **Phase 0 — Foundations** (slice 2 of 3).

## What's in it
- **New `miot-conversational` module** in the reactor (parent `pom.xml` modules + `dependencyManagement`; bundled by `miot-cli`)
- **`ConversationalComponent`** (`IMiotComponent`, gated by `miot.component.conversational.enabled`) — mirrors `IntegrationsComponent`
- **Domain**: `Conversation` + `Message` records + 5 enums (direction / role / type / status / conversation-status)
- **`ConversationRepository`** — thin Vert.x persistence skeleton (create + find-by-phone)
- **Flyway `V0.7.0`** (free 0.7.x range) → schema `miot_conversational` with:
  - `wa_conversation` — one per (tenant, phone); trip context + 24h-window state
  - `wa_message` — timeline; `service_code`/`process_instance_id` snapshotted
  - `wa_webhook_idempotency` — `(source, external_id)` unique for Meta retry de-dup
- **`FlywayMigrator`** registers the `conversational` component + `db/migration/conversational` location; flag added to `miot-cli` config

## Test plan
```
./mvnw -pl miot-cli -am test-compile   # full reactor → BUILD SUCCESS (miot-conversational = module 6/11)
```
⚠️ The migration isn't executed by the build — `FlywayMigrator` applies it at modulith boot when the component is enabled. The SQL mirrors the proven `integrations` migration; first real run is the Phase 1 dev/demo boot.

## Out of scope (later slices)
- Outbound send (template/session) + status mirroring
- Inbound webhook (verify + HMAC) + media download
- App REST surface, Settings UI, harness mediation

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)