### PR TITLE
feat(harness): Phase 3 slice 3 — explicit plan → execute → verify → re-plan

### DIFF
--- a/miot-harness/src/miot_harness/agents/agentic_planner.py
+++ b/miot-harness/src/miot_harness/agents/agentic_planner.py
@@ -30,6 +30,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from pydantic import ValidationError
 
+from miot_harness.agents.chat_models import response_text
 from miot_harness.agents.domain_analyst import render_evidence
 from miot_harness.agents.filter_expert import _strip_fences, build_tool_catalog
 from miot_harness.datasource.provider import DataSourceProfile
@@ -204,10 +205,10 @@ async def agentic_planner_node(
     messages.extend(prior_messages)
     messages.append(HumanMessage(content=human))
     response = await model.ainvoke(messages)
-
-    text = response.content if hasattr(response, "content") else str(response)
-    if not isinstance(text, str):
-        text = str(text)
+    # response_text handles Opus adaptive-thinking responses, whose content is a
+    # list of blocks (thinking + text) — str(content) there yields a Python repr,
+    # not JSON, and silently fails the parse below.
+    text = response_text(response)
 
     payload = _parse_action(text)
     if payload is None or payload.get("action") not in ("plan", "call_tool", "final"):

--- a/miot-harness/src/miot_harness/agents/agentic_planner.py
+++ b/miot-harness/src/miot_harness/agents/agentic_planner.py
@@ -137,11 +137,19 @@ def _build_step(
         raise _StepError(f"out-of-scope tool: {tool_name}")
     if not in_registry:
         raise _StepError(f"unknown tool: {tool_name}")
+    # Accept a missing/null args (→ defaults), but reject a non-object value
+    # (e.g. [], "", 0) rather than silently coercing it to {} — that would let a
+    # malformed plan step through with its args quietly dropped.
+    raw_args = raw.get("args")
+    if raw_args is None:
+        raw_args = {}
+    elif not isinstance(raw_args, dict):
+        raise _StepError("step args must be a JSON object")
     try:
         return DataStep(
             intent=str(raw.get("intent", "")),
             tool=tool_name,
-            args=raw.get("args", {}) or {},
+            args=raw_args,
             rationale=str(raw.get("rationale", "")),
         )
     except ValidationError as exc:

--- a/miot-harness/src/miot_harness/agents/agentic_planner.py
+++ b/miot-harness/src/miot_harness/agents/agentic_planner.py
@@ -232,6 +232,8 @@ async def agentic_planner_node(
             "next_action": "ready_to_synthesize",
             "current_step": None,
             "turn_count": turn_count + 1,
+            # Gap consumed: clear it so a later turn doesn't re-see a stale note.
+            "verification_gap": None,
         }
 
     if payload["action"] == "plan":
@@ -260,6 +262,9 @@ async def agentic_planner_node(
             "current_step": None,
             "turn_count": turn_count + 1,
             "next_action": "execute_plan",
+            # Gap consumed by this re-plan: clear it so the post-execution
+            # "finish" turn doesn't re-see the stale note and over-query.
+            "verification_gap": None,
         }
 
     # action == "call_tool": legacy single step.
@@ -276,4 +281,6 @@ async def agentic_planner_node(
         "current_step": step,
         "turn_count": turn_count + 1,
         "next_action": None,
+        # Gap consumed: clear it so a later turn doesn't re-see a stale note.
+        "verification_gap": None,
     }

--- a/miot-harness/src/miot_harness/agents/agentic_planner.py
+++ b/miot-harness/src/miot_harness/agents/agentic_planner.py
@@ -44,9 +44,8 @@ logger = logging.getLogger(__name__)
 # profile.primer; {catalog} / {primitives_catalog} → rendered tool lists.
 _AGENTIC_PLANNER_SYSTEM_TEMPLATE = """\
 You are the {display_name} agentic planner ({tenant_display} fleet operations).
-Each turn you choose the SINGLE next action: run one more tool to gather
-evidence, or declare the investigation finished. You DO NOT answer the
-user yourself.
+You plan the tool calls that gather the evidence needed to answer the question,
+then declare the investigation finished. You DO NOT answer the user yourself.
 
 {primer}
 
@@ -57,16 +56,25 @@ Exploration primitives (read-only SQL helpers; use ONLY when no curated
 tool covers the question):
 {primitives_catalog}
 
-Output ONLY a JSON object in one of these two shapes:
+Output ONLY a JSON object in one of these shapes:
+{{"action": "plan", "steps": [<step>, <step>, ...]}}   (each <step> = the call_tool fields below)
 {{"action": "call_tool", "tool": "...", "args": {{}}, "intent": "...", "rationale": "..."}}
 {{"action": "final", "reasoning": "..."}}
+
+Prefer "plan": emit the COMPLETE ordered sequence of steps that fully answers
+the question (e.g. read the relevant knowledge card → discover the variable /
+column names → run the join/pivot that returns the rows with their attributes).
+The executor runs EVERY step before you are consulted again, carrying results
+forward. Use "call_tool" only for a genuine single step. Use "final" only when
+the executed evidence already answers the question.
 
 Rules:
 - Prefer curated tools; primitives are a fallback for questions the
   curated catalog cannot answer.
 - args is a JSON object of parameter overrides; {{}} uses the defaults.
 - Never repeat a tool call you already executed with identical args.
-- Read any knowledge card at most once, then ACT on what it says.
+- Read any knowledge card at most once, then ACT on what it says — do not
+  put repeat reads of the same card in your plan.
 
 Rigor — do not answer from incomplete or fuzzy evidence:
 - A grep / ILIKE result is a FUZZY sample, never an authoritative count or
@@ -108,6 +116,37 @@ def _parse_action(text: str) -> dict[str, Any] | None:
     return payload
 
 
+class _StepError(ValueError):
+    """A step the planner proposed is out-of-scope, unknown, or malformed."""
+
+
+def _build_step(
+    raw: dict[str, Any], *, registry: ToolRegistry, profile: DataSourceProfile
+) -> DataStep:
+    """Validate one proposed step and build a DataStep, or raise _StepError.
+
+    Scope rules mirror the single-step path: a tool must be either curated
+    (profile.tool_prefix) or a registered primitive; anything else (storytelling
+    tools, hallucinated names) is rejected so the executor never runs it."""
+    tool_name = str(raw.get("tool", ""))
+    in_registry = tool_name in registry.names()
+    is_curated = tool_name.startswith(profile.tool_prefix)
+    is_primitive = in_registry and registry.get(tool_name).kind == "primitive"
+    if not (is_curated or is_primitive):
+        raise _StepError(f"out-of-scope tool: {tool_name}")
+    if not in_registry:
+        raise _StepError(f"unknown tool: {tool_name}")
+    try:
+        return DataStep(
+            intent=str(raw.get("intent", "")),
+            tool=tool_name,
+            args=raw.get("args", {}) or {},
+            rationale=str(raw.get("rationale", "")),
+        )
+    except ValidationError as exc:
+        raise _StepError("malformed step") from exc
+
+
 async def agentic_planner_node(
     state: dict[str, Any],
     *,
@@ -140,8 +179,19 @@ async def agentic_planner_node(
     )
     failed: list[str] = list(state.get("failed_steps", []))
     failed_lines = "\n".join(f"- {note}" for note in failed) or "(none)"
+    # On a re-plan the verifier left a gap note: the executed evidence did NOT
+    # answer the question. Surface it so the planner closes the gap instead of
+    # repeating the satisficing the verifier just rejected.
+    gap = str(state.get("verification_gap") or "").strip()
+    gap_block = (
+        f"A previous attempt was judged INCOMPLETE. Gap to close:\n{gap}\n"
+        "Plan the steps that close it; do not finalize until it is addressed.\n\n"
+        if gap
+        else ""
+    )
     human = (
         f"User question:\n{state.get('user_message', '')}\n\n"
+        f"{gap_block}"
         f"Evidence collected so far:\n{render_evidence(evidence)}\n\n"
         f"Tool calls already executed:\n{executed_lines}\n\n"
         f"Tool calls that FAILED (do not repeat them as-is; fix the args, "
@@ -160,7 +210,7 @@ async def agentic_planner_node(
         text = str(text)
 
     payload = _parse_action(text)
-    if payload is None or payload.get("action") not in ("call_tool", "final"):
+    if payload is None or payload.get("action") not in ("plan", "call_tool", "final"):
         if evidence:
             # Degrade gracefully: a malformed verdict shouldn't discard
             # real evidence — synthesize with what we have.
@@ -184,32 +234,43 @@ async def agentic_planner_node(
             "turn_count": turn_count + 1,
         }
 
-    tool_name = str(payload.get("tool", ""))
-    in_registry = tool_name in registry.names()
-    is_curated = tool_name.startswith(profile.tool_prefix)
-    is_primitive = in_registry and registry.get(tool_name).kind == "primitive"
-    if not (is_curated or is_primitive):
-        logger.error("agentic planner: out-of-scope tool %r", tool_name)
+    if payload["action"] == "plan":
+        raw_steps = payload.get("steps")
+        if not isinstance(raw_steps, list) or not raw_steps:
+            return {
+                "failure": "agentic planner returned an empty or malformed plan",
+                "next_action": None,
+            }
+        steps: list[DataStep] = []
+        try:
+            for raw in raw_steps:
+                if not isinstance(raw, dict):
+                    raise _StepError("plan step is not an object")
+                steps.append(_build_step(raw, registry=registry, profile=profile))
+        except _StepError as exc:
+            logger.error("agentic planner: invalid plan step (%s)", exc)
+            return {
+                "failure": f"agentic planner proposed an invalid plan step: {exc}",
+                "next_action": None,
+            }
+        # The executor drains pending_steps to completion before the planner is
+        # consulted again; verify then judges whether the plan answered it.
         return {
-            "failure": f"agentic planner picked out-of-scope tool: {tool_name}",
-            "next_action": None,
-        }
-    if not in_registry:
-        logger.error("agentic planner: hallucinated tool %r (not in registry)", tool_name)
-        return {
-            "failure": f"agentic planner proposed unknown tool: {tool_name}",
-            "next_action": None,
+            "pending_steps": steps,
+            "current_step": None,
+            "turn_count": turn_count + 1,
+            "next_action": "execute_plan",
         }
 
+    # action == "call_tool": legacy single step.
     try:
-        step = DataStep(
-            intent=str(payload.get("intent", "")),
-            tool=tool_name,
-            args=payload.get("args", {}) or {},
-            rationale=str(payload.get("rationale", "")),
-        )
-    except ValidationError:
-        return {"failure": "agentic planner returned malformed step", "next_action": None}
+        step = _build_step(payload, registry=registry, profile=profile)
+    except _StepError as exc:
+        logger.error("agentic planner: %s", exc)
+        return {
+            "failure": f"agentic planner picked {exc}",
+            "next_action": None,
+        }
 
     return {
         "current_step": step,

--- a/miot-harness/src/miot_harness/agents/chat_models.py
+++ b/miot-harness/src/miot_harness/agents/chat_models.py
@@ -10,12 +10,38 @@ plain ANTHROPIC_API_KEY / OPENAI_API_KEY env vars).
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
 from pydantic import SecretStr
 
 from miot_harness.config import get_settings
+
+
+def response_text(response: Any) -> str:
+    """Extract plain text from a chat-model response.
+
+    Anthropic models with extended/adaptive thinking enabled (the Opus 4.7+
+    `effort` path) return ``message.content`` as a LIST of content blocks — a
+    ``thinking`` block plus a ``text`` block — not a plain string. A naive
+    ``str(content)`` then yields a Python-repr of the list (not the model's
+    text), which silently breaks any caller that JSON-parses the answer (e.g.
+    the agentic planner / verifier). This concatenates the ``text`` blocks and
+    drops thinking, handling the plain-string case too.
+    """
+    content = getattr(response, "content", response)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts)
+    return str(content)
 
 # Anthropic `output_config.effort` levels (Opus 4.7+). "high" is the model's
 # natural default (a no-op); "xhigh"/"max" actually deepen reasoning at a

--- a/miot-harness/src/miot_harness/agents/verifier.py
+++ b/miot-harness/src/miot_harness/agents/verifier.py
@@ -28,6 +28,7 @@ from typing import Any
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from miot_harness.agents.chat_models import response_text
 from miot_harness.agents.filter_expert import _strip_fences
 from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
@@ -162,10 +163,7 @@ async def verify_node(
         response = await model.ainvoke(
             [SystemMessage(content=system), HumanMessage(content=human)]
         )
-        text = response.content if hasattr(response, "content") else str(response)
-        if not isinstance(text, str):
-            text = str(text)
-        payload = json.loads(_strip_fences(text))
+        payload = json.loads(_strip_fences(response_text(response)))
     except Exception as exc:  # noqa: BLE001 — any judge error must not trap the run
         # A judge error must never trap the run — default to done so we
         # synthesize with the evidence in hand rather than loop.

--- a/miot-harness/src/miot_harness/agents/verifier.py
+++ b/miot-harness/src/miot_harness/agents/verifier.py
@@ -170,7 +170,10 @@ async def verify_node(
         logger.warning("verifier: judge failed (%s); accepting evidence as-is", exc)
         return _done()
 
-    if not isinstance(payload, dict) or not payload.get("fulfilled", False):
+    # Only a literal JSON boolean true counts as fulfilled. A truthy non-bool
+    # (e.g. the string "false", or "yes") must NOT bypass re-planning — when in
+    # doubt, re-plan.
+    if not isinstance(payload, dict) or payload.get("fulfilled") is not True:
         gap = ""
         if isinstance(payload, dict):
             gap = str(payload.get("gap") or "")

--- a/miot-harness/src/miot_harness/agents/verifier.py
+++ b/miot-harness/src/miot_harness/agents/verifier.py
@@ -74,12 +74,20 @@ def _summarize_evidence(evidence: list[DataEvidence]) -> str:
     return "\n".join(lines) if lines else "(no evidence)"
 
 
-def _emit(progress: Progress, run_id: str, *, fulfilled: bool, gap: str | None) -> None:
+def _emit(
+    progress: Progress,
+    run_id: str,
+    *,
+    fulfilled: bool,
+    gap: str | None,
+    message: str | None = None,
+) -> None:
     progress(
         HarnessEvent(
             run_id=run_id,
             type="verification.completed",
-            message="Verified completion" if fulfilled else "Re-planning (gap found)",
+            message=message
+            or ("Verified completion" if fulfilled else "Re-planning (gap found)"),
             data={"fulfilled": fulfilled, "gap": gap or ""},
         )
     )
@@ -103,6 +111,19 @@ async def verify_node(
         _emit(progress, ctx.run_id, fulfilled=True, gap=None)
         return {"next_action": VERIFIED_DONE}
 
+    def _budget_exhausted(reason: str) -> dict[str, Any]:
+        # Stop the loop (synthesize with what we have) but report the truth:
+        # this run was NOT verified-fulfilled, the budget ran out. Misreporting
+        # it as fulfilled=true would skew completion telemetry.
+        _emit(
+            progress,
+            ctx.run_id,
+            fulfilled=False,
+            gap=reason,
+            message=f"{reason}; synthesizing with available evidence",
+        )
+        return {"next_action": VERIFIED_DONE}
+
     def _gap(reason: str) -> dict[str, Any]:
         _emit(progress, ctx.run_id, fulfilled=False, gap=reason)
         return {
@@ -115,12 +136,13 @@ async def verify_node(
             "pending_steps": [],
         }
 
-    # Out of budget → accept what we have and synthesize. Never loop forever.
+    # Out of budget → accept what we have and synthesize. Never loop forever,
+    # but record that this was forced (not a genuine fulfilled verdict).
     if replan_count >= settings.agents_agentic_max_replans:
         logger.info("verifier: replan cap reached (%d); synthesizing", replan_count)
-        return _done()
+        return _budget_exhausted("Re-plan budget exhausted")
     if turn_count >= settings.agents_agentic_max_turns:
-        return _done()
+        return _budget_exhausted("Turn budget exhausted")
 
     # Rule: nothing ran → there is nothing to answer from; re-plan.
     if not evidence:

--- a/miot-harness/src/miot_harness/agents/verifier.py
+++ b/miot-harness/src/miot_harness/agents/verifier.py
@@ -1,0 +1,158 @@
+"""Completion verifier (Phase 3 — small judge tier).
+
+The agentic planner satisfices: it forms a plan, sometimes even writes the SQL,
+then declares "final" without running it — or answers a "list" question from a
+fuzzy grep sample. Prompting alone didn't fix this (proven empirically); the
+fix is structural. This node intercepts the planner's decision to finish and
+asks: *do the EXECUTED results actually fulfil the request?*
+
+Two layers:
+
+  1. Rule-based (always on, cheap): no evidence at all → not fulfilled. Hard
+     caps (replan/turn budget) → accept and synthesize, never loop forever.
+  2. A small LLM judge (when a model is wired): catches the nuanced satisficing
+     — "list asked but only a count/sample ran", "attributes asked but only ids
+     present", "a needed query never executed". Degrades to rules-only when no
+     model is provided (e.g. tests), so the gate is safe by construction.
+
+On a gap it records `verification_gap` and routes back to the planner to
+re-plan; otherwise it lets the run synthesize.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from miot_harness.agents.filter_expert import _strip_fences
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.events import HarnessEvent
+from miot_harness.runtime.plan import DataEvidence
+from miot_harness.runtime.tool import Progress
+
+logger = logging.getLogger(__name__)
+
+# next_action values this node emits; the graph routes on them.
+VERIFIED_DONE = "verified_done"
+REPLAN = "replan"
+
+_JUDGE_SYSTEM = """\
+You are a strict completion judge for a data assistant. Decide whether the
+EXECUTED evidence already fully answers the user's question. You do NOT answer
+the question yourself.
+
+Mark fulfilled=false (and name the gap in one line) when:
+- the question asks to LIST / enumerate items but only a COUNT or a fuzzy SAMPLE
+  ran (no row-per-item result);
+- the question asks for attributes/details (codes, names, references) that are
+  NOT present in the evidence;
+- a query clearly needed to answer the question was never executed;
+- the ONLY evidence is a SAMPLE (grep/ILIKE) — never authoritative for a total
+  or a complete list.
+Mark fulfilled=true when the executed results actually answer what was asked, or
+when the evidence shows the available tools genuinely cannot answer it.
+
+Return ONLY a JSON object: {"fulfilled": true|false, "gap": "<one line>"}
+"""
+
+
+def _summarize_evidence(evidence: list[DataEvidence]) -> str:
+    lines: list[str] = []
+    for ev in evidence:
+        sample = " SAMPLE" if ev.is_sample else ""
+        line = f"- tool={ev.tool} rows={ev.sample_size}{sample}"
+        if ev.executed_sql:
+            line += f" sql={ev.executed_sql[:300]}"
+        snippet = json.dumps(ev.output, default=str)[:500]
+        lines.append(f"{line}\n    {snippet}")
+    return "\n".join(lines) if lines else "(no evidence)"
+
+
+def _emit(progress: Progress, run_id: str, *, fulfilled: bool, gap: str | None) -> None:
+    progress(
+        HarnessEvent(
+            run_id=run_id,
+            type="verification.completed",
+            message="Verified completion" if fulfilled else "Re-planning (gap found)",
+            data={"fulfilled": fulfilled, "gap": gap or ""},
+        )
+    )
+
+
+async def verify_node(
+    state: dict[str, Any],
+    *,
+    model: BaseChatModel | None,
+    settings: HarnessSettings,
+    profile: DataSourceProfile,
+    progress: Progress,
+) -> dict[str, Any]:
+    ctx: HarnessContext = state["ctx"]
+    evidence: list[DataEvidence] = list(state.get("evidence", []))
+    user_message = str(state.get("user_message", ""))
+    replan_count = int(state.get("replan_count", 0) or 0)
+    turn_count = int(state.get("turn_count", 0) or 0)
+
+    def _done() -> dict[str, Any]:
+        _emit(progress, ctx.run_id, fulfilled=True, gap=None)
+        return {"next_action": VERIFIED_DONE}
+
+    def _gap(reason: str) -> dict[str, Any]:
+        _emit(progress, ctx.run_id, fulfilled=False, gap=reason)
+        return {
+            "verification_gap": reason,
+            "replan_count": replan_count + 1,
+            "next_action": REPLAN,
+            # Clear any leftover step state so the planner starts the re-plan
+            # from a clean slate (the executor drained pending_steps already).
+            "current_step": None,
+            "pending_steps": [],
+        }
+
+    # Out of budget → accept what we have and synthesize. Never loop forever.
+    if replan_count >= settings.agents_agentic_max_replans:
+        logger.info("verifier: replan cap reached (%d); synthesizing", replan_count)
+        return _done()
+    if turn_count >= settings.agents_agentic_max_turns:
+        return _done()
+
+    # Rule: nothing ran → there is nothing to answer from; re-plan.
+    if not evidence:
+        return _gap("No data was retrieved; run the query that answers the question.")
+
+    # Rules-only mode (no judge model wired): evidence present → accept.
+    if model is None:
+        return _done()
+
+    system = _JUDGE_SYSTEM
+    human = (
+        f"User question:\n{user_message}\n\n"
+        f"Executed evidence:\n{_summarize_evidence(evidence)}\n\n"
+        "Is the question fully answered by this executed evidence?"
+    )
+    try:
+        response = await model.ainvoke(
+            [SystemMessage(content=system), HumanMessage(content=human)]
+        )
+        text = response.content if hasattr(response, "content") else str(response)
+        if not isinstance(text, str):
+            text = str(text)
+        payload = json.loads(_strip_fences(text))
+    except Exception as exc:  # noqa: BLE001 — any judge error must not trap the run
+        # A judge error must never trap the run — default to done so we
+        # synthesize with the evidence in hand rather than loop.
+        logger.warning("verifier: judge failed (%s); accepting evidence as-is", exc)
+        return _done()
+
+    if not isinstance(payload, dict) or not payload.get("fulfilled", False):
+        gap = ""
+        if isinstance(payload, dict):
+            gap = str(payload.get("gap") or "")
+        return _gap(gap or "The executed evidence does not yet answer the question.")
+    return _done()

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -407,10 +407,15 @@ def _make_lifespan(
                             effort=settings.agents_planner_effort,
                         ),
                         # Small "did we answer it?" judge for the Phase 3 verify
-                        # gate. Empty model name → rules-only verification.
+                        # gate. Only build it when the gate is ON and a model is
+                        # set — otherwise a misconfigured verifier model name
+                        # would raise and disable the datasource at boot for a
+                        # model that wouldn't even be used. Empty model name (gate
+                        # on) → rules-only verification.
                         **(
                             {"verifier": get_chat_model(settings.agents_verifier_model)}
-                            if settings.agents_verifier_model
+                            if settings.agents_agentic_verify_enabled
+                            and settings.agents_verifier_model
                             else {}
                         ),
                     },

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -406,6 +406,13 @@ def _make_lifespan(
                             settings.agents_planner_model,
                             effort=settings.agents_planner_effort,
                         ),
+                        # Small "did we answer it?" judge for the Phase 3 verify
+                        # gate. Empty model name → rules-only verification.
+                        **(
+                            {"verifier": get_chat_model(settings.agents_verifier_model)}
+                            if settings.agents_verifier_model
+                            else {}
+                        ),
                     },
                     provenance_log=ProvenanceLog(
                         settings.provenance_log_dir,

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -57,6 +57,21 @@ class HarnessSettings(BaseSettings):
     agents_agentic_max_turns: int = Field(default=12, gt=0)
     agents_critic_enabled: bool = False
 
+    # Phase 3 verify gate. When enabled, the agentic planner's decision to
+    # finish is intercepted by a verifier node (rule-based + a small LLM judge)
+    # that asks "do the EXECUTED results fulfil the request?"; on a gap it
+    # routes back to the planner to re-plan (bounded by max_replans). This makes
+    # completion structural — the planner can no longer satisfice (answer from a
+    # grep sample, or stop before running the join it already identified). When
+    # `agents_verifier_model` is unset, the gate degrades to rule-based checks
+    # only (no extra LLM call). Tests build the graph without a verifier model,
+    # so they exercise the rules-only path.
+    agents_agentic_verify_enabled: bool = True
+    agents_agentic_max_replans: int = Field(default=2, ge=0)
+    # Small "did we answer it?" judge. Held separate from the synthesizer so it
+    # can stay cheap. Empty string disables the LLM judge (rules-only verify).
+    agents_verifier_model: str = "claude-haiku-4-5"
+
     # Provenance log for agentic tool invocations (plan 13, E4). One JSONL
     # line per executed step under `<dir>/YYYY-MM-DD.jsonl`; the weekly
     # curation pass mines these for curated-function candidates.

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -40,6 +40,7 @@ from miot_harness.agents.data_fetcher import invoke_step
 from miot_harness.agents.filter_expert import build_capabilities_summary
 from miot_harness.agents.freshness_judge import freshness_judge_node
 from miot_harness.agents.synthesizer import synthesizer_node
+from miot_harness.agents.verifier import REPLAN, verify_node
 from miot_harness.config import HarnessSettings
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.provenance import ProvenanceEntry, ProvenanceLog
@@ -106,6 +107,10 @@ def build_agentic_graph(
 
     graph = StateGraph(DataState)
     max_turns = settings.agents_agentic_max_turns
+    # Phase 3 verify gate: intercept the planner's "finish" decision and check
+    # the executed evidence actually fulfils the request (rules + optional LLM
+    # judge), re-planning on a gap. When off, "finish" goes straight to synth.
+    verify_enabled = settings.agents_agentic_verify_enabled
     # Onboarding fallback for planning failures (Gap 4) — same curated
     # list canned mode shows; primitives stay out of user-facing copy.
     capabilities_hint = build_capabilities_summary(registry, profile=profile)
@@ -146,7 +151,14 @@ def build_agentic_graph(
 
     async def executor(state: DataState) -> dict[str, Any]:
         snapshot = cast(dict[str, Any], state)
-        step: DataStep | None = snapshot.get("current_step")
+        # Explicit-plan mode: drain pending_steps head-first; legacy single-step
+        # mode: run current_step. Either way we execute exactly one step per
+        # turn (per-step events/provenance), but a plan keeps control here
+        # (continue_plan) until the queue empties instead of round-tripping the
+        # planner between steps.
+        pending: list[DataStep] = list(snapshot.get("pending_steps") or [])
+        step: DataStep | None = pending[0] if pending else snapshot.get("current_step")
+        remaining = pending[1:] if pending else []
         if step is None:
             # Defensive: routing should never send us here without a step.
             return {"next_action": "ready_to_synthesize"}
@@ -163,14 +175,15 @@ def build_agentic_graph(
         if "failure" in delta:
             # A failed tool call is feedback, not a dead end: record the
             # note for the planner (which sees failed_steps in its prompt
-            # and adapts) and loop back instead of failing the whole run.
-            # The turn cap bounds repeated failures.
+            # and adapts). Keep draining a plan if steps remain; otherwise
+            # hand back to the planner. The turn cap bounds repeated failures.
             note = f"{step.tool}({json.dumps(step.args, default=str)}): {delta['failure']}"
             return _merge_events(
                 {
                     "failed_steps": [note],
                     "current_step": None,
-                    "next_action": None,
+                    "pending_steps": remaining,
+                    "next_action": "continue_plan" if remaining else None,
                 },
                 buf,
             )
@@ -189,10 +202,22 @@ def build_agentic_graph(
                 **delta,  # evidence appended by the operator.add reducer
                 "executed_steps": [step],
                 "current_step": None,
+                "pending_steps": remaining,
                 "next_action": "judge_freshness",
             },
             buf,
         )
+
+    async def verify(state: DataState) -> dict[str, Any]:
+        buf, progress = _make_event_buffer()
+        delta = await verify_node(
+            cast(dict[str, Any], state),
+            model=models.get("verifier"),
+            settings=settings,
+            profile=profile,
+            progress=progress,
+        )
+        return _merge_events(delta, buf)
 
     def freshness_judge(state: DataState) -> dict[str, Any]:
         buf, progress = _make_event_buffer()
@@ -250,6 +275,7 @@ def build_agentic_graph(
     )
     graph.add_node("planner", wrap_node_with_lifecycle("planner", planner, "agentic"))
     graph.add_node("executor", wrap_node_with_lifecycle("executor", executor, "agentic"))
+    graph.add_node("verify", wrap_node_with_lifecycle("verify", verify, "agentic"))
     graph.add_node(
         "freshness_judge",
         wrap_node_with_lifecycle("freshness_judge", freshness_judge, "agentic"),
@@ -265,12 +291,19 @@ def build_agentic_graph(
             return END
         return "planner"
 
+    # The planner's "finish" decision routes to verify when the gate is on,
+    # else straight to synthesis. Resolved once at build time.
+    _finish_target = "verify" if verify_enabled else "synthesizer"
+
     def route_from_planner(state: DataState) -> str:
         snapshot = cast(dict[str, Any], state)
         if snapshot.get("failure"):
             return "synthesizer"
         if snapshot.get("next_action") == "ready_to_synthesize":
-            return "synthesizer"
+            return _finish_target
+        # A plan (execute_plan) or a legacy single step both go to the executor.
+        if snapshot.get("next_action") == "execute_plan" or snapshot.get("pending_steps"):
+            return "executor"
         if snapshot.get("current_step") is not None:
             return "executor"
         # Defensive: a planner delta with neither step nor verdict still
@@ -281,25 +314,38 @@ def build_agentic_graph(
         snapshot = cast(dict[str, Any], state)
         if snapshot.get("failure"):
             return "synthesizer"
-        # Success sets next_action="judge_freshness"; a recorded tool
-        # failure leaves it None → straight back to the planner (there is
-        # no new evidence for the judge to look at).
-        if snapshot.get("next_action") == "judge_freshness":
+        na = snapshot.get("next_action")
+        # Success sets next_action="judge_freshness".
+        if na == "judge_freshness":
             return "freshness_judge"
+        # A failed step mid-plan (steps still queued) keeps draining the plan;
+        # a failed lone step (no evidence, none queued) goes back to the planner.
+        if na == "continue_plan":
+            return "executor"
         return "planner"
 
     def route_from_judge(state: DataState) -> str:
-        # REFUSE-zone verdicts set `failure`; fresh/warn loop back to the
-        # planner, which is the agentic analyst seat.
-        if cast(dict[str, Any], state).get("failure"):
+        # REFUSE-zone verdicts set `failure`; fresh/warn continue. While a plan
+        # is still draining, keep executing it; once drained, hand back to the
+        # planner (the agentic analyst seat) to plan more or finish.
+        snapshot = cast(dict[str, Any], state)
+        if snapshot.get("failure"):
             return "synthesizer"
+        if snapshot.get("pending_steps"):
+            return "executor"
         return "planner"
+
+    def route_from_verify(state: DataState) -> str:
+        # A gap re-plans (bounded by replan_count); otherwise synthesize.
+        if cast(dict[str, Any], state).get("next_action") == REPLAN:
+            return "planner"
+        return "synthesizer"
 
     graph.add_conditional_edges("tenancy_gate", route_from_gate, {"planner": "planner", END: END})
     graph.add_conditional_edges(
         "planner",
         route_from_planner,
-        {"synthesizer": "synthesizer", "executor": "executor"},
+        {"synthesizer": "synthesizer", "executor": "executor", "verify": "verify"},
     )
     graph.add_conditional_edges(
         "executor",
@@ -307,12 +353,18 @@ def build_agentic_graph(
         {
             "synthesizer": "synthesizer",
             "freshness_judge": "freshness_judge",
+            "executor": "executor",
             "planner": "planner",
         },
     )
     graph.add_conditional_edges(
         "freshness_judge",
         route_from_judge,
+        {"synthesizer": "synthesizer", "executor": "executor", "planner": "planner"},
+    )
+    graph.add_conditional_edges(
+        "verify",
+        route_from_verify,
         {"synthesizer": "synthesizer", "planner": "planner"},
     )
     graph.add_edge("synthesizer", "critic")

--- a/miot-harness/src/miot_harness/runtime/event_types.json
+++ b/miot-harness/src/miot_harness/runtime/event_types.json
@@ -18,6 +18,7 @@
     "thinking.completed",
     "usage.recorded",
     "freshness.warning",
+    "verification.completed",
     "answer.completed",
     "run.completed",
     "run.failed"

--- a/miot-harness/src/miot_harness/runtime/events.py
+++ b/miot-harness/src/miot_harness/runtime/events.py
@@ -25,6 +25,7 @@ HarnessEventType = Literal[
     "thinking.completed",
     "usage.recorded",
     "freshness.warning",
+    "verification.completed",
     "answer.completed",
     "run.completed",
     "run.failed",

--- a/miot-harness/src/miot_harness/runtime/plan.py
+++ b/miot-harness/src/miot_harness/runtime/plan.py
@@ -73,6 +73,18 @@ class DataState(TypedDict, total=False):
     # agentic mode is not bounded by the 4-step canned plan cap.
     current_step: DataStep | None
     executed_steps: Annotated[list[DataStep], operator.add]
+    # Phase 3 explicit-plan mode: the planner can emit an ordered multi-step
+    # plan at once; the executor drains this queue to completion (one step per
+    # executor turn, popping the head) before control returns to the planner.
+    # Plain key = replace semantics (the executor rewrites the remaining tail);
+    # NOT operator.add, which would re-append drained steps.
+    pending_steps: list[DataStep]
+    # Phase 3 verify gate: when the verifier judges the executed evidence does
+    # NOT yet fulfil the request, it records the gap here and routes back to the
+    # planner to re-plan. `replan_count` bounds those loops (separate from the
+    # planner's turn_count cap).
+    verification_gap: str | None
+    replan_count: int
     # Failed tool calls (one human-readable note each). The agentic
     # executor records failures here instead of dead-ending the run, so
     # the planner can adapt — try another tool or finalize.

--- a/miot-harness/tests/agents/test_agentic_planner.py
+++ b/miot-harness/tests/agents/test_agentic_planner.py
@@ -106,6 +106,94 @@ async def test_call_tool_action_produces_current_step() -> None:
 
 
 @pytest.mark.asyncio
+async def test_plan_action_produces_pending_steps() -> None:
+    response = json.dumps(
+        {
+            "action": "plan",
+            "steps": [
+                {"tool": "coordinador_centro_control", "args": {}, "intent": "kpis",
+                 "rationale": "overview"},
+                {"tool": "nexo_select", "args": {"table": "nexo.dx_servicios"},
+                 "intent": "rows", "rationale": "enumerate"},
+            ],
+        }
+    )
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    steps = delta["pending_steps"]
+    assert [s.tool for s in steps] == ["coordinador_centro_control", "nexo_select"]
+    assert delta["next_action"] == "execute_plan"
+    assert delta["turn_count"] == 1
+    assert delta["current_step"] is None
+    assert not delta.get("failure")
+
+
+@pytest.mark.asyncio
+async def test_plan_with_invalid_step_fails() -> None:
+    response = json.dumps(
+        {
+            "action": "plan",
+            "steps": [
+                {"tool": "coordinador_centro_control", "args": {}},
+                {"tool": "coordinador_inventada", "args": {}},  # unknown
+            ],
+        }
+    )
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert "unknown tool" in delta["failure"]
+    assert not delta.get("pending_steps")
+
+
+@pytest.mark.asyncio
+async def test_empty_plan_fails() -> None:
+    response = json.dumps({"action": "plan", "steps": []})
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert "empty or malformed plan" in delta["failure"]
+
+
+@pytest.mark.asyncio
+async def test_verification_gap_is_surfaced_to_planner() -> None:
+    captured: list[list[Any]] = []
+
+    class _Recording(FakeListChatModel):
+        async def ainvoke(self, input, *args, **kwargs):  # type: ignore[override]
+            captured.append(list(input))
+            return await super().ainvoke(input, *args, **kwargs)
+
+    response = json.dumps({"action": "final", "reasoning": "done"})
+    await agentic_planner_node(
+        _state(
+            evidence=[_evidence()],
+            verification_gap="solo corriste un grep; falta el COUNT real",
+        ),
+        registry=_registry(),
+        model=_Recording(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    human = [m for m in captured[0] if isinstance(m, HumanMessage)][-1]
+    assert "INCOMPLETE" in human.content
+    assert "falta el COUNT real" in human.content
+
+
+@pytest.mark.asyncio
 async def test_primitive_tool_is_in_scope() -> None:
     response = json.dumps(
         {

--- a/miot-harness/tests/agents/test_agentic_planner.py
+++ b/miot-harness/tests/agents/test_agentic_planner.py
@@ -178,7 +178,7 @@ async def test_verification_gap_is_surfaced_to_planner() -> None:
             return await super().ainvoke(input, *args, **kwargs)
 
     response = json.dumps({"action": "final", "reasoning": "done"})
-    await agentic_planner_node(
+    delta = await agentic_planner_node(
         _state(
             evidence=[_evidence()],
             verification_gap="solo corriste un grep; falta el COUNT real",
@@ -191,6 +191,36 @@ async def test_verification_gap_is_surfaced_to_planner() -> None:
     human = [m for m in captured[0] if isinstance(m, HumanMessage)][-1]
     assert "INCOMPLETE" in human.content
     assert "falta el COUNT real" in human.content
+    # The gap is consumed: cleared from the delta so a later turn (e.g. the
+    # post-execution finish turn) doesn't re-see a stale note.
+    assert delta["verification_gap"] is None
+
+
+@pytest.mark.asyncio
+async def test_plan_and_call_tool_clear_verification_gap() -> None:
+    plan = json.dumps(
+        {"action": "plan", "steps": [{"tool": "coordinador_centro_control", "args": {}}]}
+    )
+    plan_delta = await agentic_planner_node(
+        _state(verification_gap="gap"),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[plan]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert plan_delta["verification_gap"] is None
+
+    call = json.dumps(
+        {"action": "call_tool", "tool": "coordinador_centro_control", "args": {}}
+    )
+    call_delta = await agentic_planner_node(
+        _state(verification_gap="gap"),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[call]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert call_delta["verification_gap"] is None
 
 
 @pytest.mark.asyncio

--- a/miot-harness/tests/agents/test_agentic_planner.py
+++ b/miot-harness/tests/agents/test_agentic_planner.py
@@ -188,6 +188,36 @@ async def test_plan_with_invalid_step_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_object_args_is_rejected() -> None:
+    # args=[] is falsey but NOT an object — must be rejected, not coerced to {}.
+    response = json.dumps(
+        {"action": "call_tool", "tool": "coordinador_centro_control", "args": []}
+    )
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert "args must be a JSON object" in delta["failure"]
+
+
+@pytest.mark.asyncio
+async def test_missing_args_defaults_to_empty_object() -> None:
+    response = json.dumps({"action": "call_tool", "tool": "coordinador_centro_control"})
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=FakeListChatModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert delta["current_step"].args == {}
+    assert not delta.get("failure")
+
+
+@pytest.mark.asyncio
 async def test_empty_plan_fails() -> None:
     response = json.dumps({"action": "plan", "steps": []})
     delta = await agentic_planner_node(

--- a/miot-harness/tests/agents/test_agentic_planner.py
+++ b/miot-harness/tests/agents/test_agentic_planner.py
@@ -105,6 +105,38 @@ async def test_call_tool_action_produces_current_step() -> None:
     assert not delta.get("failure")
 
 
+class _ThinkingModel(FakeListChatModel):
+    """Mimics Opus 4.7+ under adaptive thinking: ainvoke returns an AIMessage
+    whose content is a LIST of blocks (thinking + text), not a plain string."""
+
+    async def ainvoke(self, input: Any, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        return AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "reasoning…", "signature": "sig"},
+                {"type": "text", "text": self.responses[0]},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_planner_parses_opus_thinking_list_content() -> None:
+    # Regression: with adaptive thinking on, content is a list; the planner must
+    # extract the text block and parse it, not stringify the whole list.
+    response = json.dumps(
+        {"action": "call_tool", "tool": "coordinador_centro_control", "args": {}}
+    )
+    delta = await agentic_planner_node(
+        _state(),
+        registry=_registry(),
+        model=_ThinkingModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    assert delta.get("current_step") is not None
+    assert delta["current_step"].tool == "coordinador_centro_control"
+    assert not delta.get("failure")
+
+
 @pytest.mark.asyncio
 async def test_plan_action_produces_pending_steps() -> None:
     response = json.dumps(

--- a/miot-harness/tests/agents/test_verifier.py
+++ b/miot-harness/tests/agents/test_verifier.py
@@ -1,0 +1,117 @@
+"""Completion verifier — rules + small LLM judge, with re-plan budget."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from langchain_core.language_models import FakeListChatModel
+
+from miot_harness.agents.verifier import REPLAN, VERIFIED_DONE, verify_node
+from miot_harness.config import HarnessSettings
+from miot_harness.integrations.nexo.provider import NEXO_PROFILE
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.plan import DataEvidence
+
+
+def _ctx() -> HarnessContext:
+    return HarnessContext(thread_id="t", tenant_id="mintral", user_id="u")
+
+
+def _ev(tool: str = "acs_query", *, is_sample: bool = False) -> DataEvidence:
+    return DataEvidence(
+        step_id="s1",
+        tool=tool,
+        source="acs",
+        refreshed_at=None,
+        output={"rows": [{"n": 25}]},
+        sample_size=1,
+        is_sample=is_sample,
+        executed_sql="SELECT count(*) AS n FROM acs.act_ru_task",
+    )
+
+
+def _state(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "user_message": "¿cuántos servicios?",
+        "ctx": _ctx(),
+        "evidence": [],
+        "turn_count": 0,
+        "replan_count": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _noop(_e: Any) -> None:
+    return None
+
+
+_SETTINGS = HarnessSettings(agents_agentic_max_replans=2, agents_agentic_max_turns=12)
+
+
+@pytest.mark.asyncio
+async def test_rules_only_no_evidence_replans() -> None:
+    delta = await verify_node(
+        _state(evidence=[]), model=None, settings=_SETTINGS, profile=NEXO_PROFILE,
+        progress=_noop,
+    )
+    assert delta["next_action"] == REPLAN
+    assert delta["replan_count"] == 1
+    assert delta["verification_gap"]
+
+
+@pytest.mark.asyncio
+async def test_rules_only_with_evidence_is_done() -> None:
+    delta = await verify_node(
+        _state(evidence=[_ev()]), model=None, settings=_SETTINGS, profile=NEXO_PROFILE,
+        progress=_noop,
+    )
+    assert delta["next_action"] == VERIFIED_DONE
+
+
+@pytest.mark.asyncio
+async def test_judge_gap_replans_with_gap_note() -> None:
+    judge = FakeListChatModel(
+        responses=[json.dumps({"fulfilled": False, "gap": "solo corrió un grep"})]
+    )
+    delta = await verify_node(
+        _state(evidence=[_ev(is_sample=True)]),
+        model=judge, settings=_SETTINGS, profile=NEXO_PROFILE, progress=_noop,
+    )
+    assert delta["next_action"] == REPLAN
+    assert "grep" in delta["verification_gap"]
+
+
+@pytest.mark.asyncio
+async def test_judge_fulfilled_is_done() -> None:
+    judge = FakeListChatModel(responses=[json.dumps({"fulfilled": True, "gap": ""})])
+    delta = await verify_node(
+        _state(evidence=[_ev()]),
+        model=judge, settings=_SETTINGS, profile=NEXO_PROFILE, progress=_noop,
+    )
+    assert delta["next_action"] == VERIFIED_DONE
+
+
+@pytest.mark.asyncio
+async def test_replan_cap_forces_done_even_on_gap() -> None:
+    judge = FakeListChatModel(
+        responses=[json.dumps({"fulfilled": False, "gap": "still incomplete"})]
+    )
+    # replan_count already at the cap → accept and synthesize, never loop.
+    delta = await verify_node(
+        _state(evidence=[_ev()], replan_count=2),
+        model=judge, settings=_SETTINGS, profile=NEXO_PROFILE, progress=_noop,
+    )
+    assert delta["next_action"] == VERIFIED_DONE
+
+
+@pytest.mark.asyncio
+async def test_malformed_judge_response_defaults_to_done() -> None:
+    judge = FakeListChatModel(responses=["not json at all"])
+    delta = await verify_node(
+        _state(evidence=[_ev()]),
+        model=judge, settings=_SETTINGS, profile=NEXO_PROFILE, progress=_noop,
+    )
+    assert delta["next_action"] == VERIFIED_DONE

--- a/miot-harness/tests/agents/test_verifier.py
+++ b/miot-harness/tests/agents/test_verifier.py
@@ -108,6 +108,21 @@ async def test_replan_cap_forces_done_even_on_gap() -> None:
 
 
 @pytest.mark.asyncio
+async def test_budget_exhausted_reports_not_fulfilled_in_telemetry() -> None:
+    # Forced synthesis on a cap must NOT report fulfilled=true (misleading
+    # completion telemetry) — it stops the loop but tells the truth.
+    events: list[Any] = []
+    delta = await verify_node(
+        _state(evidence=[_ev()], replan_count=2),
+        model=None, settings=_SETTINGS, profile=NEXO_PROFILE, progress=events.append,
+    )
+    assert delta["next_action"] == VERIFIED_DONE
+    completed = [e for e in events if e.type == "verification.completed"]
+    assert completed and completed[-1].data["fulfilled"] is False
+    assert "budget" in completed[-1].message.lower()
+
+
+@pytest.mark.asyncio
 async def test_malformed_judge_response_defaults_to_done() -> None:
     judge = FakeListChatModel(responses=["not json at all"])
     delta = await verify_node(

--- a/miot-harness/tests/agents/test_verifier.py
+++ b/miot-harness/tests/agents/test_verifier.py
@@ -85,6 +85,20 @@ async def test_judge_gap_replans_with_gap_note() -> None:
 
 
 @pytest.mark.asyncio
+async def test_judge_non_boolean_fulfilled_still_replans() -> None:
+    # A truthy non-bool (the string "true") must NOT count as fulfilled — only
+    # a literal JSON boolean true does. Otherwise a sloppy judge bypasses the gate.
+    judge = FakeListChatModel(
+        responses=[json.dumps({"fulfilled": "true", "gap": "ambiguous"})]
+    )
+    delta = await verify_node(
+        _state(evidence=[_ev()]),
+        model=judge, settings=_SETTINGS, profile=NEXO_PROFILE, progress=_noop,
+    )
+    assert delta["next_action"] == REPLAN
+
+
+@pytest.mark.asyncio
 async def test_judge_fulfilled_is_done() -> None:
     judge = FakeListChatModel(responses=[json.dumps({"fulfilled": True, "gap": ""})])
     delta = await verify_node(

--- a/miot-harness/tests/runtime/test_agentic_graph.py
+++ b/miot-harness/tests/runtime/test_agentic_graph.py
@@ -154,6 +154,7 @@ async def test_agentic_executor_collects_real_evidence() -> None:
         "executor",
         "freshness_judge",
         "planner",
+        "verify",  # Phase 3 gate: confirms the evidence answers before synth
         "synthesizer",
         "critic",
         "summarizer",
@@ -267,6 +268,85 @@ def test_provenance_entry_prefers_executed_sql() -> None:
     entry = _provenance_entry(ctx=_ctx(), user_message="cuántas?", step=step, evidence=ev)
     assert entry.sql == "SELECT count(*) AS n FROM acs.act_ru_task"
     assert entry.rows_returned == 1
+
+
+def _plan_response(tools: list[str]) -> str:
+    return json.dumps(
+        {
+            "action": "plan",
+            "steps": [
+                {"tool": t, "args": {}, "intent": "step", "rationale": "r"}
+                for t in tools
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_executes_to_completion_then_verifies() -> None:
+    """A multi-step plan drains fully (executor↔freshness_judge) before the
+    planner is consulted again; then verify gates synthesis."""
+    models = _models(
+        [
+            _plan_response(["coordinador_centro_control", "coordinador_centro_control"]),
+            _FINAL_RESPONSE,
+        ],
+        synthesizer_text="done",
+    )
+    graph = _graph(models=models)
+    final = await graph.ainvoke(
+        {"user_message": "lista", "ctx": _ctx(), "evidence": [], "turn_count": 0}
+    )
+    assert final.get("answer") == "done"
+    # Both planned steps ran before any re-planning.
+    assert len(final.get("executed_steps", [])) == 2
+    assert len(final.get("evidence", [])) == 2
+    visited = _visited_agents(final)
+    assert visited.count("executor") == 2
+    assert "verify" in visited
+    # Planner consulted twice total: once to emit the plan, once to finish.
+    assert visited.count("planner") == 2
+
+
+@pytest.mark.asyncio
+async def test_agentic_verify_gap_loops_back_to_planner() -> None:
+    """The LLM judge says the evidence is incomplete → re-plan; the gap note is
+    threaded; the second verify accepts and synthesizes."""
+    models = _models(
+        [_call_tool_response(), _FINAL_RESPONSE, _FINAL_RESPONSE],
+        synthesizer_text="answer",
+    )
+    models["verifier"] = FakeListChatModel(
+        responses=[
+            json.dumps({"fulfilled": False, "gap": "necesitas el COUNT real"}),
+            json.dumps({"fulfilled": True, "gap": ""}),
+        ]
+    )
+    graph = _graph(models=models)
+    final = await graph.ainvoke(
+        {"user_message": "cuántos", "ctx": _ctx(), "evidence": [], "turn_count": 0}
+    )
+    assert final.get("answer") == "answer"
+    assert final.get("replan_count") == 1
+    visited = _visited_agents(final)
+    assert visited.count("verify") == 2
+    assert visited.count("planner") == 3  # plan/finish, then re-plan, then finish
+
+
+@pytest.mark.asyncio
+async def test_agentic_verify_disabled_skips_verify_node() -> None:
+    settings = HarnessSettings(
+        agents_synthesizer_stream=False, agents_agentic_verify_enabled=False
+    )
+    models = _models([_call_tool_response(), _FINAL_RESPONSE], synthesizer_text="ok")
+    # A verifier model is present but must NOT be consulted when the gate is off.
+    models["verifier"] = FakeListChatModel(responses=[])
+    graph = _graph(settings=settings, models=models)
+    final = await graph.ainvoke(
+        {"user_message": "x", "ctx": _ctx(), "evidence": [], "turn_count": 0}
+    )
+    assert final.get("answer") == "ok"
+    assert "verify" not in _visited_agents(final)
 
 
 @pytest.mark.asyncio

--- a/miot-harness/tests/test_chat_models.py
+++ b/miot-harness/tests/test_chat_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from miot_harness.agents.chat_models import get_chat_model
+from miot_harness.agents.chat_models import get_chat_model, response_text
 from miot_harness.config import get_settings
 
 
@@ -85,3 +85,28 @@ def test_get_chat_model_invalid_effort_raises(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     with pytest.raises(ValueError, match="invalid effort"):
         get_chat_model("claude-opus-4-8", effort="turbo")  # type: ignore[arg-type]
+
+
+def test_response_text_plain_string():
+    from langchain_core.messages import AIMessage
+
+    assert response_text(AIMessage(content="hello")) == "hello"
+
+
+def test_response_text_extracts_text_from_thinking_blocks():
+    # Opus 4.7+ with adaptive thinking returns content as a list of blocks
+    # (thinking + text). response_text must return ONLY the text block's JSON,
+    # not a Python-repr of the whole list (which silently broke the planner).
+    from langchain_core.messages import AIMessage
+
+    msg = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "let me think…", "signature": "sig"},
+            {"type": "text", "text": '{"action": "final"}'},
+        ]
+    )
+    assert response_text(msg) == '{"action": "final"}'
+
+
+def test_response_text_falls_back_for_non_message():
+    assert response_text(123) == "123"

--- a/miot-harness/tests/test_events.py
+++ b/miot-harness/tests/test_events.py
@@ -51,6 +51,7 @@ def test_event_type_full_set_is_pinned():
         "thinking.completed",
         "usage.recorded",
         "freshness.warning",
+        "verification.completed",
         "answer.completed",
         "run.completed",
         "run.failed",

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
@@ -122,6 +122,13 @@ export function applyHarnessEvent(
       // node, not two).
       return slice;
 
+    case "verification.completed":
+      // Internal pipeline telemetry (the Phase 3 verify gate's "did we answer
+      // it?" verdict). Like agent.completed, it marks an internal node boundary
+      // and is intentionally not surfaced as a transcript row; the REPL
+      // renderer can show it inline. Keeps this switch exhaustive.
+      return slice;
+
     case "thinking.delta": {
       const delta =
         typeof event.data.delta === "string" ? event.data.delta : "";

--- a/turbo-repo/packages/miot-harness-client/src/types.ts
+++ b/turbo-repo/packages/miot-harness-client/src/types.ts
@@ -49,6 +49,7 @@ export const HARNESS_EVENT_TYPES = [
   "thinking.completed",
   "usage.recorded",
   "freshness.warning",
+  "verification.completed",
   "answer.completed",
   "run.completed",
   "run.failed",


### PR DESCRIPTION
## Phase 3 slice 3 — explicit plan → execute → verify → re-plan (architectural core)

Last of three Phase 3 slices. **Stacked on #785 (slice 2), which is stacked on #784 (slice 1)** — review this diff against `based/harness-phase3-executed-sql`; merge #784 then #785 first.

### Why
Side-by-side vs Claude Code, after fixing capability (Phase 1), freshness noise, knowledge (Phase 2), model tier (slice 1) and SQL grounding (slice 2), the **remaining gap is the planner loop itself**. The one-action-per-turn planner **satisfices structurally**: it forms a plan, sometimes even writes the SQL, then declares `final` *without running it* ("¿quieres que la ejecute?") — or answers a "list" question from a fuzzy grep. The plan doc proved this is **machinery, not promptable** (the rigor nudge alone didn't complete the list+pivot). This slice makes completion structural.

### What
- **planner** — new `plan` action emits the **COMPLETE ordered step sequence at once** (`call_tool`/`final` kept for back-compat). A shared `_build_step` validates each step's scope. On a re-plan, the verifier's **gap note** is surfaced so the planner closes it instead of repeating the rejected shortcut.
- **executor** — drains `pending_steps` head-first **to completion** (executor ↔ freshness_judge), carrying evidence forward, before the planner is consulted again. Legacy single-`current_step` path preserved.
- **verifier** (new `agents/verifier.py`) — intercepts the planner's "finish" decision and asks *"do the EXECUTED results fulfil the request?"*:
  - **rule-based** (always on): no evidence → re-plan; replan/turn budget exhausted → accept (never loops);
  - **small LLM judge** (when wired): list asked but only a count/SAMPLE ran; attributes asked but only ids present; a needed query never executed. **Degrades to rules-only** when no verifier model is provided (tests use this path).
  - On a gap → re-plan (bounded by `agents_agentic_max_replans`); else → synthesize.
- **graph** — `verify` node + routing (`planner-finish → verify → re-plan | synth`), gated by `agents_agentic_verify_enabled` (default on).
- **config** — `agents_agentic_verify_enabled`, `agents_agentic_max_replans` (2), `agents_verifier_model` (`claude-haiku-4-5`; empty → rules-only).
- **events** — new `verification.completed` type, kept in parity across the Python Literal, `event_types.json`, and the TS `HARNESS_EVENT_TYPES`.
- **state** — `pending_steps` / `verification_gap` / `replan_count` channels.

### Tests (+13)
- planner: `plan` → `pending_steps`; invalid/empty plan → failure; `verification_gap` surfaced on re-plan.
- verifier: rules-only no-evidence → re-plan; with-evidence → done; judge gap → re-plan w/ note; fulfilled → done; replan cap → done; malformed judge → done.
- graph: multi-step plan executes to completion **then** verifies; judge gap loops back to planner then synthesizes; `verify_enabled=false` skips the node.
- Existing Nexo agentic path unregressed (visited sequence updated for the verify hop).
- Full suite: **784 passed, 2 skipped**; ruff + mypy clean.

### Follow-up (not in this PR)
- Real-DB smoke of the two Success-criteria questions (the 25-row service pivot; the 5-largest-documents query) once the stack is merged — same manual/eval smoke as prior phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new verification step to the agent workflow, with support for multi-step plans and queued execution.
  * Improved planner handling for richer model responses and better recovery when output is unclear.

* **Bug Fixes**
  * Fixed parsing for model responses that include non-text content blocks.
  * Added safeguards so invalid or incomplete steps fail cleanly instead of breaking the run.

* **Chores**
  * Added a new verification completion event to keep event tracking consistent across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->