### PR TITLE
fix(harness): make ActiveConnections.known nullable (CodeRabbit follow-up to #806)

### DIFF
--- a/miot-harness/src/miot_harness/context_skills/loader.py
+++ b/miot-harness/src/miot_harness/context_skills/loader.py
@@ -57,12 +57,15 @@ class ActiveConnections:
       enabled connections (a skill's `requires_capability` matches this set).
     - `known`: every configured connection name, enabled or not. Used only to
       tell a likely typo (a binding to a name no connection declares) apart
-      from a connection that merely failed to boot / has no DSN.
+      from a connection that merely failed to boot / has no DSN. `None` means
+      "the configured set is not known here" — callers that populate only
+      `enabled` get silent misses for disabled bindings instead of false typo
+      warnings (an empty frozenset, by contrast, asserts "no connections").
     """
 
     enabled: frozenset[str] = frozenset()
     capabilities: frozenset[str] = frozenset()
-    known: frozenset[str] = frozenset()
+    known: frozenset[str] | None = None
 
     def eligibility(
         self, *, connection: str | None, requires_capability: str | None
@@ -78,9 +81,11 @@ class ActiveConnections:
         expected miss (eligible False, no warning) and stays silent.
         """
         if connection is not None and connection not in self.enabled:
-            # Not live. Distinguish a likely typo (no connection declares this
-            # name) from a connection that merely failed to boot / has no DSN.
-            if connection not in self.known:
+            # Not live. Warn only when the configured set IS known and this name
+            # is absent from it (a likely typo). When `known` is None the set
+            # isn't knowable here, and a known-but-disabled connection is an
+            # expected miss — stay silent rather than cry typo.
+            if self.known is not None and connection not in self.known:
                 return False, f"bound to unknown connection {connection!r}"
             return False, None
         if (

--- a/miot-harness/tests/context_skills/test_loader.py
+++ b/miot-harness/tests/context_skills/test_loader.py
@@ -196,6 +196,20 @@ def test_enabled_is_authoritative_when_known_unset() -> None:
     assert [s.skill.id for s in result.bundle.playbooks_for("any")] == ["acs-pb"]
 
 
+def test_known_none_disabled_binding_is_silent_not_typo() -> None:
+    # CodeRabbit: an omitted `known` (None) must not be conflated with "no
+    # configured connections". A binding to a non-enabled connection is then a
+    # silent miss, NOT a false "unknown connection" warning.
+    active = ActiveConnections(enabled=frozenset({"other"}))  # known defaults None
+    assert active.eligibility(connection="acs", requires_capability=None) == (
+        False,
+        None,
+    )
+    result = _boot(_bound_playbook("acs-pb", connection="acs"), active=active)
+    assert result.bundle.playbooks_for("any") == []
+    assert not any(d.level == "warning" for d in result.diagnostics)
+
+
 def test_empty_string_binding_rejected() -> None:
     import pytest
     from pydantic import ValidationError


### PR DESCRIPTION
Follow-up to **#806** (already merged). That PR's CodeRabbit review landed one Minor finding *after* the merge, so this lands the fix separately.

## What
`ActiveConnections.known` defaulted to `frozenset()`, which conflated two different states:
- *"the configured connection set isn't known here"* (a caller that populated only `enabled`/`capabilities`), and
- *"there are genuinely no configured connections"*.

With the empty default, a binding to a **non-enabled** connection was turned into a false `"unknown connection"` typo warning instead of a silent miss.

## Fix
- `known: frozenset[str] | None = None`. The typo warning fires **only when `known` is actually provided** and the name is absent from it. `None` (default) → a non-enabled binding is a silent miss. An explicit empty `frozenset()` still asserts "no connections".
- `server.py` already passes the full configured set, so real typo diagnostics are unchanged.
- Test: `known=None` + disabled binding → silent (no warning).

Local gate green: `ruff` ✓, `mypy` (102 files) ✓, `pytest` (context_skills) 47 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #826
