### PR TITLE
feat(app): celebrate build contributors

### DIFF
--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -136,7 +136,20 @@ jobs:
         env:
           GIT_SHA: ${{ needs.metadata.outputs.head_sha }}
         run: |
-          credit_rows="$(git log -1 --format='%aN%x09%aE' "$GIT_SHA")"
+          previous_stack_tag="$(
+            git tag --list 'miot-stack@v*' --merged "$GIT_SHA" --sort=-v:refname |
+              head -1 || true
+          )"
+          range="$GIT_SHA"
+          if [[ -n "$previous_stack_tag" ]]; then
+            range="${previous_stack_tag}..${GIT_SHA}"
+          fi
+
+          credit_rows="$(git log --format='%aN%x09%aE' "$range")"
+          if [[ -z "$credit_rows" ]]; then
+            credit_rows="$(git log -1 --format='%aN%x09%aE' "$GIT_SHA")"
+          fi
+
           credits_json="$(
             GIT_CREDIT_ROWS="$credit_rows" node <<'NODE'
           const rows = (process.env.GIT_CREDIT_ROWS ?? "").trim().split("\n").filter(Boolean);

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -145,35 +145,85 @@ jobs:
             range="${previous_stack_tag}..${GIT_SHA}"
           fi
 
-          credit_rows="$(git log --format='%aN%x09%aE' "$range")"
-          if [[ -z "$credit_rows" ]]; then
-            credit_rows="$(git log -1 --format='%aN%x09%aE' "$GIT_SHA")"
+          credit_log="$(git log --format='%H%x09%aN%x09%aE' --numstat "$range")"
+          if [[ -z "$credit_log" ]]; then
+            credit_log="$(git log -1 --format='%H%x09%aN%x09%aE' --numstat "$GIT_SHA")"
           fi
 
           credits_json="$(
-            GIT_CREDIT_ROWS="$credit_rows" node <<'NODE'
-          const rows = (process.env.GIT_CREDIT_ROWS ?? "").trim().split("\n").filter(Boolean);
-          const allCredits = [];
-          const seen = new Set();
-          for (const row of rows) {
-            const [name, email] = row.split("\t");
-            const username = email?.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
-            const key = (email || username || name).toLowerCase();
-            if (!name || seen.has(key)) {
+            GIT_CREDIT_LOG="$credit_log" node <<'NODE'
+          const crypto = require("crypto");
+          const lines = (process.env.GIT_CREDIT_LOG ?? "").split("\n");
+          const contributors = new Map();
+          let currentKey = null;
+
+          function githubUsername(email) {
+            return email?.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
+          }
+
+          function avatarUrl(email, username) {
+            if (username) {
+              return `https://github.com/${username}.png?size=96`;
+            }
+            if (!email) {
+              return undefined;
+            }
+            const hash = crypto.createHash("md5").update(email.trim().toLowerCase()).digest("hex");
+            return `https://www.gravatar.com/avatar/${hash}?d=identicon&s=96`;
+          }
+
+          for (const line of lines) {
+            if (!line.trim()) {
               continue;
             }
-            seen.add(key);
-            allCredits.push({
-              name,
-              ...(email ? { email } : {}),
-              ...(username ? { username, url: `https://github.com/${username}` } : {}),
-              role: "Contributor",
-            });
+
+            const parts = line.split("\t");
+            if (parts.length === 3 && /^[0-9a-f]{40}$/.test(parts[0])) {
+              const [, name, email] = parts;
+              const username = githubUsername(email);
+              currentKey = (email || username || name).toLowerCase();
+              if (!contributors.has(currentKey)) {
+                contributors.set(currentKey, {
+                  name,
+                  ...(email ? { email } : {}),
+                  ...(username ? { username, url: `https://github.com/${username}` } : {}),
+                  avatarUrl: avatarUrl(email, username),
+                  commitCount: 0,
+                  filesChanged: 0,
+                  additions: 0,
+                  deletions: 0,
+                });
+              }
+              contributors.get(currentKey).commitCount += 1;
+              continue;
+            }
+
+            if (!currentKey || parts.length < 3) {
+              continue;
+            }
+
+            const [added, deleted] = parts;
+            const credit = contributors.get(currentKey);
+            credit.filesChanged += 1;
+            credit.additions += /^\d+$/.test(added) ? Number(added) : 0;
+            credit.deletions += /^\d+$/.test(deleted) ? Number(deleted) : 0;
           }
+
+          const allCredits = [...contributors.values()].map((credit) => ({
+            ...credit,
+            impactScore: credit.commitCount * 25 + credit.filesChanged * 3 + Math.ceil((credit.additions + credit.deletions) / 50),
+          }));
           const humanCredits = allCredits.filter(
             (credit) => !credit.name.endsWith("[bot]") && credit.username !== "github-actions"
           );
-          console.log(JSON.stringify(humanCredits.length > 0 ? humanCredits : allCredits));
+          const credits = (humanCredits.length > 0 ? humanCredits : allCredits)
+            .sort((left, right) => right.commitCount - left.commitCount || right.impactScore - left.impactScore || left.name.localeCompare(right.name))
+            .map((credit, index) => ({
+              ...credit,
+              rank: index + 1,
+              role: index === 0 ? "Top contributor" : "Contributor",
+            }));
+          console.log(JSON.stringify(credits));
           NODE
           )"
           {

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -518,35 +518,85 @@ jobs:
             range="${previous_stack_tag}..${GIT_SHA}"
           fi
 
-          credit_rows="$(git log --format='%aN%x09%aE' "$range")"
-          if [[ -z "$credit_rows" ]]; then
-            credit_rows="$(git log -1 --format='%aN%x09%aE' "$GIT_SHA")"
+          credit_log="$(git log --format='%H%x09%aN%x09%aE' --numstat "$range")"
+          if [[ -z "$credit_log" ]]; then
+            credit_log="$(git log -1 --format='%H%x09%aN%x09%aE' --numstat "$GIT_SHA")"
           fi
 
           credits_json="$(
-            GIT_CREDIT_ROWS="$credit_rows" node <<'NODE'
-          const rows = (process.env.GIT_CREDIT_ROWS ?? "").trim().split("\n").filter(Boolean);
-          const allCredits = [];
-          const seen = new Set();
-          for (const row of rows) {
-            const [name, email] = row.split("\t");
-            const username = email?.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
-            const key = (email || username || name).toLowerCase();
-            if (!name || seen.has(key)) {
+            GIT_CREDIT_LOG="$credit_log" node <<'NODE'
+          const crypto = require("crypto");
+          const lines = (process.env.GIT_CREDIT_LOG ?? "").split("\n");
+          const contributors = new Map();
+          let currentKey = null;
+
+          function githubUsername(email) {
+            return email?.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
+          }
+
+          function avatarUrl(email, username) {
+            if (username) {
+              return `https://github.com/${username}.png?size=96`;
+            }
+            if (!email) {
+              return undefined;
+            }
+            const hash = crypto.createHash("md5").update(email.trim().toLowerCase()).digest("hex");
+            return `https://www.gravatar.com/avatar/${hash}?d=identicon&s=96`;
+          }
+
+          for (const line of lines) {
+            if (!line.trim()) {
               continue;
             }
-            seen.add(key);
-            allCredits.push({
-              name,
-              ...(email ? { email } : {}),
-              ...(username ? { username, url: `https://github.com/${username}` } : {}),
-              role: "Contributor",
-            });
+
+            const parts = line.split("\t");
+            if (parts.length === 3 && /^[0-9a-f]{40}$/.test(parts[0])) {
+              const [, name, email] = parts;
+              const username = githubUsername(email);
+              currentKey = (email || username || name).toLowerCase();
+              if (!contributors.has(currentKey)) {
+                contributors.set(currentKey, {
+                  name,
+                  ...(email ? { email } : {}),
+                  ...(username ? { username, url: `https://github.com/${username}` } : {}),
+                  avatarUrl: avatarUrl(email, username),
+                  commitCount: 0,
+                  filesChanged: 0,
+                  additions: 0,
+                  deletions: 0,
+                });
+              }
+              contributors.get(currentKey).commitCount += 1;
+              continue;
+            }
+
+            if (!currentKey || parts.length < 3) {
+              continue;
+            }
+
+            const [added, deleted] = parts;
+            const credit = contributors.get(currentKey);
+            credit.filesChanged += 1;
+            credit.additions += /^\d+$/.test(added) ? Number(added) : 0;
+            credit.deletions += /^\d+$/.test(deleted) ? Number(deleted) : 0;
           }
+
+          const allCredits = [...contributors.values()].map((credit) => ({
+            ...credit,
+            impactScore: credit.commitCount * 25 + credit.filesChanged * 3 + Math.ceil((credit.additions + credit.deletions) / 50),
+          }));
           const humanCredits = allCredits.filter(
             (credit) => !credit.name.endsWith("[bot]") && credit.username !== "github-actions"
           );
-          console.log(JSON.stringify(humanCredits.length > 0 ? humanCredits : allCredits));
+          const credits = (humanCredits.length > 0 ? humanCredits : allCredits)
+            .sort((left, right) => right.commitCount - left.commitCount || right.impactScore - left.impactScore || left.name.localeCompare(right.name))
+            .map((credit, index) => ({
+              ...credit,
+              rank: index + 1,
+              role: index === 0 ? "Top contributor" : "Contributor",
+            }));
+          console.log(JSON.stringify(credits));
           NODE
           )"
           {

--- a/turbo-repo/apps/app/src/app/api/build-info/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/build-info/route.test.ts
@@ -39,7 +39,14 @@ describe("build info route", () => {
           name: "Ada Lovelace",
           username: "ada",
           url: "https://github.com/ada",
+          avatarUrl: "https://github.com/ada.png?size=96",
           role: "Contributor",
+          commitCount: 3,
+          filesChanged: 8,
+          additions: 120,
+          deletions: 14,
+          impactScore: 82,
+          rank: 1,
         },
       ],
       components: {
@@ -65,7 +72,14 @@ describe("build info route", () => {
           name: "Ada Lovelace",
           username: "ada",
           url: "https://github.com/ada",
+          avatarUrl: "https://github.com/ada.png?size=96",
           role: "Contributor",
+          commitCount: 3,
+          filesChanged: 8,
+          additions: 120,
+          deletions: 14,
+          impactScore: 82,
+          rank: 1,
         },
       ],
       components: {
@@ -92,7 +106,15 @@ describe("build info route", () => {
       {
         name: "Grace Hopper",
         email: "grace@example.com",
+        avatarUrl:
+          "https://www.gravatar.com/avatar/abc123?d=identicon&s=96",
         role: "Contributor",
+        commitCount: 2,
+        filesChanged: 5,
+        additions: 30,
+        deletions: 7,
+        impactScore: 66,
+        rank: 2,
       },
     ]);
     process.env.APP_VERSION = "0.5.21";
@@ -112,7 +134,15 @@ describe("build info route", () => {
         {
           name: "Grace Hopper",
           email: "grace@example.com",
+          avatarUrl:
+            "https://www.gravatar.com/avatar/abc123?d=identicon&s=96",
           role: "Contributor",
+          commitCount: 2,
+          filesChanged: 5,
+          additions: 30,
+          deletions: 7,
+          impactScore: 66,
+          rank: 2,
         },
       ],
       components: {

--- a/turbo-repo/apps/app/src/app/api/build-info/route.ts
+++ b/turbo-repo/apps/app/src/app/api/build-info/route.ts
@@ -19,7 +19,14 @@ type BuildCredit = {
   email?: string;
   username?: string;
   url?: string;
+  avatarUrl?: string;
   role?: string;
+  commitCount?: number;
+  filesChanged?: number;
+  additions?: number;
+  deletions?: number;
+  impactScore?: number;
+  rank?: number;
 };
 
 type BuildInfo = {
@@ -75,6 +82,14 @@ function normalizeComponent(info: RawBuildComponentInfo): BuildComponentInfo {
   };
 }
 
+function normalizeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
 function normalizeCredits(credits: unknown): BuildCredit[] {
   if (!Array.isArray(credits)) {
     return [];
@@ -102,7 +117,14 @@ function normalizeCredits(credits: unknown): BuildCredit[] {
         email: candidate.email?.trim() || undefined,
         username: candidate.username?.trim() || undefined,
         url: candidate.url?.trim() || undefined,
+        avatarUrl: candidate.avatarUrl?.trim() || undefined,
         role: candidate.role?.trim() || undefined,
+        commitCount: normalizeNumber(candidate.commitCount),
+        filesChanged: normalizeNumber(candidate.filesChanged),
+        additions: normalizeNumber(candidate.additions),
+        deletions: normalizeNumber(candidate.deletions),
+        impactScore: normalizeNumber(candidate.impactScore),
+        rank: normalizeNumber(candidate.rank),
       },
     ];
   });

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -570,7 +570,14 @@ export type BuildCredit = {
   email?: string;
   username?: string;
   url?: string;
+  avatarUrl?: string;
   role?: string;
+  commitCount?: number;
+  filesChanged?: number;
+  additions?: number;
+  deletions?: number;
+  impactScore?: number;
+  rank?: number;
 };
 
 export type BuildInfo = {

--- a/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx
@@ -86,6 +86,55 @@ function ComponentFields({
   );
 }
 
+function formatStat(value?: number) {
+  return value === undefined ? "0" : new Intl.NumberFormat("en").format(value);
+}
+
+function CreditStat({
+  label,
+  value,
+}: Readonly<{
+  label: string;
+  value?: number;
+}>) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <span className="rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+      {formatStat(value)} {label}
+    </span>
+  );
+}
+
+function CreditAvatar({
+  credit,
+}: Readonly<{
+  credit: BuildCredit;
+}>) {
+  const initials = credit.name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+
+  return (
+    <div
+      aria-hidden="true"
+      className="flex size-12 shrink-0 items-center justify-center rounded-full bg-blue-50 bg-cover bg-center text-sm font-semibold text-blue-700 ring-2 ring-blue-100 dark:bg-blue-900/30 dark:text-blue-100 dark:ring-blue-800"
+      style={
+        credit.avatarUrl
+          ? { backgroundImage: `url("${credit.avatarUrl}")` }
+          : undefined
+      }
+    >
+      {!credit.avatarUrl && initials}
+    </div>
+  );
+}
+
 function Credits({
   credits,
 }: Readonly<{
@@ -97,36 +146,72 @@ function Credits({
 
   return (
     <section className="border-t border-gray-200 pt-3 dark:border-gray-700">
-      <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
-        Credits
-      </h3>
-      <ul className="grid gap-2 sm:grid-cols-2">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Credits
+        </h3>
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+          {credits.length} contributor{credits.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2">
         {credits.map((credit) => {
           const label = credit.username ? `@${credit.username}` : credit.name;
           const secondary =
             credit.role ?? (credit.username ? credit.name : credit.email);
+          const title =
+            credit.rank === 1 && credits.length > 1
+              ? "Top contributor"
+              : secondary;
 
           return (
-            <li key={`${credit.name}-${credit.email ?? credit.username ?? ""}`}>
-              {credit.url ? (
-                <Link
-                  className="text-sm font-medium text-gray-900 hover:underline dark:text-gray-100"
-                  href={credit.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {label}
-                </Link>
-              ) : (
-                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {label}
-                </span>
-              )}
-              {secondary && (
-                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
-                  {secondary}
-                </p>
-              )}
+            <li
+              className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+              key={`${credit.name}-${credit.email ?? credit.username ?? ""}`}
+            >
+              <div className="flex gap-3">
+                <CreditAvatar credit={credit} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      {credit.url ? (
+                        <Link
+                          className="truncate text-sm font-semibold text-gray-900 hover:underline dark:text-gray-100"
+                          href={credit.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {label}
+                        </Link>
+                      ) : (
+                        <span className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+                          {label}
+                        </span>
+                      )}
+                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {credit.username ? credit.name : credit.email}
+                      </p>
+                    </div>
+                    {credit.rank && (
+                      <span className="rounded-md bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-100">
+                        #{credit.rank}
+                      </span>
+                    )}
+                  </div>
+                  {title && (
+                    <p className="mt-2 text-xs font-medium text-gray-600 dark:text-gray-300">
+                      {title}
+                    </p>
+                  )}
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    <CreditStat label="commits" value={credit.commitCount} />
+                    <CreditStat label="files" value={credit.filesChanged} />
+                    <CreditStat label="++" value={credit.additions} />
+                    <CreditStat label="--" value={credit.deletions} />
+                    <CreditStat label="impact" value={credit.impactScore} />
+                  </div>
+                </div>
+              </div>
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- collect build contributors from the previous stack tag to the deployed SHA for nightly and release-train builds
- compute contributor stats from `git log --numstat`: commits, files changed, additions, deletions, impact score, and rank
- add GitHub/Gravatar avatar URLs to build credits
- render credits as contributor cards with handle, avatar, rank, role, and compact stats

Closes #817

## Tests
- npx eslint --quiet src/features/layout/components/release-view/build-info-modal.tsx src/features/layout/components/release-view/release-view.tsx src/app/api/build-info/route.ts src/app/api/build-info/route.test.ts src/features/common/providers/client-api.provider.ts
- npm run test:run -- src/app/api/build-info/route.test.ts
- ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/app-release-train.yml .github/workflows/app-nightly.yml\n- git diff --check\n- npx turbo run build --filter=@modulariot/app