### PR TITLE
fix(ci): bake build info into app images

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -134,6 +134,42 @@ jobs:
         run: npm ci
         working-directory: turbo-repo
 
+      - name: Write packaged build info
+        env:
+          RELEASE_VERSION: nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+          GIT_SHA: ${{ needs.metadata.outputs.head_sha }}
+          SHORT_SHA: ${{ needs.metadata.outputs.short_sha }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
+          APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
+        run: |
+          mkdir -p turbo-repo/apps/app/public
+          jq -n \
+            --arg release_version "$RELEASE_VERSION" \
+            --arg git_sha "$GIT_SHA" \
+            --arg short_sha "$SHORT_SHA" \
+            --arg built_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --arg workflow_run_url "$WORKFLOW_RUN_URL" \
+            --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
+            --arg app_image_tag "$APP_IMAGE_TAG" \
+            '{
+              product: "ModularIoT",
+              release_version: $release_version,
+              channel: "nightly",
+              git_sha: $git_sha,
+              short_sha: $short_sha,
+              built_at: $built_at,
+              workflow_run_url: $workflow_run_url,
+              manifest_version: 1,
+              components: {
+                app: {
+                  tag: ("app@" + $release_version),
+                  image_repository: $app_image_repository,
+                  image_tag: $app_image_tag
+                }
+              }
+            }' > turbo-repo/apps/app/public/build-info.json
+
       - name: Build app
         run: npx turbo run build --filter=@modulariot/app
         working-directory: turbo-repo

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -505,6 +505,54 @@ jobs:
         run: npm ci
         working-directory: turbo-repo
 
+      - name: Write packaged build info
+        if: needs.prepare.outputs.app_changed == 'true'
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          RELEASE_NOTES_VERSION: v${{ needs.prepare.outputs.release_notes_version }}
+          STACK_TAG: ${{ needs.prepare.outputs.stack_tag }}
+          GIT_SHA: ${{ needs.tag.outputs.sha }}
+          SHORT_SHA: ${{ needs.tag.outputs.short_sha }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          APP_VERSION: ${{ needs.prepare.outputs.app_version }}
+          APP_TAG: ${{ needs.prepare.outputs.app_tag }}
+          APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
+          APP_IMAGE_TAG: app-v${{ needs.prepare.outputs.app_version }}
+        run: |
+          mkdir -p turbo-repo/apps/app/public
+          jq -n \
+            --arg release_version "$RELEASE_VERSION" \
+            --arg release_notes_version "$RELEASE_NOTES_VERSION" \
+            --arg stack_tag "$STACK_TAG" \
+            --arg git_sha "$GIT_SHA" \
+            --arg short_sha "$SHORT_SHA" \
+            --arg built_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --arg workflow_run_url "$WORKFLOW_RUN_URL" \
+            --arg app_version "$APP_VERSION" \
+            --arg app_tag "$APP_TAG" \
+            --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
+            --arg app_image_tag "$APP_IMAGE_TAG" \
+            '{
+              product: "ModularIoT",
+              release_version: $release_version,
+              release_notes_version: $release_notes_version,
+              channel: "release",
+              stack_tag: $stack_tag,
+              git_sha: $git_sha,
+              short_sha: $short_sha,
+              built_at: $built_at,
+              workflow_run_url: $workflow_run_url,
+              manifest_version: 1,
+              components: {
+                app: {
+                  version: $app_version,
+                  tag: $app_tag,
+                  image_repository: $app_image_repository,
+                  image_tag: $app_image_tag
+                }
+              }
+            }' > turbo-repo/apps/app/public/build-info.json
+
       - name: Build app
         if: needs.prepare.outputs.app_changed == 'true'
         run: npx turbo run build --filter=@modulariot/app

--- a/turbo-repo/apps/app/src/app/api/build-info/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/build-info/route.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { GET } from "./route";
+import fs from "fs";
+import os from "os";
+import path from "path";
 
 const ENV_KEYS = [
   "MIOT_BUILD_INFO_JSON",
@@ -16,9 +19,11 @@ const ENV_KEYS = [
 
 describe("build info route", () => {
   const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    process.chdir(originalCwd);
   });
 
   it("normalizes manifest JSON from deployment payloads", async () => {
@@ -84,6 +89,47 @@ describe("build info route", () => {
           version: "0.5.21",
           tag: "app@v0.5.21",
           imageRef: "ghcr.io/microboxlabs/miot-app@sha256:def",
+        },
+      },
+    });
+  });
+
+  it("uses packaged build info when runtime env vars are absent", async () => {
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "miot-build-info-"));
+    const publicDir = path.join(tempDir, "public");
+    fs.mkdirSync(publicDir);
+    fs.writeFileSync(
+      path.join(publicDir, "build-info.json"),
+      JSON.stringify({
+        release_version: "nightly-20260628-def5678",
+        channel: "nightly",
+        git_sha: "def5678901",
+        short_sha: "def5678",
+        components: {
+          app: {
+            tag: "app@nightly-20260628-def5678",
+            image_tag: "sha-def5678",
+          },
+        },
+      })
+    );
+    process.chdir(tempDir);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toMatchObject({
+      channel: "nightly",
+      releaseVersion: "nightly-20260628-def5678",
+      gitSha: "def5678901",
+      components: {
+        app: {
+          tag: "app@nightly-20260628-def5678",
+          imageTag: "sha-def5678",
         },
       },
     });

--- a/turbo-repo/apps/app/src/app/api/build-info/route.ts
+++ b/turbo-repo/apps/app/src/app/api/build-info/route.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import fs from "fs";
+import fs from "node:fs";
 import { NextResponse } from "next/server";
-import path from "path";
+import path from "node:path";
 
 type BuildComponentInfo = {
   changed?: boolean;

--- a/turbo-repo/apps/app/src/app/api/build-info/route.ts
+++ b/turbo-repo/apps/app/src/app/api/build-info/route.ts
@@ -1,6 +1,8 @@
 "use server";
 
+import fs from "fs";
 import { NextResponse } from "next/server";
+import path from "path";
 
 type BuildComponentInfo = {
   changed?: boolean;
@@ -100,6 +102,22 @@ function parseBuildInfoJson(): BuildInfo | null {
   }
 }
 
+function readPackagedBuildInfo(): BuildInfo | null {
+  const filePath = path.join(process.cwd(), "public", "build-info.json");
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return normalizeBuildInfo(
+      JSON.parse(fs.readFileSync(filePath, "utf8")) as RawBuildInfo
+    );
+  } catch (error) {
+    console.error("Invalid packaged build-info.json:", error);
+    return null;
+  }
+}
+
 function component(prefix: string): BuildComponentInfo {
   const changed = optionalEnv(`${prefix}_CHANGED`);
 
@@ -139,12 +157,7 @@ function stripEmptyComponentValues(
   );
 }
 
-export async function GET() {
-  const fromJson = parseBuildInfoJson();
-  if (fromJson) {
-    return NextResponse.json(fromJson);
-  }
-
+function buildInfoFromEnv(): BuildInfo {
   const releaseVersion =
     optionalEnv("RELEASE_VERSION") ?? optionalEnv("APP_VERSION") ?? "local";
 
@@ -153,7 +166,7 @@ export async function GET() {
 
   const channel = optionalEnv("BUILD_CHANNEL") ?? inferChannel(releaseVersion);
 
-  return NextResponse.json({
+  return {
     product: "ModularIoT",
     channel,
     releaseVersion,
@@ -170,5 +183,33 @@ export async function GET() {
       modulith: component("MODULITH"),
       harness: component("HARNESS"),
     }),
-  } satisfies BuildInfo);
+  } satisfies BuildInfo;
+}
+
+function hasRuntimeBuildInfoEnv(): boolean {
+  return [
+    "RELEASE_VERSION",
+    "APP_VERSION",
+    "BUILD_CHANNEL",
+    "STACK_TAG",
+    "GIT_SHA",
+  ].some((key) => optionalEnv(key));
+}
+
+export async function GET() {
+  const fromJson = parseBuildInfoJson();
+  if (fromJson) {
+    return NextResponse.json(fromJson);
+  }
+
+  if (hasRuntimeBuildInfoEnv()) {
+    return NextResponse.json(buildInfoFromEnv());
+  }
+
+  const fromPackage = readPackagedBuildInfo();
+  if (fromPackage) {
+    return NextResponse.json(fromPackage);
+  }
+
+  return NextResponse.json(buildInfoFromEnv());
 }


### PR DESCRIPTION
## Summary
- Bake `public/build-info.json` into nightly app images before `next build`, so `/api/build-info` has metadata even when the deploy target does not inject runtime env vars.
- Add the same packaged build-info generation for release app images when the app image is rebuilt.
- Update `/api/build-info` precedence: `MIOT_BUILD_INFO_JSON` > runtime env vars > packaged `public/build-info.json` > local fallback.
- Add a regression test for packaged build-info fallback.

## Why
Nightly deployments can currently show `Channel: local` / `Release: local` if the private deployment workflow does not pass the dispatched metadata into the running container. The app image should carry enough build metadata to identify itself even without runtime injection.

## Validation
- `npm run test:run -- src/app/api/build-info/route.test.ts`
- `npx eslint src/app/api/build-info/route.ts src/app/api/build-info/route.test.ts`
- YAML parse for `.github/workflows/app-release-train.yml` and `.github/workflows/app-nightly.yml`
- `git diff --check`
- `npm run build -- --filter=@modulariot/app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app can now include packaged build metadata in its published output, making release details available even when runtime environment values aren’t set.

* **Bug Fixes**
  * The build-info API now falls back through multiple sources, improving reliability of version and build details.
  * Added coverage for loading build information from the packaged file when environment values are unavailable.

* **Tests**
  * Expanded automated tests to verify the new build-info fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->