### PR TITLE
feat(harness): surface connection-bound playbooks in the planner catalog (Phase 4 slice 2)

### DIFF
--- a/miot-harness/src/miot_harness/agents/agentic_planner.py
+++ b/miot-harness/src/miot_harness/agents/agentic_planner.py
@@ -33,6 +33,7 @@ from pydantic import ValidationError
 from miot_harness.agents.chat_models import response_text
 from miot_harness.agents.domain_analyst import render_evidence
 from miot_harness.agents.filter_expert import _strip_fences, build_tool_catalog
+from miot_harness.context_skills.skill_models import LoadedSkill, PlaybookSkill
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.runtime.plan import DataEvidence, DataStep
 from miot_harness.tools.registry import ToolRegistry
@@ -57,6 +58,11 @@ Exploration primitives (read-only SQL helpers; use ONLY when no curated
 tool covers the question):
 {primitives_catalog}
 
+Connection playbooks (ready-made recipes for this data source — PREFER one
+when its trigger matches; emit its steps IN ORDER as your plan instead of
+rediscovering them):
+{playbooks_catalog}
+
 Output ONLY a JSON object in one of these shapes:
 {{"action": "plan", "steps": [<step>, <step>, ...]}}   (each <step> = the call_tool fields below)
 {{"action": "call_tool", "tool": "...", "args": {{}}, "intent": "...", "rationale": "..."}}
@@ -70,6 +76,9 @@ forward. Use "call_tool" only for a genuine single step. Use "final" only when
 the executed evidence already answers the question.
 
 Rules:
+- If a connection playbook's trigger matches the question, follow it: emit its
+  listed steps (in order) as your plan. A playbook is the curated answer to its
+  question — do not re-derive the joins/columns it already encodes.
 - Prefer curated tools; primitives are a fallback for questions the
   curated catalog cannot answer.
 - args is a JSON object of parameter overrides; {{}} uses the defaults.
@@ -104,6 +113,37 @@ def build_primitives_catalog(registry: ToolRegistry) -> str:
         first_line = (tool.description or "").splitlines()[0].strip()
         lines.append(f"- {name}: {first_line}")
     return "\n".join(lines) if lines else "(no primitives registered)"
+
+
+def build_playbook_catalog(
+    playbooks: list[LoadedSkill], *, profile: DataSourceProfile
+) -> str:
+    """Render the connection-bound playbooks the planner may follow (Phase 4).
+
+    `playbooks` is the tenant-resolved playbook set (the loader already gated
+    connection/capability eligibility at boot, so every entry here is live). We
+    additionally drop any playbook bound to a *different* connection than this
+    planner's profile: its `tools` carry that connection's prefix and the step
+    scope-check would reject them, so advertising it would only be noise. An
+    unbound playbook (no `connection`) is shown for every profile.
+
+    Each line gives the trigger (`when_to_use`) and the ordered tool sequence so
+    the planner can emit the recipe as a single plan rather than rediscovering
+    it. The full Markdown body stays out of the prompt (progressive disclosure).
+    """
+    lines: list[str] = []
+    for loaded in playbooks:
+        skill = loaded.skill
+        if not isinstance(skill, PlaybookSkill):
+            continue
+        if skill.connection is not None and skill.connection != profile.name:
+            continue
+        marker = f" [connection: {skill.connection}]" if skill.connection else ""
+        trigger = (skill.when_to_use or skill.description or "").strip()
+        detail = f": {trigger}" if trigger else ""
+        steps = f" Steps: {' → '.join(skill.tools)}." if skill.tools else ""
+        lines.append(f"- {skill.name}{marker}{detail}{steps}")
+    return "\n".join(lines) if lines else "(no playbooks bound to this data source)"
 
 
 def _parse_action(text: str) -> dict[str, Any] | None:
@@ -163,6 +203,7 @@ async def agentic_planner_node(
     model: BaseChatModel,
     profile: DataSourceProfile,
     max_turns: int,
+    playbooks: list[LoadedSkill] | None = None,
 ) -> dict[str, Any]:
     evidence: list[DataEvidence] = list(state.get("evidence", []))
     turn_count = int(state.get("turn_count", 0) or 0)
@@ -179,6 +220,7 @@ async def agentic_planner_node(
         primer=profile.primer,
         catalog=build_tool_catalog(registry, profile=profile),
         primitives_catalog=build_primitives_catalog(registry),
+        playbooks_catalog=build_playbook_catalog(playbooks or [], profile=profile),
     )
 
     executed: list[DataStep] = list(state.get("executed_steps", []))

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -469,6 +469,9 @@ def _make_lifespan(
                     # system-context block folded into its primer.
                     profile=effective_profile,
                     registry=harness.tools,
+                    # Phase 4: the resolved skills bundle so the planner can
+                    # surface this tenant's eligible connection-bound playbooks.
+                    context_skills=harness.context_skills,
                 )
                 harness.meta_model = get_chat_model(
                     settings.intent_router_model,

--- a/miot-harness/src/miot_harness/context_skills/registry.py
+++ b/miot-harness/src/miot_harness/context_skills/registry.py
@@ -165,6 +165,11 @@ class ContextSkillsBundle:
                     description=skill.description,
                     when_to_use=skill.when_to_use,
                     scope=skill.scope.kind,
+                    # Connection / capability the skill binds to (Phase 4); None
+                    # when unbound. The loader already gated eligibility, so a
+                    # surfaced bound skill is one whose connection is live.
+                    connection=skill.connection,
+                    requires_capability=skill.requires_capability,
                     source=(
                         # Match the basename, not a suffix: a substring
                         # check would misbadge e.g. `foo-skill.md`.

--- a/miot-harness/src/miot_harness/context_skills/skill_models.py
+++ b/miot-harness/src/miot_harness/context_skills/skill_models.py
@@ -121,3 +121,9 @@ class SkillSummary(BaseModel):
     when_to_use: str = ""
     scope: Literal["global", "tenant"] = "global"
     source: Literal["skill_md", "manifest"] = "manifest"
+    # Phase 4 connection binding, surfaced so a `/skills` picker can badge a
+    # skill with the connection / capability it lights up for. None when the
+    # skill is unbound (eligible everywhere). The skill only appears at all when
+    # its binding is already satisfied (the loader gates eligibility at boot).
+    connection: str | None = None
+    requires_capability: str | None = None

--- a/miot-harness/src/miot_harness/runtime/agentic_graph.py
+++ b/miot-harness/src/miot_harness/runtime/agentic_graph.py
@@ -42,6 +42,7 @@ from miot_harness.agents.freshness_judge import freshness_judge_node
 from miot_harness.agents.synthesizer import synthesizer_node
 from miot_harness.agents.verifier import REPLAN, verify_node
 from miot_harness.config import HarnessSettings
+from miot_harness.context_skills.registry import ContextSkillsBundle
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.provenance import ProvenanceEntry, ProvenanceLog
 from miot_harness.runtime.context import HarnessContext
@@ -98,11 +99,18 @@ def build_agentic_graph(
     provenance_log: ProvenanceLog | None,
     profile: DataSourceProfile,
     registry: ToolRegistry,
+    context_skills: ContextSkillsBundle | None = None,
 ) -> Any:
     """Compile and return the LangGraph agentic StateGraph.
 
     `provenance_log` receives one entry per executed step (question, sql,
     rows, refreshed_at). Pass None for tests that don't need recording.
+
+    `context_skills` is the resolved bundle (Phase 4). When present, the planner
+    is handed the requesting tenant's eligible connection-bound playbooks so it
+    can follow a ready-made recipe instead of rediscovering it. None disables the
+    surface (no playbook section in the prompt) — back-compat for tests/boots
+    where the subsystem failed to load.
     """
 
     graph = StateGraph(DataState)
@@ -137,6 +145,13 @@ def build_agentic_graph(
     async def planner(state: DataState) -> dict[str, Any]:
         ctx: HarnessContext = cast(dict[str, Any], state)["ctx"]
         buf, progress = _make_event_buffer()
+        # Phase 4: hand the planner this tenant's eligible connection-bound
+        # playbooks. The bundle already gated connection/capability eligibility
+        # at boot; playbooks_for layers tenant over global. build_playbook_catalog
+        # further drops any bound to a different connection than this profile.
+        playbooks = (
+            context_skills.playbooks_for(ctx.tenant_id) if context_skills else None
+        )
         delta = await agentic_planner_node(
             cast(dict[str, Any], state),
             registry=registry,
@@ -146,6 +161,7 @@ def build_agentic_graph(
             ),
             profile=profile,
             max_turns=max_turns,
+            playbooks=playbooks,
         )
         return _merge_events(delta, buf)
 

--- a/miot-harness/tests/agents/test_agentic_planner.py
+++ b/miot-harness/tests/agents/test_agentic_planner.py
@@ -11,7 +11,11 @@ from langchain_core.language_models import FakeListChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from pydantic import BaseModel
 
-from miot_harness.agents.agentic_planner import agentic_planner_node
+from miot_harness.agents.agentic_planner import (
+    agentic_planner_node,
+    build_playbook_catalog,
+)
+from miot_harness.context_skills.skill_models import LoadedSkill, PlaybookSkill
 from miot_harness.integrations.nexo.provider import NEXO_PROFILE
 from miot_harness.runtime.context import HarnessContext
 from miot_harness.runtime.permissions import PermissionResult
@@ -470,3 +474,126 @@ async def test_planner_prompt_lists_curated_and_primitive_catalogs() -> None:
     system = captured[0][0].content
     assert "coordinador_centro_control" in system
     assert "nexo_select" in system
+
+
+# ---- Phase 4 slice 2: connection-bound playbook surfacing ----------------
+
+
+def _pb(
+    id: str,
+    *,
+    connection: str | None = None,
+    when_to_use: str = "",
+    description: str = "",
+    tools: tuple[str, ...] = (),
+) -> LoadedSkill:
+    return LoadedSkill(
+        skill=PlaybookSkill(
+            kind="playbook",
+            id=id,
+            name=id.upper(),
+            connection=connection,
+            when_to_use=when_to_use,
+            description=description,
+            tools=tools,
+        ),
+        source_path=f"{id}.yaml",
+    )
+
+
+def test_build_playbook_catalog_renders_marker_trigger_and_steps() -> None:
+    catalog = build_playbook_catalog(
+        [
+            _pb(
+                "nexo-services",
+                connection="nexo",
+                when_to_use="list services in a workflow step",
+                tools=("coordinador_centro_control", "nexo_select"),
+            )
+        ],
+        profile=NEXO_PROFILE,
+    )
+    assert "[connection: nexo]" in catalog
+    assert "list services in a workflow step" in catalog
+    assert "coordinador_centro_control → nexo_select" in catalog
+
+
+def test_build_playbook_catalog_drops_playbook_bound_to_other_connection() -> None:
+    # Bound to `acs`; this planner's profile is `nexo` → its tools carry the
+    # wrong prefix and would be rejected, so it must not be advertised.
+    catalog = build_playbook_catalog(
+        [_pb("acs-pb", connection="acs", when_to_use="alfresco workflow")],
+        profile=NEXO_PROFILE,
+    )
+    assert "acs-pb" not in catalog.lower()
+    assert catalog == "(no playbooks bound to this data source)"
+
+
+def test_build_playbook_catalog_keeps_unbound_playbook_for_any_profile() -> None:
+    catalog = build_playbook_catalog(
+        [_pb("generic", when_to_use="works anywhere")],
+        profile=NEXO_PROFILE,
+    )
+    assert "GENERIC" in catalog
+    assert "[connection:" not in catalog  # unbound → no marker
+    assert "works anywhere" in catalog
+
+
+def test_build_playbook_catalog_falls_back_to_description_then_empty() -> None:
+    catalog = build_playbook_catalog(
+        [_pb("d", connection="nexo", description="desc fallback")],
+        profile=NEXO_PROFILE,
+    )
+    assert "desc fallback" in catalog
+    assert build_playbook_catalog([], profile=NEXO_PROFILE) == (
+        "(no playbooks bound to this data source)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_planner_prompt_lists_matching_playbook() -> None:
+    captured: list[list[Any]] = []
+
+    class _RecordingModel(FakeListChatModel):
+        async def ainvoke(self, input, *args, **kwargs):  # type: ignore[override]
+            captured.append(list(input))
+            return await super().ainvoke(input, *args, **kwargs)
+
+    response = json.dumps({"action": "final", "reasoning": "done"})
+    await agentic_planner_node(
+        _state(evidence=[_evidence()]),
+        registry=_registry(),
+        model=_RecordingModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+        playbooks=[
+            _pb("nexo-services", connection="nexo", when_to_use="enumerate services"),
+            _pb("acs-pb", connection="acs", when_to_use="other connection"),
+        ],
+    )
+    system = captured[0][0].content
+    assert "Connection playbooks" in system
+    assert "enumerate services" in system
+    assert "other connection" not in system  # bound to a different connection
+
+
+@pytest.mark.asyncio
+async def test_planner_prompt_handles_no_playbooks() -> None:
+    captured: list[list[Any]] = []
+
+    class _RecordingModel(FakeListChatModel):
+        async def ainvoke(self, input, *args, **kwargs):  # type: ignore[override]
+            captured.append(list(input))
+            return await super().ainvoke(input, *args, **kwargs)
+
+    response = json.dumps({"action": "final", "reasoning": "done"})
+    # playbooks omitted (None) — back-compat, no crash, placeholder rendered.
+    await agentic_planner_node(
+        _state(evidence=[_evidence()]),
+        registry=_registry(),
+        model=_RecordingModel(responses=[response]),
+        profile=NEXO_PROFILE,
+        max_turns=12,
+    )
+    system = captured[0][0].content
+    assert "(no playbooks bound to this data source)" in system

--- a/miot-harness/tests/context_skills/test_bundle_layering.py
+++ b/miot-harness/tests/context_skills/test_bundle_layering.py
@@ -134,6 +134,34 @@ def test_list_skills_projects_summaries_source_scope_and_sort() -> None:
     assert "mintral-only" not in {s.id for s in bundle.list_skills("acme")}
 
 
+def test_list_skills_surfaces_connection_binding_marker() -> None:
+    # Phase 4 slice 2: a bound skill's summary carries the connection /
+    # capability it lights up for; an unbound skill leaves them None.
+    bundle = ContextSkillsBundle(
+        playbook_skills=(
+            LoadedSkill(
+                skill=PlaybookSkill(
+                    kind="playbook",
+                    id="acs-wf",
+                    name="ACS workflow",
+                    connection="acs",
+                    requires_capability="generic_query",
+                ),
+                source_path="/x/acs-wf.yaml",
+            ),
+            LoadedSkill(
+                skill=PlaybookSkill(kind="playbook", id="plain", name="Plain"),
+                source_path="/x/plain.yaml",
+            ),
+        )
+    )
+    by_id = {s.id: s for s in bundle.list_skills("acme")}
+    assert by_id["acs-wf"].connection == "acs"
+    assert by_id["acs-wf"].requires_capability == "generic_query"
+    assert by_id["plain"].connection is None
+    assert by_id["plain"].requires_capability is None
+
+
 def test_activate_skill_returns_name_and_body() -> None:
     bundle = ContextSkillsBundle(
         playbook_skills=(


### PR DESCRIPTION
## What

Phase 4 **slice 2 — connection-aware surfacing**. Eligible connection-bound playbooks now reach the agentic **planner catalog** and the `/skills` index, so the agent can follow a ready-made recipe instead of rediscovering the joins/columns the cold Phase 3 run had to.

Builds on slice 1 (#806 binding model + loader gating, #814 `known`-nullable follow-up), both merged.

## Changes

- **Planner catalog** (`agentic_planner.py`): new `build_playbook_catalog` renders the tenant-resolved playbook set into a new `Connection playbooks` prompt section — trigger (`when_to_use`), the ordered tool steps, and a `[connection: <name>]` marker. A new Rule tells the planner to emit a matching playbook's steps as its plan.
  - Playbooks bound to a **different** connection than the planner's profile are dropped: their prefixed tools would fail the existing step scope-check, so advertising them is only noise. Unbound playbooks show for every profile.
- **Wiring**: `agentic_planner_node` takes an optional `playbooks` list; the graph's `planner` closure resolves `bundle.playbooks_for(ctx.tenant_id)`, and `build_agentic_graph` threads the resolved `context_skills` bundle from the lifespan. `None` disables the surface (back-compat for tests / a skills-boot failure). The bundle already gated connection/capability eligibility at boot, so every entry here is live.
- **`/skills` marker**: `SkillSummary` gains `connection` / `requires_capability`, populated in `list_skills`, so a picker can badge which connection a skill lights up for. `None` when unbound.

Prompt stays **lean**: one catalog line per playbook (progressive disclosure), not the Markdown body — honoring the GATE-A decision "catalog + on-demand, NOT always-on injection".

## Tests

- `build_playbook_catalog`: marker/trigger/steps rendering, other-connection drop, unbound-shown-everywhere, `when_to_use`→`description`→empty fallbacks.
- Planner prompt: the `Connection playbooks` section appears with the matching playbook and omits the other-connection one; `None` back-compat renders the placeholder.
- Bundle: `list_skills` carries the connection/capability marker; unbound leaves both `None`.

Full suite: 816 passed, 2 skipped; mypy strict + ruff clean.

## Scope

Surfacing only. Shipping the real `acs` Alfresco-Activiti playbook and the one-plan real-DB smoke is **slice 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #875
