### PR TITLE
feat(app): WhatsApp channel settings card (configure + test)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/[connId]/test/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/[connId]/test/route.ts
@@ -1,0 +1,24 @@
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/**
+ * POST /api/admin/orgs/[orgId]/integrations/connections/[connId]/test
+ *
+ * Runs the provider's live connectivity probe. Proxies to Quarkus
+ * `POST /api/v1/orgs/{orgId}/integrations/connections/{connId}/test`.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string; connId: string }> },
+) {
+  const { orgId, connId } = await params;
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    // No body is fine — the test request is optional.
+  }
+  return forwardToQuarkus(
+    `/api/v1/orgs/${encodeURIComponent(orgId)}/integrations/connections/${encodeURIComponent(connId)}/test`,
+    { method: "POST", body },
+  );
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/**
+ * GET  /api/admin/orgs/[orgId]/integrations/connections — list connections
+ * POST /api/admin/orgs/[orgId]/integrations/connections — create a connection
+ *
+ * Proxies to Quarkus `GET/POST /api/v1/orgs/{orgId}/integrations/connections`
+ * (miot-integrations). Auth + tenant scoping are delegated to Quarkus.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { orgId } = await params;
+  const safe = encodeURIComponent(orgId);
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/connections`);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { orgId } = await params;
+  const safe = encodeURIComponent(orgId);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/connections`, {
+    method: "POST",
+    body,
+  });
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/credential-profiles/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/credential-profiles/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/**
+ * POST /api/admin/orgs/[orgId]/integrations/credential-profiles — create a
+ * credential profile (e.g. a BEARER_TOKEN holding the WhatsApp access token).
+ *
+ * Proxies to Quarkus `POST /api/v1/orgs/{orgId}/integrations/credential-profiles`.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { orgId } = await params;
+  const safe = encodeURIComponent(orgId);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(
+    `/api/v1/orgs/${safe}/integrations/credential-profiles`,
+    { method: "POST", body },
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
@@ -6,6 +6,7 @@ import { useOrgMembers } from "../hooks/use-org-members";
 import { useOrgModules } from "../hooks/use-org-modules";
 import MembersList from "./members-list";
 import ModulesList from "./modules-list";
+import WhatsAppChannelCard from "../whatsapp/whatsapp-channel-card";
 
 interface OrgDetailPanelProps {
   readonly orgSlug: string | null;
@@ -45,6 +46,7 @@ export default function OrgDetailPanel({ orgSlug, dict }: OrgDetailPanelProps) {
         error={modulesError}
         dict={dict}
       />
+      <WhatsAppChannelCard orgSlug={orgSlug} dict={dict} />
       <MembersList
         members={members}
         isLoading={membersLoading}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import {
+  createWhatsAppConnection,
+  fetchWhatsAppConnection,
+  testWhatsAppConnection,
+} from "./whatsapp-data-service";
+import type {
+  ConnectionTestResult,
+  IntegrationConnection,
+  WhatsAppFormData,
+} from "./whatsapp.types";
+
+/**
+ * The org's WhatsApp connection + create/test actions, via the Next.js proxy
+ * to Quarkus. Returns a null SWR key when orgSlug is empty so the fetch skips.
+ */
+export function useOrgWhatsApp(orgSlug: string | null) {
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const { data, error, isLoading, mutate } = useSWR<
+    IntegrationConnection | null,
+    Error
+  >(
+    orgSlug ? ["org-whatsapp", orgSlug] : null,
+    ([, slug]: [string, string]) => fetchWhatsAppConnection(slug),
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  );
+
+  function requireSlug(): string {
+    if (!orgSlug) {
+      throw new Error("No organization selected");
+    }
+    return orgSlug;
+  }
+
+  async function create(
+    form: WhatsAppFormData,
+  ): Promise<IntegrationConnection> {
+    const slug = requireSlug();
+    setActionLoading(true);
+    try {
+      const created = await createWhatsAppConnection(slug, form);
+      await mutate();
+      return created;
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function test(connectionId: string): Promise<ConnectionTestResult> {
+    const slug = requireSlug();
+    setActionLoading(true);
+    try {
+      const result = await testWhatsAppConnection(slug, connectionId);
+      await mutate();
+      return result;
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  return {
+    connection: data ?? null,
+    isLoading,
+    error: error ?? null,
+    actionLoading,
+    create,
+    test,
+    refresh: mutate,
+  };
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Badge, Button, Spinner } from "flowbite-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { FaWhatsapp } from "react-icons/fa";
 import { toast } from "sonner";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
@@ -59,6 +59,32 @@ export default function WhatsAppChannelCard({
     }
   }
 
+  function renderBody(): ReactNode {
+    if (isLoading) {
+      return <Spinner size="sm" />;
+    }
+    if (connection) {
+      return (
+        <ConfiguredRow
+          connection={connection}
+          dict={waDict}
+          testing={actionLoading}
+          onTest={handleTest}
+        />
+      );
+    }
+    return (
+      <Button
+        size="xs"
+        color="green"
+        onClick={() => setShowModal(true)}
+        disabled={!orgSlug}
+      >
+        {tr("configureButton", waDict)}
+      </Button>
+    );
+  }
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
       <div className="flex items-start justify-between">
@@ -75,27 +101,7 @@ export default function WhatsAppChannelCard({
         {tr("description", waDict)}
       </p>
 
-      <div className="mt-3">
-        {isLoading ? (
-          <Spinner size="sm" />
-        ) : connection ? (
-          <ConfiguredRow
-            connection={connection}
-            dict={waDict}
-            testing={actionLoading}
-            onTest={handleTest}
-          />
-        ) : (
-          <Button
-            size="xs"
-            color="green"
-            onClick={() => setShowModal(true)}
-            disabled={!orgSlug}
-          >
-            {tr("configureButton", waDict)}
-          </Button>
-        )}
-      </div>
+      <div className="mt-3">{renderBody()}</div>
 
       <WhatsAppConnectionModal
         show={showModal}
@@ -117,7 +123,8 @@ interface ConfiguredRowProps {
 }
 
 function ConfiguredRow({ connection, dict, testing, onTest }: ConfiguredRowProps) {
-  const phone = String(connection.metadata?.phone_number_id ?? "—");
+  const rawPhone = connection.metadata?.phone_number_id;
+  const phone = typeof rawPhone === "string" ? rawPhone : "—";
   return (
     <div className="flex items-center justify-between gap-2">
       <div className="text-sm text-gray-700 dark:text-gray-300">

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
@@ -25,7 +25,7 @@ export default function WhatsAppChannelCard({
   dict,
 }: WhatsAppChannelCardProps) {
   const waDict = (dict?.whatsappChannel as I18nRecord) ?? {};
-  const { connection, isLoading, actionLoading, create, test } =
+  const { connection, isLoading, error, actionLoading, create, test } =
     useOrgWhatsApp(orgSlug);
   const [showModal, setShowModal] = useState(false);
   const [submitError, setSubmitError] = useState<Error | null>(null);
@@ -62,6 +62,13 @@ export default function WhatsAppChannelCard({
   function renderBody(): ReactNode {
     if (isLoading) {
       return <Spinner size="sm" />;
+    }
+    if (error) {
+      return (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          {tr("loadError", waDict)}
+        </p>
+      );
     }
     if (connection) {
       return (

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Badge, Button, Spinner } from "flowbite-react";
+import { useState } from "react";
+import { FaWhatsapp } from "react-icons/fa";
+import { toast } from "sonner";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { useOrgWhatsApp } from "./use-org-whatsapp";
+import { WhatsAppConnectionModal } from "./whatsapp-connection-modal";
+import type { IntegrationConnection, WhatsAppFormData } from "./whatsapp.types";
+
+interface WhatsAppChannelCardProps {
+  readonly orgSlug: string | null;
+  readonly dict: I18nRecord;
+}
+
+/**
+ * Settings card for the org's WhatsApp channel. When no connection exists it
+ * offers a Configure action (create); once configured it shows status + a live
+ * Test. Edit/delete are deferred (the backend has no update/delete yet).
+ */
+export default function WhatsAppChannelCard({
+  orgSlug,
+  dict,
+}: WhatsAppChannelCardProps) {
+  const waDict = (dict?.whatsappChannel as I18nRecord) ?? {};
+  const { connection, isLoading, actionLoading, create, test } =
+    useOrgWhatsApp(orgSlug);
+  const [showModal, setShowModal] = useState(false);
+  const [submitError, setSubmitError] = useState<Error | null>(null);
+
+  async function handleCreate(form: WhatsAppFormData) {
+    setSubmitError(null);
+    try {
+      await create(form);
+      setShowModal(false);
+      toast.success(tr("toast.created", waDict));
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err : new Error(tr("toast.error", waDict)),
+      );
+    }
+  }
+
+  async function handleTest() {
+    if (!connection) return;
+    try {
+      const result = await test(connection.id);
+      if (result.success) {
+        toast.success(result.message || tr("toast.testSuccess", waDict));
+      } else {
+        toast.error(result.message || tr("toast.testFailed", waDict));
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : tr("toast.error", waDict),
+      );
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <FaWhatsapp className="h-5 w-5 text-green-500" />
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {tr("title", waDict)}
+          </h3>
+        </div>
+        {connection && <StatusBadge status={connection.status} dict={waDict} />}
+      </div>
+
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {tr("description", waDict)}
+      </p>
+
+      <div className="mt-3">
+        {isLoading ? (
+          <Spinner size="sm" />
+        ) : connection ? (
+          <ConfiguredRow
+            connection={connection}
+            dict={waDict}
+            testing={actionLoading}
+            onTest={handleTest}
+          />
+        ) : (
+          <Button
+            size="xs"
+            color="green"
+            onClick={() => setShowModal(true)}
+            disabled={!orgSlug}
+          >
+            {tr("configureButton", waDict)}
+          </Button>
+        )}
+      </div>
+
+      <WhatsAppConnectionModal
+        show={showModal}
+        onClose={() => setShowModal(false)}
+        onSubmit={handleCreate}
+        loading={actionLoading}
+        error={submitError}
+        dict={waDict}
+      />
+    </div>
+  );
+}
+
+interface ConfiguredRowProps {
+  readonly connection: IntegrationConnection;
+  readonly dict: I18nRecord;
+  readonly testing: boolean;
+  readonly onTest: () => void;
+}
+
+function ConfiguredRow({ connection, dict, testing, onTest }: ConfiguredRowProps) {
+  const phone = String(connection.metadata?.phone_number_id ?? "—");
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="text-sm text-gray-700 dark:text-gray-300">
+        <span className="font-medium">{tr("phoneLabel", dict)}:</span> {phone}
+      </div>
+      <Button size="xs" color="light" disabled={testing} onClick={onTest}>
+        {testing ? <Spinner size="sm" /> : tr("testButton", dict)}
+      </Button>
+    </div>
+  );
+}
+
+interface StatusBadgeProps {
+  readonly status: IntegrationConnection["status"];
+  readonly dict: I18nRecord;
+}
+
+function StatusBadge({ status, dict }: StatusBadgeProps) {
+  const map: Record<
+    IntegrationConnection["status"],
+    { color: "success" | "gray" | "failure"; key: string }
+  > = {
+    ACTIVE: { color: "success", key: "status.active" },
+    DRAFT: { color: "gray", key: "status.draft" },
+    INACTIVE: { color: "gray", key: "status.inactive" },
+    TEST_FAILED: { color: "failure", key: "status.failed" },
+  };
+  const entry = map[status] ?? map.DRAFT;
+  return <Badge color={entry.color}>{tr(entry.key, dict)}</Badge>;
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Label, TextInput } from "flowbite-react";
+import { useEffect, type ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import FormModal from "@/features/common/components/form-modal/form-modal";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr, trDynamic } from "@/features/i18n/tr.service";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_GRAPH_VERSION,
+  WhatsAppConnectionSchema,
+  type WhatsAppFormData,
+} from "./whatsapp.types";
+
+interface WhatsAppConnectionModalProps {
+  readonly show: boolean;
+  readonly onClose: () => void;
+  readonly onSubmit: (data: WhatsAppFormData) => void;
+  readonly loading?: boolean;
+  readonly error?: Error | null;
+  readonly dict: I18nRecord;
+}
+
+const DEFAULTS: WhatsAppFormData = {
+  name: "Canal WhatsApp",
+  phoneNumberId: "",
+  wabaId: "",
+  graphVersion: DEFAULT_GRAPH_VERSION,
+  baseUrl: DEFAULT_BASE_URL,
+  token: "",
+};
+
+export function WhatsAppConnectionModal({
+  show,
+  onClose,
+  onSubmit,
+  loading = false,
+  error = null,
+  dict,
+}: WhatsAppConnectionModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<WhatsAppFormData>({
+    resolver: zodResolver(WhatsAppConnectionSchema),
+    defaultValues: DEFAULTS,
+  });
+
+  useEffect(() => {
+    if (show) {
+      reset(DEFAULTS);
+    }
+  }, [show, reset]);
+
+  const submitLabel = loading
+    ? tr("modal.saving", dict)
+    : tr("modal.createButton", dict);
+
+  return (
+    <FormModal
+      isOpen={show}
+      onClose={onClose}
+      title={tr("modal.addTitle", dict)}
+      subtitle={tr("modal.subtitle", dict)}
+      submitLabel={submitLabel}
+      isProcessing={loading}
+      error={error}
+      onSubmit={handleSubmit(onSubmit)}
+      size="2xl"
+      showCancelButton
+      cancelLabel={tr("modal.cancel", dict)}
+    >
+      <div className="flex flex-col gap-4">
+        <Field
+          id="wa-name"
+          label={tr("modal.name", dict)}
+          error={trDynamic(errors.name?.message ?? "", dict)}
+        >
+          <TextInput
+            id="wa-name"
+            {...register("name")}
+            color={errors.name ? "failure" : undefined}
+          />
+        </Field>
+
+        <Field
+          id="wa-phone"
+          label={tr("modal.phoneNumberId", dict)}
+          error={trDynamic(errors.phoneNumberId?.message ?? "", dict)}
+        >
+          <TextInput
+            id="wa-phone"
+            placeholder="1188646904321987"
+            {...register("phoneNumberId")}
+            color={errors.phoneNumberId ? "failure" : undefined}
+          />
+        </Field>
+
+        <Field
+          id="wa-waba"
+          label={tr("modal.wabaId", dict)}
+          error={trDynamic(errors.wabaId?.message ?? "", dict)}
+        >
+          <TextInput
+            id="wa-waba"
+            placeholder="1333560228881251"
+            {...register("wabaId")}
+            color={errors.wabaId ? "failure" : undefined}
+          />
+        </Field>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field
+            id="wa-graph"
+            label={tr("modal.graphVersion", dict)}
+            error={trDynamic(errors.graphVersion?.message ?? "", dict)}
+          >
+            <TextInput
+              id="wa-graph"
+              {...register("graphVersion")}
+              color={errors.graphVersion ? "failure" : undefined}
+            />
+          </Field>
+
+          <Field
+            id="wa-base"
+            label={tr("modal.baseUrl", dict)}
+            error={trDynamic(errors.baseUrl?.message ?? "", dict)}
+          >
+            <TextInput
+              id="wa-base"
+              {...register("baseUrl")}
+              color={errors.baseUrl ? "failure" : undefined}
+            />
+          </Field>
+        </div>
+
+        <Field
+          id="wa-token"
+          label={tr("modal.token", dict)}
+          error={trDynamic(errors.token?.message ?? "", dict)}
+        >
+          <TextInput
+            id="wa-token"
+            type="password"
+            placeholder={tr("modal.tokenPlaceholder", dict)}
+            autoComplete="off"
+            {...register("token")}
+            color={errors.token ? "failure" : undefined}
+          />
+        </Field>
+      </div>
+    </FormModal>
+  );
+}
+
+interface FieldProps {
+  readonly id: string;
+  readonly label: string;
+  readonly error?: string;
+  readonly children: ReactNode;
+}
+
+function Field({ id, label, error, children }: FieldProps) {
+  return (
+    <div>
+      <Label htmlFor={id} className="mb-1 block">
+        {label}
+      </Label>
+      {children}
+      {error && (
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
@@ -24,7 +24,7 @@ interface WhatsAppConnectionModalProps {
 }
 
 const DEFAULTS: WhatsAppFormData = {
-  name: "Canal WhatsApp",
+  name: "",
   phoneNumberId: "",
   wabaId: "",
   graphVersion: DEFAULT_GRAPH_VERSION,
@@ -52,9 +52,9 @@ export function WhatsAppConnectionModal({
 
   useEffect(() => {
     if (show) {
-      reset(DEFAULTS);
+      reset({ ...DEFAULTS, name: tr("modal.defaultName", dict) });
     }
-  }, [show, reset]);
+  }, [show, reset, dict]);
 
   const submitLabel = loading
     ? tr("modal.saving", dict)

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-data-service.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-data-service.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { ApiError } from "../data/settings-admin-data-service";
+import {
+  WHATSAPP_PROVIDER,
+  type ConnectionTestResult,
+  type CredentialProfileResponse,
+  type IntegrationConnection,
+  type WhatsAppFormData,
+} from "./whatsapp.types";
+
+/**
+ * Thin client-side wrappers around the Next.js admin proxy routes for the
+ * org's WhatsApp integration connection. Throw {@link ApiError} on non-2xx.
+ */
+
+const integrationsBase = (orgSlug: string) =>
+  `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/integrations`;
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new ApiError({ status: res.status, url });
+  }
+  return (await res.json()) as T;
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let message: string | undefined;
+    try {
+      const parsed = (await res.json()) as {
+        message?: string;
+        error?: string | { message?: string };
+      };
+      message =
+        parsed.message ??
+        (typeof parsed.error === "string"
+          ? parsed.error
+          : parsed.error?.message);
+    } catch {
+      // non-JSON error body — fall back to the default ApiError message
+    }
+    throw new ApiError({ status: res.status, url, message });
+  }
+  return (await res.json()) as T;
+}
+
+/** The org's single WhatsApp connection, or null if not configured yet. */
+export async function fetchWhatsAppConnection(
+  orgSlug: string,
+): Promise<IntegrationConnection | null> {
+  const connections = await getJson<IntegrationConnection[]>(
+    `${integrationsBase(orgSlug)}/connections`,
+  );
+  return (
+    connections.find((c) => c.providerType === WHATSAPP_PROVIDER) ?? null
+  );
+}
+
+/**
+ * Create the WhatsApp connection: store the access token as a bearer credential
+ * profile, then create the connection referencing it. The phone-number-id /
+ * waba-id / graph-version are non-secret and go in the connection metadata.
+ */
+export async function createWhatsAppConnection(
+  orgSlug: string,
+  form: WhatsAppFormData,
+): Promise<IntegrationConnection> {
+  const credential = await postJson<CredentialProfileResponse>(
+    `${integrationsBase(orgSlug)}/credential-profiles`,
+    {
+      displayName: `WhatsApp token · ${form.phoneNumberId}`,
+      authType: "BEARER_TOKEN",
+      publicConfig: {},
+      secretConfig: { token: form.token },
+    },
+  );
+
+  return postJson<IntegrationConnection>(
+    `${integrationsBase(orgSlug)}/connections`,
+    {
+      name: form.name,
+      providerType: WHATSAPP_PROVIDER,
+      baseUrl: form.baseUrl,
+      credentialProfileId: credential.id,
+      metadata: {
+        phone_number_id: form.phoneNumberId,
+        waba_id: form.wabaId,
+        graph_version: form.graphVersion,
+      },
+    },
+  );
+}
+
+/** Run the live connectivity probe against Meta. */
+export async function testWhatsAppConnection(
+  orgSlug: string,
+  connectionId: string,
+): Promise<ConnectionTestResult> {
+  return postJson<ConnectionTestResult>(
+    `${integrationsBase(orgSlug)}/connections/${encodeURIComponent(connectionId)}/test`,
+    {},
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp.types.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp.types.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/** Mirrors the Quarkus `IntegrationConnection` DTO (miot-integrations). */
+export interface IntegrationConnection {
+  id: string;
+  tenantCode: string;
+  name: string;
+  providerType: string;
+  baseUrl: string;
+  credentialProfileId: string | null;
+  status: "DRAFT" | "ACTIVE" | "INACTIVE" | "TEST_FAILED";
+  lastTestedAt: string | null;
+  lastTestResult: boolean | null;
+  metadata: Record<string, unknown>;
+}
+
+/** Mirrors the Quarkus `CredentialProfileResponse` DTO. */
+export interface CredentialProfileResponse {
+  id: string;
+  displayName: string;
+  authType: string;
+}
+
+/** Mirrors the Quarkus `ConnectionTestResponse` DTO. */
+export interface ConnectionTestResult {
+  success: boolean;
+  testedAt: string;
+  message: string;
+}
+
+export const WHATSAPP_PROVIDER = "WHATSAPP";
+export const DEFAULT_GRAPH_VERSION = "v25.0";
+export const DEFAULT_BASE_URL = "https://graph.facebook.com/v25.0";
+
+/** Form for creating a WhatsApp connection. Messages are i18n keys (resolved via trDynamic). */
+export const WhatsAppConnectionSchema = z.object({
+  name: z.string().min(1, "validation.nameRequired"),
+  phoneNumberId: z.string().min(1, "validation.phoneNumberIdRequired"),
+  wabaId: z.string().min(1, "validation.wabaIdRequired"),
+  graphVersion: z.string().min(1, "validation.graphVersionRequired"),
+  baseUrl: z.string().url("validation.baseUrlInvalid"),
+  token: z.string().min(1, "validation.tokenRequired"),
+});
+
+export type WhatsAppFormData = z.infer<typeof WhatsAppConnectionSchema>;

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1232,6 +1232,49 @@
       "subtitle": "The trip you are looking for does not exist or is not available."
     },
     "userSettings": {
+      "organizations": {
+        "whatsappChannel": {
+          "title": "WhatsApp Channel",
+          "description": "Configure and test the WhatsApp connection used to reach drivers.",
+          "phoneLabel": "Phone number ID",
+          "configureButton": "Configure",
+          "testButton": "Test",
+          "status": {
+            "active": "Active",
+            "draft": "Draft",
+            "inactive": "Inactive",
+            "failed": "Test failed"
+          },
+          "modal": {
+            "addTitle": "Configure WhatsApp channel",
+            "subtitle": "Stores the access token securely and creates the connection.",
+            "name": "Connection name",
+            "phoneNumberId": "Phone number ID",
+            "wabaId": "WhatsApp Business Account ID",
+            "graphVersion": "Graph API version",
+            "baseUrl": "Base URL",
+            "token": "Access token",
+            "tokenPlaceholder": "System-user access token",
+            "cancel": "Cancel",
+            "saving": "Saving...",
+            "createButton": "Create"
+          },
+          "toast": {
+            "created": "WhatsApp channel configured",
+            "testSuccess": "Connection test successful",
+            "testFailed": "Connection test failed",
+            "error": "Something went wrong"
+          },
+          "validation": {
+            "nameRequired": "Connection name is required",
+            "phoneNumberIdRequired": "Phone number ID is required",
+            "wabaIdRequired": "WhatsApp Business Account ID is required",
+            "graphVersionRequired": "Graph API version is required",
+            "baseUrlInvalid": "Enter a valid URL",
+            "tokenRequired": "Access token is required"
+          }
+        }
+      },
       "breadcrumb": {
         "user": "User",
         "settings": "Settings",

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1236,6 +1236,7 @@
         "whatsappChannel": {
           "title": "WhatsApp Channel",
           "description": "Configure and test the WhatsApp connection used to reach drivers.",
+          "loadError": "Couldn't load the WhatsApp connection.",
           "phoneLabel": "Phone number ID",
           "configureButton": "Configure",
           "testButton": "Test",
@@ -1248,6 +1249,7 @@
           "modal": {
             "addTitle": "Configure WhatsApp channel",
             "subtitle": "Stores the access token securely and creates the connection.",
+            "defaultName": "WhatsApp Channel",
             "name": "Connection name",
             "phoneNumberId": "Phone number ID",
             "wabaId": "WhatsApp Business Account ID",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1236,6 +1236,7 @@
         "whatsappChannel": {
           "title": "Canal WhatsApp",
           "description": "Configura y prueba la conexión de WhatsApp para contactar a los conductores.",
+          "loadError": "No se pudo cargar la conexión de WhatsApp.",
           "phoneLabel": "ID del número",
           "configureButton": "Configurar",
           "testButton": "Probar",
@@ -1248,6 +1249,7 @@
           "modal": {
             "addTitle": "Configurar canal WhatsApp",
             "subtitle": "Guarda el token de acceso de forma segura y crea la conexión.",
+            "defaultName": "Canal WhatsApp",
             "name": "Nombre de la conexión",
             "phoneNumberId": "ID del número (phone number id)",
             "wabaId": "ID de la cuenta de WhatsApp Business (WABA)",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1232,6 +1232,49 @@
       "subtitle": "El viaje que estás buscando no existe o no se encuentra disponible."
     },
     "userSettings": {
+      "organizations": {
+        "whatsappChannel": {
+          "title": "Canal WhatsApp",
+          "description": "Configura y prueba la conexión de WhatsApp para contactar a los conductores.",
+          "phoneLabel": "ID del número",
+          "configureButton": "Configurar",
+          "testButton": "Probar",
+          "status": {
+            "active": "Activo",
+            "draft": "Borrador",
+            "inactive": "Inactivo",
+            "failed": "Prueba fallida"
+          },
+          "modal": {
+            "addTitle": "Configurar canal WhatsApp",
+            "subtitle": "Guarda el token de acceso de forma segura y crea la conexión.",
+            "name": "Nombre de la conexión",
+            "phoneNumberId": "ID del número (phone number id)",
+            "wabaId": "ID de la cuenta de WhatsApp Business (WABA)",
+            "graphVersion": "Versión de la Graph API",
+            "baseUrl": "URL base",
+            "token": "Token de acceso",
+            "tokenPlaceholder": "Token de acceso del usuario de sistema",
+            "cancel": "Cancelar",
+            "saving": "Guardando...",
+            "createButton": "Crear"
+          },
+          "toast": {
+            "created": "Canal WhatsApp configurado",
+            "testSuccess": "Prueba de conexión exitosa",
+            "testFailed": "La prueba de conexión falló",
+            "error": "Ocurrió un error"
+          },
+          "validation": {
+            "nameRequired": "El nombre de la conexión es obligatorio",
+            "phoneNumberIdRequired": "El ID del número es obligatorio",
+            "wabaIdRequired": "El ID de la cuenta de WhatsApp Business es obligatorio",
+            "graphVersionRequired": "La versión de la Graph API es obligatoria",
+            "baseUrlInvalid": "Ingresa una URL válida",
+            "tokenRequired": "El token de acceso es obligatorio"
+          }
+        }
+      },
       "breadcrumb": {
         "user": "Usuario",
         "settings": "Ajustes",


### PR DESCRIPTION
## Summary
Final foundation slice of the **WhatsApp communication-channel** capability (roadmap / **demo-first — not production**). Adds the in-app **Settings** surface to configure and **Test** the org's WhatsApp connection — the **org-level master switch** (D4). Reuses the `miot-integrations` connections API (`ProviderType=WHATSAPP`, the live `/test` probe from #751).

Scope is the **focused WhatsApp card** (chosen): create + test. Edit/delete deferred (the backend connections API has no update/delete yet).

Part of the phased plan, **Phase 0 — Foundations** (slice 3 of 3).

## What's in it (`turbo-repo/apps/app`)
- **Proxy routes** under `/api/admin/orgs/[orgId]/integrations` → `forwardToQuarkus`:
  - `connections` (GET list, POST create)
  - `credential-profiles` (POST create)
  - `connections/[connId]/test` (POST)
- **`whatsapp` feature module** (`src/features/settings-admin/whatsapp/`):
  - `whatsapp.types.ts` (DTOs + zod form schema)
  - `whatsapp-data-service.ts` (create credential-profile → create connection → test)
  - `use-org-whatsapp.ts` (SWR + create/test actions)
  - `whatsapp-connection-modal.tsx` (react-hook-form + zod, `FormModal`)
  - `whatsapp-channel-card.tsx` (status badge + Configure/Test, `sonner` toasts)
- Card wired into `org-detail-panel`; **i18n** added (`en` + `es`)

## Flow
Configure → store the access token as a `BEARER_TOKEN` credential profile → create a `WHATSAPP` connection with non-secret `metadata{phone_number_id, waba_id, graph_version}` → **Test** runs the live `GET {baseUrl}/{phone_number_id}` probe.

## Test plan
- `check-types` (CI) — could not run locally (monorepo `node_modules` not installed in this env); mirrored the Data Sources patterns closely. Watching CI.
- Manual: Settings → Organizations → select org → **WhatsApp Channel** card → Configure (creds) → Save → Test.

## Out of scope (later)
- Edit/delete (needs backend `PUT/DELETE` on connections)
- Per-trip opt-in (bento), kanban lane default, Control Tower / forum surfaces, send, webhook

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)