### PR TITLE
fix(app): neutral placeholders in the WhatsApp connection modal

### DIFF
--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
@@ -94,7 +94,7 @@ export function WhatsAppConnectionModal({
         >
           <TextInput
             id="wa-phone"
-            placeholder="1188646904321987"
+            placeholder={tr("modal.phoneNumberIdPlaceholder", dict)}
             {...register("phoneNumberId")}
             color={errors.phoneNumberId ? "failure" : undefined}
           />
@@ -107,7 +107,7 @@ export function WhatsAppConnectionModal({
         >
           <TextInput
             id="wa-waba"
-            placeholder="1333560228881251"
+            placeholder={tr("modal.wabaIdPlaceholder", dict)}
             {...register("wabaId")}
             color={errors.wabaId ? "failure" : undefined}
           />

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1257,6 +1257,8 @@
             "baseUrl": "Base URL",
             "token": "Access token",
             "tokenPlaceholder": "System-user access token",
+            "phoneNumberIdPlaceholder": "e.g. 1234567890",
+            "wabaIdPlaceholder": "e.g. 1234567890",
             "cancel": "Cancel",
             "saving": "Saving...",
             "createButton": "Create"

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1257,6 +1257,8 @@
             "baseUrl": "URL base",
             "token": "Token de acceso",
             "tokenPlaceholder": "Token de acceso del usuario de sistema",
+            "phoneNumberIdPlaceholder": "ej. 1234567890",
+            "wabaIdPlaceholder": "ej. 1234567890",
             "cancel": "Cancelar",
             "saving": "Guardando...",
             "createButton": "Crear"


### PR DESCRIPTION
## Problem
The WhatsApp connection modal used a **specific tenant's real values** as the placeholders for the phone-number-id and WABA-id fields (`1188646904321987` / `1333560228881251`). In a generic per-org card that reads like pre-filled data — and since placeholders aren't submitted, it's misleading (you still have to type the value).

## Fix
Replace with **localized neutral examples** via i18n (`modal.phoneNumberIdPlaceholder` / `modal.wabaIdPlaceholder` → "e.g. 1234567890" / "ej. 1234567890"), matching the existing `tokenPlaceholder` pattern. No real identifiers in the component.

- `whatsapp-connection-modal.tsx`: both placeholders → `tr(...)`
- `en.json` / `es.json`: two new placeholder keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #771
