### PR TITLE
feat(conversational): M2M-callable WhatsApp send for POD notifications (slice 4a)

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/OrgWhatsAppOutboundResource.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/OrgWhatsAppOutboundResource.java
@@ -1,0 +1,127 @@
+package com.microboxlabs.miot.conversational.api;
+
+import com.microboxlabs.miot.conversational.domain.Message;
+import com.microboxlabs.miot.conversational.domain.MessageStatus;
+import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
+import com.microboxlabs.miot.conversational.service.WhatsAppMessagingService;
+import com.microboxlabs.miot.core.auth.M2MAuth;
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.integrations.service.ConnectionResolutionException;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * Service-to-service (M2M) WhatsApp send, for upstream processes that own the *when* —
+ * e.g. ecm-coordinator firing POD notifications on delivery transitions (plan §4 / A.1).
+ *
+ * <p>This is a thin sibling of {@link OrgWhatsAppMessagesResource}: it delegates to the same
+ * {@link WhatsAppMessagingService#send}. It exists as a separate resource only because
+ * {@code @M2MAuth} switches its whole {@code @Path} subtree to HS256 verification
+ * (see {@code DualJwtAuthMechanism}). Keeping it on a distinct {@code …/whatsapp/outbound}
+ * path leaves the user-facing {@code …/whatsapp/*} endpoints (Control Tower, Conversations
+ * inbox) on RS256 user tokens.
+ *
+ * <p>Attribution: the transport principal here is a machine, so the message is attributed to
+ * the request's {@code actor} (the operator who triggered it upstream); when absent it falls
+ * back to the calling principal. A caller cannot impersonate a user on the RS256 path — that
+ * one ignores {@code actor} and uses the authenticated user.
+ */
+@Path("/api/v1/orgs/{organizationId}/whatsapp/outbound")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "WhatsApp Channel (M2M)", description = "Service-to-service WhatsApp send for upstream processes")
+@SecurityRequirement(name = "oidc")
+@Authenticated
+@M2MAuth
+@IfBuildProperty(name = "miot.component.conversational.enabled", stringValue = "true")
+public class OrgWhatsAppOutboundResource {
+
+    private static final String ERROR = "error";
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final SecurityIdentity identity;
+    private final WhatsAppMessagingService messagingService;
+
+    @Inject
+    public OrgWhatsAppOutboundResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            SecurityIdentity identity,
+            WhatsAppMessagingService messagingService) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.identity = identity;
+        this.messagingService = messagingService;
+    }
+
+    @POST
+    @Path("/messages")
+    @Operation(summary = "Send an outbound WhatsApp message as a service (M2M), attributed to an upstream actor")
+    public Uni<Response> sendMessage(
+            @PathParam("organizationId") String organizationId,
+            SendWhatsAppMessageRequest request) {
+        String tenant = tenantCode(organizationId);
+        String sentBy = resolveActor(request, currentPrincipal());
+        return onWorker(() -> {
+            try {
+                Message message = messagingService.send(tenant, request, sentBy);
+                Response.Status code = message.status() == MessageStatus.FAILED
+                        ? Response.Status.BAD_GATEWAY
+                        : Response.Status.CREATED;
+                return Response.status(code).entity(message).build();
+            } catch (ConnectionResolutionException e) {
+                return Response.status(Response.Status.CONFLICT).entity(Map.of(ERROR, e.getMessage())).build();
+            } catch (IllegalArgumentException e) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(Map.of(ERROR, e.getMessage())).build();
+            }
+        });
+    }
+
+    /**
+     * Who the message is attributed to: the request's {@code actor} (the upstream operator)
+     * when provided, otherwise the calling principal (the M2M client). Package-private and
+     * static so it is unit-testable without the request infrastructure.
+     */
+    static String resolveActor(SendWhatsAppMessageRequest request, String principal) {
+        String actor = request == null ? null : request.actor();
+        return actor != null && !actor.isBlank() ? actor : principal;
+    }
+
+    private static <T> Uni<T> onWorker(Supplier<T> work) {
+        return Uni.createFrom().item(work).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    private String currentPrincipal() {
+        return identity == null || identity.getPrincipal() == null ? null : identity.getPrincipal().getName();
+    }
+
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(Map.of(ERROR, "Organization context does not match request path"))
+                    .build());
+        }
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+}

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequest.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequest.java
@@ -10,6 +10,12 @@ import java.util.Map;
  * NAMED body placeholders (e.g. {@code {"driver_name": "...", "trip_reference": "..."}}).
  * The trip-context fields are optional and, when present, anchor the conversation to a
  * service/process so its history stays attributable.
+ *
+ * <p>{@code actor} names the human who triggered the send (e.g. the operator who
+ * approved/rejected a POD in an upstream process). It is honoured only on the
+ * service-to-service (M2M) send path, where the transport principal is a machine: the
+ * message is then attributed to {@code actor} rather than the M2M client. The user-facing
+ * send path ignores it and attributes to the authenticated user (no actor spoofing).
  */
 public record SendWhatsAppMessageRequest(
         String to,
@@ -22,7 +28,29 @@ public record SendWhatsAppMessageRequest(
         String driverId,
         String serviceCode,
         String processInstanceId,
-        String taskId) {
+        String taskId,
+        String actor) {
+
+    /**
+     * Backward-compatible constructor (pre-{@code actor}). Keeps existing positional callers
+     * working; {@code actor} defaults to {@code null} (the M2M path then attributes to the
+     * calling principal). Jackson always binds the canonical (all-component) constructor.
+     */
+    public SendWhatsAppMessageRequest(
+            String to,
+            String type,
+            String body,
+            String templateName,
+            String language,
+            Map<String, String> templateParams,
+            MessageRole role,
+            String driverId,
+            String serviceCode,
+            String processInstanceId,
+            String taskId) {
+        this(to, type, body, templateName, language, templateParams, role,
+                driverId, serviceCode, processInstanceId, taskId, null);
+    }
 
     private static final String TYPE_TEMPLATE = "TEMPLATE";
     private static final String DEFAULT_LANGUAGE = "es_CL";

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/api/OrgWhatsAppOutboundResourceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/api/OrgWhatsAppOutboundResourceTest.java
@@ -1,0 +1,42 @@
+package com.microboxlabs.miot.conversational.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.microboxlabs.miot.conversational.domain.MessageRole;
+import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Attribution rule for the M2M send path: the upstream {@code actor} wins; the M2M client
+ * principal is only the fallback.
+ */
+class OrgWhatsAppOutboundResourceTest {
+
+    private static final String PRINCIPAL = "ecm-coordinator@clients";
+
+    @Test
+    void actorFromRequestIsPreferredOverPrincipal() {
+        assertEquals(
+                "ops@mintral.cl",
+                OrgWhatsAppOutboundResource.resolveActor(request("ops@mintral.cl"), PRINCIPAL));
+    }
+
+    @Test
+    void fallsBackToPrincipalWhenActorMissingOrBlank() {
+        assertEquals(PRINCIPAL, OrgWhatsAppOutboundResource.resolveActor(request(null), PRINCIPAL));
+        assertEquals(PRINCIPAL, OrgWhatsAppOutboundResource.resolveActor(request("   "), PRINCIPAL));
+    }
+
+    @Test
+    void returnsNullWhenNeitherActorNorPrincipalPresent() {
+        assertNull(OrgWhatsAppOutboundResource.resolveActor(request(null), null));
+        assertNull(OrgWhatsAppOutboundResource.resolveActor(null, null));
+    }
+
+    private static SendWhatsAppMessageRequest request(String actor) {
+        return new SendWhatsAppMessageRequest(
+                "+56900000000", "TEMPLATE", null, "pod_rejected_v1", "es_CL", null,
+                MessageRole.AGENT, null, "SVC-1", null, "task-1", actor);
+    }
+}

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequestTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/dto/SendWhatsAppMessageRequestTest.java
@@ -2,6 +2,7 @@ package com.microboxlabs.miot.conversational.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.conversational.domain.MessageRole;
@@ -39,6 +40,14 @@ class SendWhatsAppMessageRequestTest {
         assertEquals(Map.of("driver_name", "Juan"), new SendWhatsAppMessageRequest(
                 "+56900", "TEMPLATE", null, "t", "es_CL", Map.of("driver_name", "Juan"),
                 null, null, null, null, null).templateParamsOrEmpty());
+    }
+
+    @Test
+    void actorDefaultsToNullViaLegacyConstructorAndIsCarriedByCanonical() {
+        assertNull(request("TEXT").actor());
+        assertEquals("ops@mintral.cl", new SendWhatsAppMessageRequest(
+                "+56900", "TEMPLATE", null, "pod_rejected_v1", "es_CL", Map.of(),
+                MessageRole.AGENT, null, "SVC-1", null, "task-1", "ops@mintral.cl").actor());
     }
 
     private static SendWhatsAppMessageRequest request(String type) {


### PR DESCRIPTION
## What
Adds a **service-to-service (M2M)** WhatsApp send so an upstream process (ecm-coordinator) can fire POD notifications, while preserving **who** triggered them. Enabler for slice 4 (plan §4 / Decisions A.1 + F).

## Why a new resource instead of `@M2MAuth` on the existing one
`@M2MAuth` switches a path to **HS256-only** (`DualJwtAuthMechanism`) and its pattern covers the whole `@Path` subtree. Putting it on `OrgWhatsAppMessagesResource` would flip `/messages` **and** `/conversations` off RS256 — breaking the FE and the future Conversations inbox (user tokens). So:

- **`OrgWhatsAppOutboundResource`** at `…/whatsapp/outbound` (`@Authenticated` + `@M2MAuth`), `POST /messages`, delegating to the **same** `WhatsAppMessagingService.send()`. Only this distinct path is HS256; `…/whatsapp/*` stays RS256.
- **`actor` on `SendWhatsAppMessageRequest`** (optional; backward-compatible constructor — Jackson binds the canonical one). The M2M path attributes the message to `actor` (the upstream operator), falling back to the M2M principal. The RS256 path **ignores** it and uses the authenticated user → no actor spoofing from the browser.

## Attribution (answers the design question)
M2M is only the *transport* principal; the *business actor* (the operator who approved/rejected the POD) rides in `actor` and is recorded as the message's `sentByUserId`. No user token is forwarded (see Decision F).

## Tests
- `OrgWhatsAppOutboundResourceTest`: actor resolution (prefer `actor`, fall back to principal, null-safe).
- `SendWhatsAppMessageRequestTest`: `actor` default via legacy ctor + carried by canonical.
- The 13 existing `WhatsAppMessagingServiceTest` cases still pass via the legacy constructor.
- `mvn -pl miot-conversational` → **21 run, 0 failures**.

## Not in scope
4b — the ecm-coordinator `WHATSAPP_POD_NOTIFY` outbox job that calls this — is a separate PR in the private repo.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)