### PR TITLE
fix(conversational): keep a space after RETURNING in wa_* SQL

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/ConversationRepository.java
@@ -46,7 +46,7 @@ public class ConversationRepository {
                 status, last_inbound_at, last_outbound_at, last_message_at,
                 session_expires_at, last_message_preview, unread_count, created_at, updated_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-            RETURNING """ + COLUMNS;
+            RETURNING\s""" + COLUMNS;
 
     // Outbound touch: bump activity timestamps + preview, and fill trip context only when
     // the send carried it (COALESCE keeps prior context for ad-hoc sends).
@@ -61,7 +61,7 @@ public class ConversationRepository {
                 last_message_preview = $7,
                 updated_at = $6
             WHERE id = $1
-            RETURNING """ + COLUMNS;
+            RETURNING\s""" + COLUMNS;
 
     private final Instance<Pool> clientInstance;
 

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/MessageRepository.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/persistence/MessageRepository.java
@@ -34,7 +34,7 @@ public class MessageRepository {
                 error_message, sent_by_user_id, service_code, process_instance_id, metadata,
                 sent_at, delivered_at, read_at, created_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
-            RETURNING """ + COLUMNS;
+            RETURNING\s""" + COLUMNS;
 
     private static final String SELECT_BY_CONVERSATION = "SELECT " + COLUMNS + """
             FROM miot_conversational.wa_message

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/persistence/ConversationalSqlIntegrityTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/persistence/ConversationalSqlIntegrityTest.java
@@ -1,0 +1,41 @@
+package com.microboxlabs.miot.conversational.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against the Java text-block trailing-whitespace strip that glued
+ * {@code RETURNING} to the first returned column (producing {@code RETURNINGid}) — a
+ * syntax error that only surfaces against a real Postgres, never in stubbed unit tests.
+ * Reads the private SQL constants reflectively (no DB needed).
+ */
+class ConversationalSqlIntegrityTest {
+
+    /** RETURNING immediately followed by a non-whitespace char = the glue bug. */
+    private static final Pattern RETURNING_GLUED = Pattern.compile("RETURNING\\S");
+
+    @Test
+    void returningKeywordIsSeparatedFromColumnsInEveryStatement() throws Exception {
+        assertSeparated(MessageRepository.class, "INSERT");
+        assertSeparated(ConversationRepository.class, "INSERT");
+        assertSeparated(ConversationRepository.class, "UPDATE_OUTBOUND");
+    }
+
+    private static void assertSeparated(Class<?> type, String field) throws Exception {
+        String sql = readStaticString(type, field);
+        assertTrue(sql.contains("RETURNING"), field + " is expected to contain a RETURNING clause");
+        assertFalse(
+                RETURNING_GLUED.matcher(sql).find(),
+                type.getSimpleName() + "." + field + " glues RETURNING to the next token:\n" + sql);
+    }
+
+    private static String readStaticString(Class<?> type, String name) throws Exception {
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+}


### PR DESCRIPTION
## What
Fixes `PgException: syntax error at or near "RETURNINGid"` when sending a WhatsApp message.

## Cause
The INSERT/UPDATE SQL ends with a Java text block `RETURNING """ + COLUMNS`. Text blocks **strip trailing whitespace** before the closing `"""`, dropping the space after `RETURNING`, which then concatenates straight onto `COLUMNS` (starts with `id`) → `RETURNINGid, ...`.

Affected: `MessageRepository.INSERT`, `ConversationRepository.INSERT`, `ConversationRepository.UPDATE_OUTBOUND`. Latent — no unit test ran the SQL against a real Postgres, and conversational only just began running on dev (after the chart-0.4.0 deploy).

## Fix
Preserve the space with the text-block `\s` escape (`RETURNING\s""" + COLUMNS`). Added `ConversationalSqlIntegrityTest` — reflects over the private SQL constants and asserts `RETURNING` is never glued to the next token (no DB needed).

## Validation
`mvn -pl miot-conversational test` → **22 run, 0 failures** (incl. the new guard).

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SQL `RETURNING` handling in conversation and message persistence queries to avoid malformed statements.
  * Prevented a whitespace-related issue that could cause returned-row mapping to fail.

* **Tests**
  * Added a safeguard test to verify SQL statements keep `RETURNING` properly separated from the next token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->