### PR TITLE
feat(conversational): named template parameters for outbound WhatsApp sends

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/client/MetaWhatsAppClient.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/client/MetaWhatsAppClient.java
@@ -10,7 +10,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Thin client over the Meta WhatsApp Cloud API send endpoint
@@ -47,8 +47,9 @@ public class MetaWhatsAppClient {
     }
 
     /**
-     * Sends a pre-approved template message. {@code bodyParams} fill the template's body
-     * placeholders ({{1}}, {{2}}, …) in order. Returns the Meta message id (wamid).
+     * Sends a pre-approved template message. {@code namedParams} fill the template's NAMED
+     * body placeholders by name (e.g. {@code driver_name}, {@code trip_reference}). Returns
+     * the Meta message id (wamid).
      */
     public String sendTemplate(
             URI baseUrl,
@@ -57,14 +58,17 @@ public class MetaWhatsAppClient {
             String toE164,
             String templateName,
             String languageCode,
-            List<String> bodyParams) {
+            Map<String, String> namedParams) {
         JsonObject template = new JsonObject()
                 .put("name", templateName)
                 .put("language", new JsonObject().put("code", languageCode));
-        if (bodyParams != null && !bodyParams.isEmpty()) {
+        if (namedParams != null && !namedParams.isEmpty()) {
             JsonArray parameters = new JsonArray();
-            for (String param : bodyParams) {
-                parameters.add(new JsonObject().put("type", "text").put("text", param));
+            for (Map.Entry<String, String> param : namedParams.entrySet()) {
+                parameters.add(new JsonObject()
+                        .put("type", "text")
+                        .put("parameter_name", param.getKey())
+                        .put("text", param.getValue()));
             }
             template.put("components", new JsonArray().add(
                     new JsonObject().put("type", "body").put("parameters", parameters)));

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequest.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequest.java
@@ -1,13 +1,15 @@
 package com.microboxlabs.miot.conversational.dto;
 
 import com.microboxlabs.miot.conversational.domain.MessageRole;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Request to send an outbound WhatsApp message. {@code type} selects {@code TEXT}
  * (free-form, only valid inside an open 24h session) or {@code TEMPLATE} (a pre-approved
- * template, valid to open a conversation). The trip-context fields are optional and, when
- * present, anchor the conversation to a service/process so its history stays attributable.
+ * template, valid to open a conversation). {@code templateParams} fills the template's
+ * NAMED body placeholders (e.g. {@code {"driver_name": "...", "trip_reference": "..."}}).
+ * The trip-context fields are optional and, when present, anchor the conversation to a
+ * service/process so its history stays attributable.
  */
 public record SendWhatsAppMessageRequest(
         String to,
@@ -15,7 +17,7 @@ public record SendWhatsAppMessageRequest(
         String body,
         String templateName,
         String language,
-        List<String> params,
+        Map<String, String> templateParams,
         MessageRole role,
         String driverId,
         String serviceCode,
@@ -37,7 +39,7 @@ public record SendWhatsAppMessageRequest(
         return role == null ? MessageRole.AGENT : role;
     }
 
-    public List<String> paramsOrEmpty() {
-        return params == null ? List.of() : params;
+    public Map<String, String> templateParamsOrEmpty() {
+        return templateParams == null ? Map.of() : templateParams;
     }
 }

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -167,8 +167,21 @@ public class WhatsAppMessagingService {
             if (request.templateName() == null || request.templateName().isBlank()) {
                 throw new IllegalArgumentException("'templateName' is required for a TEMPLATE message");
             }
+            validateTemplateParams(request.templateParamsOrEmpty());
         } else if (request.body() == null || request.body().isBlank()) {
             throw new IllegalArgumentException("'body' is required for a TEXT message");
+        }
+    }
+
+    private static void validateTemplateParams(Map<String, String> templateParams) {
+        for (Map.Entry<String, String> param : templateParams.entrySet()) {
+            if (param.getKey() == null || param.getKey().isBlank()) {
+                throw new IllegalArgumentException("templateParams contains a blank parameter name");
+            }
+            if (param.getValue() == null || param.getValue().isBlank()) {
+                throw new IllegalArgumentException(
+                        "templateParams['" + param.getKey() + "'] must have a non-blank value");
+            }
         }
     }
 

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -128,7 +128,7 @@ public class WhatsAppMessagingService {
         if (request.isTemplate()) {
             return metaClient.sendTemplate(
                     connection.baseUrl(), phoneNumberId, token, request.to(),
-                    request.templateName(), request.languageOrDefault(), request.paramsOrEmpty());
+                    request.templateName(), request.languageOrDefault(), request.templateParamsOrEmpty());
         }
         return metaClient.sendText(connection.baseUrl(), phoneNumberId, token, request.to(), request.body());
     }

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/client/MetaWhatsAppClientTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/client/MetaWhatsAppClientTest.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -55,21 +56,26 @@ class MetaWhatsAppClientTest {
     }
 
     @Test
-    void sendTemplateBuildsTemplatePayloadWithOrderedBodyParams() throws IOException {
+    void sendTemplateBuildsTemplatePayloadWithNamedBodyParams() throws IOException {
         startServer(200, OK_RESPONSE);
+        Map<String, String> namedParams = new LinkedHashMap<>();
+        namedParams.put("driver_name", "Juan");
+        namedParams.put("trip_reference", "SRV-123");
 
         String id = client.sendTemplate(URI.create(baseUrl()), PHONE_NUMBER_ID, TOKEN, TO,
-                "trip_assigned", "es_CL", List.of("Juan", "SRV-123"));
+                "trip_detention_alert_v1", "es_CL", namedParams);
 
         assertEquals(WAMID, id);
         JsonObject body = new JsonObject(seenBody.get());
         assertEquals("template", body.getString("type"));
         JsonObject template = body.getJsonObject("template");
-        assertEquals("trip_assigned", template.getString("name"));
+        assertEquals("trip_detention_alert_v1", template.getString("name"));
         assertEquals("es_CL", template.getJsonObject("language").getString("code"));
         JsonArray params = template.getJsonArray("components").getJsonObject(0).getJsonArray("parameters");
         assertEquals(2, params.size());
+        assertEquals("driver_name", params.getJsonObject(0).getString("parameter_name"));
         assertEquals("Juan", params.getJsonObject(0).getString("text"));
+        assertEquals("trip_reference", params.getJsonObject(1).getString("parameter_name"));
         assertEquals("SRV-123", params.getJsonObject(1).getString("text"));
     }
 

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequestTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequestTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.conversational.domain.MessageRole;
-import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class SendWhatsAppMessageRequestTest {
@@ -34,11 +34,11 @@ class SendWhatsAppMessageRequestTest {
     }
 
     @Test
-    void paramsNeverNull() {
-        assertTrue(request("TEXT").paramsOrEmpty().isEmpty());
-        assertEquals(List.of("a"), new SendWhatsAppMessageRequest(
-                "+56900", "TEMPLATE", null, "t", "es_CL", List.of("a"),
-                null, null, null, null, null).paramsOrEmpty());
+    void templateParamsNeverNull() {
+        assertTrue(request("TEXT").templateParamsOrEmpty().isEmpty());
+        assertEquals(Map.of("driver_name", "Juan"), new SendWhatsAppMessageRequest(
+                "+56900", "TEMPLATE", null, "t", "es_CL", Map.of("driver_name", "Juan"),
+                null, null, null, null, null).templateParamsOrEmpty());
     }
 
     private static SendWhatsAppMessageRequest request(String type) {

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -36,10 +36,21 @@ class WhatsAppMessagingServiceTest {
     }
 
     @Test
+    void validateRejectsTemplateParamWithBlankName() {
+        assertIllegalArgument(template("trip_detention_alert_v1", Map.of(" ", "Juan")), "parameter name");
+    }
+
+    @Test
+    void validateRejectsTemplateParamWithBlankValue() {
+        assertIllegalArgument(template("trip_detention_alert_v1", Map.of("driver_name", "")), "driver_name");
+    }
+
+    @Test
     void validateAcceptsWellFormedTextAndTemplate() {
         assertDoesNotThrow(() -> {
             invokeValidate(request("+56900", "TEXT", "hello", null));
             invokeValidate(request("+56900", "TEMPLATE", null, "trip_assigned"));
+            invokeValidate(template("trip_detention_alert_v1", Map.of("driver_name", "Juan")));
         });
     }
 
@@ -79,5 +90,10 @@ class WhatsAppMessagingServiceTest {
     private static SendWhatsAppMessageRequest request(String to, String type, String body, String templateName) {
         return new SendWhatsAppMessageRequest(
                 to, type, body, templateName, null, Map.of(), null, null, null, null, null);
+    }
+
+    private static SendWhatsAppMessageRequest template(String templateName, Map<String, String> params) {
+        return new SendWhatsAppMessageRequest(
+                "+56900", "TEMPLATE", null, templateName, null, params, null, null, null, null, null);
     }
 }

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -78,6 +78,6 @@ class WhatsAppMessagingServiceTest {
 
     private static SendWhatsAppMessageRequest request(String to, String type, String body, String templateName) {
         return new SendWhatsAppMessageRequest(
-                to, type, body, templateName, null, List.of(), null, null, null, null, null);
+                to, type, body, templateName, null, Map.of(), null, null, null, null, null);
     }
 }


### PR DESCRIPTION
Follow-up to #774. The 4 approved demo templates use Meta's **NAMED** parameter format (`parameter_format: NAMED`) — body placeholders are `{{driver_name}}`, `{{trip_reference}}`, `{{location}}`, `{{reason}}`. Phase 1a sent **positional** params (`{type:text, text:…}`), which Meta rejects for NAMED templates (error 132000/132001). This makes the send path actually work against the approved templates.

Closes #775.

## Changes
- **`MetaWhatsAppClient.sendTemplate`** now takes `Map<String,String> namedParams` and emits `{type:text, parameter_name:<name>, text:<value>}` per body parameter.
- **`SendWhatsAppMessageRequest`** carries `templateParams: Map<String,String>` (name → value) instead of a positional `List<String>`.
- **`WhatsAppMessagingService`** passes the named params through.

## Tests (13 green)
- `MetaWhatsAppClientTest` now asserts the named-param payload (`parameter_name` + `text`) against a live local server.
- DTO + service tests updated for the map-based params.

## Out of scope
- Listing templates from WABA — the frontend will carry the demo template catalog (manual-first).
- Frontend Control Tower "Send WhatsApp" surface — next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp template messages now support named placeholders, making it easier to fill template values by name instead of position.
  * Message requests and sending now accept named template parameters for clearer template mapping.

* **Tests**
  * Updated test coverage to verify named template parameters are handled correctly and produce the expected message payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->