### PR TITLE
feat(harness): bind skills to connections/capabilities (Phase 4 slice 1)

### DIFF
--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -26,7 +26,10 @@ from miot_harness.api.identity import (
 )
 from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.connections.loader import load_connections, select_primary
-from miot_harness.context_skills.loader import boot_context_skills
+from miot_harness.context_skills.loader import (
+    ActiveConnections,
+    boot_context_skills,
+)
 from miot_harness.context_skills.skill_models import SkillSummary
 from miot_harness.datasource.provider import BootResult, DataSourceProvider
 from miot_harness.datasource.registry import resolve as resolve_datasource
@@ -320,8 +323,31 @@ def _make_lifespan(
             primer_sections.append(
                 "# Connected data sources\n" + "\n\n".join(ckb_blocks)
             )
+        # Active connection landscape for connection-bound skills (Phase 4): a
+        # skill bound to a connection name / capability surfaces only when a
+        # matching connection booted enabled. `known` spans every configured
+        # connection so the loader can flag a typo'd binding distinctly from a
+        # connection that merely failed to boot.
+        enabled_names = {
+            name
+            for name, conn_state in app.state.connections.items()
+            if conn_state.get("enabled")
+        }
+        active_connections = ActiveConnections(
+            enabled=frozenset(enabled_names),
+            capabilities=frozenset(
+                cap
+                for conn in conn_result.connections
+                if conn.name in enabled_names
+                for cap, on in conn.capabilities.items()
+                if on
+            ),
+            known=frozenset(conn.name for conn in conn_result.connections),
+        )
         try:
-            cs = boot_context_skills(harness.tools, settings)
+            cs = boot_context_skills(
+                harness.tools, settings, active_connections=active_connections
+            )
             harness.context_skills = cs.bundle
             app.state.context_skills_registered = list(cs.registered_tools)
             app.state.context_skills_diagnostics = list(cs.diagnostics)

--- a/miot-harness/src/miot_harness/context_skills/loader.py
+++ b/miot-harness/src/miot_harness/context_skills/loader.py
@@ -47,6 +47,46 @@ class ContextSkillsBootResult:
     diagnostics: tuple[LoadDiagnostic, ...]
 
 
+@dataclass(frozen=True)
+class ActiveConnections:
+    """The connection landscape at boot, used to gate connection-bound skills.
+
+    - `enabled`: names of connections that booted enabled (their tools are
+      registered, so a bound playbook's tool refs resolve).
+    - `capabilities`: the union of capability flags that are True across the
+      enabled connections (a skill's `requires_capability` matches this set).
+    - `known`: every configured connection name, enabled or not. Used only to
+      tell a likely typo (a binding to a name no connection declares) apart
+      from a connection that merely failed to boot / has no DSN.
+    """
+
+    enabled: frozenset[str] = frozenset()
+    capabilities: frozenset[str] = frozenset()
+    known: frozenset[str] = frozenset()
+
+    def eligibility(
+        self, *, connection: str | None, requires_capability: str | None
+    ) -> tuple[bool, str | None]:
+        """Decide whether a skill with this binding is eligible.
+
+        Returns `(eligible, warning)`. `warning` is set only for a binding that
+        names a connection no configured connection declares — a likely typo
+        worth surfacing. A binding to a known-but-disabled connection, or to an
+        unavailable capability, is an expected miss (eligible False, no warning)
+        and stays silent.
+        """
+        if connection is not None and connection not in self.known:
+            return False, f"bound to unknown connection {connection!r}"
+        if connection is not None and connection not in self.enabled:
+            return False, None
+        if (
+            requires_capability is not None
+            and requires_capability not in self.capabilities
+        ):
+            return False, None
+        return True, None
+
+
 def _slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
 
@@ -64,6 +104,7 @@ def boot_context_skills(
     *,
     context_source: ContextSource | None = None,
     skill_source: SkillSource | None = None,
+    active_connections: ActiveConnections | None = None,
 ) -> ContextSkillsBootResult:
     diagnostics: list[LoadDiagnostic] = []
 
@@ -79,9 +120,13 @@ def boot_context_skills(
     diagnostics.extend(context_result.diagnostics)
     diagnostics.extend(skill_result.diagnostics)
 
+    eligible = _filter_bound_skills(
+        skill_result.skills, active_connections, diagnostics
+    )
+
     playbooks: list[LoadedSkill] = []
     connectors: list[LoadedSkill] = []
-    for loaded in skill_result.skills:
+    for loaded in eligible:
         (playbooks if isinstance(loaded.skill, PlaybookSkill) else connectors).append(
             loaded
         )
@@ -100,6 +145,42 @@ def boot_context_skills(
         registered_tools=tuple(registered),
         diagnostics=tuple(diagnostics),
     )
+
+
+def _filter_bound_skills(
+    skills: tuple[LoadedSkill, ...],
+    active: ActiveConnections | None,
+    diagnostics: list[LoadDiagnostic],
+) -> list[LoadedSkill]:
+    """Drop connection-bound skills whose connection/capability isn't active.
+
+    When `active` is None the connection landscape is unknown (e.g. a unit
+    test not exercising binding) — gate nothing, preserving prior behaviour.
+    An unbound skill (no connection / capability) is always kept.
+    """
+    if active is None:
+        return list(skills)
+    kept: list[LoadedSkill] = []
+    for loaded in skills:
+        skill = loaded.skill
+        if skill.connection is None and skill.requires_capability is None:
+            kept.append(loaded)
+            continue
+        ok, warning = active.eligibility(
+            connection=skill.connection,
+            requires_capability=skill.requires_capability,
+        )
+        if warning:
+            diagnostics.append(
+                LoadDiagnostic(
+                    loaded.source_path,
+                    "warning",
+                    f"skill {skill.id!r} {warning}; not loaded",
+                )
+            )
+        if ok:
+            kept.append(loaded)
+    return kept
 
 
 def _register_connectors(

--- a/miot-harness/src/miot_harness/context_skills/loader.py
+++ b/miot-harness/src/miot_harness/context_skills/loader.py
@@ -69,15 +69,19 @@ class ActiveConnections:
     ) -> tuple[bool, str | None]:
         """Decide whether a skill with this binding is eligible.
 
-        Returns `(eligible, warning)`. `warning` is set only for a binding that
-        names a connection no configured connection declares — a likely typo
-        worth surfacing. A binding to a known-but-disabled connection, or to an
-        unavailable capability, is an expected miss (eligible False, no warning)
-        and stays silent.
+        Returns `(eligible, warning)`. `enabled` is authoritative: a binding to
+        an enabled connection is eligible regardless of `known` (so a caller that
+        only populates `enabled` never spuriously drops live skills). `warning` is
+        set only when the connection is NOT enabled AND no configured connection
+        declares its name — a likely typo worth surfacing. A binding to a
+        known-but-disabled connection, or to an unavailable capability, is an
+        expected miss (eligible False, no warning) and stays silent.
         """
-        if connection is not None and connection not in self.known:
-            return False, f"bound to unknown connection {connection!r}"
         if connection is not None and connection not in self.enabled:
+            # Not live. Distinguish a likely typo (no connection declares this
+            # name) from a connection that merely failed to boot / has no DSN.
+            if connection not in self.known:
+                return False, f"bound to unknown connection {connection!r}"
             return False, None
         if (
             requires_capability is not None

--- a/miot-harness/src/miot_harness/context_skills/skill_models.py
+++ b/miot-harness/src/miot_harness/context_skills/skill_models.py
@@ -24,7 +24,25 @@ from miot_harness.context_skills.models import ContextScope
 HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
 
 
-class PlaybookSkill(BaseModel):
+class _ConnectionBinding(BaseModel):
+    """Optional binding of a skill to a live connection / capability (Phase 4).
+
+    - `connection`: a connection NAME. The skill is eligible only when an
+      enabled connection with that name booted (so its tools resolve).
+    - `requires_capability`: a capability flag. Eligible only when some
+      enabled connection declares that capability True.
+
+    Both may be set (AND semantics). A skill that sets neither is always
+    eligible — unchanged behaviour. Binding composes with `scope`: a skill
+    may be both tenant-scoped and connection-bound. The loader gates
+    eligibility against the active connection set at boot.
+    """
+
+    connection: str | None = None
+    requires_capability: str | None = None
+
+
+class PlaybookSkill(_ConnectionBinding):
     """Guidance over existing tools. No new executable capability."""
 
     kind: Literal["playbook"]
@@ -44,7 +62,7 @@ class PlaybookSkill(BaseModel):
     scope: ContextScope = ContextScope()
 
 
-class HttpConnectorSkill(BaseModel):
+class HttpConnectorSkill(_ConnectionBinding):
     """A declarative HTTP tool definition → a callable `HarnessTool`."""
 
     kind: Literal["http"]

--- a/miot-harness/src/miot_harness/context_skills/skill_models.py
+++ b/miot-harness/src/miot_harness/context_skills/skill_models.py
@@ -38,8 +38,11 @@ class _ConnectionBinding(BaseModel):
     eligibility against the active connection set at boot.
     """
 
-    connection: str | None = None
-    requires_capability: str | None = None
+    # min_length guards against an empty-string binding (e.g. `connection: ""`
+    # from YAML), which would otherwise look bound and be dropped/warned in a
+    # confusing way. An empty value fails validation → a load diagnostic.
+    connection: str | None = Field(default=None, min_length=1)
+    requires_capability: str | None = Field(default=None, min_length=1)
 
 
 class PlaybookSkill(_ConnectionBinding):

--- a/miot-harness/tests/context_skills/test_loader.py
+++ b/miot-harness/tests/context_skills/test_loader.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from miot_harness.config import HarnessSettings
-from miot_harness.context_skills.loader import boot_context_skills
+from miot_harness.context_skills.loader import ActiveConnections, boot_context_skills
+from miot_harness.context_skills.models import ContextScope
 from miot_harness.context_skills.skill_models import (
     HttpConnectorSkill,
     LoadedSkill,
@@ -101,6 +102,162 @@ def test_max_connector_tools_cap() -> None:
     )
     assert len(result.registered_tools) == 1
     assert any("max_connector_tools" in d.message for d in result.diagnostics)
+
+
+def _bound_playbook(
+    id: str,
+    *,
+    connection: str | None = None,
+    requires_capability: str | None = None,
+    scope: ContextScope | None = None,
+) -> LoadedSkill:
+    return LoadedSkill(
+        skill=PlaybookSkill(
+            kind="playbook",
+            id=id,
+            name=id.upper(),
+            connection=connection,
+            requires_capability=requires_capability,
+            scope=scope or ContextScope(),
+        ),
+        source_path=f"{id}.yaml",
+    )
+
+
+def _bound_connector(
+    id: str, tool_name: str, *, connection: str | None = None
+) -> LoadedSkill:
+    return LoadedSkill(
+        skill=HttpConnectorSkill(
+            kind="http",
+            id=id,
+            tool_name=tool_name,
+            url="https://api.example/x",
+            connection=connection,
+        ),
+        source_path=f"{id}.yaml",
+    )
+
+
+def _boot(*skills: LoadedSkill, active: ActiveConnections | None = None):
+    return boot_context_skills(
+        build_default_registry(),
+        HarnessSettings(),
+        context_source=_NoContext(),
+        skill_source=_Skills(*skills),
+        active_connections=active,
+    )
+
+
+def test_eligibility_decisions() -> None:
+    active = ActiveConnections(
+        enabled=frozenset({"acs"}),
+        capabilities=frozenset({"generic_query"}),
+        known=frozenset({"acs", "nexo"}),
+    )
+    # Unbound → eligible.
+    assert active.eligibility(connection=None, requires_capability=None) == (True, None)
+    # Bound to an enabled connection → eligible.
+    assert active.eligibility(connection="acs", requires_capability=None) == (True, None)
+    # Bound to a known-but-disabled connection → silent miss.
+    assert active.eligibility(connection="nexo", requires_capability=None) == (
+        False,
+        None,
+    )
+    # Bound to an unknown connection → warning.
+    ok, warn = active.eligibility(connection="typo", requires_capability=None)
+    assert ok is False
+    assert warn is not None and "typo" in warn
+    # Capability present / absent.
+    assert active.eligibility(connection=None, requires_capability="generic_query") == (
+        True,
+        None,
+    )
+    assert active.eligibility(connection=None, requires_capability="curated") == (
+        False,
+        None,
+    )
+    # AND semantics: connection enabled but capability missing → ineligible.
+    assert active.eligibility(connection="acs", requires_capability="curated") == (
+        False,
+        None,
+    )
+
+
+def test_bound_playbook_loaded_only_when_connection_enabled() -> None:
+    active = ActiveConnections(enabled=frozenset({"acs"}), known=frozenset({"acs"}))
+    result = _boot(_bound_playbook("acs-pb", connection="acs"), active=active)
+    assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["acs-pb"]
+
+
+def test_bound_playbook_dropped_when_connection_disabled() -> None:
+    # acs is configured (known) but not enabled this boot — silent miss.
+    active = ActiveConnections(enabled=frozenset(), known=frozenset({"acs"}))
+    result = _boot(_bound_playbook("acs-pb", connection="acs"), active=active)
+    assert result.bundle.playbooks_for("any") == []
+    assert not any(d.level == "warning" for d in result.diagnostics)
+
+
+def test_bound_playbook_unknown_connection_warns_and_drops() -> None:
+    active = ActiveConnections(enabled=frozenset({"acs"}), known=frozenset({"acs"}))
+    result = _boot(_bound_playbook("typo-pb", connection="nope"), active=active)
+    assert result.bundle.playbooks_for("any") == []
+    assert any(
+        "unknown connection" in d.message and d.level == "warning"
+        for d in result.diagnostics
+    )
+
+
+def test_capability_bound_playbook_gated_on_active_capability() -> None:
+    active = ActiveConnections(
+        enabled=frozenset({"acs"}),
+        capabilities=frozenset({"generic_query"}),
+        known=frozenset({"acs"}),
+    )
+    has = _bound_playbook("cap-yes", requires_capability="generic_query")
+    lacks = _bound_playbook("cap-no", requires_capability="curated")
+    result = _boot(has, lacks, active=active)
+    assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["cap-yes"]
+
+
+def test_bound_connector_registered_only_when_connection_enabled() -> None:
+    active = ActiveConnections(enabled=frozenset({"acs"}), known=frozenset({"acs", "x"}))
+    on = _bound_connector("a", "live", connection="acs")
+    off = _bound_connector("b", "dark", connection="x")  # known, disabled
+    result = boot_context_skills(
+        build_default_registry(),
+        HarnessSettings(),
+        context_source=_NoContext(),
+        skill_source=_Skills(on, off),
+        active_connections=active,
+    )
+    assert result.registered_tools == ("skill_live",)
+
+
+def test_unbound_skill_always_loaded_regardless_of_active_set() -> None:
+    active = ActiveConnections(enabled=frozenset(), known=frozenset())
+    result = _boot(_bound_playbook("plain"), active=active)
+    assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["plain"]
+
+
+def test_none_active_set_disables_gating_back_compat() -> None:
+    # Callers that don't pass active_connections (older tests) gate nothing,
+    # even for a bound skill.
+    result = _boot(_bound_playbook("acs-pb", connection="acs"), active=None)
+    assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["acs-pb"]
+
+
+def test_binding_composes_with_tenant_scope() -> None:
+    active = ActiveConnections(enabled=frozenset({"acs"}), known=frozenset({"acs"}))
+    pb = _bound_playbook(
+        "acs-t",
+        connection="acs",
+        scope=ContextScope(kind="tenant", tenant_id="mintral"),
+    )
+    result = _boot(pb, active=active)
+    # Eligible for its tenant, absent for others (scope still applies).
+    assert [s.skill.id for s in result.bundle.playbooks_for("mintral")] == ["acs-t"]
+    assert result.bundle.playbooks_for("other") == []
 
 
 def test_playbook_unknown_tool_warns() -> None:

--- a/miot-harness/tests/context_skills/test_loader.py
+++ b/miot-harness/tests/context_skills/test_loader.py
@@ -184,6 +184,28 @@ def test_eligibility_decisions() -> None:
     )
 
 
+def test_enabled_is_authoritative_when_known_unset() -> None:
+    # Copilot footgun: a caller that populates only `enabled` (leaving `known`
+    # at its empty default) must NOT see enabled connections treated as unknown.
+    active = ActiveConnections(enabled=frozenset({"acs"}))
+    assert active.eligibility(connection="acs", requires_capability=None) == (
+        True,
+        None,
+    )
+    result = _boot(_bound_playbook("acs-pb", connection="acs"), active=active)
+    assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["acs-pb"]
+
+
+def test_empty_string_binding_rejected() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        PlaybookSkill(kind="playbook", id="x", name="X", connection="")
+    with pytest.raises(ValidationError):
+        PlaybookSkill(kind="playbook", id="x", name="X", requires_capability="")
+
+
 def test_bound_playbook_loaded_only_when_connection_enabled() -> None:
     active = ActiveConnections(enabled=frozenset({"acs"}), known=frozenset({"acs"}))
     result = _boot(_bound_playbook("acs-pb", connection="acs"), active=active)


### PR DESCRIPTION
## Phase 4 slice 1 — binding model + loader gating

First slice of the generic-data-access ladder's rung 4: *expertise authored as skills, activated per data source*. Lets an authored playbook or HTTP connector skill **bind to a connection (or capability)** so it surfaces only when that connection is live — instead of every skill being eligible for every tenant/connection.

Builds on Phase 2 (knowledge packs) and Phase 3 (agentic plan→verify mode), all merged.

### What changes
- **`skill_models`** — a shared `_ConnectionBinding` mixin on `PlaybookSkill` and `HttpConnectorSkill` adds two optional fields: `connection` (a connection name) and `requires_capability` (a capability flag). A skill that sets neither is **always eligible — no behaviour change** for existing skills. Binding composes with the existing tenant `scope`.
- **`loader`** — `ActiveConnections` (enabled connection names + the union of their capability flags + every known/configured name) and `_filter_bound_skills`:
  - bound to an **enabled** connection / **available** capability → eligible;
  - bound to a **known-but-disabled** connection or an **unavailable** capability → silent miss (expected);
  - bound to an **unknown** connection name → **warning diagnostic** (likely typo), dropped.
  - Never raises — matches the existing "bad manifest is a diagnostic, not a boot failure" contract. `active_connections` defaults to `None` (gating off) for back-compat with callers/tests that don't pass it.
- **`server`** — builds the active connection set from the per-connection boot results and passes it to `boot_context_skills`.

### Scope
- ✅ Binding model + loader gating (this slice).
- ⏭️ Connection-aware surfacing in `/skills` + the planner catalog (slice 2).
- ⏭️ Ship the real `acs` Alfresco-Activiti playbook + real-DB smoke (slice 3).

### Tests
Added to `tests/context_skills/test_loader.py`: eligibility truth table, bound playbook loaded only when its connection is enabled, silent drop when disabled, warning on unknown connection, capability gating, connector registered only when enabled, unbound-always-loaded, `None`-active back-compat, and binding × tenant-scope composition.

Local gate green: `ruff` ✓, `mypy` (102 files) ✓, `pytest` 802 passed / 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now be tied to specific connections and required capabilities.
  * Only skills matching currently available connections are loaded, helping users see the right tools and playbooks.
  * Connection availability checks now include clearer warnings when a binding appears to reference an unknown connection name.

* **Bug Fixes**
  * Prevents bound skills from appearing when their connection is disabled or lacks the needed capability.
  * Unbound skills continue to load as before, preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->