### PR TITLE
feat(app): edit a WhatsApp connection in Settings

### DIFF
--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/[connId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/connections/[connId]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/**
+ * PATCH /api/admin/orgs/[orgId]/integrations/connections/[connId]
+ *
+ * Partial update of an integration connection (name / baseUrl / metadata, and an
+ * optional token rotation). Proxies to Quarkus
+ * `PATCH /api/v1/orgs/{orgId}/integrations/connections/{connId}`.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string; connId: string }> },
+) {
+  const { orgId, connId } = await params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(
+    `/api/v1/orgs/${encodeURIComponent(orgId)}/integrations/connections/${encodeURIComponent(connId)}`,
+    { method: "PATCH", body },
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
@@ -6,6 +6,7 @@ import {
   createWhatsAppConnection,
   fetchWhatsAppConnection,
   testWhatsAppConnection,
+  updateWhatsAppConnection,
 } from "./whatsapp-data-service";
 import type {
   ConnectionTestResult,
@@ -50,6 +51,21 @@ export function useOrgWhatsApp(orgSlug: string | null) {
     }
   }
 
+  async function update(
+    connectionId: string,
+    form: WhatsAppFormData,
+  ): Promise<IntegrationConnection> {
+    const slug = requireSlug();
+    setActionLoading(true);
+    try {
+      const updated = await updateWhatsAppConnection(slug, connectionId, form);
+      await mutate();
+      return updated;
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
   async function test(connectionId: string): Promise<ConnectionTestResult> {
     const slug = requireSlug();
     setActionLoading(true);
@@ -68,6 +84,7 @@ export function useOrgWhatsApp(orgSlug: string | null) {
     error: error ?? null,
     actionLoading,
     create,
+    update,
     test,
     refresh: mutate,
   };

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
@@ -8,6 +8,7 @@ import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import { useOrgWhatsApp } from "./use-org-whatsapp";
 import { WhatsAppConnectionModal } from "./whatsapp-connection-modal";
+import { DEFAULT_GRAPH_VERSION } from "./whatsapp.types";
 import type { IntegrationConnection, WhatsAppFormData } from "./whatsapp.types";
 
 interface WhatsAppChannelCardProps {
@@ -16,26 +17,45 @@ interface WhatsAppChannelCardProps {
 }
 
 /**
- * Settings card for the org's WhatsApp channel. When no connection exists it
- * offers a Configure action (create); once configured it shows status + a live
- * Test. Edit/delete are deferred (the backend has no update/delete yet).
+ * Settings card for the org's WhatsApp channel. When no connection exists it offers a
+ * Configure action (create); once configured it shows status, a live Test, and an Edit
+ * action (update config / rotate the token).
  */
 export default function WhatsAppChannelCard({
   orgSlug,
   dict,
 }: WhatsAppChannelCardProps) {
   const waDict = (dict?.whatsappChannel as I18nRecord) ?? {};
-  const { connection, isLoading, error, actionLoading, create, test } =
+  const { connection, isLoading, error, actionLoading, create, update, test } =
     useOrgWhatsApp(orgSlug);
-  const [showModal, setShowModal] = useState(false);
+  const [modalMode, setModalMode] = useState<"create" | "edit" | null>(null);
   const [submitError, setSubmitError] = useState<Error | null>(null);
+
+  function openModal(mode: "create" | "edit") {
+    setSubmitError(null);
+    setModalMode(mode);
+  }
 
   async function handleCreate(form: WhatsAppFormData) {
     setSubmitError(null);
     try {
       await create(form);
-      setShowModal(false);
+      setModalMode(null);
       toast.success(tr("toast.created", waDict));
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err : new Error(tr("toast.error", waDict)),
+      );
+    }
+  }
+
+  async function handleUpdate(form: WhatsAppFormData) {
+    if (!connection) return;
+    setSubmitError(null);
+    try {
+      await update(connection.id, form);
+      setModalMode(null);
+      toast.success(tr("toast.updated", waDict));
     } catch (err) {
       setSubmitError(
         err instanceof Error ? err : new Error(tr("toast.error", waDict)),
@@ -75,8 +95,9 @@ export default function WhatsAppChannelCard({
         <ConfiguredRow
           connection={connection}
           dict={waDict}
-          testing={actionLoading}
+          busy={actionLoading}
           onTest={handleTest}
+          onEdit={() => openModal("edit")}
         />
       );
     }
@@ -84,7 +105,7 @@ export default function WhatsAppChannelCard({
       <Button
         size="xs"
         color="green"
-        onClick={() => setShowModal(true)}
+        onClick={() => openModal("create")}
         disabled={!orgSlug}
       >
         {tr("configureButton", waDict)}
@@ -111,9 +132,13 @@ export default function WhatsAppChannelCard({
       <div className="mt-3">{renderBody()}</div>
 
       <WhatsAppConnectionModal
-        show={showModal}
-        onClose={() => setShowModal(false)}
-        onSubmit={handleCreate}
+        show={modalMode !== null}
+        mode={modalMode ?? "create"}
+        initial={
+          modalMode === "edit" && connection ? connectionToForm(connection) : null
+        }
+        onClose={() => setModalMode(null)}
+        onSubmit={modalMode === "edit" ? handleUpdate : handleCreate}
         loading={actionLoading}
         error={submitError}
         dict={waDict}
@@ -125,11 +150,12 @@ export default function WhatsAppChannelCard({
 interface ConfiguredRowProps {
   readonly connection: IntegrationConnection;
   readonly dict: I18nRecord;
-  readonly testing: boolean;
+  readonly busy: boolean;
   readonly onTest: () => void;
+  readonly onEdit: () => void;
 }
 
-function ConfiguredRow({ connection, dict, testing, onTest }: ConfiguredRowProps) {
+function ConfiguredRow({ connection, dict, busy, onTest, onEdit }: ConfiguredRowProps) {
   const rawPhone = connection.metadata?.phone_number_id;
   const phone = typeof rawPhone === "string" ? rawPhone : "—";
   return (
@@ -137,11 +163,30 @@ function ConfiguredRow({ connection, dict, testing, onTest }: ConfiguredRowProps
       <div className="text-sm text-gray-700 dark:text-gray-300">
         <span className="font-medium">{tr("phoneLabel", dict)}:</span> {phone}
       </div>
-      <Button size="xs" color="light" disabled={testing} onClick={onTest}>
-        {testing ? <Spinner size="sm" /> : tr("testButton", dict)}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button size="xs" color="light" disabled={busy} onClick={onEdit}>
+          {tr("editButton", dict)}
+        </Button>
+        <Button size="xs" color="light" disabled={busy} onClick={onTest}>
+          {busy ? <Spinner size="sm" /> : tr("testButton", dict)}
+        </Button>
+      </div>
     </div>
   );
+}
+
+function connectionToForm(connection: IntegrationConnection): WhatsAppFormData {
+  const meta = connection.metadata ?? {};
+  const str = (value: unknown, fallback = ""): string =>
+    typeof value === "string" ? value : fallback;
+  return {
+    name: connection.name,
+    phoneNumberId: str(meta.phone_number_id),
+    wabaId: str(meta.waba_id),
+    graphVersion: str(meta.graph_version, DEFAULT_GRAPH_VERSION),
+    baseUrl: connection.baseUrl,
+    token: "",
+  };
 }
 
 interface StatusBadgeProps {

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_BASE_URL,
   DEFAULT_GRAPH_VERSION,
   WhatsAppConnectionSchema,
+  WhatsAppEditSchema,
   type WhatsAppFormData,
 } from "./whatsapp.types";
 
@@ -18,6 +19,8 @@ interface WhatsAppConnectionModalProps {
   readonly show: boolean;
   readonly onClose: () => void;
   readonly onSubmit: (data: WhatsAppFormData) => void;
+  readonly mode?: "create" | "edit";
+  readonly initial?: WhatsAppFormData | null;
   readonly loading?: boolean;
   readonly error?: Error | null;
   readonly dict: I18nRecord;
@@ -36,35 +39,50 @@ export function WhatsAppConnectionModal({
   show,
   onClose,
   onSubmit,
+  mode = "create",
+  initial = null,
   loading = false,
   error = null,
   dict,
 }: WhatsAppConnectionModalProps) {
+  const isEdit = mode === "edit";
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors },
   } = useForm<WhatsAppFormData>({
-    resolver: zodResolver(WhatsAppConnectionSchema),
+    resolver: zodResolver(isEdit ? WhatsAppEditSchema : WhatsAppConnectionSchema),
     defaultValues: DEFAULTS,
   });
 
   useEffect(() => {
-    if (show) {
-      reset({ ...DEFAULTS, name: tr("modal.defaultName", dict) });
+    if (!show) {
+      return;
     }
-  }, [show, reset, dict]);
+    reset(
+      isEdit && initial
+        ? initial
+        : { ...DEFAULTS, name: tr("modal.defaultName", dict) },
+    );
+  }, [show, isEdit, initial, reset, dict]);
 
-  const submitLabel = loading
-    ? tr("modal.saving", dict)
-    : tr("modal.createButton", dict);
+  let submitLabel: string;
+  if (loading) {
+    submitLabel = tr("modal.saving", dict);
+  } else if (isEdit) {
+    submitLabel = tr("modal.saveButton", dict);
+  } else {
+    submitLabel = tr("modal.createButton", dict);
+  }
 
   return (
     <FormModal
       isOpen={show}
       onClose={onClose}
-      title={tr("modal.addTitle", dict)}
+      title={
+        isEdit ? tr("modal.editTitle", dict) : tr("modal.addTitle", dict)
+      }
       subtitle={tr("modal.subtitle", dict)}
       submitLabel={submitLabel}
       isProcessing={loading}
@@ -147,7 +165,11 @@ export function WhatsAppConnectionModal({
           <TextInput
             id="wa-token"
             type="password"
-            placeholder={tr("modal.tokenPlaceholder", dict)}
+            placeholder={
+              isEdit
+                ? tr("modal.tokenEditPlaceholder", dict)
+                : tr("modal.tokenPlaceholder", dict)
+            }
             autoComplete="off"
             {...register("token")}
             color={errors.token ? "failure" : undefined}

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-data-service.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-data-service.ts
@@ -25,9 +25,13 @@ async function getJson<T>(url: string): Promise<T> {
   return (await res.json()) as T;
 }
 
-async function postJson<T>(url: string, body: unknown): Promise<T> {
+async function mutateJson<T>(
+  method: string,
+  url: string,
+  body: unknown,
+): Promise<T> {
   const res = await fetch(url, {
-    method: "POST",
+    method,
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
@@ -49,6 +53,14 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     throw new ApiError({ status: res.status, url, message });
   }
   return (await res.json()) as T;
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  return mutateJson<T>("POST", url, body);
+}
+
+async function patchJson<T>(url: string, body: unknown): Promise<T> {
+  return mutateJson<T>("PATCH", url, body);
 }
 
 /** The org's single WhatsApp connection, or null if not configured yet. */
@@ -95,6 +107,35 @@ export async function createWhatsAppConnection(
         graph_version: form.graphVersion,
       },
     },
+  );
+}
+
+/**
+ * Update the connection: name / base URL / metadata (phone-number-id, waba-id,
+ * graph-version). The token is sent only when the operator enters a new one — a blank
+ * token leaves the stored credential unchanged (rotation is handled by the backend).
+ */
+export async function updateWhatsAppConnection(
+  orgSlug: string,
+  connectionId: string,
+  form: WhatsAppFormData,
+): Promise<IntegrationConnection> {
+  const body: Record<string, unknown> = {
+    name: form.name,
+    baseUrl: form.baseUrl,
+    metadata: {
+      phone_number_id: form.phoneNumberId,
+      waba_id: form.wabaId,
+      graph_version: form.graphVersion,
+    },
+  };
+  const token = form.token?.trim();
+  if (token) {
+    body.token = token;
+  }
+  return patchJson<IntegrationConnection>(
+    `${integrationsBase(orgSlug)}/connections/${encodeURIComponent(connectionId)}`,
+    body,
   );
 }
 

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp.types.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp.types.ts
@@ -43,3 +43,11 @@ export const WhatsAppConnectionSchema = z.object({
 });
 
 export type WhatsAppFormData = z.infer<typeof WhatsAppConnectionSchema>;
+
+/**
+ * Edit form: same fields as create, but the token is optional — leaving it blank keeps
+ * the stored token. The form still uses {@link WhatsAppFormData} (token defaults to "").
+ */
+export const WhatsAppEditSchema = WhatsAppConnectionSchema.extend({
+  token: z.string().optional(),
+});

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1240,6 +1240,7 @@
           "phoneLabel": "Phone number ID",
           "configureButton": "Configure",
           "testButton": "Test",
+          "editButton": "Edit",
           "status": {
             "active": "Active",
             "draft": "Draft",
@@ -1261,10 +1262,14 @@
             "wabaIdPlaceholder": "e.g. 1234567890",
             "cancel": "Cancel",
             "saving": "Saving...",
-            "createButton": "Create"
+            "createButton": "Create",
+            "editTitle": "Edit WhatsApp channel",
+            "saveButton": "Save",
+            "tokenEditPlaceholder": "Leave blank to keep the current token"
           },
           "toast": {
             "created": "WhatsApp channel configured",
+            "updated": "WhatsApp channel updated",
             "testSuccess": "Connection test successful",
             "testFailed": "Connection test failed",
             "error": "Something went wrong"

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1240,6 +1240,7 @@
           "phoneLabel": "ID del número",
           "configureButton": "Configurar",
           "testButton": "Probar",
+          "editButton": "Editar",
           "status": {
             "active": "Activo",
             "draft": "Borrador",
@@ -1261,10 +1262,14 @@
             "wabaIdPlaceholder": "ej. 1234567890",
             "cancel": "Cancelar",
             "saving": "Guardando...",
-            "createButton": "Crear"
+            "createButton": "Crear",
+            "editTitle": "Editar canal WhatsApp",
+            "saveButton": "Guardar",
+            "tokenEditPlaceholder": "Déjalo en blanco para mantener el token actual"
           },
           "toast": {
             "created": "Canal WhatsApp configurado",
+            "updated": "Canal WhatsApp actualizado",
             "testSuccess": "Prueba de conexión exitosa",
             "testFailed": "La prueba de conexión falló",
             "error": "Ocurrió un error"


### PR DESCRIPTION
WhatsApp v2 Phase 1.5, slice 1b — the FE side of the connection update. Consumes the PATCH from #799. Closes #800.

The Settings WhatsApp card could only **create + test** a connection. Now it can **edit** one (and rotate the token).

## Changes (`turbo-repo/apps/app`)
- **Proxy route** `PATCH /api/admin/orgs/[orgId]/integrations/connections/[connId]` → Quarkus `PATCH …/connections/{id}`.
- **`whatsapp-data-service`**: `updateWhatsAppConnection` (+ a shared `mutateJson` used by both POST and PATCH). The token is sent **only when the operator enters a new one** (rotation); blank keeps the stored token.
- **Modal edit mode**: pre-fills name / phone-number-id / waba-id / graph-version / base-url from the connection; token optional (`WhatsAppEditSchema`); "Edit" title + "Save" button + "leave blank to keep current" hint.
- **Card**: an **Edit** action on the configured row; update handler + toast.
- **`use-org-whatsapp`**: `update` action. en/es i18n.

## Validation
- `check-types`: 0 errors in the touched files (repo-wide failures are unbuilt workspace packages, unrelated).
- `eslint`: 0 errors / 0 warnings on the touched files.

## Next
Slice 2 builds on this surface: WhatsApp **test mode + test recipients** stored in the connection `metadata`, toggled live from the same edit modal (no restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)