### PR TITLE
feat(conversational): test-mode recipient allowlist (block non-team sends)

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -16,6 +16,12 @@ miot.component.integrations.enabled=${miot.component.all.enabled}
 miot.component.conversational.enabled=${miot.component.all.enabled}
 miot.integrations.secret-key=${MIOT_INTEGRATIONS_SECRET_KEY:not-configured}
 
+# --- Conversational test mode (demo/dev safety) ---
+# When enabled, outbound WhatsApp sends are allowed ONLY to the listed recipients
+# (comma-separated E.164); any other recipient is rejected. Keep disabled in production.
+miot.conversational.test-mode.enabled=${MIOT_CONVERSATIONAL_TEST_MODE:false}
+miot.conversational.test-mode.allowed-recipients=${MIOT_CONVERSATIONAL_TEST_RECIPIENTS:}
+
 # --- HTTP ---
 quarkus.http.port=8180
 

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -19,9 +19,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 /**
@@ -42,21 +46,30 @@ public class WhatsAppMessagingService {
     private final MetaWhatsAppClient metaClient;
     private final ConversationRepository conversationRepository;
     private final MessageRepository messageRepository;
+    private final boolean testModeEnabled;
+    private final Set<String> testRecipientDigits;
 
     @Inject
     public WhatsAppMessagingService(
             IntegrationConnectionResolver connectionResolver,
             MetaWhatsAppClient metaClient,
             ConversationRepository conversationRepository,
-            MessageRepository messageRepository) {
+            MessageRepository messageRepository,
+            @ConfigProperty(name = "miot.conversational.test-mode.enabled", defaultValue = "false")
+            boolean testModeEnabled,
+            @ConfigProperty(name = "miot.conversational.test-mode.allowed-recipients", defaultValue = "")
+            String testModeAllowedRecipients) {
         this.connectionResolver = connectionResolver;
         this.metaClient = metaClient;
         this.conversationRepository = conversationRepository;
         this.messageRepository = messageRepository;
+        this.testModeEnabled = testModeEnabled;
+        this.testRecipientDigits = parseRecipients(testModeAllowedRecipients);
     }
 
     public Message send(String tenantCode, SendWhatsAppMessageRequest request, String sentByUserId) {
         validate(request);
+        enforceTestMode(testModeEnabled, testRecipientDigits, request.to());
 
         ResolvedConnection connection = connectionResolver.resolve(tenantCode, ProviderType.WHATSAPP);
         String phoneNumberId = connection.metadataString(PHONE_NUMBER_ID);
@@ -183,6 +196,38 @@ public class WhatsAppMessagingService {
                         "templateParams['" + param.getKey() + "'] must have a non-blank value");
             }
         }
+    }
+
+    /**
+     * Demo/dev safety: when test mode is on, only allow sends to the configured team
+     * recipients (compared by digits, so formatting is ignored). Any other recipient is
+     * rejected so a real driver is never messaged while testing. No-op when disabled.
+     */
+    static void enforceTestMode(boolean enabled, Set<String> allowedDigits, String to) {
+        if (!enabled) {
+            return;
+        }
+        if (!allowedDigits.contains(digitsOnly(to))) {
+            throw new IllegalArgumentException(
+                    "Test mode is active for this environment — the recipient is not on the "
+                            + "allowed test-recipient list");
+        }
+    }
+
+    /** Parses a comma-separated recipient list into a set of digit-only forms for matching. */
+    static Set<String> parseRecipients(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return Set.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(WhatsAppMessagingService::digitsOnly)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /** Reduces a phone number to digits only, so formatting differences don't affect matching. */
+    static String digitsOnly(String phone) {
+        return phone == null ? "" : phone.replaceAll("\\D", "");
     }
 
     /** Masks a phone number for logs, keeping only the last 4 digits (PII reduction). */

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -10,6 +10,7 @@ import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -74,6 +75,28 @@ class WhatsAppMessagingServiceTest {
         assertEquals("****1587", maskPhone.invoke(null, "+56962311587"));
         assertEquals("****", maskPhone.invoke(null, "123"));
         assertEquals("****", maskPhone.invoke(null, new Object[] {null}));
+    }
+
+    @Test
+    void testModeBlocksRecipientNotOnTheAllowlist() {
+        Set<String> allowed = WhatsAppMessagingService.parseRecipients("+56 9 9129 1120, +56986720429");
+        assertThrows(IllegalArgumentException.class,
+                () -> WhatsAppMessagingService.enforceTestMode(true, allowed, "+56951294287"));
+    }
+
+    @Test
+    void testModeAllowsAllowlistedRecipientIgnoringFormatting() {
+        Set<String> allowed = WhatsAppMessagingService.parseRecipients("+56 9 9129 1120");
+        assertDoesNotThrow(() -> {
+            WhatsAppMessagingService.enforceTestMode(true, allowed, "+56991291120");
+            WhatsAppMessagingService.enforceTestMode(true, allowed, "569 9129-1120");
+        });
+    }
+
+    @Test
+    void testModeDisabledAllowsAnyRecipient() {
+        assertDoesNotThrow(() ->
+                WhatsAppMessagingService.enforceTestMode(false, Set.of(), "+56951294287"));
     }
 
     private static void assertIllegalArgument(SendWhatsAppMessageRequest request, String field) {


### PR DESCRIPTION
Demo/dev safety: never message a real driver while testing — route the WhatsApp channel only to the team's own phones.

Closes #794.

## Behavior
A per-environment **test mode**:
- `miot.conversational.test-mode.enabled` — `MIOT_CONVERSATIONAL_TEST_MODE` (default `false`)
- `miot.conversational.test-mode.allowed-recipients` — `MIOT_CONVERSATIONAL_TEST_RECIPIENTS` (comma-separated E.164)

When enabled, `WhatsAppMessagingService.send` allows a recipient **only** if it's on the allowlist; any other recipient is **rejected with a 400** (surfaced in the operator toast). Matching is **formatting-insensitive** (compares digits only, so `+56 9 9129 1120` == `+56991291120`). When disabled (prod), behavior is unchanged.

## Changes
- `WhatsAppMessagingService`: parse the allowlist from config (ctor `@ConfigProperty`); enforce right after `validate()`.
- Defaults (off / empty) in `miot-cli/application.properties`.
- Unit tests: allowlist block, formatting-insensitive match, disabled passthrough. conversational 21 — all green.

## Follow-up (separate, after this deploys on the nightly)
Enable in **coordinador-dev** via miot-deployments: `MIOT_CONVERSATIONAL_TEST_MODE=true` + the team list. **Prod stays off.** The team numbers will be supplied out-of-band (kept out of git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)