### PR TITLE
fix(conversational): address Copilot review on Phase 1a (#774)

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
@@ -78,11 +78,26 @@ public class ConversationRepository {
     }
 
     public Conversation findByTenantAndId(String tenantCode, String conversationId) {
+        UUID id = parseUuidOrNull(conversationId);
+        if (id == null) {
+            return null;
+        }
         var rows = client().preparedQuery(SELECT_BY_TENANT_AND_ID)
-                .execute(Tuple.of(tenantCode, UUID.fromString(conversationId)))
+                .execute(Tuple.of(tenantCode, id))
                 .await().indefinitely();
         var iterator = rows.iterator();
         return iterator.hasNext() ? mapRow(iterator.next()) : null;
+    }
+
+    private static UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     public List<Conversation> listByTenant(String tenantCode, int limit) {

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -80,7 +80,7 @@ public class WhatsAppMessagingService {
             metaMessageId = dispatch(connection, phoneNumberId, token, request);
             status = MessageStatus.SENT;
         } catch (WhatsAppSendException e) {
-            LOG.warnf(e, "WhatsApp send failed for tenant %s to %s", tenantCode, request.to());
+            LOG.warnf(e, "WhatsApp send failed for tenant %s to %s", tenantCode, maskPhone(request.to()));
             status = MessageStatus.FAILED;
             errorMessage = e.getMessage();
         }
@@ -183,6 +183,14 @@ public class WhatsAppMessagingService {
                         "templateParams['" + param.getKey() + "'] must have a non-blank value");
             }
         }
+    }
+
+    /** Masks a phone number for logs, keeping only the last 4 digits (PII reduction). */
+    private static String maskPhone(String phone) {
+        if (phone == null || phone.length() <= 4) {
+            return "****";
+        }
+        return "****" + phone.substring(phone.length() - 4);
     }
 
     private static Map<String, Object> metadata(ResolvedConnection connection) {

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/persistence/ConversationRepositoryTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/persistence/ConversationRepositoryTest.java
@@ -1,0 +1,25 @@
+package com.microboxlabs.miot.conversational.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A blank or non-UUID conversation id must short-circuit to {@code null} before any DB
+ * access, so an invalid path param surfaces as 404 rather than a 500 from
+ * {@code UUID.fromString}. The guard runs before {@code client()}, so a null pool is safe.
+ */
+class ConversationRepositoryTest {
+
+    private final ConversationRepository repository = new ConversationRepository(null);
+
+    @Test
+    void findByTenantAndIdReturnsNullForBlankId() {
+        assertNull(repository.findByTenantAndId("tenant", "  "));
+    }
+
+    @Test
+    void findByTenantAndIdReturnsNullForNonUuidId() {
+        assertNull(repository.findByTenantAndId("tenant", "not-a-uuid"));
+    }
+}

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -67,6 +67,15 @@ class WhatsAppMessagingServiceTest {
         assertEquals("[template] trip_assigned", preview);
     }
 
+    @Test
+    void maskPhoneKeepsOnlyLastFourDigits() throws Exception {
+        Method maskPhone = WhatsAppMessagingService.class.getDeclaredMethod("maskPhone", String.class);
+        maskPhone.setAccessible(true);
+        assertEquals("****1587", maskPhone.invoke(null, "+56962311587"));
+        assertEquals("****", maskPhone.invoke(null, "123"));
+        assertEquals("****", maskPhone.invoke(null, new Object[] {null}));
+    }
+
     private static void assertIllegalArgument(SendWhatsAppMessageRequest request, String field) {
         InvocationTargetException wrapper = assertThrows(InvocationTargetException.class,
                 () -> invokeValidate(request));

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionResolver.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionResolver.java
@@ -48,13 +48,16 @@ public class IntegrationConnectionResolver {
         if (connection.credentialProfileId() != null) {
             CredentialProfile credential =
                     credentialProfileRepository.findByTenantAndId(tenantCode, connection.credentialProfileId());
-            if (credential != null) {
-                try {
-                    secret = secretCipher.decrypt(credential.encryptedSecretJson());
-                } catch (RuntimeException e) {
-                    throw new ConnectionResolutionException(
-                            "Could not read the credential for the " + providerType + " connection", e);
-                }
+            if (credential == null) {
+                throw new ConnectionResolutionException(
+                        "The credential profile linked to the " + providerType
+                                + " connection could not be found");
+            }
+            try {
+                secret = secretCipher.decrypt(credential.encryptedSecretJson());
+            } catch (RuntimeException e) {
+                throw new ConnectionResolutionException(
+                        "Could not read the credential for the " + providerType + " connection", e);
             }
         }
         return new ResolvedConnection(connection.id(), connection.baseUrl(), connection.metadata(), secret);


### PR DESCRIPTION
Three robustness/PII fixes from Copilot's review of the merged #774 (verified valid against current code).

Closes #786.

## Changes
- **`IntegrationConnectionResolver.resolve`** — when a connection has a `credentialProfileId` but the profile can't be found, it returned an empty secret (→ a confusing downstream "missing token"). Now fails fast with `ConnectionResolutionException`, matching the Javadoc contract.
- **`ConversationRepository.findByTenantAndId`** — guards blank / non-UUID `conversationId` path params: returns `null` (→ 404) instead of `UUID.fromString` throwing (→ 500). Matches `CredentialProfileRepository.findByTenantAndId`.
- **`WhatsAppMessagingService`** — masks the recipient phone in the send-failure warn log (keeps only the last 4 digits) to reduce PII in logs.

## Tests
- `ConversationRepositoryTest` — blank + non-UUID ids short-circuit to `null` (no DB access).
- `WhatsAppMessagingServiceTest.maskPhoneKeepsOnlyLastFourDigits`.
- integrations 28, conversational 18 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)