### PR TITLE
feat(harness): Phase 3 slice 2 — executed-SQL in evidence + synthesizer grounding

### DIFF
--- a/miot-harness/src/miot_harness/agents/data_fetcher.py
+++ b/miot-harness/src/miot_harness/agents/data_fetcher.py
@@ -121,6 +121,10 @@ def _evidence_from_output(
         status = "no_timestamp" if has_rows else "empty_no_timestamp"
         is_stale = True
 
+    # Executed SQL (generic safe-query tools surface it as output.executed_sql)
+    # so the synthesizer cites what actually ran. A grep is a fuzzy ILIKE sample
+    # — flag it so the synthesizer never reports its row count as a total.
+    executed_sql = dump.get("executed_sql")
     return DataEvidence(
         step_id=step_id,
         tool=tool,
@@ -132,6 +136,8 @@ def _evidence_from_output(
         sample_size=sample_size,
         is_stale=is_stale,
         freshness_status=status,
+        executed_sql=str(executed_sql) if executed_sql else None,
+        is_sample=tool.endswith("_grep"),
     )
 
 

--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -80,6 +80,14 @@ Rules:
 - If the evidence is empty or insufficient, say what you don't know.
 - Do not invent rows or numbers; quote what's in the evidence.
 - Do not mention internal pipeline (filter_expert, plan, etc.).
+- When asked what query you ran, quote the `executed_sql` of the relevant
+  evidence line verbatim. Never invent, guess, or paraphrase a query you did
+  not run; if no evidence line carries executed_sql, say you don't have it.
+- Evidence flagged SAMPLE is a fuzzy ILIKE/grep search — illustrative only.
+  Never report its row count as a total or present it as a complete list. Any
+  count or total MUST come from an aggregate/COUNT result, not from counting
+  sample rows.
+- Do not pad the answer with attributes or values that are not in the evidence.
 {freshness_rules}
 """
 
@@ -170,11 +178,18 @@ def _render_evidence_for_synth(evidence: list[DataEvidence]) -> str:
     for ev in evidence:
         refreshed = ev.refreshed_at.isoformat() if ev.refreshed_at else "unknown"
         stale = " STALE" if ev.is_stale else ""
+        # SAMPLE flags fuzzy grep/ILIKE evidence — illustrative, never a total.
+        sample = " SAMPLE" if ev.is_sample else ""
         snippet = json.dumps(ev.output, default=str)[:1200]
-        lines.append(
-            f"tool={ev.tool} source={ev.source} refreshed_at={refreshed}{stale} "
-            f"status={ev.freshness_status} rows={ev.sample_size}\n  {snippet}"
+        header = (
+            f"tool={ev.tool} source={ev.source} refreshed_at={refreshed}{stale}{sample} "
+            f"status={ev.freshness_status} rows={ev.sample_size}"
         )
+        # The exact SQL that ran (when the tool ran one): the synthesizer quotes
+        # this verbatim if asked what query produced the answer.
+        if ev.executed_sql:
+            header += f"\n  executed_sql: {ev.executed_sql[:600]}"
+        lines.append(f"{header}\n  {snippet}")
     return "\n".join(lines)
 
 

--- a/miot-harness/src/miot_harness/datasource/safe_query.py
+++ b/miot-harness/src/miot_harness/datasource/safe_query.py
@@ -18,6 +18,7 @@ hardening, layered on top — not a prerequisite).
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any
 
 from miot_harness.datasource.safe_sql import (
@@ -33,6 +34,22 @@ from miot_harness.datasource.safe_sql import (
 from miot_harness.datasource.sql_policy import TableAccessPolicy
 
 DEFAULT_STATEMENT_TIMEOUT_MS = 5000
+
+
+@dataclass(frozen=True, slots=True)
+class QueryRun:
+    """Rows plus the rendered, gate-validated SQL that actually executed.
+
+    Returned by the row-producing primitives (``safe_select`` / ``safe_grep`` /
+    ``safe_run_select``) so the caller can surface *what it actually ran* as
+    evidence — the agent cites the real query instead of confabulating one when
+    asked. ``sql`` is the exact string handed to ``conn.fetch`` (including the
+    harness-injected hard-cap wrap on ``safe_run_select``); literal parameters
+    (e.g. an ILIKE pattern) are bound separately and appear as ``$1``.
+    """
+
+    rows: list[dict[str, Any]]
+    sql: str
 
 
 def _record_to_dict(record: Any) -> dict[str, Any]:
@@ -148,7 +165,7 @@ async def safe_select(
     columns: list[str] | None = None,
     max_rows: int = HARD_LIMIT_CAP,
     statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
-) -> list[dict[str, Any]]:
+) -> QueryRun:
     """Bounded, gate-validated, read-only SELECT against a policy-allowed table."""
 
     bounded_limit = _bounded(limit, max_rows)
@@ -166,7 +183,7 @@ async def safe_select(
     rows = await fetch_readonly(
         pool, safe_sql, statement_timeout_ms=statement_timeout_ms
     )
-    return [dict(row) for row in rows]
+    return QueryRun(rows=[dict(row) for row in rows], sql=safe_sql)
 
 
 async def safe_grep(
@@ -179,7 +196,7 @@ async def safe_grep(
     limit: int = DEFAULT_LIMIT,
     max_rows: int = HARD_LIMIT_CAP,
     statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
-) -> list[dict[str, Any]]:
+) -> QueryRun:
     """SELECT * WHERE col ILIKE pattern — sugar over ``safe_select``."""
 
     bounded_limit = _bounded(limit, max_rows)
@@ -190,7 +207,7 @@ async def safe_grep(
     rows = await fetch_readonly(
         pool, safe_sql, pattern, statement_timeout_ms=statement_timeout_ms
     )
-    return [dict(row) for row in rows]
+    return QueryRun(rows=[dict(row) for row in rows], sql=safe_sql)
 
 
 def _plan_from_explain(rows: list[Any]) -> dict[str, Any]:
@@ -258,7 +275,7 @@ async def safe_run_select(
     max_rows: int = HARD_LIMIT_CAP,
     cost_threshold: float | None = None,
     statement_timeout_ms: int | None = DEFAULT_STATEMENT_TIMEOUT_MS,
-) -> list[dict[str, Any]]:
+) -> QueryRun:
     """Run an arbitrary read-only SELECT (the broad Tier-B query surface).
 
     Unlike ``safe_select`` (a single-table builder), this accepts full SQL —
@@ -293,4 +310,4 @@ async def safe_run_select(
             # SELECT * over a JOIN can yield duplicate column labels; dict(r)
             # would silently keep only the last. Preserve every column by
             # suffixing collisions (id_, id__2, …) so no data is lost.
-            return [_record_to_dict(r) for r in rows]
+            return QueryRun(rows=[_record_to_dict(r) for r in rows], sql=wrapped)

--- a/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/primitive_tools.py
@@ -69,6 +69,10 @@ class _ExplainInput(BaseModel):
 class _RowsOutput(BaseModel):
     rows: list[dict[str, Any]] = Field(default_factory=list)
     source: str = ""
+    # The rendered SQL that actually executed (select/grep/query). Threaded into
+    # DataEvidence so the agent can cite what it ran. None for introspection
+    # tools (list_tables) that have no user-facing query to report.
+    executed_sql: str | None = None
 
 
 class _DescribeOutput(BaseModel):
@@ -173,7 +177,7 @@ def build_generic_tools(
     async def call_select(
         ctx: HarnessContext, parsed: _SelectInput, progress: Progress
     ) -> _RowsOutput:
-        rows = await safe_select(
+        run = await safe_select(
             pool=pool,
             policy=policy,
             table=parsed.table,
@@ -184,12 +188,12 @@ def build_generic_tools(
             max_rows=max_rows,
             statement_timeout_ms=statement_timeout_ms,
         )
-        return _RowsOutput(rows=rows, source=source_label)
+        return _RowsOutput(rows=run.rows, source=source_label, executed_sql=run.sql)
 
     async def call_grep(
         ctx: HarnessContext, parsed: _GrepInput, progress: Progress
     ) -> _RowsOutput:
-        rows = await safe_grep(
+        run = await safe_grep(
             pool=pool,
             policy=policy,
             table=parsed.table,
@@ -199,12 +203,12 @@ def build_generic_tools(
             max_rows=max_rows,
             statement_timeout_ms=statement_timeout_ms,
         )
-        return _RowsOutput(rows=rows, source=source_label)
+        return _RowsOutput(rows=run.rows, source=source_label, executed_sql=run.sql)
 
     async def call_query(
         ctx: HarnessContext, parsed: _QueryInput, progress: Progress
     ) -> _RowsOutput:
-        rows = await safe_run_select(
+        run = await safe_run_select(
             pool=pool,
             policy=policy,
             sql=parsed.sql,
@@ -212,7 +216,7 @@ def build_generic_tools(
             cost_threshold=explain_cost_threshold,
             statement_timeout_ms=statement_timeout_ms,
         )
-        return _RowsOutput(rows=rows, source=source_label)
+        return _RowsOutput(rows=run.rows, source=source_label, executed_sql=run.sql)
 
     async def call_explain(
         ctx: HarnessContext, parsed: _ExplainInput, progress: Progress

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -69,10 +69,15 @@ def _provenance_entry(
     step: DataStep,
     evidence: DataEvidence,
 ) -> ProvenanceEntry:
-    # Curated tools don't expose their rendered SQL; the canonical
-    # `tool(args)` string keeps the (question, sql) tuple mineable by the
-    # weekly curation pass either way.
-    sql = evidence.output.get("sql") or f"{step.tool}({json.dumps(step.args, default=str)})"
+    # Generic safe-query tools surface the rendered SQL they ran
+    # (evidence.executed_sql); curated tools don't, so fall back to the
+    # canonical `tool(args)` string. Either keeps the (question, sql) tuple
+    # mineable by the weekly curation pass.
+    sql = (
+        evidence.executed_sql
+        or evidence.output.get("sql")
+        or f"{step.tool}({json.dumps(step.args, default=str)})"
+    )
     plan_cost = evidence.output.get("total_cost")
     return ProvenanceEntry(
         question=user_message,

--- a/miot-harness/src/miot_harness/runtime/plan.py
+++ b/miot-harness/src/miot_harness/runtime/plan.py
@@ -41,6 +41,13 @@ class DataEvidence(BaseModel):
     sample_size: int = 0
     is_stale: bool = False
     freshness_status: FreshnessStatus = "fresh"
+    # The rendered SQL that actually executed (when the tool ran one), so the
+    # synthesizer can cite it verbatim instead of confabulating a query.
+    executed_sql: str | None = None
+    # True for fuzzy/illustrative evidence (a grep/ILIKE sample): never a
+    # definitive count or complete list. The synthesizer must caveat it and
+    # never report its row count as a total.
+    is_sample: bool = False
 
 
 class DataState(TypedDict, total=False):

--- a/miot-harness/tests/datasource/test_safe_query.py
+++ b/miot-harness/tests/datasource/test_safe_query.py
@@ -84,10 +84,13 @@ class _RecordingPool:
 @pytest.mark.asyncio
 async def test_select_runs_read_only_with_timeout() -> None:
     pool = _RecordingPool(fetch_return=[{"id": 1}])
-    rows = await safe_select(
+    run = await safe_select(
         pool=pool, policy=ACS, table="acs.act_ru_task", limit=10
     )
-    assert rows == [{"id": 1}]
+    assert run.rows == [{"id": 1}]
+    # QueryRun.sql carries the exact rendered SQL that executed.
+    assert run.sql == pool.conn.fetched[-1][0]
+    assert "LIMIT 10" in run.sql
     assert pool.conn.txn_readonly is True  # BEGIN READ ONLY
     assert any("statement_timeout" in s for s in pool.conn.executed)
     assert "LIMIT 10" in pool.conn.fetched[-1][0]
@@ -144,12 +147,14 @@ async def test_select_can_disable_timeout() -> None:
 @pytest.mark.asyncio
 async def test_grep_builds_ilike_and_is_read_only() -> None:
     pool = _RecordingPool(fetch_return=[{"id": 1}])
-    await safe_grep(
+    run = await safe_grep(
         pool=pool, policy=ACS, table="acs.act_ru_task", column="assignee_", pattern="%x%"
     )
     sql, args = pool.conn.fetched[-1]
     assert "ILIKE" in sql.upper()
     assert args == ("%x%",)
+    # The pattern is bound as $1 (not inlined); QueryRun.sql is the executed SQL.
+    assert run.sql == sql
     assert pool.conn.txn_readonly is True
 
 
@@ -234,10 +239,12 @@ _JOIN = (
 @pytest.mark.asyncio
 async def test_run_select_allows_join_caps_and_is_read_only() -> None:
     pool = _RecordingPool(fetch_return=[{"id_": "1", "text_": "x"}])
-    rows = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, max_rows=200)
-    assert rows == [{"id_": "1", "text_": "x"}]
+    run = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, max_rows=200)
+    assert run.rows == [{"id_": "1", "text_": "x"}]
     sql = pool.conn.fetched[-1][0]
     assert "_miot_q" in sql and "LIMIT 200" in sql  # harness-injected hard cap
+    # QueryRun.sql is the exact executed string, including the hard-cap wrap.
+    assert run.sql == sql
     assert pool.conn.txn_readonly is True
     assert any("statement_timeout" in s for s in pool.conn.executed)
 
@@ -283,8 +290,8 @@ async def test_run_select_cost_gate_passes_under_budget() -> None:
         return [{"id_": "1"}]
 
     pool = RecordingPool(responder=_responder)
-    rows = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, cost_threshold=10_000.0)
-    assert rows == [{"id_": "1"}]
+    run = await safe_run_select(pool=pool, policy=ACS, sql=_JOIN, cost_threshold=10_000.0)
+    assert run.rows == [{"id_": "1"}]
 
 
 # --------------------- gate regression: boolean operators + EXPLAIN json ----
@@ -303,7 +310,7 @@ def test_gate_accepts_boolean_operators_in_where() -> None:
 @pytest.mark.asyncio
 async def test_run_select_handles_join_with_and_or() -> None:
     pool = _RecordingPool(fetch_return=[{"id_": "1"}])
-    rows = await safe_run_select(
+    run = await safe_run_select(
         pool=pool,
         policy=ACS,
         sql=(
@@ -312,7 +319,7 @@ async def test_run_select_handles_join_with_and_or() -> None:
             "WHERE v.name_ = 'mintral_serviceCode' AND t.suspension_state_ = 1"
         ),
     )
-    assert rows == [{"id_": "1"}]
+    assert run.rows == [{"id_": "1"}]
 
 
 @pytest.mark.asyncio

--- a/miot-harness/tests/runtime/test_agentic_graph.py
+++ b/miot-harness/tests/runtime/test_agentic_graph.py
@@ -248,6 +248,27 @@ async def test_agentic_executor_writes_provenance(tmp_path: Path) -> None:
     assert entry["rows_returned"] == 1
 
 
+def test_provenance_entry_prefers_executed_sql() -> None:
+    # When a generic safe-query tool ran real SQL, provenance records THAT,
+    # not the synthetic `tool(args)` fallback used for curated tools.
+    from miot_harness.runtime.agentic_graph import _provenance_entry
+    from miot_harness.runtime.plan import DataEvidence, DataStep
+
+    step = DataStep(intent="i", tool="acs_query", args={"sql": "..."}, rationale="r")
+    ev = DataEvidence(
+        step_id=step.id,
+        tool="acs_query",
+        source="acs",
+        refreshed_at=None,
+        output={"rows": [{"n": 25}]},
+        sample_size=1,
+        executed_sql="SELECT count(*) AS n FROM acs.act_ru_task",
+    )
+    entry = _provenance_entry(ctx=_ctx(), user_message="cuántas?", step=step, evidence=ev)
+    assert entry.sql == "SELECT count(*) AS n FROM acs.act_ru_task"
+    assert entry.rows_returned == 1
+
+
 @pytest.mark.asyncio
 async def test_agentic_graph_caps_turns() -> None:
     """At the cap with no evidence the planner fails fast — never hangs,

--- a/miot-harness/tests/test_data_fetcher.py
+++ b/miot-harness/tests/test_data_fetcher.py
@@ -295,6 +295,36 @@ def test_live_source_empty_is_empty_not_no_timestamp() -> None:
     assert ev.is_stale is False
 
 
+def test_evidence_threads_executed_sql_from_output() -> None:
+    # Generic safe-query tools surface output.executed_sql; it must land on the
+    # evidence so the synthesizer can cite what actually ran.
+    ev = _classify(
+        {"rows": [{"a": 1}], "executed_sql": "SELECT a FROM acs.t LIMIT 100"},
+        has_freshness_model=False,
+    )
+    assert ev.executed_sql == "SELECT a FROM acs.t LIMIT 100"
+
+
+def test_evidence_executed_sql_absent_is_none() -> None:
+    ev = _classify({"rows": [{"a": 1}]}, has_freshness_model=False)
+    assert ev.executed_sql is None
+
+
+def test_evidence_grep_tool_is_marked_sample() -> None:
+    from miot_harness.agents.data_fetcher import _evidence_from_output
+
+    grep_ev = _evidence_from_output(
+        "s1", "acs_grep", {"rows": [{"a": 1}]},
+        warn_minutes=30, source_label="acs", has_freshness_model=False,
+    )
+    query_ev = _evidence_from_output(
+        "s2", "acs_query", {"rows": [{"a": 1}]},
+        warn_minutes=30, source_label="acs", has_freshness_model=False,
+    )
+    assert grep_ev.is_sample is True  # fuzzy ILIKE sample — never a total
+    assert query_ev.is_sample is False
+
+
 def test_freshness_status_fresh_rows_and_fresh_timestamp() -> None:
     ev = _classify({"rows": [{"a": 1}], "refreshed_at": datetime.now(UTC)})
     assert ev.freshness_status == "fresh"

--- a/miot-harness/tests/test_synthesizer.py
+++ b/miot-harness/tests/test_synthesizer.py
@@ -162,6 +162,48 @@ def test_rendered_evidence_includes_status_and_rows() -> None:
     assert "rows=0" in rendered
 
 
+def test_rendered_evidence_includes_executed_sql_and_sample_flag() -> None:
+    from miot_harness.agents.synthesizer import _render_evidence_for_synth
+
+    query_ev = DataEvidence(
+        step_id="s1",
+        tool="acs_query",
+        source="acs",
+        refreshed_at=None,
+        output={"rows": [{"n": 25}]},
+        sample_size=1,
+        freshness_status="fresh",
+        executed_sql="SELECT count(*) AS n FROM acs.act_ru_task",
+    )
+    grep_ev = DataEvidence(
+        step_id="s2",
+        tool="acs_grep",
+        source="acs",
+        refreshed_at=None,
+        output={"rows": [{"name_": "x"}]},
+        sample_size=1,
+        freshness_status="fresh",
+        executed_sql="SELECT * FROM acs.act_ru_variable WHERE name_ ILIKE $1 LIMIT 100",
+        is_sample=True,
+    )
+    rendered = _render_evidence_for_synth([query_ev, grep_ev])
+    # Executed SQL is surfaced verbatim so the synthesizer cites the real query.
+    assert "executed_sql: SELECT count(*) AS n FROM acs.act_ru_task" in rendered
+    # The grep line is flagged SAMPLE so the synthesizer never treats it as a total.
+    assert "SAMPLE" in rendered
+    grep_line = next(ln for ln in rendered.splitlines() if "tool=acs_grep" in ln)
+    assert "SAMPLE" in grep_line
+
+
+def test_system_prompt_carries_executed_sql_and_sample_grounding_rules() -> None:
+    from miot_harness.agents.synthesizer import _SYNTH_SYSTEM_TEMPLATE
+
+    rules = _SYNTH_SYSTEM_TEMPLATE.lower()
+    assert "executed_sql" in rules
+    assert "sample" in rules
+    assert "count" in rules
+
+
 @pytest.mark.asyncio
 async def test_system_prompt_carries_per_status_messaging_rules() -> None:
     """The synthesizer must be instructed how to phrase each freshness


### PR DESCRIPTION
## Phase 3 slice 2 — executed-SQL in evidence + synthesizer grounding

Second of three Phase 3 slices. **Stacked on #784 (slice 1)** — review this diff against `based/harness-phase3-planner`; merge #784 first.

### Why
Two trust failures observed live, both because the answer layer was blind to what actually ran:
1. Asked *"what query did you run?"*, the synthesizer **confabulated** a query — it never received the SQL the tool executed.
2. It reported a fuzzy `grep` sample as an **authoritative total**.

### What
- **`safe_query.QueryRun(rows, sql)`** — the row-producing primitives (`safe_select` / `safe_grep` / `safe_run_select`) now return the rows *plus the exact rendered SQL that executed* (including the hard-cap wrap on `run_select`; ILIKE patterns stay bound as `$1`). Generic-only primitives; the 3 wrappers + tests updated.
- **`_RowsOutput.executed_sql`** surfaces it from the tool wrappers (None for introspection tools with no user-facing query).
- **`DataEvidence.executed_sql`** + **`DataEvidence.is_sample`** — `is_sample` flags a grep/ILIKE fuzzy sample (never a definitive count/list).
- **`_evidence_from_output`** threads `executed_sql` and marks grep evidence `is_sample`. Canned/Nexo path unaffected (no executed_sql; not a grep).
- **provenance** records the real `executed_sql`, falling back to the curated `tool(args)` string for tools that don't expose SQL.
- **synthesizer**: renders `executed_sql` + a `SAMPLE` flag per evidence line, and the system prompt now (a) requires citing `executed_sql` **verbatim** when asked what ran, (b) forbids reporting a `SAMPLE` row count as a total — counts must come from an aggregate/COUNT, (c) forbids padding with attributes not in the evidence.

### Tests (+6)
- `QueryRun.sql` == the exact executed string (select/grep/run_select).
- evidence threads `executed_sql`; grep tool → `is_sample`.
- synthesizer renders `executed_sql` + `SAMPLE`; grounding rules present in the prompt.
- provenance prefers `executed_sql` over the synthetic fallback.
- Full suite: **771 passed, 2 skipped**; ruff + mypy clean.

### Not in this slice
- Explicit plan → execute → verify → re-plan (the architectural core) → slice 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #789
