### PR TITLE
feat: skills listing, /-autocomplete palette, and skill invocation across harness + CLI + chat

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miot-harness"
-version = "0.1.0"
+version = "0.2.0"
 description = "ASK MIOT multi-agent backend harness pilot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -26,6 +26,7 @@ from miot_harness.api.identity import (
 )
 from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.context_skills.loader import boot_context_skills
+from miot_harness.context_skills.skill_models import SkillSummary
 from miot_harness.datasource.registry import resolve as resolve_datasource
 from miot_harness.observability.otel import configure_tracing, shutdown_tracing
 from miot_harness.observability.provenance import ProvenanceLog
@@ -611,6 +612,26 @@ def create_app() -> FastAPI:
             ) from exc
         _enforce_tenant_owns_run(record, auth, run_id)
         return record
+
+    @app.get("/skills", response_model=list[SkillSummary])
+    async def get_skills(
+        tenant: str | None = Query(None),
+        auth: Mapping[str, Any] = Depends(require_auth),
+    ) -> list[SkillSummary]:
+        """List the skills available to the caller — the data behind a
+        `/skills` picker (chat) and `miot harness skills` (CLI).
+
+        Tenant precedence mirrors the runs endpoints: a verified header
+        tenant wins, else the `tenant` query param, else the configured
+        default. Returns ``[]`` when the Context/Skills subsystem failed to
+        boot (same degrade-don't-crash contract as the rest of the API).
+        """
+        harness: HarnessSupervisor = app.state.harness
+        bundle = harness.context_skills
+        if bundle is None:
+            return []
+        tenant_id = auth.get("tenant_id") or tenant or settings.default_tenant_id
+        return bundle.list_skills(tenant_id)
 
     @app.post("/runs:start", status_code=202)
     async def start_run(

--- a/miot-harness/src/miot_harness/context_skills/registry.py
+++ b/miot-harness/src/miot_harness/context_skills/registry.py
@@ -166,8 +166,11 @@ class ContextSkillsBundle:
                     when_to_use=skill.when_to_use,
                     scope=skill.scope.kind,
                     source=(
+                        # Match the basename, not a suffix: a substring
+                        # check would misbadge e.g. `foo-skill.md`.
                         "skill_md"
-                        if loaded.source_path.lower().endswith("skill.md")
+                        if loaded.source_path.rsplit("/", 1)[-1].lower()
+                        == "skill.md"
                         else "manifest"
                     ),
                 )

--- a/miot-harness/src/miot_harness/context_skills/registry.py
+++ b/miot-harness/src/miot_harness/context_skills/registry.py
@@ -22,7 +22,11 @@ from dataclasses import dataclass
 
 from miot_harness.agents.meta_agent import MetaAgentCatalogEntry
 from miot_harness.context_skills.models import SystemContext
-from miot_harness.context_skills.skill_models import LoadedSkill, PlaybookSkill
+from miot_harness.context_skills.skill_models import (
+    LoadedSkill,
+    PlaybookSkill,
+    SkillSummary,
+)
 
 
 @dataclass(frozen=True)
@@ -137,6 +141,55 @@ class ContextSkillsBundle:
             chosen[skill.id] = loaded
             chosen_tenant[skill.id] = tenant_scoped
         return list(chosen.values())
+
+    # ---- skill listing (autocomplete / picker) ----------------------------
+
+    def list_skills(self, tenant_id: str) -> list[SkillSummary]:
+        """Compact skill summaries for the requesting tenant — the data
+        behind a `/skills` listing / autocomplete.
+
+        Same set and layering as `playbooks_for` (Agent-Skills `SKILL.md`
+        directory skills included, since they load as playbooks), projected
+        to `SkillSummary` and sorted by name for a stable picker. `source`
+        is derived from the load path so the UI can badge a `SKILL.md`
+        directory skill distinctly from a YAML manifest.
+        """
+        summaries: list[SkillSummary] = []
+        for loaded in self.playbooks_for(tenant_id):
+            skill = loaded.skill
+            assert isinstance(skill, PlaybookSkill)  # playbooks_for guarantees
+            summaries.append(
+                SkillSummary(
+                    id=skill.id,
+                    name=skill.name,
+                    description=skill.description,
+                    when_to_use=skill.when_to_use,
+                    scope=skill.scope.kind,
+                    source=(
+                        "skill_md"
+                        if loaded.source_path.lower().endswith("skill.md")
+                        else "manifest"
+                    ),
+                )
+            )
+        return sorted(summaries, key=lambda s: s.name.lower())
+
+    def activate_skill(
+        self, tenant_id: str, skill_id: str
+    ) -> tuple[str, str] | None:
+        """Resolve a skill the tenant can see to ``(name, body)`` for
+        injection into a run, or ``None`` when unknown or bodyless.
+
+        This is the invocation half of skills: `list_skills` discovers
+        them, `activate_skill` hands back the SKILL.md body so the
+        supervisor can inject it as run guidance.
+        """
+        for loaded in self.playbooks_for(tenant_id):
+            skill = loaded.skill
+            assert isinstance(skill, PlaybookSkill)  # playbooks_for guarantees
+            if skill.id == skill_id and loaded.playbook_body:
+                return skill.name, loaded.playbook_body
+        return None
 
     # ---- helpers ----------------------------------------------------------
 

--- a/miot-harness/src/miot_harness/context_skills/skill_models.py
+++ b/miot-harness/src/miot_harness/context_skills/skill_models.py
@@ -84,3 +84,19 @@ class LoadedSkill(BaseModel):
     # when no playbook_ref was given).
     playbook_body: str | None = None
     source_path: str = ""
+
+
+class SkillSummary(BaseModel):
+    """Compact, API-facing projection of a skill for listing / autocomplete.
+
+    Mirrors the meta-catalog skill index: `description` / `when_to_use` are
+    the trigger text a `/skills`-style picker shows. `source` distinguishes
+    an Agent-Skills `SKILL.md` directory skill from a YAML manifest.
+    """
+
+    id: str
+    name: str
+    description: str = ""
+    when_to_use: str = ""
+    scope: Literal["global", "tenant"] = "global"
+    source: Literal["skill_md", "manifest"] = "manifest"

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -78,6 +78,11 @@ class UserRequest(BaseModel):
     mode: RunMode = "auto"
     conversation_id: str | None = None
     debug: bool = False
+    # Optional skill to activate for this run. When set and resolvable,
+    # the supervisor injects that skill's SKILL.md body as run guidance so
+    # the agent follows it (the invocation half of skills). Unknown ids are
+    # ignored — the run proceeds normally.
+    skill_id: str | None = None
     # Steering Plan A: optional permission posture supplied by the caller.
     # When omitted, the supervisor falls back to the sticky conversation
     # policy, then the tenant default.

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -26,7 +26,7 @@ import logging
 from typing import Any
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 
 from miot_harness.agents.direct_agent import (
     FALLBACK_DIRECT_ANSWER,
@@ -216,6 +216,7 @@ class HarnessSupervisor:
         # actually carry context across `/runs` calls (plan 13 §E5). Empty
         # list when no store, no conversation_id, or no prior history.
         prior_messages = self._hydrate_history(request)
+        prior_messages = self._inject_skill(request, ctx, prior_messages)
 
         try:
             if route.route == HarnessRoute.DATA_QUERY:
@@ -334,6 +335,37 @@ class HarnessSupervisor:
 
         if self.event_bus is not None:
             self.event_bus.close(run_id)
+
+    def _inject_skill(
+        self,
+        request: UserRequest,
+        ctx: HarnessContext,
+        prior_messages: list[BaseMessage],
+    ) -> list[BaseMessage]:
+        """Prepend an activated skill's body as run guidance.
+
+        When ``request.skill_id`` resolves to a skill the tenant can see,
+        its SKILL.md body is injected as a ``SystemMessage`` at the front
+        of the conversation so every run path (direct/meta/data/agentic)
+        follows it — the invocation half of skills. Unknown or bodyless
+        ids are ignored and the run proceeds normally (never a hard fail).
+        """
+        if not request.skill_id or self.context_skills is None:
+            return prior_messages
+        activated = self.context_skills.activate_skill(
+            ctx.tenant_id, request.skill_id
+        )
+        if activated is None:
+            return prior_messages
+        name, body = activated
+        guidance = SystemMessage(
+            content=(
+                f"# Active skill: {name}\n\n"
+                f'The user invoked the "{name}" skill. Follow these '
+                f"instructions for this run:\n\n{body}"
+            )
+        )
+        return [guidance, *prior_messages]
 
     def _hydrate_history(self, request: UserRequest) -> list[BaseMessage]:
         """Read prior turns from `ConversationStore` and trim them to fit the

--- a/miot-harness/tests/api/test_skills.py
+++ b/miot-harness/tests/api/test_skills.py
@@ -1,0 +1,90 @@
+"""Tests for the GET /skills listing endpoint (skills autocomplete/picker)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from miot_harness.api.server import create_app
+from miot_harness.context_skills.registry import ContextSkillsBundle
+from miot_harness.context_skills.skill_models import LoadedSkill, PlaybookSkill
+
+
+def _bundle() -> ContextSkillsBundle:
+    return ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook",
+                    id="skill-creator",
+                    name="skill-creator",
+                    description="Create new skills.",
+                    when_to_use="Create new skills.",
+                ),
+                source_path="/w/skills/skill-creator/SKILL.md",
+            ),
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook",
+                    id="delivery-compliance-story",
+                    name="Delivery Compliance Story",
+                    description="Delivery compliance.",
+                ),
+                source_path="/w/skills/playbooks/delivery.yaml",
+            ),
+        )
+    )
+
+
+def test_skills_lists_bundle_with_source_badge() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.harness.context_skills = _bundle()
+        resp = client.get("/skills")
+    assert resp.status_code == 200
+    body = resp.json()
+    by_id = {s["id"]: s for s in body}
+    assert by_id["skill-creator"]["source"] == "skill_md"
+    assert by_id["delivery-compliance-story"]["source"] == "manifest"
+    # description doubles as the trigger for an Agent-Skills directory skill.
+    assert by_id["skill-creator"]["when_to_use"] == "Create new skills."
+    # Sorted by name (case-insensitive): "Delivery..." before "skill-creator".
+    assert [s["name"] for s in body] == [
+        "Delivery Compliance Story",
+        "skill-creator",
+    ]
+
+
+def test_skills_empty_when_subsystem_absent() -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.harness.context_skills = None
+        resp = client.get("/skills")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_skills_tenant_query_scopes_results() -> None:
+    bundle = ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(kind="playbook", id="global-pb", name="Global"),
+                source_path="/w/g.yaml",
+            ),
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook",
+                    id="mintral-pb",
+                    name="Mintral",
+                    scope={"kind": "tenant", "tenant_id": "mintral"},  # type: ignore[arg-type]
+                ),
+                source_path="/w/m.yaml",
+            ),
+        )
+    )
+    app = create_app()
+    with TestClient(app) as client:
+        app.state.harness.context_skills = bundle
+        mintral = {s["id"] for s in client.get("/skills?tenant=mintral").json()}
+        acme = {s["id"] for s in client.get("/skills?tenant=acme").json()}
+    assert mintral == {"global-pb", "mintral-pb"}
+    assert acme == {"global-pb"}

--- a/miot-harness/tests/context_skills/test_bundle_layering.py
+++ b/miot-harness/tests/context_skills/test_bundle_layering.py
@@ -95,3 +95,57 @@ def test_skill_index_appended_to_facts() -> None:
     )
     names = {e.name for e in bundle.facts_for("acme")}
     assert "skill:pb1" in names
+
+
+def test_list_skills_projects_summaries_source_scope_and_sort() -> None:
+    bundle = ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook",
+                    id="zeta",
+                    name="Zeta",
+                    description="z desc",
+                    when_to_use="when z",
+                ),
+                source_path="/x/zeta.yaml",
+            ),
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook", id="alpha", name="Alpha", description="a desc"
+                ),
+                source_path="/x/alpha/SKILL.md",
+            ),
+            _playbook("mintral-only", "tenant", "mintral"),
+        )
+    )
+    skills = bundle.list_skills("mintral")
+    by_id = {s.id: s for s in skills}
+    # Global ∪ tenant, same layering as playbooks_for.
+    assert {"zeta", "alpha", "mintral-only"} <= set(by_id)
+    # source is derived from the load path: SKILL.md vs YAML manifest.
+    assert by_id["alpha"].source == "skill_md"
+    assert by_id["zeta"].source == "manifest"
+    assert by_id["zeta"].when_to_use == "when z"
+    # Stable, case-insensitive name sort for a deterministic picker.
+    names = [s.name for s in skills]
+    assert names == sorted(names, key=str.lower)
+    # A different tenant doesn't see the mintral-scoped skill.
+    assert "mintral-only" not in {s.id for s in bundle.list_skills("acme")}
+
+
+def test_activate_skill_returns_name_and_body() -> None:
+    bundle = ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(kind="playbook", id="sc", name="Skill Creator"),
+                playbook_body="BODY TEXT",
+                source_path="/w/sc/SKILL.md",
+            ),
+            _playbook("nobody", "global", None),  # no playbook_body
+        )
+    )
+    assert bundle.activate_skill("acme", "sc") == ("Skill Creator", "BODY TEXT")
+    # Bodyless and unknown skills are not activatable.
+    assert bundle.activate_skill("acme", "nobody") is None
+    assert bundle.activate_skill("acme", "missing") is None

--- a/miot-harness/tests/runtime/test_supervisor_skill.py
+++ b/miot-harness/tests/runtime/test_supervisor_skill.py
@@ -1,0 +1,80 @@
+"""Skill invocation: an activated skill's body is injected as run guidance."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from miot_harness.context_skills.registry import ContextSkillsBundle
+from miot_harness.context_skills.skill_models import LoadedSkill, PlaybookSkill
+from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.router import IntentRouter
+from miot_harness.runtime.run_store import JsonRunStore
+from miot_harness.runtime.supervisor import HarnessSupervisor
+from miot_harness.storytelling.module import StorytellingModule
+from miot_harness.tools.registry import ToolRegistry
+
+
+def _supervisor(tmp_path: Any, bundle: ContextSkillsBundle | None) -> HarnessSupervisor:
+    sup = HarnessSupervisor(
+        router=IntentRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        tenant_lock="mintral",
+    )
+    sup.context_skills = bundle
+    return sup
+
+
+def _bundle() -> ContextSkillsBundle:
+    return ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook", id="skill-creator", name="Skill Creator"
+                ),
+                playbook_body="# Skill Creator\nStep 1: decide what it does.",
+                source_path="/w/skills/skill-creator/SKILL.md",
+            ),
+            LoadedSkill(
+                skill=PlaybookSkill(kind="playbook", id="bodyless", name="Bodyless"),
+                playbook_body=None,
+                source_path="/w/skills/bodyless.yaml",
+            ),
+        )
+    )
+
+
+def test_inject_skill_prepends_body(tmp_path: Any) -> None:
+    sup = _supervisor(tmp_path, _bundle())
+    req = UserRequest(message="make one", tenant_id="mintral", skill_id="skill-creator")
+    out = sup._inject_skill(req, req.to_context(), [HumanMessage(content="prior")])
+    assert isinstance(out[0], SystemMessage)
+    assert "Skill Creator" in str(out[0].content)
+    assert "Step 1: decide" in str(out[0].content)
+    # Existing history is preserved after the injected guidance.
+    assert isinstance(out[1], HumanMessage)
+
+
+def test_inject_skill_unknown_id_is_noop(tmp_path: Any) -> None:
+    sup = _supervisor(tmp_path, _bundle())
+    req = UserRequest(message="x", tenant_id="mintral", skill_id="nope")
+    assert sup._inject_skill(req, req.to_context(), []) == []
+
+
+def test_inject_skill_bodyless_is_noop(tmp_path: Any) -> None:
+    sup = _supervisor(tmp_path, _bundle())
+    req = UserRequest(message="x", tenant_id="mintral", skill_id="bodyless")
+    assert sup._inject_skill(req, req.to_context(), []) == []
+
+
+def test_inject_skill_noop_without_skill_id_or_bundle(tmp_path: Any) -> None:
+    with_bundle = _supervisor(tmp_path, _bundle())
+    req = UserRequest(message="x", tenant_id="mintral")
+    assert with_bundle._inject_skill(req, req.to_context(), []) == []
+
+    no_bundle = _supervisor(tmp_path, None)
+    req2 = UserRequest(message="x", tenant_id="mintral", skill_id="skill-creator")
+    assert no_bundle._inject_skill(req2, req2.to_context(), []) == []

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "miot-harness"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -1253,7 +1253,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1263,7 +1263,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1297,7 +1297,7 @@
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1356,7 +1356,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2417,7 +2417,7 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
@@ -6745,7 +6745,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6759,7 +6758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6773,7 +6771,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6787,7 +6784,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6801,7 +6797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6815,7 +6810,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6829,7 +6823,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6843,7 +6836,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6857,7 +6849,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6871,7 +6862,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6885,7 +6875,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6899,7 +6888,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6913,7 +6901,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6927,7 +6914,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6941,7 +6927,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6955,7 +6940,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6969,7 +6953,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6983,7 +6966,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6997,7 +6979,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7011,7 +6992,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7025,7 +7005,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7039,7 +7018,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7053,7 +7031,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7067,7 +7044,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7081,7 +7057,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17664,7 +17639,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -25572,7 +25547,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25590,7 +25564,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25608,7 +25581,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25626,7 +25598,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25644,7 +25615,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25662,7 +25632,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25680,7 +25649,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25698,7 +25666,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25716,7 +25683,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25734,7 +25700,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25752,7 +25717,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25770,7 +25734,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25788,7 +25751,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25806,7 +25768,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25824,7 +25785,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25842,7 +25802,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25860,7 +25819,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25878,7 +25836,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25896,7 +25853,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25914,7 +25870,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25932,7 +25887,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25950,7 +25904,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25968,7 +25921,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25986,7 +25938,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26004,7 +25955,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26022,7 +25972,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26080,7 +26029,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -28526,7 +28474,7 @@
     },
     "packages/miot-chat": {
       "name": "@microboxlabs/miot-chat",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@microboxlabs/miot-auth": "*",
@@ -28795,12 +28743,12 @@
     },
     "packages/miot-cli": {
       "name": "@microboxlabs/miot-cli",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@microboxlabs/miot-auth": "*",
         "@microboxlabs/miot-calendar-client": "*",
-        "@microboxlabs/miot-chat": "^0.1.1",
+        "@microboxlabs/miot-chat": "^0.2.0",
         "@microboxlabs/miot-connection-client": "*",
         "@microboxlabs/miot-harness-client": "*",
         "commander": "^14.0.0"
@@ -29059,7 +29007,7 @@
     },
     "packages/miot-harness-client": {
       "name": "@microboxlabs/miot-harness-client",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@repo/eslint-config": "*",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -2417,7 +2417,7 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.2",
+      "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,

--- a/turbo-repo/packages/miot-chat/package.json
+++ b/turbo-repo/packages/miot-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-chat",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -17,7 +17,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/turbo-repo/packages/miot-chat/src/tui/App.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/App.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput } from "ink";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { randomUUID } from "node:crypto";
+import type { SkillSummary } from "@microboxlabs/miot-harness-client";
 import type { ResolvedConfig } from "../config.js";
 import { packageVersion } from "../version.js";
 import { Editor } from "./input/Editor.js";
@@ -38,6 +39,9 @@ import {
   type ModalSpec,
   type SlashContext,
 } from "./slash/registry.js";
+import { Palette } from "./slash/Palette.js";
+import { matchSkillRun } from "./slash/skillCommand.js";
+import type { PaletteState } from "./input/Editor.js";
 import { helpCommand } from "./slash/handlers/help.js";
 import { clearCommand } from "./slash/handlers/clear.js";
 import { resetCommand } from "./slash/handlers/reset.js";
@@ -53,6 +57,7 @@ import { resumeCommand } from "./slash/handlers/resume.js";
 import { exportCommand } from "./slash/handlers/export.js";
 import { runsCommand } from "./slash/handlers/runs.js";
 import { approveCommand } from "./slash/handlers/approve.js";
+import { skillsCommand } from "./slash/handlers/skills.js";
 import { readSession, listSessions } from "./persistence/store.js";
 import { defaultMiotChatHome } from "./persistence/paths.js";
 import type { TranscriptItem } from "./session/types.js";
@@ -107,8 +112,38 @@ function AppInner(
   const { setTheme } = useTheme();
   const [extraItems, setExtraItems] = useState<TranscriptItem[]>([]);
   const [modal, setModalState] = useState<ModalState>({ spec: null });
+  const [palette, setPalette] = useState<PaletteState>({
+    active: false,
+    query: "",
+    index: 0,
+  });
+  const [skills, setSkills] = useState<SkillSummary[]>([]);
 
-  const registry = useMemo(() => {
+  // Pull the harness skills so each becomes a `/<id>` command in the
+  // palette — discoverable and callable like Claude Code. Degrades
+  // silently: if the client has no skills resource or the harness is
+  // unreachable, the palette just shows the built-in commands.
+  const tenantId = session.state.meta.tenantId;
+  useEffect(() => {
+    const list = props.client.skills?.list;
+    if (!list) return;
+    let cancelled = false;
+    void list({ tenant: tenantId })
+      .then((loaded) => {
+        if (!cancelled) setSkills(loaded);
+      })
+      .catch(() => {
+        /* harness down / no skills — palette omits them */
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [props.client, tenantId]);
+
+  // Built-in commands plus one `/<id>` entry per harness skill, so `/`
+  // lists everything with descriptions. `skillIds` is the set of names
+  // that route to a skill run (vs a built-in command handler).
+  const { registry, skillIds } = useMemo(() => {
     const reg = new SlashRegistry();
     reg
       .register(helpCommand)
@@ -125,9 +160,24 @@ function AppInner(
       .register(resumeCommand)
       .register(exportCommand)
       .register(runsCommand)
-      .register(approveCommand);
-    return reg;
-  }, []);
+      .register(approveCommand)
+      .register(skillsCommand);
+    const builtinNames = new Set(reg.all().map((c) => c.name));
+    const ids = new Set<string>();
+    for (const skill of skills) {
+      if (builtinNames.has(skill.id)) continue; // never shadow a built-in
+      reg.register({
+        name: skill.id,
+        summary: skill.description || skill.when_to_use || skill.name,
+        usage: `/${skill.id}`,
+        // Execution happens in handleSubmit (a skill run, not a command
+        // handler); this entry exists for palette display + tab-complete.
+        handle: () => ({}),
+      });
+      ids.add(skill.id);
+    }
+    return { registry: reg, skillIds: ids };
+  }, [skills]);
 
   const appendSystem = useCallback(
     (text: string): void => {
@@ -205,13 +255,23 @@ function AppInner(
 
   const handleSubmit = useCallback(
     (text: string): void => {
+      // `/<skill-id> [args]` runs a turn with that skill activated — the
+      // harness injects its SKILL.md body as guidance. Args become the
+      // message; with no args we send a gentle kickoff and let the skill
+      // drive (e.g. ask its own clarifying questions).
+      const skillRun = matchSkillRun(text, skillIds);
+      if (skillRun) {
+        appendSystem(`↳ skill: ${skillRun.skillId}`);
+        void session.submit(skillRun.message, { skillId: skillRun.skillId });
+        return;
+      }
       if (text.trim().startsWith("/")) {
         void dispatchSlash(text);
         return;
       }
       void session.submit(text);
     },
-    [dispatchSlash, session],
+    [appendSystem, dispatchSlash, session, skillIds],
   );
 
   const closeModal = useCallback(
@@ -306,8 +366,22 @@ function AppInner(
         />
       ) : null}
       <TipLine tipIndex={turnCount(session.state)} />
+      {editorActive && palette.active ? (
+        <Box paddingX={1}>
+          <Palette
+            registry={registry}
+            query={palette.query}
+            selectedIndex={palette.index}
+          />
+        </Box>
+      ) : null}
       <InputFrame label={`miot · ${meta.mode}`} labelWarn={agenticWarn}>
-        <Editor onSubmit={handleSubmit} isFocused={editorActive} />
+        <Editor
+          onSubmit={handleSubmit}
+          isFocused={editorActive}
+          registry={registry}
+          onPaletteState={setPalette}
+        />
       </InputFrame>
       <FooterLine
         turns={turnCount(session.state)}

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Editor.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Editor.test.tsx
@@ -3,9 +3,23 @@ import { render } from "ink-testing-library";
 import { Editor } from "../../input/Editor.js";
 import { mapKey, type KeyState } from "../../input/keymap.js";
 import { appendHistory, initialHistory } from "../../input/history.js";
+import { SlashRegistry, type SlashCommand } from "../../slash/registry.js";
 
 function key(partial: Partial<KeyState> = {}): KeyState {
   return { ...partial };
+}
+
+function slashRegistry(): SlashRegistry {
+  const mk = (name: string): SlashCommand => ({
+    name,
+    summary: name,
+    usage: `/${name}`,
+    handle: () => ({}),
+  });
+  return new SlashRegistry()
+    .register(mk("skills"))
+    .register(mk("clear"))
+    .register(mk("help"));
 }
 
 describe("mapKey", () => {
@@ -58,11 +72,14 @@ describe("mapKey", () => {
     expect(mapKey("c", key({ ctrl: true }))).toEqual({ kind: "CANCEL" });
   });
 
-  it("Escape / Tab / PageUp / PageDown are ignored (null)", () => {
+  it("Escape / PageUp / PageDown are ignored (null)", () => {
     expect(mapKey("", key({ escape: true }))).toBeNull();
-    expect(mapKey("", key({ tab: true }))).toBeNull();
     expect(mapKey("", key({ pageUp: true }))).toBeNull();
     expect(mapKey("", key({ pageDown: true }))).toBeNull();
+  });
+
+  it("Tab maps to COMPLETE (slash-autocomplete)", () => {
+    expect(mapKey("", key({ tab: true }))).toEqual({ kind: "COMPLETE" });
   });
 
   it("printable input with ctrl is not inserted", () => {
@@ -130,5 +147,59 @@ describe("<Editor /> component", () => {
     stdin.write("\x1b[A");
     await Promise.resolve();
     expect(lastFrame() ?? "").toContain("echo hello");
+  });
+});
+
+describe("<Editor /> slash autocomplete", () => {
+  it("opens the palette while composing a /command and reports state", async () => {
+    const onPaletteState = vi.fn();
+    const { stdin } = render(
+      <Editor
+        onSubmit={() => undefined}
+        registry={slashRegistry()}
+        onPaletteState={onPaletteState}
+      />,
+    );
+    stdin.write("/sk");
+    await Promise.resolve();
+    expect(onPaletteState.mock.calls.at(-1)?.[0]).toMatchObject({
+      active: true,
+      query: "sk",
+    });
+  });
+
+  it("Enter runs the highlighted command", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <Editor onSubmit={onSubmit} registry={slashRegistry()} />,
+    );
+    stdin.write("/sk");
+    await Promise.resolve();
+    stdin.write("\r");
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith("/skills");
+  });
+
+  it("Tab completes the highlighted command into the buffer", async () => {
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = render(
+      <Editor onSubmit={onSubmit} registry={slashRegistry()} />,
+    );
+    stdin.write("/sk");
+    await Promise.resolve();
+    stdin.write("\t");
+    await Promise.resolve();
+    expect(lastFrame() ?? "").toContain("/skills");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("without a registry, /text submits verbatim (no palette)", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(<Editor onSubmit={onSubmit} />);
+    stdin.write("/sk");
+    await Promise.resolve();
+    stdin.write("\r");
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith("/sk");
   });
 });

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/skillCommand.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/skillCommand.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { matchSkillRun } from "../slash/skillCommand.js";
+
+const SKILLS = new Set(["skill-creator", "delivery-compliance-story"]);
+
+describe("matchSkillRun", () => {
+  it("routes /<skill-id> <args> to a skill run with the args as message", () => {
+    expect(matchSkillRun("/skill-creator make a jira-sync", SKILLS)).toEqual({
+      skillId: "skill-creator",
+      message: "make a jira-sync",
+    });
+  });
+
+  it("uses a kickoff message when the skill is called with no args", () => {
+    expect(matchSkillRun("/skill-creator", SKILLS)).toEqual({
+      skillId: "skill-creator",
+      message: "Let's get started.",
+    });
+  });
+
+  it("returns null for unknown tokens (falls through to slash dispatch)", () => {
+    expect(matchSkillRun("/help", SKILLS)).toBeNull();
+    expect(matchSkillRun("/skills", SKILLS)).toBeNull();
+    expect(matchSkillRun("/nope do it", SKILLS)).toBeNull();
+  });
+
+  it("returns null for plain (non-slash) text", () => {
+    expect(matchSkillRun("just chatting", SKILLS)).toBeNull();
+  });
+});

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/slash.skills.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/slash.skills.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { skillsCommand } from "../slash/handlers/skills.js";
+
+function mkCtx(client: unknown): Record<string, unknown> {
+  let i = 0;
+  let n = 0;
+  return {
+    client,
+    session: {
+      meta: { tenantId: "mintral", userId: "u", conversationId: "c" },
+    },
+    now: () => `2026-01-01T00:00:0${n++}Z`,
+    uuid: () => `id-${++i}`,
+  };
+}
+
+const SKILLS = [
+  {
+    id: "skill-creator",
+    name: "skill-creator",
+    description: "Create new skills.",
+    when_to_use: "Create new skills.",
+    scope: "global" as const,
+    source: "skill_md" as const,
+  },
+  {
+    id: "delivery-compliance-story",
+    name: "Delivery Compliance Story",
+    description: "Delivery compliance.",
+    when_to_use: "late deliveries",
+    scope: "global" as const,
+    source: "manifest" as const,
+  },
+];
+
+describe("/skills", () => {
+  it("lists skills as a system item, scoped to the session tenant", async () => {
+    const list = vi.fn().mockResolvedValue(SKILLS);
+    const r = await skillsCommand.handle([], mkCtx({ skills: { list } }));
+    expect(list).toHaveBeenCalledWith({ tenant: "mintral" });
+    expect(r.output?.kind).toBe("system");
+    if (r.output?.kind === "system") {
+      expect(r.output.text).toContain("available skills (2):");
+      expect(r.output.text).toContain("skill-creator");
+      expect(r.output.text).toContain("Delivery Compliance Story");
+    }
+  });
+
+  it("handles an empty skill set", async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    const r = await skillsCommand.handle([], mkCtx({ skills: { list } }));
+    if (r.output?.kind === "system") {
+      expect(r.output.text).toBe("no skills available");
+    }
+  });
+
+  it("surfaces a client error as a slash error, not a throw", async () => {
+    const list = vi.fn().mockRejectedValue(new Error("harness down"));
+    const r = await skillsCommand.handle([], mkCtx({ skills: { list } }));
+    expect(r.error).toContain("harness down");
+  });
+
+  it("errors cleanly when client is not bound", async () => {
+    const r = await skillsCommand.handle([], {
+      session: { meta: { tenantId: "x" } },
+      now: () => "t",
+      uuid: () => "id",
+    });
+    expect(r.error).toContain("not bound");
+  });
+});

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/slash.skills.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/slash.skills.test.ts
@@ -49,6 +49,7 @@ describe("/skills", () => {
   it("handles an empty skill set", async () => {
     const list = vi.fn().mockResolvedValue([]);
     const r = await skillsCommand.handle([], mkCtx({ skills: { list } }));
+    expect(r.output?.kind).toBe("system");
     if (r.output?.kind === "system") {
       expect(r.output.text).toBe("no skills available");
     }

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
@@ -60,6 +60,15 @@ describe("transcript projector — meta events", () => {
     expect(next.transcript).toEqual([]);
   });
 
+  it("approval.auto and steering.mode_denied are no-op status markers", () => {
+    const ctx = mkCtx();
+    const seeded: TranscriptSlice = { ...emptySlice(), currentRunId: "r1" };
+    for (const type of ["approval.auto", "steering.mode_denied"] as const) {
+      const next = applyHarnessEvent(seeded, evt(type), "r1", ctx);
+      expect(next).toEqual(seeded);
+    }
+  });
+
   it("run.completed and run.failed are no-ops on the slice", () => {
     const ctx = mkCtx();
     const seeded: TranscriptSlice = {

--- a/turbo-repo/packages/miot-chat/src/tui/input/Editor.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/input/Editor.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput } from "ink";
-import { useReducer, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import {
   appendHistory,
   initialHistory,
@@ -14,6 +14,13 @@ import {
   initialEditor,
   type EditorState,
 } from "./reducer.js";
+import type { SlashRegistry } from "../slash/registry.js";
+
+export interface PaletteState {
+  active: boolean;
+  query: string;
+  index: number;
+}
 
 export interface EditorProps {
   onSubmit: (text: string) => void;
@@ -21,6 +28,11 @@ export interface EditorProps {
   prompt?: string;
   initialHistory?: HistoryStore;
   isFocused?: boolean;
+  // When set, composing a `/command` (no space yet) opens the slash
+  // autocomplete: ↑/↓ select, Tab completes, Enter runs the highlighted
+  // command. The parent renders the dropdown from `onPaletteState`.
+  registry?: SlashRegistry;
+  onPaletteState?: (state: PaletteState) => void;
 }
 
 export function Editor(props: EditorProps): React.ReactElement {
@@ -32,7 +44,8 @@ export function Editor(props: EditorProps): React.ReactElement {
       // arrives here are real EditorActions.
       if (
         action.kind === "SUBMIT" ||
-        action.kind === "CANCEL"
+        action.kind === "CANCEL" ||
+        action.kind === "COMPLETE"
       ) {
         return state;
       }
@@ -43,12 +56,66 @@ export function Editor(props: EditorProps): React.ReactElement {
   const [history, setHistory] = useState<HistoryStore>(
     props.initialHistory ?? initialHistory(),
   );
+  const [paletteIndex, setPaletteIndex] = useState(0);
+
+  const text = bufferText(editor);
+  // The palette opens only while typing the command token itself: a
+  // leading "/" and no space/newline yet. Typing a space (args) closes it.
+  const paletteOpen =
+    props.registry !== undefined &&
+    text.startsWith("/") &&
+    !text.includes(" ") &&
+    !text.includes("\n");
+  const query = paletteOpen ? text.slice(1) : "";
+  const matches = paletteOpen ? props.registry!.findMatches(query) : [];
+  const selected = matches.length
+    ? Math.min(paletteIndex, matches.length - 1)
+    : 0;
+
+  // A new filter resets the highlight to the top of the list.
+  useEffect(() => {
+    setPaletteIndex(0);
+  }, [query, paletteOpen]);
+
+  // Lift palette state so the parent can render the dropdown above the
+  // input frame (the Editor owns the keyboard; the parent owns layout).
+  const notifyPalette = props.onPaletteState;
+  useEffect(() => {
+    notifyPalette?.({
+      active: paletteOpen && matches.length > 0,
+      query,
+      index: selected,
+    });
+  }, [notifyPalette, paletteOpen, matches.length, query, selected]);
 
   function handle(action: KeymapAction): void {
     if (action.kind === "CANCEL") {
       if (props.onCancel) props.onCancel();
       return;
     }
+    // Slash-autocomplete interactions take priority while the palette is
+    // open with results: navigate / complete / run the highlighted command.
+    if (paletteOpen && matches.length > 0) {
+      if (action.kind === "MOVE_UP") {
+        setPaletteIndex(Math.max(0, selected - 1));
+        return;
+      }
+      if (action.kind === "MOVE_DOWN") {
+        setPaletteIndex(Math.min(matches.length - 1, selected + 1));
+        return;
+      }
+      if (action.kind === "COMPLETE") {
+        dispatch({ kind: "SET_TEXT", text: `/${matches[selected]!.name} ` });
+        return;
+      }
+      if (action.kind === "SUBMIT") {
+        dispatch({ kind: "CLEAR" });
+        props.onSubmit(`/${matches[selected]!.name}`);
+        return;
+      }
+    }
+    // Tab outside the palette is a no-op (not an editor action).
+    if (action.kind === "COMPLETE") return;
     if (action.kind === "SUBMIT") {
       const text = bufferText(editor);
       if (text.trim().length === 0) return;

--- a/turbo-repo/packages/miot-chat/src/tui/input/keymap.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/input/keymap.ts
@@ -3,7 +3,8 @@ import type { EditorAction } from "./reducer.js";
 export type KeymapAction =
   | EditorAction
   | { kind: "SUBMIT" }
-  | { kind: "CANCEL" };
+  | { kind: "CANCEL" }
+  | { kind: "COMPLETE" };
 
 export interface KeyState {
   upArrow?: boolean;
@@ -40,7 +41,7 @@ export function mapKey(
   if (key.ctrl && input === "a") return { kind: "MOVE_HOME" };
   if (key.ctrl && input === "e") return { kind: "MOVE_END" };
   if (key.ctrl && input === "k") return { kind: "KILL_LINE" };
-  if (key.tab) return null;
+  if (key.tab) return { kind: "COMPLETE" };
   if (key.escape) return null;
   if (key.pageUp || key.pageDown) return null;
   if (input.length > 0 && !key.ctrl && !key.meta) {

--- a/turbo-repo/packages/miot-chat/src/tui/slash/Palette.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/slash/Palette.tsx
@@ -1,38 +1,88 @@
 import { Box, Text } from "ink";
 import type { SlashRegistry } from "./registry.js";
+import { useTheme } from "../theme/ThemeProvider.js";
+import { useTerminalWidth } from "../hooks/useTerminalWidth.js";
 
 export interface PaletteProps {
   registry: SlashRegistry;
-  // Query without the leading "/". Empty string is allowed; it shows all
-  // commands.
+  // Query without the leading "/". Empty string shows all commands.
   query: string;
   // Which match is highlighted. The parent owns navigation state so the
   // palette stays presentational.
   selectedIndex: number;
-  // How many rows to show before truncating (default 6).
+  // Size of the scrolling viewport (rows of commands shown at once).
   maxRows?: number;
+  // Max wrapped lines of description shown per command before ellipsis.
+  descLines?: number;
+}
+
+const DEFAULT_MAX_ROWS = 8;
+const DEFAULT_DESC_LINES = 2;
+
+/** Collapse whitespace and clamp to at most `lines` rows of `width`. */
+function clampDescription(text: string, width: number, lines: number): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  const budget = Math.max(1, width * lines);
+  if (collapsed.length <= budget) return collapsed;
+  return `${collapsed.slice(0, Math.max(0, budget - 1)).trimEnd()}…`;
 }
 
 export function Palette(props: PaletteProps): React.ReactElement | null {
-  const maxRows = props.maxRows ?? 6;
+  const { theme } = useTheme();
+  const columns = useTerminalWidth();
   const matches = props.registry.findMatches(props.query);
   if (matches.length === 0) return null;
-  const visible = matches.slice(0, maxRows);
-  const truncated = matches.length - visible.length;
-  const cappedIndex = Math.max(
+
+  const maxRows = props.maxRows ?? DEFAULT_MAX_ROWS;
+  const descLines = props.descLines ?? DEFAULT_DESC_LINES;
+  const selected = Math.max(0, Math.min(props.selectedIndex, matches.length - 1));
+
+  // Scrolling window centered on the selection — slides as you arrow
+  // through, so every command is reachable (no hard "N more" cutoff).
+  const startIndex = Math.max(
     0,
-    Math.min(props.selectedIndex, visible.length - 1),
+    Math.min(selected - Math.floor(maxRows / 2), matches.length - maxRows),
   );
+  const endIndex = Math.min(startIndex + maxRows, matches.length);
+  const visible = matches.slice(startIndex, endIndex);
+
+  // Name column: the widest usage string, capped at ~35% of the terminal.
+  const widestUsage = Math.max(...matches.map((c) => c.usage.length));
+  const nameWidth = Math.min(
+    widestUsage + 2,
+    Math.max(12, Math.floor(columns * 0.35)),
+  );
+  // Remaining width for the wrapping description (leave a small margin).
+  const descWidth = Math.max(12, columns - nameWidth - 4);
 
   return (
-    <Box flexDirection="column" borderStyle="round" paddingX={1}>
-      {visible.map((cmd, i) => (
-        <Text key={cmd.name} inverse={i === cappedIndex}>
-          {cmd.usage.padEnd(22)} {cmd.summary}
-        </Text>
-      ))}
-      {truncated > 0 ? (
-        <Text dimColor>… {truncated} more</Text>
+    <Box flexDirection="column">
+      {startIndex > 0 ? (
+        <Text color={theme.dim}>↑ {startIndex} more</Text>
+      ) : null}
+      {visible.map((cmd, i) => {
+        const isSelected = startIndex + i === selected;
+        const color = isSelected ? theme.accent : theme.dim;
+        const description = cmd.summary
+          ? clampDescription(cmd.summary, descWidth, descLines)
+          : "";
+        return (
+          <Box key={cmd.name} flexDirection="row">
+            <Box width={nameWidth} flexShrink={0}>
+              <Text color={color} bold={isSelected} wrap="truncate">
+                {cmd.usage}
+              </Text>
+            </Box>
+            <Box width={descWidth}>
+              <Text color={color} wrap="wrap">
+                {description}
+              </Text>
+            </Box>
+          </Box>
+        );
+      })}
+      {endIndex < matches.length ? (
+        <Text color={theme.dim}>↓ {matches.length - endIndex} more</Text>
       ) : null}
     </Box>
   );

--- a/turbo-repo/packages/miot-chat/src/tui/slash/handlers/skills.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/slash/handlers/skills.ts
@@ -1,0 +1,68 @@
+import type {
+  MiotHarnessClient,
+  SkillSummary,
+} from "@microboxlabs/miot-harness-client";
+import type {
+  SlashCommand,
+  SlashContext,
+  SlashResult,
+} from "../registry.js";
+import type { SessionState, TranscriptItem } from "../../session/types.js";
+
+interface SkillsCtx extends SlashContext {
+  client: MiotHarnessClient;
+  session: SessionState;
+  now: () => string;
+  uuid: () => string;
+}
+
+function isSkillsCtx(ctx: SlashContext): ctx is SkillsCtx {
+  return (
+    typeof ctx.client === "object" &&
+    ctx.client !== null &&
+    "skills" in (ctx.client as object) &&
+    typeof ctx.session === "object" &&
+    ctx.session !== null &&
+    typeof ctx.now === "function" &&
+    typeof ctx.uuid === "function"
+  );
+}
+
+function formatSkills(skills: SkillSummary[]): string {
+  if (skills.length === 0) return "no skills available";
+  const lines = skills.map((s) => {
+    const trigger = (s.when_to_use || s.description || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    const short = trigger.length > 80 ? `${trigger.slice(0, 79)}…` : trigger;
+    return short ? `  • ${s.name} — ${short}` : `  • ${s.name}`;
+  });
+  return [`available skills (${skills.length}):`, ...lines].join("\n");
+}
+
+export const skillsCommand: SlashCommand = {
+  name: "skills",
+  summary: "List skills the harness can use",
+  usage: "/skills",
+  handle: async (_args, ctx): Promise<SlashResult> => {
+    if (!isSkillsCtx(ctx)) {
+      return { error: "skills: client/session not bound on SlashContext" };
+    }
+    try {
+      const skills = await ctx.client.skills.list({
+        tenant: ctx.session.meta.tenantId,
+      });
+      const item: TranscriptItem = {
+        kind: "system",
+        id: ctx.uuid(),
+        text: formatSkills(skills),
+        ts: ctx.now(),
+      };
+      return { output: item };
+    } catch (err) {
+      return {
+        error: `skills: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+};

--- a/turbo-repo/packages/miot-chat/src/tui/slash/handlers/skills.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/slash/handlers/skills.ts
@@ -17,12 +17,15 @@ interface SkillsCtx extends SlashContext {
 }
 
 function isSkillsCtx(ctx: SlashContext): ctx is SkillsCtx {
+  // Verify the bits the handler actually uses — that `skills.list` is
+  // callable and a tenant id is present — not just that the keys exist, so
+  // a partial/older client or context yields the clean "not bound" error
+  // instead of a thrown TypeError.
+  const client = ctx.client as { skills?: { list?: unknown } } | undefined;
+  const session = ctx.session as { meta?: { tenantId?: unknown } } | undefined;
   return (
-    typeof ctx.client === "object" &&
-    ctx.client !== null &&
-    "skills" in (ctx.client as object) &&
-    typeof ctx.session === "object" &&
-    ctx.session !== null &&
+    typeof client?.skills?.list === "function" &&
+    typeof session?.meta?.tenantId === "string" &&
     typeof ctx.now === "function" &&
     typeof ctx.uuid === "function"
   );

--- a/turbo-repo/packages/miot-chat/src/tui/slash/skillCommand.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/slash/skillCommand.ts
@@ -1,0 +1,25 @@
+const DEFAULT_KICKOFF = "Let's get started.";
+
+export interface SkillRun {
+  skillId: string;
+  message: string;
+}
+
+/**
+ * Match a `/<skill-id> [args]` invocation against the known skill ids.
+ * Returns the skill id + message (args, or a kickoff when none), or null
+ * when the input isn't a slash command for a known skill (so the caller
+ * falls through to normal slash-command dispatch).
+ */
+export function matchSkillRun(
+  input: string,
+  skillIds: ReadonlySet<string>,
+): SkillRun | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const match = trimmed.match(/^\/(\S+)\s*([\s\S]*)$/);
+  const token = match?.[1] ?? "";
+  if (!skillIds.has(token)) return null;
+  const args = (match?.[2] ?? "").trim();
+  return { skillId: token, message: args.length > 0 ? args : DEFAULT_KICKOFF };
+}

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
@@ -30,6 +30,14 @@ export function applyHarnessEvent(
     case "run.started":
       return { ...slice, currentRunId: runId };
 
+    case "approval.auto":
+    case "steering.mode_denied":
+      // Status-only markers (an approval auto-resolved; a steering mode was
+      // denied). The session reducer / footer surfaces these; the transcript
+      // projector leaves the slice unchanged, like run.completed below. Also
+      // keeps this switch exhaustive over HarnessEventType.
+      return slice;
+
     case "run.completed":
     case "run.failed":
       // The session reducer's END_TURN orchestrates the final transition;

--- a/turbo-repo/packages/miot-chat/src/tui/useSession.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/useSession.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path";
 import type {
   HarnessEvent,
   HarnessRunRecord,
+  SkillSummary,
   UserRequest,
 } from "@microboxlabs/miot-harness-client";
 import { initialSession, reduce } from "./session/reducer.js";
@@ -54,6 +55,15 @@ export interface HarnessClientLike {
       opts?: { signal?: AbortSignal },
     ) => Promise<HarnessRunRecord>;
   };
+  // Optional: the harness skills listing. When present, the App registers
+  // each skill as a `/<id>` slash command in the palette. Optional so mocks
+  // and older clients without the resource still satisfy the type.
+  skills?: {
+    list: (opts?: {
+      tenant?: string;
+      signal?: AbortSignal;
+    }) => Promise<SkillSummary[]>;
+  };
 }
 
 export interface UseSessionOptions {
@@ -65,7 +75,7 @@ export interface UseSessionOptions {
 export interface UseSessionApi {
   state: SessionState;
   dispatch: (action: SessionAction) => void;
-  submit: (prompt: string) => Promise<void>;
+  submit: (prompt: string, opts?: { skillId?: string }) => Promise<void>;
   abort: () => void;
 }
 
@@ -84,7 +94,7 @@ export function useSession(opts: UseSessionOptions): UseSessionApi {
   const abortRef = useRef<AbortController | null>(null);
 
   const submit = useCallback(
-    async (prompt: string): Promise<void> => {
+    async (prompt: string, submitOpts?: { skillId?: string }): Promise<void> => {
       const meta = stateRef.current.meta;
       const trimmed = prompt.trim();
       if (trimmed.length === 0) return;
@@ -104,6 +114,7 @@ export function useSession(opts: UseSessionOptions): UseSessionApi {
             user_id: meta.userId,
             mode: meta.mode,
             conversation_id: meta.conversationId,
+            ...(submitOpts?.skillId ? { skill_id: submitOpts.skillId } : {}),
             ...(meta.debug ? { debug: true } : {}),
           },
           { signal: controller.signal },

--- a/turbo-repo/packages/miot-cli/package.json
+++ b/turbo-repo/packages/miot-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -17,7 +17,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -28,7 +30,7 @@
   "dependencies": {
     "@microboxlabs/miot-auth": "*",
     "@microboxlabs/miot-calendar-client": "*",
-    "@microboxlabs/miot-chat": "^0.1.1",
+    "@microboxlabs/miot-chat": "^0.2.0",
     "@microboxlabs/miot-connection-client": "*",
     "@microboxlabs/miot-harness-client": "*",
     "commander": "^14.0.0"

--- a/turbo-repo/packages/miot-cli/src/commands/harness/create.ts
+++ b/turbo-repo/packages/miot-cli/src/commands/harness/create.ts
@@ -24,6 +24,7 @@ interface CreateOpts {
   mode?: RunMode;
   conversation?: string;
   thread?: string;
+  skill?: string;
 }
 
 export function registerHarnessCreateCommand(parent: Command): void {
@@ -44,6 +45,10 @@ export function registerHarnessCreateCommand(parent: Command): void {
       "Conversation ID for multi-turn context (defaults to a fresh UUID server-side)",
     )
     .option("--thread <id>", "Thread ID (defaults to the harness's demo-thread)")
+    .option(
+      "--skill <id>",
+      "Activate a skill for this run (injects its SKILL.md body as guidance)",
+    )
     .action(async (message: string, opts: CreateOpts, cmd: Command) => {
       const { client, outputMode } = getHarnessActionContext(cmd);
       try {
@@ -56,6 +61,7 @@ export function registerHarnessCreateCommand(parent: Command): void {
             conversation_id: opts.conversation,
           }),
           ...(opts.thread !== undefined && { thread_id: opts.thread }),
+          ...(opts.skill !== undefined && { skill_id: opts.skill }),
         };
         const result = await client.runs.create(req);
         if (outputMode === "json") {

--- a/turbo-repo/packages/miot-cli/src/commands/harness/index.ts
+++ b/turbo-repo/packages/miot-cli/src/commands/harness/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { registerHarnessCreateCommand } from "./create.js";
 import { registerHarnessRunsCommand } from "./runs.js";
+import { registerHarnessSkillsCommand } from "./skills.js";
 
 export function registerHarnessCommand(program: Command): void {
   const harness = program
@@ -19,4 +20,5 @@ export function registerHarnessCommand(program: Command): void {
 
   registerHarnessCreateCommand(harness);
   registerHarnessRunsCommand(harness);
+  registerHarnessSkillsCommand(harness);
 }

--- a/turbo-repo/packages/miot-cli/src/commands/harness/skills.ts
+++ b/turbo-repo/packages/miot-cli/src/commands/harness/skills.ts
@@ -1,0 +1,46 @@
+import type { Command } from "commander";
+import { getHarnessActionContext } from "../../harness-context.js";
+import { printJson, printTable } from "../../output.js";
+import { handleError } from "../../utils/error.js";
+
+interface SkillsOpts {
+  tenant?: string;
+}
+
+/** Truncate trigger text so the table stays readable on one line. */
+function truncate(value: string, max = 72): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
+}
+
+export function registerHarnessSkillsCommand(parent: Command): void {
+  parent
+    .command("skills")
+    .description("List the skills the harness exposes (GET /skills).")
+    .option("--tenant <id>", "Tenant ID to scope the skill list")
+    .action(async (opts: SkillsOpts, cmd: Command) => {
+      const { client, outputMode } = getHarnessActionContext(cmd);
+      try {
+        const skills = await client.skills.list({
+          ...(opts.tenant !== undefined && { tenant: opts.tenant }),
+        });
+        if (outputMode === "json") {
+          printJson(skills);
+        } else {
+          const rows = skills.map((s) => ({
+            ...s,
+            when_to_use: truncate(s.when_to_use || s.description),
+          }));
+          printTable(rows, [
+            { header: "ID", key: "id" },
+            { header: "NAME", key: "name" },
+            { header: "SCOPE", key: "scope" },
+            { header: "SOURCE", key: "source" },
+            { header: "WHEN TO USE", key: "when_to_use" },
+          ]);
+        }
+      } catch (err) {
+        handleError(err, outputMode);
+      }
+    });
+}

--- a/turbo-repo/packages/miot-harness-client/package.json
+++ b/turbo-repo/packages/miot-harness-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-harness-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-harness-client/src/__tests__/skills.test.ts
+++ b/turbo-repo/packages/miot-harness-client/src/__tests__/skills.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createMiotHarnessClient } from "../client.js";
+import type { SkillSummary } from "../types.js";
+import { createMockFetch } from "./test-utils.js";
+
+const SKILLS: SkillSummary[] = [
+  {
+    id: "skill-creator",
+    name: "skill-creator",
+    description: "Create new skills.",
+    when_to_use: "Create new skills.",
+    scope: "global",
+    source: "skill_md",
+  },
+];
+
+describe("skills.list", () => {
+  it("GETs /skills and returns the summaries", async () => {
+    const { fn, call } = createMockFetch(SKILLS);
+    const client = createMiotHarnessClient({
+      baseUrl: "http://harness.local",
+      fetch: fn,
+    });
+    const result = await client.skills.list();
+    expect(result).toEqual(SKILLS);
+    expect(call.url).toBe("http://harness.local/skills");
+    expect(call.init.method).toBe("GET");
+  });
+
+  it("passes the tenant as a query param", async () => {
+    const { fn, call } = createMockFetch(SKILLS);
+    const client = createMiotHarnessClient({
+      baseUrl: "http://harness.local",
+      fetch: fn,
+    });
+    await client.skills.list({ tenant: "mintral" });
+    expect(call.url).toBe("http://harness.local/skills?tenant=mintral");
+  });
+});

--- a/turbo-repo/packages/miot-harness-client/src/client.ts
+++ b/turbo-repo/packages/miot-harness-client/src/client.ts
@@ -1,5 +1,6 @@
 import { MiotHarnessApiError } from "./errors.js";
 import { createRunsApi } from "./resources/runs.js";
+import { createSkillsApi } from "./resources/skills.js";
 import type { ClientConfig, ErrorResponse } from "./types.js";
 
 export interface RequestOptions {
@@ -106,6 +107,7 @@ export function createMiotHarnessClient(config: ClientConfig) {
 
   return {
     runs: createRunsApi(ctx),
+    skills: createSkillsApi(ctx),
   };
 }
 

--- a/turbo-repo/packages/miot-harness-client/src/index.ts
+++ b/turbo-repo/packages/miot-harness-client/src/index.ts
@@ -16,5 +16,6 @@ export type {
   HarnessEventType,
   HarnessRunRecord,
   RunMode,
+  SkillSummary,
   UserRequest,
 } from "./types.js";

--- a/turbo-repo/packages/miot-harness-client/src/resources/skills.ts
+++ b/turbo-repo/packages/miot-harness-client/src/resources/skills.ts
@@ -1,0 +1,25 @@
+import type { ClientContext } from "../client.js";
+import type { SkillSummary } from "../types.js";
+
+const BASE = "/skills";
+
+export function createSkillsApi(ctx: ClientContext) {
+  return {
+    /**
+     * List the skills available to the caller (`GET /skills`) — the data
+     * behind a `/skills` picker / autocomplete. `tenant` scopes the result;
+     * when omitted the server applies the verified header tenant or its
+     * configured default.
+     */
+    list(opts?: {
+      tenant?: string;
+      signal?: AbortSignal;
+    }): Promise<SkillSummary[]> {
+      return ctx.fetcher("GET", BASE, {
+        headers: { Accept: "application/json" },
+        ...(opts?.tenant !== undefined && { query: { tenant: opts.tenant } }),
+        signal: opts?.signal,
+      });
+    },
+  };
+}

--- a/turbo-repo/packages/miot-harness-client/src/types.ts
+++ b/turbo-repo/packages/miot-harness-client/src/types.ts
@@ -9,6 +9,12 @@ export interface UserRequest {
   mode?: RunMode;
   conversation_id?: string | null;
   /**
+   * Skill to activate for this run. When set and resolvable server-side,
+   * the harness injects that skill's SKILL.md body as run guidance so the
+   * agent follows it. Unknown ids are ignored (the run proceeds normally).
+   */
+  skill_id?: string;
+  /**
    * When true, the SSE stream carries full tool inputs and truncated
    * tool outputs (~2 KB cap). Off by default. Coordinador outputs
    * contain customer/fleet data — gate this behind auth in production.
@@ -31,6 +37,8 @@ export const HARNESS_EVENT_TYPES = [
   "tool.completed",
   "tool.failed",
   "approval.requested",
+  "approval.auto",
+  "steering.mode_denied",
   "artifact.created",
   "plan.created",
   /** @deprecated superseded by agent.started / agent.completed. */
@@ -135,6 +143,23 @@ export interface HarnessRunRecord {
   artifacts: Array<Record<string, unknown>>;
   answer: string | null;
   conversation_id: string | null;
+}
+
+/**
+ * Compact projection of a skill, as returned by `GET /skills`. Mirrors the
+ * Python `SkillSummary` in
+ * `miot-harness/src/miot_harness/context_skills/skill_models.py`.
+ * `description` / `when_to_use` are the trigger text shown in a `/skills`
+ * picker; `source` distinguishes an Agent-Skills `SKILL.md` directory skill
+ * from a YAML manifest.
+ */
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  when_to_use: string;
+  scope: "global" | "tenant";
+  source: "skill_md" | "manifest";
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
## What & why
Follow-up to #748 (SKILL.md discovery, merged). #748 made the harness **discover** Agent Skills; this makes them **listable, discoverable in the chat UI, and callable** — closing the gap that you couldn't actually *call* a loaded skill.

## Changes
**Harness (`miot-harness` 0.1.0 → 0.2.0)**
- `GET /skills` + `ContextSkillsBundle.list_skills(tenant)` → `SkillSummary` (`id`, `name`, `description`, `when_to_use`, `scope`, `source`=`skill_md`|`manifest`).
- **Invocation**: `UserRequest.skill_id`; `activate_skill(tenant, id)`; the supervisor injects the chosen skill's `SKILL.md` body as a `SystemMessage` into `prior_messages`, so every run path (direct/meta/data/agentic) follows it. Unknown/bodyless ids are ignored.

**`@microboxlabs/miot-harness-client` 0.2.0 → 0.3.0**
- `client.skills.list()` resource + `SkillSummary` type; `skill_id` on `UserRequest`.
- Sync `HARNESS_EVENT_TYPES` with the Python source of truth (`approval.auto`, `steering.mode_denied`) — fixes the pre-existing parity-guard failure so the package tests are green for release.

**`@microboxlabs/miot-chat` 0.1.1 → 0.2.0**
- Claude-Code-style `/` autocomplete **palette** wired into the Editor (scrolling window, wrapping descriptions, accent highlight; ↑/↓ select, Tab completes, Enter runs).
- Each harness skill is registered as a `/<skill-id>` command → `/` lists skills with descriptions and **`/<skill-id> [args]` runs the skill**.

**`@microboxlabs/miot-cli` 0.4.2 → 0.5.0**
- `miot harness skills` (table/json) and `miot harness create --skill <id>`. Dep range `miot-chat` `^0.1.1` → `^0.2.0`.

## Test plan
- harness: `pytest` **249 passed / 1 skipped**; `ruff` + `mypy` clean. New: bundle `list_skills`/`activate_skill`, `GET /skills` (3), supervisor `_inject_skill` (4).
- `miot-harness-client`: **24 passed** (incl. `skills.list`); parity restored.
- `miot-chat`: **402 passed** (Palette, Editor palette nav, `matchSkillRun`, `/skills` handler).
- `miot-cli`: **70 passed**. tsc + lint clean across all three; dists build.
- Verified end-to-end against a local harness via PTY: `/` lists skills with descriptions; `/skill-creator <args>` and `miot harness create --skill skill-creator` both make the agent follow the skill's SKILL.md.

## Release
- **npm** publishes on `<pkg>@v*` tags — push in dependency order after merge: `miot-harness-client@v0.3.0` → `miot-chat@v0.2.0` → `miot-cli@v0.5.0`.
- **Harness image**: `harness.yaml` rebuilds `ghcr.io/microboxlabs/miot-harness:latest` (+ `sha-`) on trunk merge; a version tag produces `:<version>`.

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skills listing endpoint (`GET /skills`) with tenant scoping.
  * Added a `skills` CLI subcommand, plus `harness create --skill <id>` to start runs with a specific skill.
  * Updated chat UI with a skills palette and `/<skill-id>` slash routing.

* **Bug Fixes**
  * Skill guidance is injected only when the selected, tenant-visible skill is available and has content; otherwise runs proceed normally.

* **Chores**
  * Bumped package versions for the harness, client, and related tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->