### PR TITLE
chore(tests): replace the real business phone number with a placeholder

### DIFF
--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -71,7 +71,7 @@ class WhatsAppMessagingServiceTest {
     void maskPhoneKeepsOnlyLastFourDigits() throws Exception {
         Method maskPhone = WhatsAppMessagingService.class.getDeclaredMethod("maskPhone", String.class);
         maskPhone.setAccessible(true);
-        assertEquals("****1587", maskPhone.invoke(null, "+56962311587"));
+        assertEquals("****0001", maskPhone.invoke(null, "+56900000001"));
         assertEquals("****", maskPhone.invoke(null, "123"));
         assertEquals("****", maskPhone.invoke(null, new Object[] {null}));
     }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/WhatsAppConnectionTesterTest.java
@@ -50,7 +50,7 @@ class WhatsAppConnectionTesterTest {
 
     @Test
     void returnsSuccessWhenMetaReturns2xx() throws IOException {
-        startServer(200, "{\"id\":\"" + PHONE_NUMBER_ID + "\",\"display_phone_number\":\"+56 9 6231 1587\"}");
+        startServer(200, "{\"id\":\"" + PHONE_NUMBER_ID + "\",\"display_phone_number\":\"+56 9 0000 0001\"}");
         IntegrationConnection connection = connection(URI.create(baseUrl()), Map.of("phone_number_id", PHONE_NUMBER_ID));
 
         ConnectionTestResponse response = tester.test(connection, bearerCredential(TOKEN), new ConnectionTestRequest("GET", null));


### PR DESCRIPTION
Follow-up to the no-real-numbers cleanup (the #795 incident). Two **merged** tests embedded the live business WABA number (`+56 9 6231 1587`); swapping both for placeholders so no real phone number lives in the codebase.

- `WhatsAppMessagingServiceTest.maskPhoneKeepsOnlyLastFourDigits`: `+56962311587` → `+56900000001` (expected suffix updated to `****0001`).
- `WhatsAppConnectionTesterTest` mock `display_phone_number` → `+56 9 0000 0001` (not asserted on; cosmetic in the mock).

Left as-is: the WABA `phone_number_id` (`1188646904321987`) — an opaque API asset id, not a dialable number.

integrations 28, conversational 18 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)