### PR TITLE
feat(harness-proxy): proxy GET /skills through the front door

### DIFF
--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessClient.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
@@ -53,6 +54,15 @@ public interface HarnessClient {
     @Path("/runs/{runId}")
     Uni<Response> getRun(
             @PathParam("runId") String runId,
+            @HeaderParam("Authorization") String authorization,
+            @HeaderParam("X-Miot-Tenant-Client-Id") String tenantClientId,
+            @HeaderParam("X-Miot-User-Email") String userEmail,
+            @HeaderParam("X-Miot-Auth-Mode") String authMode);
+
+    @GET
+    @Path("/skills")
+    Uni<Response> listSkills(
+            @QueryParam("tenant") String tenant,
             @HeaderParam("Authorization") String authorization,
             @HeaderParam("X-Miot-Tenant-Client-Id") String tenantClientId,
             @HeaderParam("X-Miot-User-Email") String userEmail,

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/HarnessProxyResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -27,7 +28,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
- * Auth0-gated proxy for miot-harness's {@code /runs} endpoints.
+ * Auth0-gated proxy for miot-harness's {@code /runs} and {@code /skills}
+ * endpoints.
  *
  * <p>The {@code /api/v1/orgs/{slug}/...} prefix makes
  * {@code OrganizationRequestFilter} resolve the org membership before
@@ -103,6 +105,25 @@ public class HarnessProxyResource {
         String userEmail = organizationContext.getUserEmail();
         String authMode = userEmail != null ? "web" : "m2m";
         return passThrough(harness.getRun(runId, authorization, tenantClientId, userEmail, authMode));
+    }
+
+    /**
+     * Lists the skills the harness can run — the data behind the chat
+     * {@code /skills} picker and {@code miot harness skills}. Sits behind
+     * the same auth + org-membership chain as the run routes, and forwards
+     * the optional {@code tenant} query param plus the caller identity so
+     * the harness resolves the same tenant it would for a run.
+     */
+    @GET
+    @Path("/skills")
+    public Uni<Response> listSkills(@PathParam("slug") String slug,
+                                    @QueryParam("tenant") String tenant,
+                                    @HeaderParam("Authorization") String authorization) {
+        String tenantClientId = tenantContext.getClientId();
+        String userEmail = organizationContext.getUserEmail();
+        String authMode = userEmail != null ? "web" : "m2m";
+        return passThrough(
+                harness.listSkills(tenant, authorization, tenantClientId, userEmail, authMode));
     }
 
     /**

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceSkillsTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourceSkillsTest.java
@@ -1,0 +1,131 @@
+package com.microboxlabs.miot.core.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile;
+import com.microboxlabs.miot.core.auth.HarnessProxyTestProfile.WireMockLifecycle;
+import com.microboxlabs.miot.core.auth.StubAlfrescoMembershipClient;
+import com.microboxlabs.miot.core.auth.TestTokenFactory;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code HarnessProxyResource#listSkills} forwards the upstream
+ * harness {@code GET /skills} response (body + status) unchanged, forwards
+ * the caller identity headers plus the optional {@code tenant} query param,
+ * and sits behind the same {@code DualJwtAuthMechanism} +
+ * {@code OrganizationRequestFilter} chain as the run routes.
+ */
+@QuarkusTest
+@TestProfile(HarnessProxyTestProfile.class)
+class HarnessProxyResourceSkillsTest {
+
+    private static final String ORG_SLUG = "harness-skills-test-org";
+    private static final String ORG_GROUP = "GROUP_harness_skills_test";
+    private static final String ORG_TENANT = "harness-skills-tenant";
+    private static final String NON_MEMBER = "intruder@test.example";
+    private static final String FAKE_SKILLS =
+            "[{\"id\":\"demo-skill\",\"name\":\"Demo Skill\",\"description\":\"d\","
+                    + "\"when_to_use\":\"\",\"scope\":\"tenant\",\"source\":\"skill_md\"}]";
+
+    @Inject
+    AgroalDataSource ds;
+
+    @BeforeEach
+    void seedOrgAndStubs() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "INSERT INTO miot_core.organizations "
+                        + "(slug, name, alfresco_group_id, tenant_client_id, active) "
+                        + "VALUES (?, ?, ?, ?, true)")) {
+            st.setString(1, ORG_SLUG);
+            st.setString(2, "Harness Skills Test Org");
+            st.setString(3, ORG_GROUP);
+            st.setString(4, ORG_TENANT);
+            st.executeUpdate();
+        }
+        WireMockLifecycle.server().resetAll();
+        // urlPathEqualTo so the stub matches whether or not the proxy appends
+        // a ?tenant query string.
+        WireMockLifecycle.server().stubFor(
+                WireMock.get(WireMock.urlPathEqualTo("/skills"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(FAKE_SKILLS)));
+    }
+
+    @AfterEach
+    void cleanupOrg() throws SQLException {
+        try (Connection c = ds.getConnection(); var st = c.prepareStatement(
+                "DELETE FROM miot_core.organizations WHERE slug = ?")) {
+            st.setString(1, ORG_SLUG);
+            st.executeUpdate();
+        }
+    }
+
+    @Test
+    void memberListsSkillsReturnsProxiedBodyAndForwardsIdentity() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        Response resp = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/skills");
+        assertThat(resp.statusCode(), is(200));
+        assertThat(resp.body().asString(), containsString("\"id\":\"demo-skill\""));
+        WireMockLifecycle.server().verify(WireMock.getRequestedFor(
+                WireMock.urlPathEqualTo("/skills"))
+                .withHeader("X-Miot-Tenant-Client-Id", WireMock.equalTo(ORG_TENANT))
+                .withHeader("X-Miot-User-Email",
+                        WireMock.equalTo(StubAlfrescoMembershipClient.MEMBER_EMAIL))
+                .withHeader("X-Miot-Auth-Mode", WireMock.equalTo("web")));
+    }
+
+    @Test
+    void tenantQueryParamIsForwardedUpstream() {
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        given()
+                .header("Authorization", "Bearer " + token)
+                .queryParam("tenant", "mintral")
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/skills")
+                .then()
+                .statusCode(200);
+        WireMockLifecycle.server().verify(WireMock.getRequestedFor(
+                WireMock.urlPathEqualTo("/skills"))
+                .withQueryParam("tenant", WireMock.equalTo("mintral")));
+    }
+
+    @Test
+    void nonMemberHits403WithoutCallingUpstream() {
+        String token = TestTokenFactory.signWebToken(NON_MEMBER);
+        int status = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/skills")
+                .statusCode();
+        assertThat(status, is(403));
+        WireMockLifecycle.server().verify(0,
+                WireMock.getRequestedFor(WireMock.urlPathEqualTo("/skills")));
+    }
+
+    @Test
+    void noTokenHits401() {
+        int status = given()
+                .when()
+                .get("/api/v1/orgs/" + ORG_SLUG + "/harness/skills")
+                .statusCode();
+        assertThat(status, is(401));
+    }
+}


### PR DESCRIPTION
Closes #762

## Why

In **front-door mode** the chat/CLI call `GET /api/v1/orgs/{slug}/harness/skills`, but `HarnessProxyResource` only mapped the `/runs*` routes — so the modulith returned **404** and the chat showed:

```
skills: harness error: http_404
```

The skills-listing feature (#755/#756) added `/skills` to the harness, client, chat and CLI, but **no matching proxy route in the modulith front door** — so it only worked in direct mode (`--harness-base-url`). The deployed harness serves `/skills` fine (verified 200 on the dev pod); only the proxy hop was missing.

Knock-on: the chat fetches the skill list to register the `/<skill-id>` autocomplete commands, so in front-door mode those never populated either. (Skill **invocation** already worked — it rides `POST /runs` via `skill_id`; this restores **discovery**.)

## What

- `HarnessClient`: add `listSkills(tenant, authorization, …identity headers)` → `GET /skills` with `@QueryParam("tenant")`.
- `HarnessProxyResource`: add `GET /skills` mirroring `getRun` — same Auth0 + `OrganizationRequestFilter` membership chain, forwards the `X-Miot-*` identity headers plus the optional `?tenant` query param so the harness resolves the same tenant it would for a run, and passes the upstream body/status through unchanged.
- `HarnessProxyResourceSkillsTest`: member lists skills (proxied body + identity/tenant forwarded), non-member → 403 without calling upstream, no token → 401 — mirrors `HarnessProxyResourceGetTest`.

`miot-core` `test-compile` passes locally; the QuarkusTest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)