### PR TITLE
feat(harness): Phase 2 slice 1 — schema introspection + lazy index + describe-with-FKs

### DIFF
--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -56,6 +56,7 @@ def _evidence_from_output(
     *,
     warn_minutes: int,
     source_label: str,
+    has_freshness_model: bool = True,
 ) -> DataEvidence:
     if hasattr(output, "model_dump"):
         dump = output.model_dump()
@@ -101,11 +102,18 @@ def _evidence_from_output(
     # looks unrefreshed" (the beta-review Gap 2 conflation).
     has_rows = sample_size > 0
     age_is_stale = False
-    if isinstance(refreshed_at, datetime):
+    if not has_freshness_model:
+        # Live datasources (generic pg) have no snapshot/refresh model: a
+        # missing refreshed_at is normal, NOT staleness. Current data is fresh;
+        # zero rows is just "no matching rows". Never emit a no_timestamp/stale
+        # warning the synthesizer would surface as "trust with caution".
+        status: FreshnessStatus = "fresh" if has_rows else "empty"
+        is_stale = False
+    elif isinstance(refreshed_at, datetime):
         age_minutes = (datetime.now(UTC) - refreshed_at).total_seconds() / 60
         age_is_stale = age_minutes > warn_minutes
         if has_rows:
-            status: FreshnessStatus = "stale" if age_is_stale else "fresh"
+            status = "stale" if age_is_stale else "fresh"
         else:
             status = "empty"
         is_stale = age_is_stale
@@ -176,6 +184,7 @@ async def invoke_step(
             else profile.freshness_warn_minutes
         ),
         source_label=profile.source_label,
+        has_freshness_model=profile.has_freshness_model,
     )
     return {"evidence": [evidence]}
 

--- a/miot-harness/src/miot_harness/agents/freshness_judge.py
+++ b/miot-harness/src/miot_harness/agents/freshness_judge.py
@@ -36,6 +36,12 @@ def freshness_judge_node(
     progress: Progress,
     profile: DataSourceProfile,
 ) -> dict[str, Any]:
+    # Live datasources (no snapshot/refresh model) are never "stale": skip the
+    # judge entirely so a missing `refreshed_at` doesn't emit a misleading
+    # snapshot-age warning. (Nexo keeps the model; generic pg connections don't.)
+    if not profile.has_freshness_model:
+        return {"next_action": "analyze", "freshness": FRESHNESS_FRESH}
+
     # Effective thresholds: env override wins (including an explicit 0),
     # else the profile default. This is the single resolution point that
     # data_fetcher mirrors when it stamps is_stale.

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -45,19 +45,11 @@ def _tenant_refusal(profile: DataSourceProfile, tenant_lock: str) -> str:
     )
 
 
-# {display_name} → profile.display_name (the active datasource's human name).
-_SYNTH_SYSTEM_TEMPLATE = """\
-You are the {display_name} synthesizer. Write the final answer for the user
-in the same language as their question. Be concise (≤200 words).
-
-{primer}
-
-Rules:
+# Freshness guidance for SNAPSHOT datasources (Nexo's fn_dx_* tables). Omitted
+# for live sources, which have no snapshot/refresh model.
+_SYNTH_FRESHNESS_RULES = """\
 - Cite refreshed_at from the evidence (timestamp + "datos del snapshot ...").
 - If any evidence has is_stale=true, say so explicitly ("datos antiguos").
-- If the evidence is empty or insufficient, say what you don't know.
-- Do not invent rows or numbers; quote what's in the evidence.
-- Do not mention internal pipeline (filter_expert, plan, etc.).
 
 Per-status phrasing (each evidence line carries status=... and rows=...):
 - status=empty → the snapshot IS fresh but the filter matched nothing:
@@ -68,7 +60,27 @@ Per-status phrasing (each evidence line carries status=... and rows=...):
   say "datos sin marca de tiempo de actualización — trátalos con cautela".
 - status=empty_no_timestamp → no rows AND no timestamp; the view looks
   unrefreshed: say "esta vista parece no haberse refrescado; no puedo
-  distinguir 'sin datos' de 'snapshot vacío'".
+  distinguir 'sin datos' de 'snapshot vacío'"."""
+
+# Guidance for LIVE datasources (generic pg): current data, no snapshot model.
+_SYNTH_LIVE_RULES = """\
+- This is a LIVE datasource: the evidence is the current state. Do NOT add
+  freshness/snapshot/timestamp caveats and do NOT treat a missing refresh
+  timestamp as staleness. status=empty just means no rows matched."""
+
+
+# {display_name} → profile.display_name; {freshness_rules} → snapshot-vs-live.
+_SYNTH_SYSTEM_TEMPLATE = """\
+You are the {display_name} synthesizer. Write the final answer for the user
+in the same language as their question. Be concise (≤200 words).
+
+{primer}
+
+Rules:
+- If the evidence is empty or insufficient, say what you don't know.
+- Do not invent rows or numbers; quote what's in the evidence.
+- Do not mention internal pipeline (filter_expert, plan, etc.).
+{freshness_rules}
 """
 
 
@@ -211,7 +223,13 @@ async def synthesizer_node(
 
     user_message = state.get("user_message", "")
     system = _SYNTH_SYSTEM_TEMPLATE.format(
-        display_name=profile.display_name, primer=profile.primer
+        display_name=profile.display_name,
+        primer=profile.primer,
+        freshness_rules=(
+            _SYNTH_FRESHNESS_RULES
+            if profile.has_freshness_model
+            else _SYNTH_LIVE_RULES
+        ),
     )
     if extra_system_rules:
         system = f"{system}\n{extra_system_rules}"

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -197,6 +197,9 @@ def _make_lifespan(
         # never lands in the close list.
         providers_to_close: list[DataSourceProvider] = [provider]
         primary_result: BootResult | None = None
+        # Connection Knowledge Base (Phase 2): per-connection grounding blocks
+        # (secondary primers + schema indexes), folded into the agent primer below.
+        ckb_blocks: list[str] = []
         for conn in conn_result.connections:
             is_primary = primary is not None and conn.name == primary.name
             # Resolve + boot inside the guard: an unknown/typo'd backend
@@ -214,6 +217,7 @@ def _make_lifespan(
                 boot_res = BootResult(
                     enabled=False, registered=(), reason=f"boot failed: {exc}"
                 )
+            summary = boot_res.schema_summary
             app.state.connections[conn.name] = {
                 "backend": conn.backend,
                 "enabled": boot_res.enabled,
@@ -224,7 +228,29 @@ def _make_lifespan(
                 "registered": list(boot_res.registered),
                 "reason": boot_res.reason,
                 "snapshot_age_minutes": boot_res.snapshot_age_minutes,
+                # Connection Knowledge Base (Phase 2): schema index summary.
+                "schema": (
+                    {
+                        "schemas": list(summary.schemas),
+                        "table_count": summary.total_tables,
+                        "indexed": len(summary.tables),
+                        "truncated": summary.truncated,
+                    }
+                    if summary is not None
+                    else None
+                ),
             }
+            # Accumulate the CKB grounding block for each enabled connection.
+            # The primary's primer is already in provider.profile.primer, so add
+            # it only for secondaries; the schema index is new for all.
+            if boot_res.enabled:
+                parts: list[str] = []
+                if not is_primary and conn.primer:
+                    parts.append(conn.primer)
+                if summary is not None and summary.tables:
+                    parts.append(summary.render())
+                if parts:
+                    ckb_blocks.append(f"## {conn.name}\n" + "\n\n".join(parts))
             if is_primary:
                 primary_result = boot_res
 
@@ -259,7 +285,15 @@ def _make_lifespan(
         # so it reaches every agent path while staying byte-stable across
         # tenants — keeping the Anthropic cache prefix hot. The per-tenant
         # overlay is applied per request on the meta path (see supervisor).
-        effective_profile = provider.profile
+        # Assemble the agent primer: base profile primer + the CKB block
+        # (per-connection schema indexes / secondary primers) + the global
+        # system-context block. One replace() so it stays byte-stable for the
+        # process lifetime (cache prefix stays hot).
+        primer_sections: list[str] = [provider.profile.primer]
+        if ckb_blocks:
+            primer_sections.append(
+                "# Connected data sources\n" + "\n\n".join(ckb_blocks)
+            )
         try:
             cs = boot_context_skills(harness.tools, settings)
             harness.context_skills = cs.bundle
@@ -267,13 +301,7 @@ def _make_lifespan(
             app.state.context_skills_diagnostics = list(cs.diagnostics)
             global_block = cs.bundle.global_primer()
             if global_block:
-                effective_profile = replace(
-                    provider.profile,
-                    primer=(
-                        f"{provider.profile.primer}\n\n"
-                        f"# System context\n{global_block}"
-                    ),
-                )
+                primer_sections.append(f"# System context\n{global_block}")
             for diag in cs.diagnostics:
                 (logger.error if diag.level == "error" else logger.warning)(
                     "Context/Skills: %s (%s)", diag.message, diag.path
@@ -289,6 +317,12 @@ def _make_lifespan(
                 exc,
             )
             harness.context_skills = None
+
+        effective_profile = (
+            replace(provider.profile, primer="\n\n".join(primer_sections))
+            if len(primer_sections) > 1
+            else provider.profile
+        )
 
         if not result.enabled:
             logger.info(

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -247,7 +247,9 @@ def _make_lifespan(
                 parts: list[str] = []
                 if not is_primary and conn.primer:
                     parts.append(conn.primer)
-                if summary is not None and summary.tables:
+                # total_tables (not tables) so the header + truncation note still
+                # render when the index is capped to 0 (generic_schema_max_tables=0).
+                if summary is not None and summary.total_tables:
                     parts.append(summary.render())
                 if parts:
                     ckb_blocks.append(f"## {conn.name}\n" + "\n\n".join(parts))

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -113,6 +113,14 @@ class HarnessSettings(BaseSettings):
     # declare `capabilities.generic_query: true` to light up. Off everywhere
     # today; only the dev/local `acs` connection opts in.
     generic_query_enabled: bool = False
+    # Connection Knowledge Base (Phase 2): boot-time schema index for generic
+    # `pg` connections (table list + types + row estimates, folded into the
+    # agent grounding). Kill switch (mirrors the freshness survey); only affects
+    # connections that are already generic-query-enabled. `max_tables` bounds the
+    # always-on index so a large schema can't bloat every prompt (explicit
+    # truncation note, never silent).
+    generic_schema_introspect_enabled: bool = True
+    generic_schema_max_tables: int = Field(default=80, ge=0)
     # Hard cap on connector tools registered from skill files — bounds the
     # blast radius of a misconfigured/oversized ConfigMap.
     max_connector_tools: int = Field(default=50, ge=0)

--- a/miot-harness/src/miot_harness/datasource/provider.py
+++ b/miot-harness/src/miot_harness/datasource/provider.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from miot_harness.agents.meta_agent import MetaAgentCatalogEntry
     from miot_harness.config import HarnessSettings
     from miot_harness.connections.models import Connection
+    from miot_harness.datasource.schema_introspect import SchemaSummary
     from miot_harness.tools.registry import ToolRegistry
 
 
@@ -99,6 +100,10 @@ class BootResult:
     # Descriptor-derived meta-agent catalog (title/layer/body + freshness
     # suffix). Empty → the server falls back to generic entries.
     catalog_entries: tuple[MetaAgentCatalogEntry, ...] = ()
+    # Connection Knowledge Base (Phase 2): the boot-time schema index for
+    # generic connections. None for providers that don't introspect (e.g.
+    # Nexo, which surfaces its function catalog instead).
+    schema_summary: SchemaSummary | None = None
 
 
 class DataSourceProvider(ABC):

--- a/miot-harness/src/miot_harness/datasource/provider.py
+++ b/miot-harness/src/miot_harness/datasource/provider.py
@@ -66,6 +66,11 @@ class DataSourceProfile:
     tenant_refusal_template: str
     freshness_warn_minutes: int
     freshness_refuse_minutes: int
+    # Whether this datasource has a snapshot/refresh freshness model (Nexo's
+    # `fn_dx_*` snapshot tables do; a live operational DB does not). When False,
+    # the freshness judge is a no-op — a live source with no `refreshed_at` is
+    # not "stale", so the snapshot-age warning is suppressed.
+    has_freshness_model: bool = True
 
 
 @dataclass(frozen=True)

--- a/miot-harness/src/miot_harness/datasource/safe_query.py
+++ b/miot-harness/src/miot_harness/datasource/safe_query.py
@@ -17,6 +17,7 @@ hardening, layered on top — not a prerequisite).
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from miot_harness.datasource.safe_sql import (
@@ -175,6 +176,33 @@ async def safe_grep(
     return [dict(row) for row in rows]
 
 
+def _plan_from_explain(rows: list[Any]) -> dict[str, Any]:
+    """Extract the top Plan node from EXPLAIN (FORMAT JSON) rows.
+
+    asyncpg returns json/jsonb columns as STRINGS (no codec), so the
+    ``QUERY PLAN`` value may be a JSON string rather than a parsed list —
+    decode it before indexing.
+    """
+    if not rows:
+        raise UnsupportedConstruct("EXPLAIN returned no rows")
+    try:
+        payload = rows[0]["QUERY PLAN"]
+    except (KeyError, TypeError, IndexError) as exc:
+        raise UnsupportedConstruct("EXPLAIN output missing QUERY PLAN") from exc
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise UnsupportedConstruct("EXPLAIN output not valid JSON") from exc
+    if not payload:
+        raise UnsupportedConstruct("EXPLAIN output missing QUERY PLAN")
+    first = payload[0]
+    if not isinstance(first, dict):
+        raise UnsupportedConstruct("EXPLAIN output has unexpected shape")
+    plan = first.get("Plan", {})
+    return plan if isinstance(plan, dict) else {}
+
+
 async def safe_explain(
     *,
     pool: Any,
@@ -192,16 +220,7 @@ async def safe_explain(
         f"EXPLAIN (FORMAT JSON) {safe_inner}",
         statement_timeout_ms=statement_timeout_ms,
     )
-    if not rows:
-        raise UnsupportedConstruct("EXPLAIN returned no rows")
-    row = rows[0]
-    try:
-        payload = row["QUERY PLAN"]
-    except (KeyError, TypeError, IndexError) as exc:
-        raise UnsupportedConstruct("EXPLAIN output missing QUERY PLAN") from exc
-    if not payload:
-        raise UnsupportedConstruct("EXPLAIN output missing QUERY PLAN")
-    plan = payload[0].get("Plan", {})
+    plan = _plan_from_explain(rows)
     total_cost = float(plan.get("Total Cost", 0.0))
     if total_cost > cost_threshold:
         raise CostGateViolation(
@@ -212,3 +231,46 @@ async def safe_explain(
         "node_type": plan.get("Node Type"),
         "plan": plan,
     }
+
+
+async def safe_run_select(
+    *,
+    pool: Any,
+    policy: TableAccessPolicy,
+    sql: str,
+    max_rows: int = HARD_LIMIT_CAP,
+    cost_threshold: float | None = None,
+    statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
+) -> list[dict[str, Any]]:
+    """Run an arbitrary read-only SELECT (the broad Tier-B query surface).
+
+    Unlike ``safe_select`` (a single-table builder), this accepts full SQL —
+    JOINs, CTEs, GROUP BY, aggregates — validated by the SAME sqlglot gate
+    (SELECT-only, allowlisted tables/functions). The harness enforces a hard
+    result cap by wrapping the validated query, runs it in the read-only
+    envelope, and optionally refuses over-budget plans via an EXPLAIN cost gate.
+
+    Note: the cap is applied by an outer ``SELECT * FROM (<query>) LIMIT n``;
+    Postgres preserves an inner ORDER BY through a single subquery in practice.
+    """
+    ast = validate_select_sql(sql, table_policy=policy)
+    inner = render_safe(ast)
+    cap = max(1, min(int(max_rows), HARD_LIMIT_CAP))
+    wrapped = f"SELECT * FROM ({inner}) AS _miot_q LIMIT {cap}"
+
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            if statement_timeout_ms:
+                await conn.execute(
+                    f"SET LOCAL statement_timeout = {int(statement_timeout_ms)}"
+                )
+            if cost_threshold is not None:
+                plan_rows = await conn.fetch(f"EXPLAIN (FORMAT JSON) {wrapped}")
+                total_cost = float(_plan_from_explain(plan_rows).get("Total Cost", 0.0))
+                if total_cost > cost_threshold:
+                    raise CostGateViolation(
+                        f"plan total_cost={total_cost:.1f} exceeds threshold "
+                        f"{cost_threshold:.1f}"
+                    )
+            rows = await conn.fetch(wrapped)
+            return [dict(r) for r in rows]

--- a/miot-harness/src/miot_harness/datasource/safe_query.py
+++ b/miot-harness/src/miot_harness/datasource/safe_query.py
@@ -35,6 +35,23 @@ from miot_harness.datasource.sql_policy import TableAccessPolicy
 DEFAULT_STATEMENT_TIMEOUT_MS = 5000
 
 
+def _record_to_dict(record: Any) -> dict[str, Any]:
+    """Row → dict, disambiguating duplicate column labels (e.g. from SELECT *
+    over a JOIN) so no column is silently dropped. asyncpg Records and plain
+    dicts both expose keys()/values()."""
+    keys = list(record.keys())
+    values = list(record.values())
+    out: dict[str, Any] = {}
+    for key, value in zip(keys, values, strict=False):
+        name = key
+        i = 2
+        while name in out:
+            name = f"{key}_{i}"
+            i += 1
+        out[name] = value
+    return out
+
+
 async def fetch_readonly(
     pool: Any,
     sql: str,
@@ -273,4 +290,7 @@ async def safe_run_select(
                         f"{cost_threshold:.1f}"
                     )
             rows = await conn.fetch(wrapped)
-            return [dict(r) for r in rows]
+            # SELECT * over a JOIN can yield duplicate column labels; dict(r)
+            # would silently keep only the last. Preserve every column by
+            # suffixing collisions (id_, id__2, …) so no data is lost.
+            return [_record_to_dict(r) for r in rows]

--- a/miot-harness/src/miot_harness/datasource/safe_query.py
+++ b/miot-harness/src/miot_harness/datasource/safe_query.py
@@ -34,7 +34,7 @@ from miot_harness.datasource.sql_policy import TableAccessPolicy
 DEFAULT_STATEMENT_TIMEOUT_MS = 5000
 
 
-async def _fetch_readonly(
+async def fetch_readonly(
     pool: Any,
     sql: str,
     *args: Any,
@@ -84,7 +84,7 @@ async def safe_list_tables(
         "WHERE table_schema = ANY($1::text[]) "
         "ORDER BY table_schema, table_name"
     )
-    rows = await _fetch_readonly(
+    rows = await fetch_readonly(
         pool, sql, sorted(schemas), statement_timeout_ms=statement_timeout_ms
     )
     return [dict(row) for row in rows]
@@ -108,7 +108,7 @@ async def safe_describe(
         "SELECT column_name, data_type FROM information_schema.columns "
         "WHERE table_schema = $1 AND table_name = $2 ORDER BY ordinal_position"
     )
-    rows = await _fetch_readonly(
+    rows = await fetch_readonly(
         pool, sql, schema, name, statement_timeout_ms=statement_timeout_ms
     )
     return [dict(row) for row in rows]
@@ -145,7 +145,7 @@ async def safe_select(
 
     ast = validate_select_sql(sql, table_policy=policy)
     safe_sql = render_safe(ast)
-    rows = await _fetch_readonly(
+    rows = await fetch_readonly(
         pool, safe_sql, statement_timeout_ms=statement_timeout_ms
     )
     return [dict(row) for row in rows]
@@ -169,7 +169,7 @@ async def safe_grep(
     sql_for_gate = f"SELECT * FROM {table} WHERE {col} ILIKE $1 LIMIT {bounded_limit}"
     ast = validate_select_sql(sql_for_gate, table_policy=policy)
     safe_sql = render_safe(ast)
-    rows = await _fetch_readonly(
+    rows = await fetch_readonly(
         pool, safe_sql, pattern, statement_timeout_ms=statement_timeout_ms
     )
     return [dict(row) for row in rows]
@@ -187,7 +187,7 @@ async def safe_explain(
 
     ast = validate_select_sql(query, table_policy=policy)
     safe_inner = render_safe(ast)
-    rows = await _fetch_readonly(
+    rows = await fetch_readonly(
         pool,
         f"EXPLAIN (FORMAT JSON) {safe_inner}",
         statement_timeout_ms=statement_timeout_ms,

--- a/miot-harness/src/miot_harness/datasource/safe_sql.py
+++ b/miot-harness/src/miot_harness/datasource/safe_sql.py
@@ -180,16 +180,20 @@ def validate_select_sql(sql: str, *, table_policy: TableAccessPolicy) -> exp.Exp
             f"(found at: {lat.sql(dialect='postgres')[:80]!r})"
         )
 
-    # 3. Every function call must be in the safe-builtin allowlist.
-    #    sqlglot emits dedicated AST classes for common builtins (`Sum`,
-    #    `Count`, `Cast`, `Coalesce`, `TimestampTrunc`, ...) and
-    #    `exp.Anonymous` for everything else. We accept if ANY candidate
-    #    name (sql_name, key, class name, Anonymous.this) is in the
-    #    allowlist — robust to sqlglot's per-builtin AST normalization.
-    for func in ast.find_all(exp.Func):
+    # 3. Arbitrary/unknown function NAMES must be allowlisted.
+    #    The escape-hatch threats — pg_read_file, dblink, pg_sleep, set_config,
+    #    lo_import, pg_terminate_backend, pg_advisory_lock, … — are all parsed by
+    #    sqlglot as `exp.Anonymous` (it has no dedicated class for them). Every
+    #    DEDICATED Func subclass (Sum/Count/Cast/Coalesce/Case/And/Or/Extract/
+    #    Interval/window fns/…) is a recognized, inherently read-only SQL
+    #    construct — gating those by name caused false rejects (AND/OR/CASE) and
+    #    blocked legitimate analytical SQL. So we gate ONLY Anonymous names
+    #    against the allowlist; that is exactly where the dangerous functions
+    #    live, and adding a new Postgres function name still requires a review.
+    for func in ast.find_all(exp.Anonymous):
         candidates = _function_name_candidates(func)
         if not candidates:
-            continue  # synthetic Func with no resolvable name — skip
+            continue  # unresolvable name — nothing to match
         if not candidates & _SAFE_FUNCTIONS:
             picked = next(iter(candidates))
             raise UnsupportedConstruct(

--- a/miot-harness/src/miot_harness/datasource/schema_introspect.py
+++ b/miot-harness/src/miot_harness/datasource/schema_introspect.py
@@ -166,23 +166,32 @@ async def introspect_schema(
     )
 
 
+# Positional mapping so composite (multi-column) FKs pair each local column with
+# the CORRECT referenced column. Joining KCU↔CCU on constraint name alone
+# Cartesian-products multi-column keys; instead go through referential_constraints
+# and match the referenced key_column_usage by
+# `kcu.position_in_unique_constraint = ref_kcu.ordinal_position`.
 _FK_QUERY = """
 SELECT kcu.column_name AS column,
-       ccu.table_schema AS ref_schema,
-       ccu.table_name AS ref_table,
-       ccu.column_name AS ref_column,
+       ref_kcu.table_schema AS ref_schema,
+       ref_kcu.table_name AS ref_table,
+       ref_kcu.column_name AS ref_column,
        tc.constraint_name AS constraint
 FROM information_schema.table_constraints tc
+JOIN information_schema.referential_constraints rc
+  ON rc.constraint_schema = tc.constraint_schema
+ AND rc.constraint_name = tc.constraint_name
 JOIN information_schema.key_column_usage kcu
-  ON tc.constraint_name = kcu.constraint_name
- AND tc.table_schema = kcu.table_schema
-JOIN information_schema.constraint_column_usage ccu
-  ON ccu.constraint_name = tc.constraint_name
- AND ccu.table_schema = tc.table_schema
+  ON kcu.constraint_schema = tc.constraint_schema
+ AND kcu.constraint_name = tc.constraint_name
+JOIN information_schema.key_column_usage ref_kcu
+  ON ref_kcu.constraint_schema = rc.unique_constraint_schema
+ AND ref_kcu.constraint_name = rc.unique_constraint_name
+ AND ref_kcu.ordinal_position = kcu.position_in_unique_constraint
 WHERE tc.constraint_type = 'FOREIGN KEY'
   AND tc.table_schema = $1
   AND tc.table_name = $2
-ORDER BY kcu.column_name
+ORDER BY tc.constraint_name, kcu.ordinal_position
 """
 
 

--- a/miot-harness/src/miot_harness/datasource/schema_introspect.py
+++ b/miot-harness/src/miot_harness/datasource/schema_introspect.py
@@ -1,0 +1,209 @@
+"""Boot-time schema introspection for generic connections (Phase 2, slice 1).
+
+Builds a compact, byte-stable **schema index** for a connection's allowed
+schema(s): one line per table (name · type · row estimate). This is the
+always-loaded "header" layer of the Connection Knowledge Base — the agent sees
+what tables exist without spending a turn on `list_tables`; columns and FKs stay
+lazy (`describe`).
+
+Also exposes `introspect_foreign_keys` for the `describe`-with-FKs body.
+
+All queries run inside Phase 1's read-only envelope (`fetch_readonly`:
+`BEGIN READ ONLY` + `SET LOCAL statement_timeout`). Introspection reads
+`pg_catalog`/`information_schema` directly (parameterised, harness-authored — not
+agent SQL), so it does not go through the agent-facing SELECT gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from miot_harness.datasource.safe_query import (
+    DEFAULT_STATEMENT_TIMEOUT_MS,
+    fetch_readonly,
+)
+from miot_harness.datasource.sql_policy import TableAccessPolicy
+
+
+@dataclass(frozen=True)
+class TableInfo:
+    schema: str
+    name: str
+    table_type: str  # BASE TABLE | VIEW | MATERIALIZED VIEW | ...
+    row_estimate: int | None  # pg_class.reltuples; None when never analyzed (<0)
+
+    @property
+    def qualified(self) -> str:
+        return f"{self.schema}.{self.name}"
+
+
+@dataclass(frozen=True)
+class SchemaSummary:
+    connection: str
+    schemas: tuple[str, ...]
+    tables: tuple[TableInfo, ...]  # capped to max_tables, sorted by qualified name
+    total_tables: int  # before the cap
+    primer: str = ""  # the connection.md body (carried for the grounding fold)
+
+    @property
+    def truncated(self) -> bool:
+        return self.total_tables > len(self.tables)
+
+    def render(self) -> str:
+        """Compact, deterministic markdown index for the agent prompt.
+
+        Sorted by qualified name (NOT row count) so the text is byte-stable for
+        the process lifetime — keeps the prompt-cache prefix hot. Row estimates
+        are fixed at boot, so they don't vary per request.
+        """
+        schema_label = ", ".join(self.schemas)
+        head = f"Schema `{schema_label}` ({self.total_tables} tables):"
+        lines = [head]
+        for t in self.tables:
+            est = _fmt_estimate(t.row_estimate)
+            suffix = f" · {est}" if est else ""
+            kind = "" if t.table_type == "BASE TABLE" else f" [{t.table_type.lower()}]"
+            lines.append(f"- {t.qualified}{kind}{suffix}")
+        if self.truncated:
+            extra = self.total_tables - len(self.tables)
+            lines.append(f"- (+{extra} more — use the connection's list_tables tool)")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class ForeignKey:
+    column: str
+    ref_schema: str
+    ref_table: str
+    ref_column: str
+    constraint: str = ""
+
+    def render(self) -> str:
+        return f"{self.column} → {self.ref_schema}.{self.ref_table}.{self.ref_column}"
+
+
+def _estimate(raw: object) -> int | None:
+    """pg_class.reltuples → row estimate; <0 means never analyzed (unknown)."""
+    if not isinstance(raw, (int, float)):
+        return None
+    val = int(raw)
+    return val if val >= 0 else None
+
+
+def _fmt_estimate(rows: int | None) -> str:
+    if rows is None:
+        return ""
+    if rows <= 0:
+        return "empty"
+    if rows < 1000:
+        return f"~{rows} rows"
+    if rows < 1_000_000:
+        return f"~{rows / 1000:.0f}k rows"
+    return f"~{rows / 1_000_000:.1f}M rows"
+
+
+# Table list + type + row estimate from pg_catalog (reltuples is a planner
+# statistic — free, no COUNT(*)). relkind: r=table, v=view, m=matview,
+# p=partitioned, f=foreign.
+_TABLES_QUERY = """
+SELECT n.nspname AS table_schema,
+       c.relname AS table_name,
+       CASE c.relkind
+            WHEN 'r' THEN 'BASE TABLE'
+            WHEN 'v' THEN 'VIEW'
+            WHEN 'm' THEN 'MATERIALIZED VIEW'
+            WHEN 'p' THEN 'PARTITIONED TABLE'
+            WHEN 'f' THEN 'FOREIGN TABLE'
+            ELSE c.relkind::text
+       END AS table_type,
+       c.reltuples::bigint AS row_estimate
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = ANY($1::text[])
+  AND c.relkind IN ('r', 'v', 'm', 'p', 'f')
+ORDER BY n.nspname, c.relname
+"""
+
+
+async def introspect_schema(
+    *,
+    pool: object,
+    policy: TableAccessPolicy,
+    connection: str,
+    max_tables: int = 80,
+    primer: str = "",
+    statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
+) -> SchemaSummary:
+    """Survey the policy's allowed schema(s) into a bounded SchemaSummary."""
+    schemas = policy.allowed_schemas()
+    if not schemas:
+        return SchemaSummary(
+            connection=connection, schemas=(), tables=(), total_tables=0, primer=primer
+        )
+    sorted_schemas = tuple(sorted(schemas))
+    rows = await fetch_readonly(
+        pool,
+        _TABLES_QUERY,
+        list(sorted_schemas),
+        statement_timeout_ms=statement_timeout_ms,
+    )
+    all_tables = [
+        TableInfo(
+            schema=r["table_schema"],
+            name=r["table_name"],
+            table_type=r["table_type"],
+            row_estimate=_estimate(r["row_estimate"]),
+        )
+        for r in rows
+    ]
+    capped = all_tables[: max(0, max_tables)]
+    return SchemaSummary(
+        connection=connection,
+        schemas=sorted_schemas,
+        tables=tuple(capped),
+        total_tables=len(all_tables),
+        primer=primer,
+    )
+
+
+_FK_QUERY = """
+SELECT kcu.column_name AS column,
+       ccu.table_schema AS ref_schema,
+       ccu.table_name AS ref_table,
+       ccu.column_name AS ref_column,
+       tc.constraint_name AS constraint
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_name = tc.constraint_name
+ AND ccu.table_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_schema = $1
+  AND tc.table_name = $2
+ORDER BY kcu.column_name
+"""
+
+
+async def introspect_foreign_keys(
+    *,
+    pool: object,
+    schema: str,
+    table: str,
+    statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
+) -> list[ForeignKey]:
+    """Declared foreign keys for one table (for `describe`-with-FKs)."""
+    rows = await fetch_readonly(
+        pool, _FK_QUERY, schema, table, statement_timeout_ms=statement_timeout_ms
+    )
+    return [
+        ForeignKey(
+            column=r["column"],
+            ref_schema=r["ref_schema"],
+            ref_table=r["ref_table"],
+            ref_column=r["ref_column"],
+            constraint=r["constraint"],
+        )
+        for r in rows
+    ]

--- a/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
@@ -20,6 +20,7 @@ from miot_harness.datasource.safe_query import (
     safe_list_tables,
     safe_select,
 )
+from miot_harness.datasource.schema_introspect import introspect_foreign_keys
 from miot_harness.datasource.sql_policy import TableAccessPolicy
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.permissions import PermissionResult
@@ -55,6 +56,12 @@ class _ExplainInput(BaseModel):
 
 class _RowsOutput(BaseModel):
     rows: list[dict[str, Any]] = Field(default_factory=list)
+    source: str = ""
+
+
+class _DescribeOutput(BaseModel):
+    columns: list[dict[str, Any]] = Field(default_factory=list)
+    foreign_keys: list[dict[str, Any]] = Field(default_factory=list)
     source: str = ""
 
 
@@ -98,14 +105,33 @@ def build_generic_tools(
 
     async def call_describe(
         ctx: HarnessContext, parsed: _DescribeInput, progress: Progress
-    ) -> _RowsOutput:
-        rows = await safe_describe(
+    ) -> _DescribeOutput:
+        columns = await safe_describe(
             pool=pool,
             policy=policy,
             table=parsed.table,
             statement_timeout_ms=statement_timeout_ms,
         )
-        return _RowsOutput(rows=rows, source=source_label)
+        # FK relationships (the "how does this table connect" body). The policy
+        # already validated the table in safe_describe; reuse its schema/name.
+        schema, _, name = parsed.table.partition(".")
+        fks = await introspect_foreign_keys(
+            pool=pool,
+            schema=schema,
+            table=name,
+            statement_timeout_ms=statement_timeout_ms,
+        )
+        return _DescribeOutput(
+            columns=columns,
+            foreign_keys=[
+                {
+                    "column": fk.column,
+                    "references": f"{fk.ref_schema}.{fk.ref_table}.{fk.ref_column}",
+                }
+                for fk in fks
+            ],
+            source=source_label,
+        )
 
     async def call_select(
         ctx: HarnessContext, parsed: _SelectInput, progress: Progress
@@ -178,11 +204,12 @@ def build_generic_tools(
         HarnessTool(
             name=f"{tool_prefix}describe",
             description=(
-                f"Columns + types of a schema-qualified table {scope}. "
-                "Use to discover a table's shape before select."
+                f"Columns + types AND foreign-key relationships of a "
+                f"schema-qualified table {scope}. Use to discover a table's shape "
+                "and how it joins to others before select."
             ),
             input_model=_DescribeInput,
-            output_model=_RowsOutput,
+            output_model=_DescribeOutput,
             call=call_describe,
             **common,
         ),

--- a/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
@@ -132,6 +132,9 @@ def build_generic_tools(
             table=name,
             statement_timeout_ms=statement_timeout_ms,
         )
+        # Only surface FKs whose referenced table is itself within the
+        # allowlist — don't leak table/schema names the agent can't query
+        # (e.g. an FK into public.*).
         return _DescribeOutput(
             columns=columns,
             foreign_keys=[
@@ -140,6 +143,7 @@ def build_generic_tools(
                     "references": f"{fk.ref_schema}.{fk.ref_table}.{fk.ref_column}",
                 }
                 for fk in fks
+                if policy.is_allowed(schema=fk.ref_schema, table=fk.ref_table)
             ],
             source=source_label,
         )

--- a/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
@@ -18,6 +18,7 @@ from miot_harness.datasource.safe_query import (
     safe_explain,
     safe_grep,
     safe_list_tables,
+    safe_run_select,
     safe_select,
 )
 from miot_harness.datasource.schema_introspect import introspect_foreign_keys
@@ -48,6 +49,16 @@ class _GrepInput(BaseModel):
     column: str
     pattern: str = Field(description="ILIKE pattern, e.g. %assignee%")
     limit: int = 100
+
+
+class _QueryInput(BaseModel):
+    sql: str = Field(
+        description=(
+            "A full read-only SQL SELECT (JOINs, CTEs, GROUP BY, aggregates "
+            "allowed) over the connection's allowed schemas. Schema-qualify "
+            "every table, e.g. acs.act_ru_task."
+        )
+    )
 
 
 class _ExplainInput(BaseModel):
@@ -164,6 +175,19 @@ def build_generic_tools(
         )
         return _RowsOutput(rows=rows, source=source_label)
 
+    async def call_query(
+        ctx: HarnessContext, parsed: _QueryInput, progress: Progress
+    ) -> _RowsOutput:
+        rows = await safe_run_select(
+            pool=pool,
+            policy=policy,
+            sql=parsed.sql,
+            max_rows=max_rows,
+            cost_threshold=explain_cost_threshold,
+            statement_timeout_ms=statement_timeout_ms,
+        )
+        return _RowsOutput(rows=rows, source=source_label)
+
     async def call_explain(
         ctx: HarnessContext, parsed: _ExplainInput, progress: Progress
     ) -> _ExplainOutput:
@@ -224,6 +248,20 @@ def build_generic_tools(
             input_model=_SelectInput,
             output_model=_RowsOutput,
             call=call_select,
+            **common,
+        ),
+        HarnessTool(
+            name=f"{tool_prefix}query",
+            description=(
+                f"Run a FULL read-only SQL SELECT {scope} — JOINs, CTEs, GROUP BY, "
+                "aggregates. Prefer this for anything spanning more than one table "
+                "(e.g. joining a task to its process variables). sqlglot-gated: "
+                "SELECT-only, allowlisted tables/functions; result is LIMIT-capped, "
+                "runs BEGIN READ ONLY with a statement timeout + EXPLAIN cost gate."
+            ),
+            input_model=_QueryInput,
+            output_model=_RowsOutput,
+            call=call_query,
             **common,
         ),
         HarnessTool(

--- a/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
@@ -212,6 +212,7 @@ class GenericPgProvider(DataSourceProvider):
                     "generic_pg %s: schema introspection failed (%s); continuing",
                     name,
                     exc,
+                    exc_info=True,  # keep the traceback for catalog/permission diag
                 )
 
         return BootResult(

--- a/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
@@ -51,6 +51,7 @@ _GENERIC_DEFAULT_PROFILE = DataSourceProfile(
     ),
     freshness_warn_minutes=0,
     freshness_refuse_minutes=0,
+    has_freshness_model=False,
 )
 
 
@@ -161,6 +162,7 @@ class GenericPgProvider(DataSourceProvider):
             ),
             freshness_warn_minutes=0,
             freshness_refuse_minutes=0,
+            has_freshness_model=False,
         )
 
         application_name = (

--- a/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
@@ -27,6 +27,7 @@ from miot_harness.datasource.provider import (
 )
 from miot_harness.datasource.safe_query import DEFAULT_STATEMENT_TIMEOUT_MS
 from miot_harness.datasource.safe_sql import HARD_LIMIT_CAP
+from miot_harness.datasource.schema_introspect import introspect_schema
 from miot_harness.datasource.sql_policy import SchemaAllowlistPolicy
 from miot_harness.integrations.generic_pg.primitive_tools import build_generic_tools
 from miot_harness.tools.registry import ToolRegistry
@@ -190,7 +191,30 @@ class GenericPgProvider(DataSourceProvider):
                 enabled=False, registered=(), reason=f"boot failed: {exc}"
             )
 
-        return BootResult(enabled=True, registered=tuple(registered))
+        # Connection Knowledge Base (Phase 2): boot-time schema index. A failure
+        # here must NOT disable the connection — the query tools already
+        # registered; the index is additive grounding.
+        schema_summary = None
+        if settings.generic_schema_introspect_enabled:
+            try:
+                schema_summary = await introspect_schema(
+                    pool=self._pool,
+                    policy=policy,
+                    connection=name,
+                    max_tables=settings.generic_schema_max_tables,
+                    primer=connection.primer,
+                    statement_timeout_ms=statement_timeout_ms,
+                )
+            except Exception as exc:  # noqa: BLE001 — index is best-effort
+                logger.error(
+                    "generic_pg %s: schema introspection failed (%s); continuing",
+                    name,
+                    exc,
+                )
+
+        return BootResult(
+            enabled=True, registered=tuple(registered), schema_summary=schema_summary
+        )
 
     async def close(self) -> None:
         if self._pool is not None:

--- a/miot-harness/tests/connections/test_lifespan_multi.py
+++ b/miot-harness/tests/connections/test_lifespan_multi.py
@@ -18,6 +18,7 @@ from miot_harness.api.server import create_app
 from miot_harness.config import get_settings
 from miot_harness.integrations.nexo.boot import NexoBootResult
 from tests.fixtures.fake_provider import FakeProvider
+from tests.fixtures.recording_pool import RecordingPool
 
 NEXO_MD = """---
 name: nexo
@@ -243,8 +244,17 @@ def test_generic_pg_registers_tools_when_flag_enabled(monkeypatch, tmp_path):
 
     nexo_pool = MagicMock()
     nexo_pool.close = AsyncMock()
-    acs_pool = MagicMock()
-    acs_pool.close = AsyncMock()
+    # Recording pool so boot-time schema introspection actually runs (Phase 2).
+    acs_pool = RecordingPool(
+        fetch_return=[
+            {
+                "table_schema": "acs",
+                "table_name": "act_ru_task",
+                "table_type": "BASE TABLE",
+                "row_estimate": 1200,
+            }
+        ]
+    )
     p1, p2 = _nexo_patches(nexo_pool)
     with (
         p1,
@@ -259,6 +269,9 @@ def test_generic_pg_registers_tools_when_flag_enabled(monkeypatch, tmp_path):
             conns = app.state.connections
             assert conns["acs"]["enabled"] is True
             assert conns["acs"]["backend"] == "pg"
+            # Schema index introspected + recorded for /health.
+            assert conns["acs"]["schema"]["table_count"] == 1
+            assert conns["acs"]["schema"]["schemas"] == ["acs"]
             names = app.state.harness.tools.names()
             for t in ("acs_list_tables", "acs_describe", "acs_select", "acs_grep"):
                 assert t in names

--- a/miot-harness/tests/datasource/test_safe_query.py
+++ b/miot-harness/tests/datasource/test_safe_query.py
@@ -328,3 +328,23 @@ async def test_explain_parses_json_string_payload() -> None:
     )
     assert result["total_cost"] == pytest.approx(42.0)
     assert result["node_type"] == "Seq Scan"
+
+
+# --------------------- duplicate-column handling (run_safe_select) ---------
+
+class _DupRecord:
+    """Mimics an asyncpg Record with duplicate column labels (SELECT * JOIN)."""
+
+    def keys(self) -> list:
+        return ["id_", "name_", "id_", "rev_", "name_"]
+
+    def values(self) -> list:
+        return [1, "task", 2, 7, "var"]
+
+
+def test_record_to_dict_preserves_duplicate_columns() -> None:
+    from miot_harness.datasource.safe_query import _record_to_dict
+
+    out = _record_to_dict(_DupRecord())
+    # No data lost: collisions are suffixed, not overwritten.
+    assert out == {"id_": 1, "name_": "task", "id__2": 2, "rev_": 7, "name__2": "var"}

--- a/miot-harness/tests/datasource/test_safe_query.py
+++ b/miot-harness/tests/datasource/test_safe_query.py
@@ -16,17 +16,21 @@ from miot_harness.datasource.safe_query import (
     safe_explain,
     safe_grep,
     safe_list_tables,
+    safe_run_select,
     safe_select,
 )
 from miot_harness.datasource.safe_sql import (
     AllowlistViolation,
     CostGateViolation,
+    MutationRejected,
     UnsupportedConstruct,
+    validate_select_sql,
 )
 from miot_harness.datasource.sql_policy import (
     RegexTablePolicy,
     SchemaAllowlistPolicy,
 )
+from tests.fixtures.recording_pool import RecordingPool
 
 ACS = SchemaAllowlistPolicy(frozenset({"acs"}))
 
@@ -217,3 +221,110 @@ async def test_explain_refuses_over_budget() -> None:
         await safe_explain(
             pool=pool, policy=ACS, query="SELECT * FROM acs.act_ru_task", cost_threshold=100.0
         )
+
+
+# --------------------- run_safe_select (broad query) ---------------------
+
+_JOIN = (
+    "SELECT t.id_, v.text_ FROM acs.act_ru_task t "
+    "JOIN acs.act_ru_variable v ON v.task_id_ = t.id_"
+)
+
+
+@pytest.mark.asyncio
+async def test_run_select_allows_join_caps_and_is_read_only() -> None:
+    pool = _RecordingPool(fetch_return=[{"id_": "1", "text_": "x"}])
+    rows = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, max_rows=200)
+    assert rows == [{"id_": "1", "text_": "x"}]
+    sql = pool.conn.fetched[-1][0]
+    assert "_miot_q" in sql and "LIMIT 200" in sql  # harness-injected hard cap
+    assert pool.conn.txn_readonly is True
+    assert any("statement_timeout" in s for s in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_run_select_rejects_cross_schema_join() -> None:
+    pool = _RecordingPool()
+    with pytest.raises(AllowlistViolation):
+        await safe_run_select(
+            pool=pool,
+            policy=ACS,
+            sql="SELECT * FROM acs.act_ru_task t JOIN public.users u ON u.id = t.id_",
+        )
+    assert pool.conn.fetched == []  # never reached the DB
+
+
+@pytest.mark.asyncio
+async def test_run_select_rejects_mutation() -> None:
+    pool = _RecordingPool()
+    with pytest.raises(MutationRejected):
+        await safe_run_select(pool=pool, policy=ACS, sql="DELETE FROM acs.act_ru_task")
+
+
+@pytest.mark.asyncio
+async def test_run_select_cost_gate_refuses_over_budget() -> None:
+    def _responder(sql: str) -> list:
+        if sql.startswith("EXPLAIN"):
+            return [{"QUERY PLAN": [{"Plan": {"Total Cost": 99_999.0}}]}]
+        return [{"id_": "1"}]
+
+    pool = RecordingPool(responder=_responder)
+    with pytest.raises(CostGateViolation):
+        await safe_run_select(
+            pool=pool, policy=ACS, sql=_JOIN, cost_threshold=100.0
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_select_cost_gate_passes_under_budget() -> None:
+    def _responder(sql: str) -> list:
+        if sql.startswith("EXPLAIN"):
+            return [{"QUERY PLAN": [{"Plan": {"Total Cost": 12.0}}]}]
+        return [{"id_": "1"}]
+
+    pool = RecordingPool(responder=_responder)
+    rows = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, cost_threshold=10_000.0)
+    assert rows == [{"id_": "1"}]
+
+
+# --------------------- gate regression: boolean operators + EXPLAIN json ----
+
+def test_gate_accepts_boolean_operators_in_where() -> None:
+    # Regression: AND/OR/NOT are exp.Func subclasses in some sqlglot versions;
+    # they must NOT be rejected by the function allowlist (else any
+    # multi-condition WHERE fails).
+    validate_select_sql(
+        "SELECT t.id_ FROM acs.act_ru_task t "
+        "WHERE t.suspension_state_ = 1 AND (t.assignee_ IS NULL OR t.owner_ IS NULL)",
+        table_policy=ACS,
+    )  # raises on failure
+
+
+@pytest.mark.asyncio
+async def test_run_select_handles_join_with_and_or() -> None:
+    pool = _RecordingPool(fetch_return=[{"id_": "1"}])
+    rows = await safe_run_select(
+        pool=pool,
+        policy=ACS,
+        sql=(
+            "SELECT t.id_, v.text_ FROM acs.act_ru_task t "
+            "JOIN acs.act_ru_variable v ON v.proc_inst_id_ = t.proc_inst_id_ "
+            "WHERE v.name_ = 'mintral_serviceCode' AND t.suspension_state_ = 1"
+        ),
+    )
+    assert rows == [{"id_": "1"}]
+
+
+@pytest.mark.asyncio
+async def test_explain_parses_json_string_payload() -> None:
+    # asyncpg returns the QUERY PLAN as a JSON string, not a parsed list.
+    pool = _RecordingPool(
+        fetch_return=[
+            {"QUERY PLAN": '[{"Plan": {"Total Cost": 42.0, "Node Type": "Seq Scan"}}]'}
+        ]
+    )
+    result = await safe_explain(
+        pool=pool, policy=ACS, query="SELECT * FROM acs.act_ru_task", cost_threshold=1e9
+    )
+    assert result["total_cost"] == pytest.approx(42.0)
+    assert result["node_type"] == "Seq Scan"

--- a/miot-harness/tests/datasource/test_schema_introspect.py
+++ b/miot-harness/tests/datasource/test_schema_introspect.py
@@ -1,0 +1,130 @@
+"""Boot-time schema introspection: index, FKs, byte-stability (Phase 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.datasource.schema_introspect import (
+    SchemaSummary,
+    TableInfo,
+    introspect_foreign_keys,
+    introspect_schema,
+)
+from miot_harness.datasource.sql_policy import (
+    RegexTablePolicy,
+    SchemaAllowlistPolicy,
+)
+from tests.fixtures.recording_pool import RecordingPool
+
+ACS = SchemaAllowlistPolicy(frozenset({"acs"}))
+
+
+def _t(name: str, typ: str, est: int) -> dict:
+    return {
+        "table_schema": "acs",
+        "table_name": name,
+        "table_type": typ,
+        "row_estimate": est,
+    }
+
+
+def _table_rows() -> list[dict]:
+    return [
+        _t("act_ru_task", "BASE TABLE", 1200),
+        _t("act_hi_procinst", "BASE TABLE", 340000),
+        _t("v_open", "VIEW", -1),
+        _t("act_empty", "BASE TABLE", 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_introspect_builds_summary_read_only() -> None:
+    pool = RecordingPool(fetch_return=_table_rows())
+    summary = await introspect_schema(pool=pool, policy=ACS, connection="acs")
+    assert summary.connection == "acs"
+    assert summary.schemas == ("acs",)
+    assert summary.total_tables == 4
+    assert {t.name for t in summary.tables} == {
+        "act_ru_task",
+        "act_hi_procinst",
+        "v_open",
+        "act_empty",
+    }
+    # Ran inside BEGIN READ ONLY with a statement timeout.
+    assert pool.conn.txn_readonly is True
+    assert any("statement_timeout" in s for s in pool.conn.executed)
+    # The schemas were passed as a text[] param.
+    assert pool.conn.fetched[-1][1][0] == ["acs"]
+
+
+@pytest.mark.asyncio
+async def test_introspect_unknown_estimate_is_none() -> None:
+    pool = RecordingPool(fetch_return=_table_rows())
+    summary = await introspect_schema(pool=pool, policy=ACS, connection="acs")
+    by_name = {t.name: t for t in summary.tables}
+    assert by_name["v_open"].row_estimate is None  # reltuples -1 → unknown
+    assert by_name["act_empty"].row_estimate == 0
+
+
+@pytest.mark.asyncio
+async def test_introspect_caps_and_marks_truncated() -> None:
+    pool = RecordingPool(fetch_return=_table_rows())
+    summary = await introspect_schema(
+        pool=pool, policy=ACS, connection="acs", max_tables=2
+    )
+    assert len(summary.tables) == 2
+    assert summary.total_tables == 4
+    assert summary.truncated is True
+    assert "more" in summary.render()
+
+
+@pytest.mark.asyncio
+async def test_non_enumerable_policy_yields_empty_summary() -> None:
+    pool = RecordingPool(fetch_return=_table_rows())
+    summary = await introspect_schema(
+        pool=pool, policy=RegexTablePolicy(r"^nexo\.dx_.*$"), connection="x"
+    )
+    assert summary.total_tables == 0
+    assert summary.tables == ()
+    # Never queried (no schemas to scan).
+    assert pool.conn.fetched == []
+
+
+def test_render_is_byte_stable_and_readable() -> None:
+    summary = SchemaSummary(
+        connection="acs",
+        schemas=("acs",),
+        tables=(
+            TableInfo("acs", "act_ru_task", "BASE TABLE", 1200),
+            TableInfo("acs", "act_hi_procinst", "BASE TABLE", 340000),
+            TableInfo("acs", "v_open", "VIEW", None),
+        ),
+        total_tables=3,
+    )
+    out = summary.render()
+    # Stable across calls.
+    assert out == summary.render()
+    assert "Schema `acs` (3 tables)" in out
+    assert "acs.act_ru_task · ~1k rows" in out
+    assert "acs.act_hi_procinst · ~340k rows" in out
+    assert "acs.v_open [view]" in out
+
+
+@pytest.mark.asyncio
+async def test_introspect_foreign_keys() -> None:
+    pool = RecordingPool(
+        fetch_return=[
+            {
+                "column": "execution_id_",
+                "ref_schema": "acs",
+                "ref_table": "act_ru_execution",
+                "ref_column": "id_",
+                "constraint": "act_fk_task_exe",
+            }
+        ]
+    )
+    fks = await introspect_foreign_keys(pool=pool, schema="acs", table="act_ru_task")
+    assert len(fks) == 1
+    assert fks[0].render() == "execution_id_ → acs.act_ru_execution.id_"
+    assert pool.conn.txn_readonly is True
+    assert pool.conn.fetched[-1][1] == ("acs", "act_ru_task")

--- a/miot-harness/tests/datasource/test_schema_introspect.py
+++ b/miot-harness/tests/datasource/test_schema_introspect.py
@@ -128,3 +128,25 @@ async def test_introspect_foreign_keys() -> None:
     assert fks[0].render() == "execution_id_ → acs.act_ru_execution.id_"
     assert pool.conn.txn_readonly is True
     assert pool.conn.fetched[-1][1] == ("acs", "act_ru_task")
+
+
+@pytest.mark.asyncio
+async def test_composite_foreign_key_pairs_positionally() -> None:
+    # The positional-mapping query returns one row per (local, referenced) column
+    # pair, already correctly aligned — so a 2-column FK yields 2 ForeignKeys
+    # with the right pairing (not a Cartesian product).
+    def _fk(col: str, ref_col: str) -> dict:
+        return {
+            "column": col,
+            "ref_schema": "s",
+            "ref_table": "parent",
+            "ref_column": ref_col,
+            "constraint": "fk_ab",
+        }
+
+    pool = RecordingPool(fetch_return=[_fk("a_id", "x_id"), _fk("b_id", "y_id")])
+    fks = await introspect_foreign_keys(pool=pool, schema="s", table="child")
+    assert [fk.render() for fk in fks] == [
+        "a_id → s.parent.x_id",
+        "b_id → s.parent.y_id",
+    ]

--- a/miot-harness/tests/fixtures/recording_pool.py
+++ b/miot-harness/tests/fixtures/recording_pool.py
@@ -1,0 +1,68 @@
+"""A recording asyncpg-shaped pool for tests (no real DB).
+
+Captures the read-only transaction flag, `SET LOCAL statement_timeout`, and the
+SQL/args each query would run; returns a fixed result set per fetch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+class RecordingConn:
+    def __init__(
+        self,
+        fetch_return: list[Any],
+        responder: Callable[[str], list[Any]] | None = None,
+    ) -> None:
+        self.executed: list[str] = []
+        self.fetched: list[tuple[str, tuple[Any, ...]]] = []
+        self.txn_readonly: bool | None = None
+        self._fetch_return = fetch_return
+        self._responder = responder
+
+    def transaction(self, *, readonly: bool = False) -> Any:
+        self.txn_readonly = readonly
+
+        class _Txn:
+            async def __aenter__(self_: Any) -> None:
+                return None
+
+            async def __aexit__(self_: Any, *a: Any) -> None:
+                return None
+
+        return _Txn()
+
+    async def execute(self, sql: str, *args: Any) -> None:
+        self.executed.append(sql)
+
+    async def fetch(self, sql: str, *args: Any) -> list[Any]:
+        self.fetched.append((sql, args))
+        if self._responder is not None:
+            return self._responder(sql)
+        return self._fetch_return
+
+
+class RecordingPool:
+    def __init__(
+        self,
+        fetch_return: list[Any] | None = None,
+        responder: Callable[[str], list[Any]] | None = None,
+    ) -> None:
+        self.conn = RecordingConn(fetch_return or [], responder)
+
+    def acquire(self) -> Any:
+        conn = self.conn
+
+        class _Acq:
+            async def __aenter__(self_: Any) -> Any:
+                return conn
+
+            async def __aexit__(self_: Any, *a: Any) -> None:
+                return None
+
+        return _Acq()
+
+    async def close(self) -> None:
+        return None

--- a/miot-harness/tests/integrations/generic_pg/test_provider.py
+++ b/miot-harness/tests/integrations/generic_pg/test_provider.py
@@ -133,6 +133,7 @@ async def test_boot_registers_generic_tools(monkeypatch: pytest.MonkeyPatch) -> 
         "acs_list_tables",
         "acs_describe",
         "acs_select",
+        "acs_query",
         "acs_grep",
         "acs_explain",
     ):

--- a/miot-harness/tests/integrations/generic_pg/test_provider.py
+++ b/miot-harness/tests/integrations/generic_pg/test_provider.py
@@ -243,3 +243,42 @@ async def test_describe_returns_columns_and_fks(
     assert out.foreign_keys == [
         {"column": "execution_id_", "references": "acs.act_ru_execution.id_"}
     ]
+
+
+def _fk_leak_responder(sql: str) -> list:
+    if "information_schema.columns" in sql:
+        return [{"column_name": "id_", "data_type": "character varying"}]
+    if "FOREIGN KEY" in sql:
+        return [
+            {"column": "execution_id_", "ref_schema": "acs",
+             "ref_table": "act_ru_execution", "ref_column": "id_", "constraint": "fk1"},
+            {"column": "creator_", "ref_schema": "public",
+             "ref_table": "users", "ref_column": "id", "constraint": "fk2"},
+        ]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_describe_filters_fk_references_outside_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = RecordingPool(responder=_fk_leak_responder)
+    monkeypatch.setattr(
+        "miot_harness.integrations.generic_pg.provider.create_pg_pool",
+        AsyncMock(return_value=pool),
+    )
+    registry = ToolRegistry()
+    await GenericPgProvider().boot(
+        registry,
+        HarnessSettings(
+            generic_query_enabled=True, generic_schema_introspect_enabled=False
+        ),
+        _conn(),
+    )
+    out = await registry.get("acs_describe").invoke(
+        HarnessContext(thread_id="t", tenant_id="demo", user_id="u"),
+        {"table": "acs.act_ru_task"},
+        lambda _e: None,
+    )
+    refs = [fk["references"] for fk in out.foreign_keys]
+    assert refs == ["acs.act_ru_execution.id_"]  # public.users.id filtered out

--- a/miot-harness/tests/integrations/generic_pg/test_provider.py
+++ b/miot-harness/tests/integrations/generic_pg/test_provider.py
@@ -9,7 +9,44 @@ import pytest
 from miot_harness.config import HarnessSettings
 from miot_harness.connections.models import Connection
 from miot_harness.integrations.generic_pg.provider import GenericPgProvider
+from miot_harness.runtime.context import HarnessContext
 from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.recording_pool import RecordingPool
+
+
+def _t(name: str, est: int) -> dict:
+    return {
+        "table_schema": "acs",
+        "table_name": name,
+        "table_type": "BASE TABLE",
+        "row_estimate": est,
+    }
+
+
+_TABLE_ROWS = [_t("act_ru_task", 1200), _t("act_ru_execution", 800)]
+_COL_ROWS = [
+    {"column_name": "id_", "data_type": "character varying"},
+    {"column_name": "execution_id_", "data_type": "character varying"},
+]
+_FK_ROWS = [
+    {
+        "column": "execution_id_",
+        "ref_schema": "acs",
+        "ref_table": "act_ru_execution",
+        "ref_column": "id_",
+        "constraint": "act_fk_task_exe",
+    }
+]
+
+
+def _responder(sql: str) -> list:
+    if "pg_catalog.pg_class" in sql:
+        return _TABLE_ROWS
+    if "information_schema.columns" in sql:
+        return _COL_ROWS
+    if "FOREIGN KEY" in sql:
+        return _FK_ROWS
+    return []
 
 
 def _conn(**overrides: object) -> Connection:
@@ -27,7 +64,12 @@ def _conn(**overrides: object) -> Connection:
 
 
 def _enabled() -> HarnessSettings:
-    return HarnessSettings(generic_query_enabled=True)
+    # Schema introspection off by default in these registration/gating tests
+    # (they use a bare MagicMock pool); the dedicated introspection test below
+    # exercises it with a recording pool.
+    return HarnessSettings(
+        generic_query_enabled=True, generic_schema_introspect_enabled=False
+    )
 
 
 @pytest.mark.asyncio
@@ -139,7 +181,6 @@ async def test_tenant_lock_denies_other_tenant(
         _conn(options={"search_path": "acs", "tenant_lock": "acme"}),
     )
     tool = registry.get("acs_select")
-    from miot_harness.runtime.context import HarnessContext
     from miot_harness.runtime.permissions import PermissionDecision
 
     def _ctx(tenant: str) -> HarnessContext:
@@ -149,3 +190,55 @@ async def test_tenant_lock_denies_other_tenant(
     allow = await tool.check_permission(_ctx("acme"), tool.input_model(table="acs.x"))
     assert deny.decision == PermissionDecision.DENY
     assert allow.decision == PermissionDecision.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_boot_populates_schema_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    pool = RecordingPool(responder=_responder)
+    monkeypatch.setattr(
+        "miot_harness.integrations.generic_pg.provider.create_pg_pool",
+        AsyncMock(return_value=pool),
+    )
+    result = await GenericPgProvider().boot(
+        ToolRegistry(),
+        HarnessSettings(
+            generic_query_enabled=True, generic_schema_introspect_enabled=True
+        ),
+        _conn(),
+    )
+    assert result.enabled is True
+    assert result.schema_summary is not None
+    assert result.schema_summary.total_tables == 2
+    assert {t.name for t in result.schema_summary.tables} == {
+        "act_ru_task",
+        "act_ru_execution",
+    }
+
+
+@pytest.mark.asyncio
+async def test_describe_returns_columns_and_fks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = RecordingPool(responder=_responder)
+    monkeypatch.setattr(
+        "miot_harness.integrations.generic_pg.provider.create_pg_pool",
+        AsyncMock(return_value=pool),
+    )
+    registry = ToolRegistry()
+    await GenericPgProvider().boot(
+        registry,
+        HarnessSettings(
+            generic_query_enabled=True, generic_schema_introspect_enabled=False
+        ),
+        _conn(),
+    )
+    tool = registry.get("acs_describe")
+    out = await tool.invoke(
+        HarnessContext(thread_id="t", tenant_id="demo", user_id="u"),
+        {"table": "acs.act_ru_task"},
+        lambda _e: None,
+    )
+    assert any(c["column_name"] == "id_" for c in out.columns)
+    assert out.foreign_keys == [
+        {"column": "execution_id_", "references": "acs.act_ru_execution.id_"}
+    ]

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -265,7 +265,9 @@ async def test_fetcher_no_pending_step_is_noop():
     assert update.get("next_action") == "ready_to_synthesize"
 
 
-def _classify(payload: dict[str, Any]) -> DataEvidence:
+def _classify(
+    payload: dict[str, Any], *, has_freshness_model: bool = True
+) -> DataEvidence:
     from miot_harness.agents.data_fetcher import _evidence_from_output
 
     return _evidence_from_output(
@@ -274,7 +276,23 @@ def _classify(payload: dict[str, Any]) -> DataEvidence:
         payload,
         warn_minutes=30,
         source_label=NEXO_PROFILE.source_label,
+        has_freshness_model=has_freshness_model,
     )
+
+
+def test_live_source_no_timestamp_is_fresh_not_stale() -> None:
+    # A live datasource (has_freshness_model=False) with no refreshed_at must
+    # NOT be flagged no_timestamp/stale — that drove the misleading
+    # "trust with caution" note on a live operational schema.
+    ev = _classify({"rows": [{"a": 1}]}, has_freshness_model=False)
+    assert ev.freshness_status == "fresh"
+    assert ev.is_stale is False
+
+
+def test_live_source_empty_is_empty_not_no_timestamp() -> None:
+    ev = _classify({"rows": []}, has_freshness_model=False)
+    assert ev.freshness_status == "empty"
+    assert ev.is_stale is False
 
 
 def test_freshness_status_fresh_rows_and_fresh_timestamp() -> None:

--- a/miot-harness/tests/test_freshness_judge.py
+++ b/miot-harness/tests/test_freshness_judge.py
@@ -163,3 +163,43 @@ def test_empty_no_timestamp_warns_with_reason_but_never_refuses():
     warnings = [e for e in events if e.type == "freshness.warning"]
     assert len(warnings) == 1
     assert warnings[0].data.get("reason") == "empty_no_timestamp"
+
+
+def test_no_freshness_model_skips_judge_no_warning():
+    """A live datasource (has_freshness_model=False) must not warn on missing
+    refreshed_at — the snapshot-age model doesn't apply to it."""
+    from dataclasses import replace
+
+    live_profile = replace(NEXO_PROFILE, has_freshness_model=False)
+    state: dict[str, Any] = {
+        "ctx": _ctx(),
+        "evidence": [_ev(None)],  # live row, no snapshot timestamp
+        "turn_count": 1,
+    }
+    events: list[HarnessEvent] = []
+
+    update = freshness_judge_node(
+        state, settings=HarnessSettings(), progress=events.append, profile=live_profile
+    )
+
+    assert update["next_action"] == "analyze"
+    assert update.get("freshness") == FRESHNESS_FRESH
+    assert "freshness.warning" not in {e.type for e in events}
+
+
+def test_snapshot_model_still_warns_on_missing_timestamp():
+    """Regression guard: with a freshness model (Nexo), missing refreshed_at
+    still warns (the existing behaviour Phase 1.5 must not break)."""
+    state: dict[str, Any] = {
+        "ctx": _ctx(),
+        "evidence": [_ev(None)],
+        "turn_count": 1,
+    }
+    events: list[HarnessEvent] = []
+
+    update = freshness_judge_node(
+        state, settings=HarnessSettings(), progress=events.append, profile=NEXO_PROFILE
+    )
+
+    assert update.get("freshness") == FRESHNESS_WARN
+    assert "freshness.warning" in {e.type for e in events}


### PR DESCRIPTION
## Phase 2, slice 1 — Schema introspection + lazy index + `describe`-with-FKs

First slice of **rung 2 (Connection Knowledge Base)**. Makes a generic
connection's schema visible to the agent *without* a hand-written table list, and
lets the agent see how tables join — using the skills-style lazy pattern
(headers always loaded, bodies on demand).

> Plan: `.cursor/plans/ai-first/14-generic-data-access/phase-2-schema-introspection.md`
> Slice 2 (curated knowledge packs + Alfresco detection) and slice 3 (heuristic
> relation inference) follow as separate PRs.

### What's in this slice
- **`datasource/schema_introspect.py`** — `introspect_schema()` → a bounded,
  **byte-stable** `SchemaSummary` (table · type · row estimate from
  `pg_class.reltuples`): the always-loaded "header" index. `introspect_foreign_keys()`
  for the `describe` body. Both run inside Phase 1's read-only envelope (promoted
  `_fetch_readonly` → `fetch_readonly` so introspection reuses it, no dup).
- **`GenericPgProvider.boot`** runs introspection **best-effort** (a failure
  never disables the connection — the query tools already registered) and returns
  it on `BootResult.schema_summary`.
- **`<conn>_describe`** now returns columns **AND** foreign-key relationships.
- **`api/server.py`** folds each *enabled* connection's schema index (+ secondary
  connection primers) into the agent primer via the existing `replace()` seam, in
  one byte-stable assembly (cache prefix stays hot). `/health/ready` exposes a
  per-connection `schema` block.
- **config**: `generic_schema_introspect_enabled` (kill switch; inert unless
  generic query is on) + `generic_schema_max_tables` (bounds the always-on index;
  explicit truncation note, never silent).

### Lazy delivery
Headers (table list + row estimates) always in the prompt; bodies (columns, FKs)
pulled on demand via `describe`. This is the skills technique applied to schema.

### Verification
- **736 tests** (+ introspection unit tests: index, FKs, byte-stable render, cap,
  non-enumerable policy; provider boot-populates-summary + describe-with-FKs;
  lifespan schema fold; shared recording-pool fixture). mypy strict + ruff clean.
- **Real dev `acs`**: 70 tables, row estimates (`~193k`, `~1.5M`, `~3 rows`),
  truncation note, and the real Activiti FK graph (`execution_id_ →
  act_ru_execution.id_`, `proc_def_id_ → act_re_procdef.id_`, …).
- Flag-gated; nexo path unchanged; generic-`pg` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Connection Knowledge Base schema indexing for supported generic connections, including per-connection schema summaries and grounding in the agent’s connected data sources context.
  * Enhanced database tools: `describe` now returns foreign-key relationships; introduced a safe, read-only `query` primitive supporting JOINs/CTEs/aggregations with row limiting and optional cost gating.
  * Configuration controls added for generic schema introspection (enable/disable and max tables).
* **Bug Fixes**
  * Improved SQL read-only execution safety with statement timeouts, stricter select validation, and resilient EXPLAIN JSON parsing.
  * Freshness evaluation now treats datasources without freshness models as fresh when `refreshed_at` is missing, avoiding stale warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #779
