### PR TITLE
fix(ci): trigger Quarkus CI on changes to its own workflow file

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -30,10 +30,12 @@ on:
   push:
     paths:
       - 'quarkus-srv/**'
+      - '.github/workflows/quarkus.yml'
     branches: [trunk, main]
   pull_request:
     paths:
       - 'quarkus-srv/**'
+      - '.github/workflows/quarkus.yml'
     branches: [trunk, main]
   workflow_dispatch:
 


### PR DESCRIPTION
## What
Adds `.github/workflows/quarkus.yml` to the `paths` of both the `push` and `pull_request` triggers in the Quarkus CI workflow.

## Why
The workflow was filtered to `quarkus-srv/**` only, so **edits to the workflow never trigger it** — which is exactly why #831 (the conversational build-flag fix) merged without rebuilding the modulith image.

## Side effect (intended)
On merge, the trunk merge-commit changes `quarkus.yml` (now an included path) → the **push trigger fires on trunk** → Quarkus CI rebuilds `:latest`/`sha-*` **with conversational** (already in trunk via #831) → `app-nightly` retags it → dev finally gets the conversational channel + the M2M POD-send endpoint (#825). No token/config changes needed afterward.

## Note
This PR won't self-trigger the Quarkus build: `pull_request` evaluates `paths` against the **base** branch's current (unfixed) filter. The build runs on the **merge to trunk**. The runner was validated locally to build cleanly with conversational enabled.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)