### PR TITLE
fix(app): WhatsApp Settings edit — instant refresh + show connection name

### DIFF
--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/use-org-whatsapp.ts
@@ -44,7 +44,8 @@ export function useOrgWhatsApp(orgSlug: string | null) {
     setActionLoading(true);
     try {
       const created = await createWhatsAppConnection(slug, form);
-      await mutate();
+      // Seed the cache from the response so the card updates instantly (no refetch flicker).
+      await mutate(created, { revalidate: false });
       return created;
     } finally {
       setActionLoading(false);
@@ -59,7 +60,9 @@ export function useOrgWhatsApp(orgSlug: string | null) {
     setActionLoading(true);
     try {
       const updated = await updateWhatsAppConnection(slug, connectionId, form);
-      await mutate();
+      // Seed the cache from the response so the card reflects the edit immediately,
+      // instead of briefly showing the previous values during a revalidation refetch.
+      await mutate(updated, { revalidate: false });
       return updated;
     } finally {
       setActionLoading(false);

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-channel-card.tsx
@@ -5,7 +5,7 @@ import { useState, type ReactNode } from "react";
 import { FaWhatsapp } from "react-icons/fa";
 import { toast } from "sonner";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
-import { tr } from "@/features/i18n/tr.service";
+import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { useOrgWhatsApp } from "./use-org-whatsapp";
 import { WhatsAppConnectionModal } from "./whatsapp-connection-modal";
 import { DEFAULT_GRAPH_VERSION } from "./whatsapp.types";
@@ -161,7 +161,12 @@ function ConfiguredRow({ connection, dict, busy, onTest, onEdit }: ConfiguredRow
   return (
     <div className="flex items-center justify-between gap-2">
       <div className="text-sm text-gray-700 dark:text-gray-300">
-        <span className="font-medium">{tr("phoneLabel", dict)}:</span> {phone}
+        <div className="font-medium text-gray-900 dark:text-gray-100">
+          {connection.name}
+        </div>
+        <div>
+          <span className="font-medium">{tr("phoneLabel", dict)}:</span> {phone}
+        </div>
       </div>
       <div className="flex items-center gap-2">
         <Button size="xs" color="light" disabled={busy} onClick={onEdit}>
@@ -205,5 +210,5 @@ function StatusBadge({ status, dict }: StatusBadgeProps) {
     TEST_FAILED: { color: "failure", key: "status.failed" },
   };
   const entry = map[status] ?? map.DRAFT;
-  return <Badge color={entry.color}>{tr(entry.key, dict)}</Badge>;
+  return <Badge color={entry.color}>{trDynamic(entry.key, dict)}</Badge>;
 }

--- a/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/whatsapp/whatsapp-connection-modal.tsx
@@ -83,7 +83,9 @@ export function WhatsAppConnectionModal({
       title={
         isEdit ? tr("modal.editTitle", dict) : tr("modal.addTitle", dict)
       }
-      subtitle={tr("modal.subtitle", dict)}
+      subtitle={
+        isEdit ? tr("modal.editSubtitle", dict) : tr("modal.subtitle", dict)
+      }
       submitLabel={submitLabel}
       isProcessing={loading}
       error={error}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1250,6 +1250,7 @@
           "modal": {
             "addTitle": "Configure WhatsApp channel",
             "subtitle": "Stores the access token securely and creates the connection.",
+            "editSubtitle": "Update the connection details. Leave the token blank to keep the current one.",
             "defaultName": "WhatsApp Channel",
             "name": "Connection name",
             "phoneNumberId": "Phone number ID",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1250,6 +1250,7 @@
           "modal": {
             "addTitle": "Configurar canal WhatsApp",
             "subtitle": "Guarda el token de acceso de forma segura y crea la conexión.",
+            "editSubtitle": "Actualiza los datos de la conexión. Deja el token en blanco para mantener el actual.",
             "defaultName": "Canal WhatsApp",
             "name": "Nombre de la conexión",
             "phoneNumberId": "ID del número (phone number id)",


### PR DESCRIPTION
Fixes from a **live smoke test** of the Settings edit (#801) in coordinador-dev (reproduced in-browser, confirmed in the network trace). Closes #807.

## Observations → fixes
1. **Saving briefly showed the previous values.** `useOrgWhatsApp.update()`/`create()` called `mutate()` (revalidate), so SWR served the stale cached connection during the refetch (network: PATCH 200 → GET refetch). → Seed the cache from the mutation's returned connection with `mutate(result, { revalidate: false })` — instant, flicker-free.
2. **Editing the name looked like a no-op on the card.** The card row only rendered the phone-number-id. → Now shows the connection **name** above the phone id.
3. **Edit modal subtitle** still said "…creates the connection". → Added `editSubtitle`.
4. Drive-by: `trDynamic` for the runtime status-badge key (clears the i18n lint rule).

## Not a bug (explained, no change)
Changing the **WABA account id** doesn't break `/test` or sending — only `phone_number_id` is used at runtime (the WABA id is for template-management APIs). Verified against the tester/send code.

## Validation
`check-types` + `eslint` clean on the touched files; reproduced + re-verified the fix path in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)