### PR TITLE
feat(conversational): metadata-driven WhatsApp test mode

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -19,8 +19,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.jboss.logging.Logger;
 
@@ -37,6 +39,8 @@ public class WhatsAppMessagingService {
     private static final String PHONE_NUMBER_ID = "phone_number_id";
     private static final String TOKEN = "token";
     private static final int PREVIEW_MAX = 280;
+    private static final String TEST_MODE_ENABLED = "test_mode_enabled";
+    private static final String TEST_RECIPIENTS = "test_recipients";
 
     private final IntegrationConnectionResolver connectionResolver;
     private final MetaWhatsAppClient metaClient;
@@ -69,6 +73,7 @@ public class WhatsAppMessagingService {
             throw new ConnectionResolutionException(
                     "WhatsApp connection credential is missing the access token");
         }
+        enforceTestMode(connection, request.to());
 
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         Conversation conversation = findOrCreateConversation(tenantCode, request, now);
@@ -183,6 +188,56 @@ public class WhatsAppMessagingService {
                         "templateParams['" + param.getKey() + "'] must have a non-blank value");
             }
         }
+    }
+
+    /**
+     * Demo/dev safety: when the connection's metadata has {@code test_mode_enabled} truthy,
+     * only allow sends to recipients on {@code test_recipients} (digit-only match, so
+     * formatting is ignored). Any other recipient is rejected so a real driver is never
+     * messaged while testing. Off/absent → no restriction. Config is per-connection (DB),
+     * editable in Settings at runtime — no restart.
+     */
+    static void enforceTestMode(ResolvedConnection connection, String to) {
+        Map<String, Object> metadata = connection.metadata();
+        if (metadata == null || !isTruthy(metadata.get(TEST_MODE_ENABLED))) {
+            return;
+        }
+        if (!parseRecipients(metadata.get(TEST_RECIPIENTS)).contains(digitsOnly(to))) {
+            throw new IllegalArgumentException(
+                    "Test mode is active for this WhatsApp connection — the recipient is not "
+                            + "on the allowed test-recipient list");
+        }
+    }
+
+    private static boolean isTruthy(Object value) {
+        return Boolean.TRUE.equals(value) || "true".equalsIgnoreCase(String.valueOf(value));
+    }
+
+    /** Accepts a JSON array (Iterable) or a comma-separated string; returns digit-only forms. */
+    static Set<String> parseRecipients(Object value) {
+        Set<String> recipients = new HashSet<>();
+        if (value instanceof Iterable<?> iterable) {
+            for (Object item : iterable) {
+                addDigits(recipients, String.valueOf(item));
+            }
+        } else if (value != null) {
+            for (String part : String.valueOf(value).split(",")) {
+                addDigits(recipients, part);
+            }
+        }
+        return recipients;
+    }
+
+    private static void addDigits(Set<String> recipients, String raw) {
+        String digits = digitsOnly(raw);
+        if (!digits.isBlank()) {
+            recipients.add(digits);
+        }
+    }
+
+    /** Reduces a phone to digits only, so formatting differences don't affect matching. */
+    static String digitsOnly(String phone) {
+        return phone == null ? "" : phone.replaceAll("\\D", "");
     }
 
     /** Masks a phone number for logs, keeping only the last 4 digits (PII reduction). */

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -7,9 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
+import com.microboxlabs.miot.integrations.service.ResolvedConnection;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -74,6 +79,43 @@ class WhatsAppMessagingServiceTest {
         assertEquals("****0001", maskPhone.invoke(null, "+56900000001"));
         assertEquals("****", maskPhone.invoke(null, "123"));
         assertEquals("****", maskPhone.invoke(null, new Object[] {null}));
+    }
+
+    // Placeholder numbers only — never put real phone numbers in the codebase.
+    @Test
+    void testModeBlocksRecipientNotOnTheAllowlist() {
+        ResolvedConnection connection = testConnection(true, List.of("+56 9 0000 0001", "+56900000002"));
+        assertThrows(IllegalArgumentException.class,
+                () -> WhatsAppMessagingService.enforceTestMode(connection, "+56900009999"));
+    }
+
+    @Test
+    void testModeAllowsAllowlistedRecipientIgnoringFormatting() {
+        ResolvedConnection connection = testConnection(true, List.of("+56 9 0000 0001"));
+        assertDoesNotThrow(() -> WhatsAppMessagingService.enforceTestMode(connection, "569 0000-0001"));
+    }
+
+    @Test
+    void testModeDisabledAllowsAnyRecipient() {
+        ResolvedConnection connection = testConnection(false, List.of("+56900000001"));
+        assertDoesNotThrow(() -> WhatsAppMessagingService.enforceTestMode(connection, "+56900009999"));
+    }
+
+    @Test
+    void parseRecipientsAcceptsListOrCommaSeparatedString() {
+        Set<String> expected = Set.of("56900000001", "56900000002");
+        assertEquals(expected,
+                WhatsAppMessagingService.parseRecipients(List.of("+56 9 0000 0001", "+56900000002")));
+        assertEquals(expected,
+                WhatsAppMessagingService.parseRecipients("+56900000001, +56 9 0000 0002"));
+    }
+
+    private static ResolvedConnection testConnection(boolean enabled, List<String> recipients) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("test_mode_enabled", enabled);
+        metadata.put("test_recipients", recipients);
+        return new ResolvedConnection(
+                "conn-1", URI.create("https://graph.facebook.com/v25.0"), metadata, Map.of());
     }
 
     private static void assertIllegalArgument(SendWhatsAppMessageRequest request, String field) {


### PR DESCRIPTION
WhatsApp v2 Phase 1.5, slice 2 (backend). Reintroduces test mode — now configured in the connection **`metadata` (DB)**, editable in Settings at runtime (no restart). Supersedes the env-based #796.

Closes #802.

## Behavior
In `WhatsAppMessagingService.send`, after resolving the connection, read its metadata:
- `test_mode_enabled` (truthy boolean/string)
- `test_recipients` (JSON array **or** comma-separated string of E.164)

When enabled, a send is allowed **only** if the recipient is on the list (digit-only match, so `+56 9 0000 0001` == `+56900000001`); otherwise rejected with **400**. Off/absent → unchanged.

## Tests (conversational 22)
`enforceTestMode` block / formatting-insensitive allow / disabled passthrough, and `parseRecipients` (list + comma-string). **Placeholder numbers only.**

## Companion (after #801 merges)
The Settings UI to toggle test mode + edit the recipient list (writes these into the connection metadata via the PATCH) is the FE half of this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)