### PR TITLE
docs(integration): Event Evidence API reference (POST /v1/stream/events)

### DIFF
--- a/turbo-repo/apps/docs/app/api/downloads/postman/event-evidence/route.ts
+++ b/turbo-repo/apps/docs/app/api/downloads/postman/event-evidence/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+export async function GET() {
+  try {
+    const filePath = join(process.cwd(), 'public', 'collections', 'event-evidence-postman-collection.json')
+    const fileContent = await readFile(filePath, 'utf-8')
+
+    return new NextResponse(fileContent, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': 'attachment; filename="event-evidence-postman-collection.json"',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'File not found' },
+      { status: 404 }
+    )
+  }
+}

--- a/turbo-repo/apps/docs/content/en/integration/api-reference/_meta.ts
+++ b/turbo-repo/apps/docs/content/en/integration/api-reference/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   index: 'Overview',
-  'asset-track': 'Asset Track'
+  'asset-track': 'Asset Track',
+  'event-evidence': 'Event Evidence'
 }

--- a/turbo-repo/apps/docs/content/en/integration/api-reference/event-evidence.mdx
+++ b/turbo-repo/apps/docs/content/en/integration/api-reference/event-evidence.mdx
@@ -1,0 +1,357 @@
+# Event Evidence
+
+Post a domain **event** (a "symptom") together with its **video evidence** in a single multipart request. The video is stored as an object and a small typed JSON **envelope** — carrying a reference to that object — is published to the event bus. This pattern is called **media-by-reference**: the binary never travels on the message bus. A namespaced `event_type` discriminator makes the endpoint extensible to many future symptoms without changing the API.
+
+## Endpoint
+
+```
+POST https://iot.streamhub.cl/v1/stream/events
+```
+
+## Authentication
+
+Requires a valid Bearer token with `stream:write` scope.
+
+```
+Authorization: Bearer <access_token>
+```
+
+→ See **Authentication > API Login** to obtain a token.
+
+## Request
+
+The request is `multipart/form-data` with two part names:
+
+| Part | Content-Type | Required | Description |
+|------|--------------|----------|-------------|
+| `envelope` | `application/json` | **Yes** | The typed event envelope (exactly one part) |
+| `media` | `video/mp4`, `video/h264` | No | Evidence file(s); send a part named `media` once per file (0..N) |
+
+> The file part is literally named **`media`**. To attach several clips, repeat the `media` part. Files are matched to the envelope's `media[]` hints **by order**, not by name.
+
+### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Authorization` | Yes | `Bearer <access_token>` (scope `stream:write`) |
+| `Content-Type` | Yes | `multipart/form-data` (set automatically by most HTTP clients) |
+| `Accept` | Recommended | `application/json` |
+| `X-Request-Id` | No | Request id for tracing; echoed back on the response (one is generated if omitted) |
+
+### Body (EventEnvelope)
+
+The `envelope` part is a typed, versioned JSON document. Send only the essentials — the server enriches the rest.
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "warehouse.restricted_zone.person",
+  "event_id": "evt-7f3a...",
+  "occurred_at": "2026-06-20T14:32:05Z",
+  "severity": "alert",
+  "subject": { "device_id": "cam-bodega-04", "zone_id": "zona-restringida-A" },
+  "detections": [ { "class": "person", "score": 0.97, "bbox": [0.10, 0.20, 0.30, 0.40] } ],
+  "media": [ { "ref": "clip" } ]
+}
+```
+
+> `client_id` is taken from the token — do not send it. `media[]` is optional: you may omit it entirely and just upload the `media` part(s).
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | **Yes** | Envelope schema version. Currently `"1.0"`. |
+| `event_type` | string | **Yes** | Namespaced symptom discriminator from the allowlist (see below). |
+| `event_id` | string | No | Idempotency key. If omitted, the server mints `evt-<uuid>`. |
+| `occurred_at` | string | **Yes** | ISO 8601 timestamp of when the symptom occurred. |
+| `ended_at` | string | No | ISO 8601 end of the window, for long-running symptoms. |
+| `severity` | string | No | `info`, `warning`, `alert`, or `critical`. |
+| `subject` | object | **Yes** | Who / where the event refers to (see below). |
+| `detections` | array | No | Detected objects (see below). |
+| `media` | array | No | Per-file hints, matched to the `media` parts by order (see below). |
+| `attributes` | object | No | Free-form, schema-per-`event_type` (forward-compatible). |
+
+#### subject
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `device_id` | string | **Yes** | Device identifier (e.g. the camera id). |
+| `client_id` | string | No | Normally derived from the token; override allowed. |
+| `zone_id` | string | No | Restricted/relevant zone id. |
+
+> Domain-specific identifiers (e.g. a vehicle's license plate) belong in `attributes`, not `subject`, so the subject stays one coherent domain across all event types.
+
+#### detections[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `class` | string | No | Detected class, e.g. `"person"`. (The wire field name is `class`.) |
+| `score` | number | No | Confidence score, `0..1`. |
+| `bbox` | number[] | No | Normalized bounding box `[x, y, w, h]` in `0..1` (4 values, top-left origin). |
+
+#### media[] (hints only)
+
+All optional — everything else about the media is computed by the server.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ref` | string | No | Informational label for the matching file part. |
+| `duration_seconds` | number | No | Clip duration, if the device knows it. |
+| `checksum_sha256` | string | No | SHA-256 of the file; verified server-side if present. |
+| `source` | string | No | `device` or `generated`. Defaults to `device`. |
+
+### `event_type` allowlist
+
+`event_type` must be a registered symptom. Unknown values are rejected before any storage or publish.
+
+| Value | Description |
+|-------|-------------|
+| `warehouse.restricted_zone.person` | A person detected inside a restricted warehouse zone. |
+
+> The allowlist grows additively — new symptoms are onboarded without an API change. Contact the ModularIoT team to register a new `event_type`.
+
+---
+
+## Response
+
+### Accepted (202)
+
+A lean acknowledgment. The storage location and playback URL are intentionally **not** exposed by the ingest API.
+
+```json
+{
+  "status": "accepted",
+  "event_id": "evt-7f3a...",
+  "media_count": 1
+}
+```
+
+Repeated requests with the same `event_id` are idempotent: the second call returns the cached response with an `Idempotent-Replay: true` header — no duplicate storage or publish.
+
+### Validation Error (400)
+
+A required field is missing or malformed.
+
+```json
+{
+  "status": "error",
+  "code": "validation_error",
+  "details": { "eventType": "event_type is required" }
+}
+```
+
+### Unknown event_type (400)
+
+```json
+{
+  "status": "error",
+  "code": "unknown_event_type",
+  "details": { "event_type": "Unsupported event_type: warehouse.not_a_real_symptom" }
+}
+```
+
+### Checksum Mismatch (400)
+
+Returned when a `checksum_sha256` hint does not match the uploaded file.
+
+```json
+{
+  "status": "error",
+  "code": "checksum_mismatch",
+  "details": { "media[0]": "sha256 mismatch" }
+}
+```
+
+### Unauthorized (401) / Forbidden (403)
+
+`401` when the token is missing or expired; `403` when the token is valid but lacks the `stream:write` scope.
+
+---
+
+## How the Media is Stored (media-by-reference)
+
+1. The uploaded video is stored as an object, **isolated per `client_id`** (multi-tenant via the token).
+2. A small JSON **envelope**, carrying a reference to the stored object, is published to the event bus for downstream consumers (timeline, warehouse projection, playback).
+3. The ingest **response never exposes** the storage location or playback URL — those travel only in the published envelope.
+
+This keeps the request small and the binary off the message bus, while consumers still reach the exact clip by reference.
+
+---
+
+## Postman Collection
+
+<div className="postman-intro">
+  <svg className="postman-logo" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.527.099C6.955-.744.942 3.9.099 10.473c-.843 6.572 3.8 12.584 10.373 13.428 6.573.843 12.587-3.801 13.428-10.374C24.744 6.955 20.101.943 13.527.099zm2.471 7.485a.855.855 0 0 0-.593.25l-4.453 4.453-.307-.307-.643-.643c4.389-4.376 5.18-4.418 5.996-3.753zm-4.863 4.861l4.44-4.44a.62.62 0 1 1 .847.903l-4.699 4.125-.588-.588zm.33.694l-1.1.238a.06.06 0 0 1-.067-.032.06.06 0 0 1 .01-.073l.645-.645.512.512zm-2.803-.459l1.172-1.172.879.878-1.979.426a.074.074 0 0 1-.085-.039.072.072 0 0 1 .013-.093zm-3.646 6.058a.076.076 0 0 1-.069-.083.077.077 0 0 1 .022-.046h.002l.946-.946 1.222 1.222-2.123-.147zm2.425-1.256a.228.228 0 0 0-.117.256l.203.865a.125.125 0 0 1-.211.117h-.003l-.934-.934-.294-.295 3.762-3.758 1.82-.393.874.874c-1.255 1.102-2.971 2.201-5.1 3.268zm5.279-3.428h-.002l-.839-.839 4.699-4.125a.952.952 0 0 0 .119-.127c-.148 1.345-2.029 3.245-3.977 5.091zm3.657-6.46l-.003-.002a1.822 1.822 0 0 1 2.459-2.684l-1.61 1.613a.119.119 0 0 0 0 .169l1.247 1.247a1.817 1.817 0 0 1-2.093-.343zm2.578 0a1.714 1.714 0 0 1-.271.218h-.001l-1.207-1.207 1.533-1.533c.661.72.637 1.832-.054 2.522zM18.855 6.05a.143.143 0 0 0-.053.157.416.416 0 0 1-.053.45.14.14 0 0 0 .023.197.141.141 0 0 0 .084.03.14.14 0 0 0 .106-.05.691.691 0 0 0 .087-.751.138.138 0 0 0-.194-.033z"/></svg>
+  <span>Download our ready-to-use Postman collection (login + 7 example requests):</span>
+</div>
+
+<a href="/api/downloads/postman/event-evidence" download="event-evidence-postman-collection.json" className="download-btn">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+  <span>Download Postman Collection</span>
+</a>
+
+The collection includes:
+- **Authentication** — pre-configured Auth0 login that saves the token automatically
+- **Restricted Zone Person** — canonical envelope + clip
+- **Minimal** — required fields only, clip only
+- **With Hints** — `duration_seconds` / `source` / `checksum_sha256`
+- **Multiple Clips** — two `media` parts
+- **Idempotent Replay** — fixed `event_id`
+- **Unknown event_type / Missing Required Field** — the `400` cases
+
+> Open each request's **Body** tab and attach a real `.mp4` to the `media` file field before sending. The client must have the `stream:write` scope.
+
+---
+
+## Complete Examples
+
+### curl (multipart)
+
+```bash
+# 1) Get a token (must include the stream:write scope)
+TOKEN=$(curl -s --request POST \
+  --url https://api.microboxlabs.com/api/v1/login \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET",
+    "audience": "https://iot.streamhub.cl/v1/asset/track",
+    "grant_type": "client_credentials"
+  }' | jq -r '.access_token')
+
+# 2) Post the event + clip. Note the per-part content types.
+curl --request POST \
+  --url https://iot.streamhub.cl/v1/stream/events \
+  --header "Authorization: Bearer $TOKEN" \
+  --header 'Accept: application/json' \
+  --header 'X-Request-Id: req-001' \
+  --form 'envelope={"schema_version":"1.0","event_type":"warehouse.restricted_zone.person","occurred_at":"2026-06-20T14:32:05Z","severity":"alert","subject":{"device_id":"cam-bodega-04","zone_id":"zona-restringida-A"},"detections":[{"class":"person","score":0.97,"bbox":[0.10,0.20,0.30,0.40]}]};type=application/json' \
+  --form 'media=@./restricted-zone-person.mp4;type=video/mp4'
+```
+
+### Node.js (fetch)
+
+```javascript
+import { readFile } from "node:fs/promises";
+
+const envelope = {
+  schema_version: "1.0",
+  event_type: "warehouse.restricted_zone.person",
+  occurred_at: "2026-06-20T14:32:05Z",
+  severity: "alert",
+  subject: { device_id: "cam-bodega-04", zone_id: "zona-restringida-A" },
+  detections: [{ class: "person", score: 0.97, bbox: [0.1, 0.2, 0.3, 0.4] }],
+};
+
+const form = new FormData();
+form.append("envelope", new Blob([JSON.stringify(envelope)], { type: "application/json" }));
+form.append("media", new Blob([await readFile("restricted-zone-person.mp4")], { type: "video/mp4" }), "clip.mp4");
+
+const res = await fetch("https://iot.streamhub.cl/v1/stream/events", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+    "X-Request-Id": crypto.randomUUID(),
+    // Do NOT set Content-Type — fetch adds the multipart boundary for you.
+  },
+  body: form,
+});
+
+if (!res.ok) throw new Error(`stream/events ${res.status}: ${await res.text()}`);
+console.log(await res.json()); // { status: "accepted", event_id, media_count }
+```
+
+### Python (requests)
+
+```python
+import json, uuid, requests
+
+envelope = {
+    "schema_version": "1.0",
+    "event_type": "warehouse.restricted_zone.person",
+    "occurred_at": "2026-06-20T14:32:05Z",
+    "severity": "alert",
+    "subject": {"device_id": "cam-bodega-04", "zone_id": "zona-restringida-A"},
+    "detections": [{"class": "person", "score": 0.97, "bbox": [0.10, 0.20, 0.30, 0.40]}],
+}
+
+with open("restricted-zone-person.mp4", "rb") as clip:
+    files = {
+        "envelope": (None, json.dumps(envelope), "application/json"),
+        "media": ("clip.mp4", clip, "video/mp4"),
+    }
+    res = requests.post(
+        "https://iot.streamhub.cl/v1/stream/events",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "X-Request-Id": str(uuid.uuid4()),
+        },
+        files=files,
+        timeout=30,
+    )
+
+res.raise_for_status()
+print(res.json())  # {'status': 'accepted', 'event_id': '...', 'media_count': 1}
+```
+
+For **multiple clips**, use a list of tuples (a dict can't repeat the `media` key):
+
+```python
+files = [
+    ("envelope", (None, json.dumps(envelope), "application/json")),
+    ("media", ("front.mp4", open("front.mp4", "rb"), "video/mp4")),
+    ("media", ("aisle.mp4", open("aisle.mp4", "rb"), "video/mp4")),
+]
+```
+
+### Java (HttpClient)
+
+`HttpClient` has no built-in multipart writer, so build the body from ordered byte chunks:
+
+```java
+import java.net.URI;
+import java.net.http.*;
+import java.nio.file.*;
+import java.util.*;
+
+String boundary = "----miot" + UUID.randomUUID();
+String envelope = """
+    {"schema_version":"1.0","event_type":"warehouse.restricted_zone.person",
+     "occurred_at":"2026-06-20T14:32:05Z","severity":"alert",
+     "subject":{"device_id":"cam-bodega-04","zone_id":"zona-restringida-A"},
+     "detections":[{"class":"person","score":0.97,"bbox":[0.10,0.20,0.30,0.40]}]}
+    """;
+
+List<byte[]> parts = new ArrayList<>();
+parts.add(("--" + boundary + "\r\n"
+    + "Content-Disposition: form-data; name=\"envelope\"\r\n"
+    + "Content-Type: application/json\r\n\r\n" + envelope + "\r\n").getBytes());
+parts.add(("--" + boundary + "\r\n"
+    + "Content-Disposition: form-data; name=\"media\"; filename=\"clip.mp4\"\r\n"
+    + "Content-Type: video/mp4\r\n\r\n").getBytes());
+parts.add(Files.readAllBytes(Path.of("restricted-zone-person.mp4")));
+parts.add(("\r\n--" + boundary + "--\r\n").getBytes());
+
+HttpRequest req = HttpRequest.newBuilder(URI.create("https://iot.streamhub.cl/v1/stream/events"))
+    .header("Authorization", "Bearer " + token)
+    .header("Accept", "application/json")
+    .header("X-Request-Id", UUID.randomUUID().toString())
+    .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+    .POST(HttpRequest.BodyPublishers.ofByteArrays(parts))
+    .build();
+
+HttpResponse<String> res = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+if (res.statusCode() >= 300) throw new RuntimeException("stream/events " + res.statusCode() + ": " + res.body());
+```
+
+---
+
+## Notes
+
+- **Multiple clips:** repeat the `media` part and add one hint per file in `media[]` (matched by order). The response `media_count` reflects how many were stored.
+- **Idempotency:** set a stable `event_id` to make retries safe — duplicates are de-duplicated for 24 hours.
+- **Max upload size:** up to 256 MB per request. For larger or many clips, split across events.
+- **Checksums (optional):** include `checksum_sha256` in a `media[]` hint to have the server verify the upload (`shasum -a 256 clip.mp4`). A mismatch returns `400 checksum_mismatch`.

--- a/turbo-repo/apps/docs/content/en/integration/api-reference/index.mdx
+++ b/turbo-repo/apps/docs/content/en/integration/api-reference/index.mdx
@@ -68,6 +68,7 @@ All endpoints return JSON responses with consistent structure.
 | Code | Meaning |
 |------|---------|
 | 200 | Success |
+| 202 | Accepted - Request accepted for asynchronous processing |
 | 400 | Bad Request - Validation error or malformed request |
 | 401 | Unauthorized - Invalid or expired token |
 | 403 | Forbidden - Valid token but insufficient permissions |
@@ -79,5 +80,6 @@ All endpoints return JSON responses with consistent structure.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | POST | `/v1/asset/track` | Send asset tracking data with telemetry |
+| POST | `/v1/stream/events` | Post an event (a "symptom") with video evidence |
 
-→ See **Asset Track** for detailed endpoint documentation.
+→ See **Asset Track** and **Event Evidence** for detailed endpoint documentation.

--- a/turbo-repo/apps/docs/content/es/integration/api-reference/_meta.ts
+++ b/turbo-repo/apps/docs/content/es/integration/api-reference/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   index: 'Descripción General',
-  'asset-track': 'Asset Track'
+  'asset-track': 'Asset Track',
+  'event-evidence': 'Event Evidence'
 }

--- a/turbo-repo/apps/docs/content/es/integration/api-reference/event-evidence.mdx
+++ b/turbo-repo/apps/docs/content/es/integration/api-reference/event-evidence.mdx
@@ -1,0 +1,357 @@
+# Event Evidence
+
+Envía un **evento** de dominio (un "síntoma") junto con su **evidencia en video** en una sola solicitud multipart. El video se guarda como objeto y a su lado se publica en el bus de eventos un pequeño **envelope** JSON tipado que lleva una referencia a ese objeto. Este patrón se llama **media-por-referencia**: el binario nunca viaja por el bus de mensajes. Un discriminador `event_type` con espacio de nombres hace el endpoint extensible a muchos síntomas futuros sin cambiar la API.
+
+## Endpoint
+
+```
+POST https://iot.streamhub.cl/v1/stream/events
+```
+
+## Autenticación
+
+Requiere un token Bearer válido con el scope `stream:write`.
+
+```
+Authorization: Bearer <access_token>
+```
+
+→ Ver **Autenticación > API Login** para obtener un token.
+
+## Solicitud
+
+La solicitud es `multipart/form-data` con dos nombres de parte:
+
+| Parte | Content-Type | Requerido | Descripción |
+|-------|--------------|-----------|-------------|
+| `envelope` | `application/json` | **Sí** | El envelope tipado del evento (exactamente una parte) |
+| `media` | `video/mp4`, `video/h264` | No | Archivo(s) de evidencia; envía una parte llamada `media` por cada archivo (0..N) |
+
+> La parte de archivo se llama literalmente **`media`**. Para adjuntar varios clips, repite la parte `media`. Los archivos se emparejan con los hints `media[]` del envelope **por orden**, no por nombre.
+
+### Headers
+
+| Header | Requerido | Descripción |
+|--------|-----------|-------------|
+| `Authorization` | Sí | `Bearer <access_token>` (scope `stream:write`) |
+| `Content-Type` | Sí | `multipart/form-data` (lo agregan automáticamente la mayoría de los clientes HTTP) |
+| `Accept` | Recomendado | `application/json` |
+| `X-Request-Id` | No | Id de solicitud para trazabilidad; se devuelve en la respuesta (se genera uno si se omite) |
+
+### Body (EventEnvelope)
+
+La parte `envelope` es un documento JSON tipado y versionado. Envía solo lo esencial — el servidor completa el resto.
+
+```json
+{
+  "schema_version": "1.0",
+  "event_type": "warehouse.restricted_zone.person",
+  "event_id": "evt-7f3a...",
+  "occurred_at": "2026-06-20T14:32:05Z",
+  "severity": "alert",
+  "subject": { "device_id": "cam-bodega-04", "zone_id": "zona-restringida-A" },
+  "detections": [ { "class": "person", "score": 0.97, "bbox": [0.10, 0.20, 0.30, 0.40] } ],
+  "media": [ { "ref": "clip" } ]
+}
+```
+
+> `client_id` se obtiene del token — no lo envíes. `media[]` es opcional: puedes omitirlo por completo y solo subir la(s) parte(s) `media`.
+
+### Referencia de Campos
+
+| Campo | Tipo | Requerido | Descripción |
+|-------|------|-----------|-------------|
+| `schema_version` | string | **Sí** | Versión del esquema del envelope. Actualmente `"1.0"`. |
+| `event_type` | string | **Sí** | Discriminador de síntoma con espacio de nombres, de la lista permitida (ver abajo). |
+| `event_id` | string | No | Clave de idempotencia. Si se omite, el servidor genera `evt-<uuid>`. |
+| `occurred_at` | string | **Sí** | Timestamp ISO 8601 de cuándo ocurrió el síntoma. |
+| `ended_at` | string | No | Fin de la ventana (ISO 8601), para síntomas de larga duración. |
+| `severity` | string | No | `info`, `warning`, `alert` o `critical`. |
+| `subject` | object | **Sí** | A quién / dónde se refiere el evento (ver abajo). |
+| `detections` | array | No | Objetos detectados (ver abajo). |
+| `media` | array | No | Hints por archivo, emparejados a las partes `media` por orden (ver abajo). |
+| `attributes` | object | No | Libre, esquema-por-`event_type` (compatible hacia adelante). |
+
+#### subject
+
+| Campo | Tipo | Requerido | Descripción |
+|-------|------|-----------|-------------|
+| `device_id` | string | **Sí** | Identificador del dispositivo (p. ej. el id de la cámara). |
+| `client_id` | string | No | Normalmente se deriva del token; se permite override. |
+| `zone_id` | string | No | Id de la zona restringida/relevante. |
+
+> Los identificadores específicos de dominio (p. ej. la patente de un vehículo) van en `attributes`, no en `subject`, para que el subject mantenga un solo dominio coherente en todos los tipos de evento.
+
+#### detections[]
+
+| Campo | Tipo | Requerido | Descripción |
+|-------|------|-----------|-------------|
+| `class` | string | No | Clase detectada, p. ej. `"person"`. (El nombre del campo en el wire es `class`.) |
+| `score` | number | No | Score de confianza, `0..1`. |
+| `bbox` | number[] | No | Bounding box normalizado `[x, y, w, h]` en `0..1` (4 valores, origen arriba-izquierda). |
+
+#### media[] (solo hints)
+
+Todos opcionales — el servidor calcula todo lo demás del media.
+
+| Campo | Tipo | Requerido | Descripción |
+|-------|------|-----------|-------------|
+| `ref` | string | No | Etiqueta informativa para la parte de archivo correspondiente. |
+| `duration_seconds` | number | No | Duración del clip, si el dispositivo la conoce. |
+| `checksum_sha256` | string | No | SHA-256 del archivo; se verifica en el servidor si está presente. |
+| `source` | string | No | `device` o `generated`. Por defecto `device`. |
+
+### Lista permitida de `event_type`
+
+`event_type` debe ser un síntoma registrado. Los valores desconocidos se rechazan antes de cualquier almacenamiento o publicación.
+
+| Valor | Descripción |
+|-------|-------------|
+| `warehouse.restricted_zone.person` | Una persona detectada dentro de una zona restringida de bodega. |
+
+> La lista crece de forma aditiva — los nuevos síntomas se incorporan sin cambiar la API. Contacta al equipo de ModularIoT para registrar un nuevo `event_type`.
+
+---
+
+## Respuesta
+
+### Aceptado (202)
+
+Un acuse de recibo liviano. La ubicación de almacenamiento y la URL de reproducción **no** se exponen intencionalmente en la API de ingesta.
+
+```json
+{
+  "status": "accepted",
+  "event_id": "evt-7f3a...",
+  "media_count": 1
+}
+```
+
+Las solicitudes repetidas con el mismo `event_id` son idempotentes: la segunda llamada devuelve la respuesta cacheada con el header `Idempotent-Replay: true` — sin duplicar almacenamiento ni publicación.
+
+### Error de Validación (400)
+
+Falta un campo requerido o está mal formado.
+
+```json
+{
+  "status": "error",
+  "code": "validation_error",
+  "details": { "eventType": "event_type is required" }
+}
+```
+
+### event_type Desconocido (400)
+
+```json
+{
+  "status": "error",
+  "code": "unknown_event_type",
+  "details": { "event_type": "Unsupported event_type: warehouse.not_a_real_symptom" }
+}
+```
+
+### Checksum no Coincide (400)
+
+Se devuelve cuando un hint `checksum_sha256` no coincide con el archivo subido.
+
+```json
+{
+  "status": "error",
+  "code": "checksum_mismatch",
+  "details": { "media[0]": "sha256 mismatch" }
+}
+```
+
+### No Autorizado (401) / Prohibido (403)
+
+`401` cuando el token falta o expiró; `403` cuando el token es válido pero no tiene el scope `stream:write`.
+
+---
+
+## Cómo se Almacena el Media (media-por-referencia)
+
+1. El video subido se guarda como objeto, **aislado por `client_id`** (multi-tenant vía el token).
+2. Un pequeño **envelope** JSON, que lleva una referencia al objeto almacenado, se publica en el bus de eventos para los consumidores aguas abajo (timeline, proyección de bodega, reproducción).
+3. La **respuesta de ingesta nunca expone** la ubicación de almacenamiento ni la URL de reproducción — esas viajan solo en el envelope publicado.
+
+Esto mantiene la solicitud pequeña y el binario fuera del bus de mensajes, mientras los consumidores siguen alcanzando el clip exacto por referencia.
+
+---
+
+## Colección Postman
+
+<div className="postman-intro">
+  <svg className="postman-logo" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.527.099C6.955-.744.942 3.9.099 10.473c-.843 6.572 3.8 12.584 10.373 13.428 6.573.843 12.587-3.801 13.428-10.374C24.744 6.955 20.101.943 13.527.099zm2.471 7.485a.855.855 0 0 0-.593.25l-4.453 4.453-.307-.307-.643-.643c4.389-4.376 5.18-4.418 5.996-3.753zm-4.863 4.861l4.44-4.44a.62.62 0 1 1 .847.903l-4.699 4.125-.588-.588zm.33.694l-1.1.238a.06.06 0 0 1-.067-.032.06.06 0 0 1 .01-.073l.645-.645.512.512zm-2.803-.459l1.172-1.172.879.878-1.979.426a.074.074 0 0 1-.085-.039.072.072 0 0 1 .013-.093zm-3.646 6.058a.076.076 0 0 1-.069-.083.077.077 0 0 1 .022-.046h.002l.946-.946 1.222 1.222-2.123-.147zm2.425-1.256a.228.228 0 0 0-.117.256l.203.865a.125.125 0 0 1-.211.117h-.003l-.934-.934-.294-.295 3.762-3.758 1.82-.393.874.874c-1.255 1.102-2.971 2.201-5.1 3.268zm5.279-3.428h-.002l-.839-.839 4.699-4.125a.952.952 0 0 0 .119-.127c-.148 1.345-2.029 3.245-3.977 5.091zm3.657-6.46l-.003-.002a1.822 1.822 0 0 1 2.459-2.684l-1.61 1.613a.119.119 0 0 0 0 .169l1.247 1.247a1.817 1.817 0 0 1-2.093-.343zm2.578 0a1.714 1.714 0 0 1-.271.218h-.001l-1.207-1.207 1.533-1.533c.661.72.637 1.832-.054 2.522zM18.855 6.05a.143.143 0 0 0-.053.157.416.416 0 0 1-.053.45.14.14 0 0 0 .023.197.141.141 0 0 0 .084.03.14.14 0 0 0 .106-.05.691.691 0 0 0 .087-.751.138.138 0 0 0-.194-.033z"/></svg>
+  <span>Descarga nuestra colección Postman lista para usar (login + 7 solicitudes de ejemplo):</span>
+</div>
+
+<a href="/api/downloads/postman/event-evidence" download="event-evidence-postman-collection.json" className="download-btn">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+  <span>Descargar Colección Postman</span>
+</a>
+
+La colección incluye:
+- **Authentication** — login Auth0 preconfigurado que guarda el token automáticamente
+- **Restricted Zone Person** — envelope canónico + clip
+- **Minimal** — solo campos requeridos, solo clip
+- **With Hints** — `duration_seconds` / `source` / `checksum_sha256`
+- **Multiple Clips** — dos partes `media`
+- **Idempotent Replay** — `event_id` fijo
+- **Unknown event_type / Missing Required Field** — los casos `400`
+
+> Abre la pestaña **Body** de cada solicitud y adjunta un `.mp4` real al campo de archivo `media` antes de enviar. El cliente debe tener el scope `stream:write`.
+
+---
+
+## Ejemplos Completos
+
+### curl (multipart)
+
+```bash
+# 1) Obtener un token (debe incluir el scope stream:write)
+TOKEN=$(curl -s --request POST \
+  --url https://api.microboxlabs.com/api/v1/login \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET",
+    "audience": "https://iot.streamhub.cl/v1/asset/track",
+    "grant_type": "client_credentials"
+  }' | jq -r '.access_token')
+
+# 2) Enviar el evento + clip. Nota los content types por parte.
+curl --request POST \
+  --url https://iot.streamhub.cl/v1/stream/events \
+  --header "Authorization: Bearer $TOKEN" \
+  --header 'Accept: application/json' \
+  --header 'X-Request-Id: req-001' \
+  --form 'envelope={"schema_version":"1.0","event_type":"warehouse.restricted_zone.person","occurred_at":"2026-06-20T14:32:05Z","severity":"alert","subject":{"device_id":"cam-bodega-04","zone_id":"zona-restringida-A"},"detections":[{"class":"person","score":0.97,"bbox":[0.10,0.20,0.30,0.40]}]};type=application/json' \
+  --form 'media=@./restricted-zone-person.mp4;type=video/mp4'
+```
+
+### Node.js (fetch)
+
+```javascript
+import { readFile } from "node:fs/promises";
+
+const envelope = {
+  schema_version: "1.0",
+  event_type: "warehouse.restricted_zone.person",
+  occurred_at: "2026-06-20T14:32:05Z",
+  severity: "alert",
+  subject: { device_id: "cam-bodega-04", zone_id: "zona-restringida-A" },
+  detections: [{ class: "person", score: 0.97, bbox: [0.1, 0.2, 0.3, 0.4] }],
+};
+
+const form = new FormData();
+form.append("envelope", new Blob([JSON.stringify(envelope)], { type: "application/json" }));
+form.append("media", new Blob([await readFile("restricted-zone-person.mp4")], { type: "video/mp4" }), "clip.mp4");
+
+const res = await fetch("https://iot.streamhub.cl/v1/stream/events", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+    "X-Request-Id": crypto.randomUUID(),
+    // NO definas Content-Type — fetch agrega el boundary multipart por ti.
+  },
+  body: form,
+});
+
+if (!res.ok) throw new Error(`stream/events ${res.status}: ${await res.text()}`);
+console.log(await res.json()); // { status: "accepted", event_id, media_count }
+```
+
+### Python (requests)
+
+```python
+import json, uuid, requests
+
+envelope = {
+    "schema_version": "1.0",
+    "event_type": "warehouse.restricted_zone.person",
+    "occurred_at": "2026-06-20T14:32:05Z",
+    "severity": "alert",
+    "subject": {"device_id": "cam-bodega-04", "zone_id": "zona-restringida-A"},
+    "detections": [{"class": "person", "score": 0.97, "bbox": [0.10, 0.20, 0.30, 0.40]}],
+}
+
+with open("restricted-zone-person.mp4", "rb") as clip:
+    files = {
+        "envelope": (None, json.dumps(envelope), "application/json"),
+        "media": ("clip.mp4", clip, "video/mp4"),
+    }
+    res = requests.post(
+        "https://iot.streamhub.cl/v1/stream/events",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "X-Request-Id": str(uuid.uuid4()),
+        },
+        files=files,
+        timeout=30,
+    )
+
+res.raise_for_status()
+print(res.json())  # {'status': 'accepted', 'event_id': '...', 'media_count': 1}
+```
+
+Para **varios clips**, usa una lista de tuplas (un dict no puede repetir la clave `media`):
+
+```python
+files = [
+    ("envelope", (None, json.dumps(envelope), "application/json")),
+    ("media", ("front.mp4", open("front.mp4", "rb"), "video/mp4")),
+    ("media", ("aisle.mp4", open("aisle.mp4", "rb"), "video/mp4")),
+]
+```
+
+### Java (HttpClient)
+
+`HttpClient` no tiene escritor multipart incorporado, así que arma el body con chunks de bytes ordenados:
+
+```java
+import java.net.URI;
+import java.net.http.*;
+import java.nio.file.*;
+import java.util.*;
+
+String boundary = "----miot" + UUID.randomUUID();
+String envelope = """
+    {"schema_version":"1.0","event_type":"warehouse.restricted_zone.person",
+     "occurred_at":"2026-06-20T14:32:05Z","severity":"alert",
+     "subject":{"device_id":"cam-bodega-04","zone_id":"zona-restringida-A"},
+     "detections":[{"class":"person","score":0.97,"bbox":[0.10,0.20,0.30,0.40]}]}
+    """;
+
+List<byte[]> parts = new ArrayList<>();
+parts.add(("--" + boundary + "\r\n"
+    + "Content-Disposition: form-data; name=\"envelope\"\r\n"
+    + "Content-Type: application/json\r\n\r\n" + envelope + "\r\n").getBytes());
+parts.add(("--" + boundary + "\r\n"
+    + "Content-Disposition: form-data; name=\"media\"; filename=\"clip.mp4\"\r\n"
+    + "Content-Type: video/mp4\r\n\r\n").getBytes());
+parts.add(Files.readAllBytes(Path.of("restricted-zone-person.mp4")));
+parts.add(("\r\n--" + boundary + "--\r\n").getBytes());
+
+HttpRequest req = HttpRequest.newBuilder(URI.create("https://iot.streamhub.cl/v1/stream/events"))
+    .header("Authorization", "Bearer " + token)
+    .header("Accept", "application/json")
+    .header("X-Request-Id", UUID.randomUUID().toString())
+    .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+    .POST(HttpRequest.BodyPublishers.ofByteArrays(parts))
+    .build();
+
+HttpResponse<String> res = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+if (res.statusCode() >= 300) throw new RuntimeException("stream/events " + res.statusCode() + ": " + res.body());
+```
+
+---
+
+## Notas
+
+- **Varios clips:** repite la parte `media` y agrega un hint por archivo en `media[]` (emparejados por orden). El `media_count` de la respuesta refleja cuántos se almacenaron.
+- **Idempotencia:** define un `event_id` estable para que los reintentos sean seguros — los duplicados se descartan por 24 horas.
+- **Tamaño máximo de subida:** hasta 256 MB por solicitud. Para clips más grandes o muchos clips, divídelos en varios eventos.
+- **Checksums (opcional):** incluye `checksum_sha256` en un hint de `media[]` para que el servidor verifique la subida (`shasum -a 256 clip.mp4`). Una discrepancia devuelve `400 checksum_mismatch`.

--- a/turbo-repo/apps/docs/content/es/integration/api-reference/index.mdx
+++ b/turbo-repo/apps/docs/content/es/integration/api-reference/index.mdx
@@ -68,6 +68,7 @@ Todos los endpoints devuelven respuestas JSON con estructura consistente.
 | Código | Significado |
 |--------|-------------|
 | 200 | Éxito |
+| 202 | Aceptado - Solicitud aceptada para procesamiento asíncrono |
 | 400 | Solicitud Incorrecta - Error de validación o solicitud malformada |
 | 401 | No Autorizado - Token inválido o expirado |
 | 403 | Prohibido - Token válido pero permisos insuficientes |
@@ -79,5 +80,6 @@ Todos los endpoints devuelven respuestas JSON con estructura consistente.
 | Método | Endpoint | Descripción |
 |--------|----------|-------------|
 | POST | `/v1/asset/track` | Enviar datos de seguimiento de activos con telemetría |
+| POST | `/v1/stream/events` | Enviar un evento (un "síntoma") con evidencia en video |
 
-→ Ver **Asset Track** para documentación detallada del endpoint.
+→ Ver **Asset Track** y **Event Evidence** para documentación detallada del endpoint.

--- a/turbo-repo/apps/docs/public/collections/event-evidence-postman-collection.json
+++ b/turbo-repo/apps/docs/public/collections/event-evidence-postman-collection.json
@@ -1,0 +1,512 @@
+{
+  "info": {
+    "_postman_id": "miot-event-evidence-v1",
+    "name": "ModularIoT Event Evidence API",
+    "description": "Ingest a domain event (a \"symptom\") together with its video evidence via `POST /v1/stream/events` (multipart/form-data).\n\n## Setup\n\n1. Import this collection into Postman.\n2. Create an environment with:\n   - `base_url`: https://iot.streamhub.cl\n   - `auth_url`: https://api.microboxlabs.com/api/v1/login\n   - `client_id`: Your client ID\n   - `client_secret`: Your client secret\n   - `audience`: https://iot.streamhub.cl/v1/asset/track\n3. Run **Authentication > Login** first — the token is saved automatically and reused.\n4. In each **Event Evidence** request, open the Body tab and attach a real `.mp4` to the `media` file field before sending.\n\n## Required scope\n\nThe client must be granted the **`stream:write`** scope, otherwise the API returns `403`.\n\n## Contract\n\n- `envelope` part: the typed JSON envelope (Content-Type `application/json`).\n- `media` part(s): the video file(s); repeat the `media` field for multiple clips (matched by order).\n- `client_id` is taken from the token — do not send it.\n- Response: `202 Accepted` with `{ status, event_id, media_count }`. The GCS URI / playback URL are not exposed.\n\n## Documentation\n\nSee https://docs.modulariot.com/integration/api-reference/event-evidence for full API documentation.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{access_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://iot.streamhub.cl",
+      "type": "string"
+    },
+    {
+      "key": "auth_url",
+      "value": "https://api.microboxlabs.com/api/v1/login",
+      "type": "string"
+    },
+    {
+      "key": "client_id",
+      "value": "YOUR_CLIENT_ID",
+      "type": "string"
+    },
+    {
+      "key": "client_secret",
+      "value": "YOUR_CLIENT_SECRET",
+      "type": "string"
+    },
+    {
+      "key": "audience",
+      "value": "https://iot.streamhub.cl/v1/asset/track",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData.access_token) {",
+                  "    pm.collectionVariables.set('access_token', jsonData.access_token);",
+                  "    console.log('Token saved successfully');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"client_id\": \"{{client_id}}\",\n  \"client_secret\": \"{{client_secret}}\",\n  \"audience\": \"{{audience}}\",\n  \"grant_type\": \"client_credentials\"\n}"
+            },
+            "url": {
+              "raw": "{{auth_url}}",
+              "host": [
+                "{{auth_url}}"
+              ]
+            },
+            "description": "Authenticate with Auth0 to get an access token (must include the stream:write scope). The token is saved to collection variables automatically."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Event Evidence",
+      "item": [
+        {
+          "name": "Ingest Event - Restricted Zone Person (inline clip)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 Accepted', function () {",
+                  "    pm.response.to.have.status(202);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.restricted_zone.person\",\"occurred_at\":\"2026-06-20T14:32:05Z\",\"severity\":\"alert\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"},\"detections\":[{\"class\":\"person\",\"score\":0.97,\"bbox\":[0.1,0.2,0.3,0.4]}],\"media\":[{\"ref\":\"clip\"}]}"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach an .mp4 / .h264 clip"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Canonical happy path: an `envelope` JSON part + one `media` file. The server mints `event_id`; `client_id` comes from the token. Attach an .mp4 to the `media` field. Expect 202 with { status, event_id, media_count }."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - Minimal (clip only)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 Accepted', function () {",
+                  "    pm.response.to.have.status(202);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.restricted_zone.person\",\"occurred_at\":\"2026-06-20T14:35:00Z\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"}}"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach an .mp4 / .h264 clip"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Smallest valid request: required fields only, no media[] and no detections. The server synthesizes the media descriptor from the uploaded part."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - With Hints",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 Accepted', function () {",
+                  "    pm.response.to.have.status(202);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.restricted_zone.person\",\"occurred_at\":\"2026-06-20T14:40:00Z\",\"severity\":\"warning\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"},\"detections\":[{\"class\":\"person\",\"score\":0.88,\"bbox\":[0.42,0.3,0.18,0.55]}],\"media\":[{\"ref\":\"clip\",\"duration_seconds\":12.5,\"source\":\"device\"}]}"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach an .mp4 / .h264 clip"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Optional client hints in media[] (duration_seconds, source). Add checksum_sha256 to have the server verify the upload (a mismatch returns 400 checksum_mismatch)."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - Multiple Clips",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 Accepted', function () {",
+                  "    pm.response.to.have.status(202);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.restricted_zone.person\",\"occurred_at\":\"2026-06-20T14:45:00Z\",\"severity\":\"alert\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"},\"media\":[{\"ref\":\"clip-front\"},{\"ref\":\"clip-aisle\"}]}"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach the FIRST clip"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach the SECOND clip"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Two media file parts matched to the media[] hints by order. Attach two .mp4 files. Expect media_count: 2."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - Idempotent Replay",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 202 Accepted', function () {",
+                  "    pm.response.to.have.status(202);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.restricted_zone.person\",\"occurred_at\":\"2026-06-20T14:50:00Z\",\"severity\":\"alert\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"},\"event_id\":\"evt-postman-demo-0001\",\"media\":[{\"ref\":\"clip\"}]}"
+                },
+                {
+                  "key": "media",
+                  "type": "file",
+                  "src": null,
+                  "description": "Attach an .mp4 / .h264 clip"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Explicit event_id. Run twice: the second call returns the cached response with header Idempotent-Replay: true. Change event_id to force a fresh ingest."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - Unknown event_type (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400 Bad Request', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "pm.test('error code is unknown_event_type', function () {",
+                  "    pm.expect(pm.response.json().code).to.eql('unknown_event_type');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"event_type\":\"warehouse.not_a_real_symptom\",\"occurred_at\":\"2026-06-20T14:55:00Z\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"}}"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "event_type not in the allowlist → 400 unknown_event_type. No file needed; validation happens before storage."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest Event - Missing Required Field (400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 400 Bad Request', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "pm.test('error code is validation_error', function () {",
+                  "    pm.expect(pm.response.json().code).to.eql('validation_error');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Request-Id",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "envelope",
+                  "type": "text",
+                  "contentType": "application/json",
+                  "value": "{\"schema_version\":\"1.0\",\"occurred_at\":\"2026-06-20T15:00:00Z\",\"subject\":{\"device_id\":\"cam-bodega-04\",\"zone_id\":\"zona-restringida-A\"}}"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/stream/events",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "stream",
+                "events"
+              ]
+            },
+            "description": "Missing event_type (a required field) → 400 validation_error. No file needed."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds end-user documentation for the new **Event Evidence** ingestion endpoint (`POST /v1/stream/events`) so integrators know how to post an event (a "symptom") with video evidence. Mirrors the existing **Asset Track** reference; bilingual (`en` + `es`).

## Changes

**New page** — `integration/api-reference/event-evidence` (en + es)
- Multipart contract: the `envelope` JSON part + repeated `media` file parts (matched by order)
- Envelope JSON + field-reference tables (`subject`, `detections[]`, `media[]` hints), the `event_type` allowlist
- Responses: `202` lean ack `{ status, event_id, media_count }`; `400` validation / unknown-type / checksum-mismatch; `401`/`403`
- A **media-by-reference** explainer (why the response intentionally hides storage URLs)
- Complete examples: **curl, Node.js (fetch), Python (requests), Java (HttpClient)**

**Navigation & landing**
- Registered in `api-reference/_meta.ts` and the API Reference `index` (endpoint row + `202` status), both locales

**Postman collection**
- `public/collections/event-evidence-postman-collection.json` — Login (token auto-save) + 7 example requests mirroring the Bruno set; the `envelope` part is typed `application/json`
- Served via a parallel route `app/api/downloads/postman/event-evidence/route.ts`, with a download button on the page

## Verification
- `npx next build` → compiles, **235/235 static pages**, both download routes registered
- `npm run check-types` → clean

> Note: the endpoint requires the **`stream:write`** scope — documented prominently on the page and in the collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Event Evidence API reference in English and Spanish, including endpoint details, request format, responses, and usage examples.
  * Added the Event Evidence entry to the API reference navigation and overview pages.
  * Added a downloadable Postman collection for testing the Event Evidence workflow.

* **Bug Fixes**
  * Added clearer handling for missing download files, returning a friendly 404 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->