### PR TITLE
feat(app): show logo and release notes in build modal

### DIFF
--- a/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
@@ -12,6 +12,7 @@ import type {
   BuildInfo,
   BuildComponentInfo,
 } from "@/features/common/providers/client-api.provider";
+import AppLogo from "@/features/common/components/app-logo/app-logo";
 
 function Field({
   label,
@@ -82,23 +83,26 @@ export default function BuildInfoModal({
   buildInfo,
   isOpen,
   onClose,
+  releaseNotesVersion,
 }: Readonly<{
   buildInfo: BuildInfo | null;
   isOpen: boolean;
   onClose: () => void;
+  releaseNotesVersion?: string;
 }>) {
-  const releaseNotesVersion = buildInfo?.releaseNotesVersion;
-
   return (
     <Modal dismissible show={isOpen} onClose={onClose} size="3xl">
       <ModalHeader className="border-none">
-        <div>
-          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-            ModularIoT
-          </h2>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Build deployed
-          </p>
+        <div className="flex items-center gap-4">
+          <AppLogo width={150} height={32} className="shrink-0" priority />
+          <div>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              ModularIoT
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Build deployed
+            </p>
+          </div>
         </div>
       </ModalHeader>
       <ModalBody>

--- a/turbo-repo/apps/app/src/features/layout/components/release-view/release-view.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/release-view/release-view.tsx
@@ -67,11 +67,12 @@ export default function ReleaseView({
   const latestReleaseVersion = releaseFiles
     .map((file) => file.replace(".mdx", ""))
     .sort(compareVersions)[0];
+  const releaseNotesVersion =
+    buildInfo?.releaseNotesVersion || latestReleaseVersion;
   const version =
-    buildInfo?.releaseNotesVersion ||
-    (buildInfo?.channel === "nightly"
+    buildInfo?.channel === "nightly"
       ? buildInfo.releaseVersion
-      : latestReleaseVersion || buildInfo?.releaseVersion || "unknown");
+      : releaseNotesVersion || buildInfo?.releaseVersion || "unknown";
 
   return (
     <>
@@ -94,6 +95,7 @@ export default function ReleaseView({
         buildInfo={buildInfo}
         isOpen={isBuildInfoOpen}
         onClose={() => setIsBuildInfoOpen(false)}
+        releaseNotesVersion={releaseNotesVersion}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Add the existing ModularIoT app logo to the build-info modal header.
- Pass the latest bundled release-note version into the modal as a fallback link target, so nightly builds can still offer a release-notes link while displaying their nightly build id.

## Validation
- `npx eslint src/features/layout/components/release-view/release-view.tsx src/features/layout/components/release-view/build-info-modal.tsx src/app/api/build-info/route.ts src/app/api/build-info/route.test.ts`
- `npm run test:run -- src/app/api/build-info/route.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The release information modal now shows the app logo in its header.
  * Release notes links now use a clearer version value, improving which release notes are shown.

* **Bug Fixes**
  * Version display logic was updated to better handle nightly builds and missing version data, reducing cases where an incorrect or unknown version could appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->