### PR TITLE
feat(app): show full stack build metadata

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -137,25 +137,36 @@ jobs:
       - name: Write packaged build info
         env:
           RELEASE_VERSION: nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+          STACK_TAG: miot-stack@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           GIT_SHA: ${{ needs.metadata.outputs.head_sha }}
           SHORT_SHA: ${{ needs.metadata.outputs.short_sha }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
+          MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
+          MODULITH_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
+          HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
+          HARNESS_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
         run: |
           mkdir -p turbo-repo/apps/app/public
           jq -n \
             --arg release_version "$RELEASE_VERSION" \
+            --arg stack_tag "$STACK_TAG" \
             --arg git_sha "$GIT_SHA" \
             --arg short_sha "$SHORT_SHA" \
             --arg built_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
             --arg workflow_run_url "$WORKFLOW_RUN_URL" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
+            --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
+            --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
+            --arg harness_image_tag "$HARNESS_IMAGE_TAG" \
             '{
               product: "ModularIoT",
               release_version: $release_version,
               channel: "nightly",
+              stack_tag: $stack_tag,
               git_sha: $git_sha,
               short_sha: $short_sha,
               built_at: $built_at,
@@ -163,9 +174,22 @@ jobs:
               manifest_version: 1,
               components: {
                 app: {
+                  version: $release_version,
                   tag: ("app@" + $release_version),
                   image_repository: $app_image_repository,
                   image_tag: $app_image_tag
+                },
+                modulith: {
+                  version: $release_version,
+                  tag: ("modulith@" + $release_version),
+                  image_repository: $modulith_image_repository,
+                  image_tag: $modulith_image_tag
+                },
+                harness: {
+                  version: $release_version,
+                  tag: ("harness@" + $release_version),
+                  image_repository: $harness_image_repository,
+                  image_tag: $harness_image_tag
                 }
               }
             }' > turbo-repo/apps/app/public/build-info.json

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -518,6 +518,14 @@ jobs:
           APP_TAG: ${{ needs.prepare.outputs.app_tag }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: app-v${{ needs.prepare.outputs.app_version }}
+          MODULITH_VERSION: ${{ needs.prepare.outputs.modulith_version }}
+          MODULITH_TAG: ${{ needs.prepare.outputs.modulith_tag }}
+          MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
+          MODULITH_IMAGE_TAG: modulith-v${{ needs.prepare.outputs.modulith_version }}
+          HARNESS_VERSION: ${{ needs.prepare.outputs.harness_version }}
+          HARNESS_TAG: ${{ needs.prepare.outputs.harness_tag }}
+          HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
+          HARNESS_IMAGE_TAG: harness-v${{ needs.prepare.outputs.harness_version }}
         run: |
           mkdir -p turbo-repo/apps/app/public
           jq -n \
@@ -532,6 +540,14 @@ jobs:
             --arg app_tag "$APP_TAG" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg modulith_version "$MODULITH_VERSION" \
+            --arg modulith_tag "$MODULITH_TAG" \
+            --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
+            --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
+            --arg harness_version "$HARNESS_VERSION" \
+            --arg harness_tag "$HARNESS_TAG" \
+            --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
+            --arg harness_image_tag "$HARNESS_IMAGE_TAG" \
             '{
               product: "ModularIoT",
               release_version: $release_version,
@@ -549,6 +565,18 @@ jobs:
                   tag: $app_tag,
                   image_repository: $app_image_repository,
                   image_tag: $app_image_tag
+                },
+                modulith: {
+                  version: $modulith_version,
+                  tag: $modulith_tag,
+                  image_repository: $modulith_image_repository,
+                  image_tag: $modulith_image_tag
+                },
+                harness: {
+                  version: $harness_version,
+                  tag: $harness_tag,
+                  image_repository: $harness_image_repository,
+                  image_tag: $harness_image_tag
                 }
               }
             }' > turbo-repo/apps/app/public/build-info.json

--- a/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
@@ -54,6 +54,7 @@ function ComponentFields({
   const visibleValues = [
     component.version,
     component.tag,
+    component.imageRepository,
     component.imageTag,
     component.sourceTag,
     component.imageRef,
@@ -71,6 +72,11 @@ function ComponentFields({
       <dl className="space-y-1">
         <Field label="Version" value={component.version} />
         <Field label="Tag" value={component.tag} monospace />
+        <Field
+          label="Image repo"
+          value={component.imageRepository}
+          monospace
+        />
         <Field label="Image tag" value={component.imageTag} monospace />
         <Field label="Source tag" value={component.sourceTag} monospace />
         <Field label="Image ref" value={component.imageRef} monospace />
@@ -95,14 +101,9 @@ export default function BuildInfoModal({
       <ModalHeader className="border-none">
         <div className="flex items-center gap-4">
           <AppLogo width={150} height={32} className="shrink-0" priority />
-          <div>
-            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-              ModularIoT
-            </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Build deployed
-            </p>
-          </div>
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            Build deployed
+          </p>
         </div>
       </ModalHeader>
       <ModalBody>


### PR DESCRIPTION
## Summary
- remove the duplicate ModularIoT text from the build-info modal header
- show image repository rows for component build metadata
- package stack/app/modulith/harness metadata into nightly and release-train app builds

Closes #811

## Tests
- npx eslint src/features/layout/components/release-view/build-info-modal.tsx src/features/layout/components/release-view/release-view.tsx src/app/api/build-info/route.ts src/app/api/build-info/route.test.ts
- npm run test:run -- src/app/api/build-info/route.test.ts
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml\n- git diff --check\n- npx turbo run build --filter=@modulariot/app