### PR TITLE
fix(ci): build the modulith image with the conversational component

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -85,7 +85,7 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Build & Test
-        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true -Dmiot.component.integrations.enabled=true
+        run: ./mvnw clean verify -Dmiot.component.fleet.enabled=true -Dmiot.component.driver.enabled=true -Dmiot.component.tracking.enabled=true -Dmiot.component.gateway.enabled=true -Dmiot.component.integrations.enabled=true -Dmiot.component.conversational.enabled=true
         working-directory: quarkus-srv
 
       - name: SonarCloud Scan


### PR DESCRIPTION
## What
Adds `-Dmiot.component.conversational.enabled=true` to the modulith **Build & Test** step (`.github/workflows/quarkus.yml`), so the `miot-conversational` channel — and the M2M POD-send endpoint from #825 — actually ships in the image.

## Why
The component gate is `@IfBuildProperty` (**build-time**). The build enabled fleet/driver/tracking/gateway/integrations but **not** conversational, so all conversational beans were compiled out of the miot-cli runner. Helm's `conversational.enabled: true` is a **runtime** flag → no effect.

### Evidence (dev `nightly-20260629`)
```
Discovered @M2MAuth resource: OrgAsyncJobsResource -> .../integrations/jobs
Discovered @M2MAuth resource: AssetTrackingResource -> /api/v1/asset/track
HS256 verification configured for 2 @M2MAuth path pattern(s)
RS256 verification failed for path /api/v1/orgs/mintral/whatsapp/outbound/messages:
  Unable to find a suitable verification key for JWS w/ header {"alg":"HS256",...} from JWKs [RSA...]
```
The path wasn't a registered `@M2MAuth` path → HS256 token verified as RS256 → 401.

## After this merges
Next nightly → conversational ships → the M2M endpoint authenticates on dev with the existing token (issuer/audience already match dev config). First boot runs the conversational Flyway `wa_*` migrations (`miot_conversational` schema) — additive.

## Out of scope (flagged)
The native build (`quarkus.yml`, `mvnw package -Pnative`) sets **no** component flags at all → the native image is built with all components disabled. Pre-existing; separate follow-up if that image is deployed anywhere.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration to include an additional Quarkus feature during verification, so the full application set is now covered in CI builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->