### PR TITLE
fix(app): disable Control Tower WhatsApp send until slice 3

### DIFF
--- a/turbo-repo/apps/app/src/features/symptoms/components/map-view/blurrable-dropdown.tsx
+++ b/turbo-repo/apps/app/src/features/symptoms/components/map-view/blurrable-dropdown.tsx
@@ -59,6 +59,10 @@ export default function BlurrableDropdown({
       label: (dict.symptoms as I18nRecord).contact_via_whatsapp as string,
       icon: FaWhatsapp,
       option: "contact_via_whatsapp" as SelectedOption,
+      // Disabled until the Control Tower symptom→WhatsApp flow is finalized (single
+      // symptom template + missing-data guard, no random picker). Matches the other
+      // not-yet-ready options above; flip to re-enable.
+      disabled: true,
     },
     {
       id: 3,


### PR DESCRIPTION
## What
Disables the **"Contactar via WhatsApp"** option in the Control Tower symptom action dropdown by marking it `disabled: true` — matching the existing pattern for not-yet-ready options (`derive_to_specialist`, `contact_carabineros`, `copilot`). It greys out and can no longer open the picker modal.

## Why
The Control Tower symptom→WhatsApp send was wired up during the initial integration, but the proper de-scope (single symptom template + missing-data guard, **no** random template picker) is **slice 3**, deferred to a later session. Until then the half-finished picker shouldn't be usable in demos — restoring the original "disabled" state.

All send infra (data-service, templates, API route, backend) and the modal wiring stay intact; slice 3 re-enables by flipping the one flag.

## Validation
- `tsc --noEmit` clean; `eslint` clean (the lone `dict: any` warning is pre-existing).
- One-line change; the `disabled` flag flows directly into the already-proven `<DropdownItem disabled>` + greyed-class path used by 3 sibling options.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)