### PR TITLE
feat(ci): restore docs stack image builds

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -101,6 +101,7 @@ const pathStarts = (prefixes) => [...changedFiles].some((file) => prefixes.some(
 // Stack release notes are bundled into the Next.js app, so the app package,
 // tag, and image intentionally stay in sync with the stack version.
 const appChanged = true;
+const docsChanged = true;
 const modulithChanged = pathStarts(["quarkus-srv/"]);
 
 const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
@@ -109,6 +110,7 @@ const harnessChanged = pathStarts(["miot-harness/"]) || !latestHarnessVersion;
 const appVersion = stackVersion;
 const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : latestModulithVersion;
 const harnessVersion = harnessChanged ? bumpPatch(latestHarnessVersion) : latestHarnessVersion;
+const docsVersion = stackVersion;
 
 if (!appVersion) {
   throw new Error("No app@v* tag exists and the app did not change in this milestone.");
@@ -131,6 +133,11 @@ const plan = {
       version: appVersion,
       tag: `app@v${appVersion}`,
     },
+    docs: {
+      changed: docsChanged,
+      version: docsVersion,
+      tag: `docs@v${docsVersion}`,
+    },
     modulith: {
       changed: modulithChanged,
       version: modulithVersion,
@@ -152,6 +159,9 @@ const outputs = {
   app_changed: String(appChanged),
   app_version: appVersion,
   app_tag: plan.components.app.tag,
+  docs_changed: String(docsChanged),
+  docs_version: docsVersion,
+  docs_tag: plan.components.docs.tag,
   modulith_changed: String(modulithChanged),
   modulith_version: modulithVersion,
   modulith_tag: plan.components.modulith.tag,

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - 'turbo-repo/apps/app/**'
+      - 'turbo-repo/apps/docs/**'
       - 'turbo-repo/packages/ui/**'
       - 'turbo-repo/packages/db/**'
       - 'turbo-repo/packages/typescript-config/**'
@@ -46,6 +47,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
   APP_IMAGE_NAME: miot-app
+  DOCS_IMAGE_NAME: miot-docs
   MODULITH_IMAGE_NAME: miot-srv
   HARNESS_IMAGE_NAME: miot-harness
 
@@ -283,6 +285,8 @@ jobs:
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
+          DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
+          DOCS_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
           HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
@@ -299,6 +303,8 @@ jobs:
             --arg workflow_run_url "$WORKFLOW_RUN_URL" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg docs_image_repository "$DOCS_IMAGE_REPOSITORY" \
+            --arg docs_image_tag "$DOCS_IMAGE_TAG" \
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg harness_image_repository "$HARNESS_IMAGE_REPOSITORY" \
@@ -321,6 +327,12 @@ jobs:
                   tag: ("app@" + $release_version),
                   image_repository: $app_image_repository,
                   image_tag: $app_image_tag
+                },
+                docs: {
+                  version: $release_version,
+                  tag: ("docs@" + $release_version),
+                  image_repository: $docs_image_repository,
+                  image_tag: $docs_image_tag
                 },
                 modulith: {
                   version: $release_version,
@@ -390,6 +402,88 @@ jobs:
         run: |
           {
             echo "# MIOT App Nightly"
+            echo ""
+            echo "- Image: \`${{ steps.image.outputs.image }}\`"
+            echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`sha-${{ needs.metadata.outputs.short_sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-docs:
+    name: Build and publish nightly docs image
+    runs-on: ubuntu-latest
+    needs: metadata
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          ref: ${{ needs.metadata.outputs.head_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: turbo-repo/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: turbo-repo
+
+      - name: Build docs
+        run: npx turbo run build --filter=@modulariot/docs
+        working-directory: turbo-repo
+
+      - name: Prepare Docker context
+        run: |
+          mkdir -p /tmp/build-docs/.next
+          cp -r turbo-repo/apps/docs/.next/standalone /tmp/build-docs/.next/standalone
+          cp -r turbo-repo/apps/docs/.next/static /tmp/build-docs/.next/static
+          cp -r turbo-repo/apps/docs/public /tmp/build-docs/public
+          cp turbo-repo/docker/nextjs.standalone-docs.Dockerfile /tmp/build-docs/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: /tmp/build-docs/
+          file: /tmp/build-docs/nextjs.standalone-docs.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.metadata.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.title=${{ env.DOCS_IMAGE_NAME }}
+            org.opencontainers.image.description=ModularIoT docs nightly build
+            org.opencontainers.image.vendor=MicroboxLabs
+            org.opencontainers.image.revision=${{ needs.metadata.outputs.head_sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          provenance: true
+          sbom: true
+
+      - name: Resolve immutable image reference
+        id: image
+        run: echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Nightly summary
+        run: |
+          {
+            echo "# MIOT Docs Nightly"
             echo ""
             echo "- Image: \`${{ steps.image.outputs.image }}\`"
             echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`sha-${{ needs.metadata.outputs.short_sha }}\`"
@@ -602,7 +696,7 @@ jobs:
   deploy:
     name: Dispatch development environment deploys
     runs-on: ubuntu-latest
-    needs: [metadata, build-app, resolve-modulith, resolve-harness]
+    needs: [metadata, build-app, build-docs, resolve-modulith, resolve-harness]
     permissions:
       contents: read
     environment:
@@ -620,11 +714,15 @@ jobs:
           SHORT_SHA: ${{ needs.metadata.outputs.short_sha }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           APP_TAG: app@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+          DOCS_TAG: docs@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           MODULITH_TAG: modulith@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           HARNESS_TAG: harness@nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           APP_IMAGE_REF: ${{ needs.build-app.outputs.image }}
+          DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
+          DOCS_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
+          DOCS_IMAGE_REF: ${{ needs.build-docs.outputs.image }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: ${{ needs.resolve-modulith.outputs.image_tag }}
           MODULITH_IMAGE_REF: ${{ needs.resolve-modulith.outputs.image }}
@@ -650,11 +748,15 @@ jobs:
             --arg built_at "$BUILT_AT" \
             --arg workflow_run_url "$WORKFLOW_RUN_URL" \
             --arg app_tag "$APP_TAG" \
+            --arg docs_tag "$DOCS_TAG" \
             --arg modulith_tag "$MODULITH_TAG" \
             --arg harness_tag "$HARNESS_TAG" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
             --arg app_image_ref "$APP_IMAGE_REF" \
+            --arg docs_image_repository "$DOCS_IMAGE_REPOSITORY" \
+            --arg docs_image_tag "$DOCS_IMAGE_TAG" \
+            --arg docs_image_ref "$DOCS_IMAGE_REF" \
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
@@ -679,6 +781,12 @@ jobs:
                     image_repository: $app_image_repository,
                     image_tag: $app_image_tag,
                     image_ref: $app_image_ref
+                  },
+                  docs: {
+                    tag: $docs_tag,
+                    image_repository: $docs_image_repository,
+                    image_tag: $docs_image_tag,
+                    image_ref: $docs_image_ref
                   },
                   modulith: {
                     tag: $modulith_tag,

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -22,6 +22,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_OWNER: microboxlabs
   APP_IMAGE_NAME: miot-app
+  DOCS_IMAGE_NAME: miot-docs
   MODULITH_IMAGE_NAME: miot-srv
   HARNESS_IMAGE_NAME: miot-harness
   JAVA_VERSION: "21"
@@ -39,6 +40,9 @@ jobs:
       app_changed: ${{ steps.plan.outputs.app_changed }}
       app_version: ${{ steps.plan.outputs.app_version }}
       app_tag: ${{ steps.plan.outputs.app_tag }}
+      docs_changed: ${{ steps.plan.outputs.docs_changed }}
+      docs_version: ${{ steps.plan.outputs.docs_version }}
+      docs_tag: ${{ steps.plan.outputs.docs_tag }}
       modulith_changed: ${{ steps.plan.outputs.modulith_changed }}
       modulith_version: ${{ steps.plan.outputs.modulith_version }}
       modulith_tag: ${{ steps.plan.outputs.modulith_tag }}
@@ -78,6 +82,7 @@ jobs:
               latest="$(
                 {
                   git tag --list 'app@v*' | sed 's/^app@v//'
+                  git tag --list 'docs@v*' | sed 's/^docs@v//'
                   git tag --list 'modulith@v*' | sed 's/^modulith@v//'
                   git tag --list 'harness@v*' | sed 's/^harness@v//'
                 } | sort -V | tail -1
@@ -219,6 +224,8 @@ jobs:
             .replaceAll("{{stack_tag}}", "${{ steps.plan.outputs.stack_tag }}")
             .replaceAll("{{app_tag}}", "${{ steps.plan.outputs.app_tag }}")
             .replaceAll("{{app_changed}}", "${{ steps.plan.outputs.app_changed }}")
+            .replaceAll("{{docs_tag}}", "${{ steps.plan.outputs.docs_tag }}")
+            .replaceAll("{{docs_changed}}", "${{ steps.plan.outputs.docs_changed }}")
             .replaceAll("{{modulith_tag}}", "${{ steps.plan.outputs.modulith_tag }}")
             .replaceAll("{{modulith_changed}}", "${{ steps.plan.outputs.modulith_changed }}")
             .replaceAll("{{harness_tag}}", "${{ steps.plan.outputs.harness_tag }}")
@@ -289,6 +296,7 @@ jobs:
 
           Components:
           - App: ${{ steps.plan.outputs.app_tag }} (changed: ${{ steps.plan.outputs.app_changed }})
+          - Docs: ${{ steps.plan.outputs.docs_tag }} (changed: ${{ steps.plan.outputs.docs_changed }})
           - Modulith: ${{ steps.plan.outputs.modulith_tag }} (changed: ${{ steps.plan.outputs.modulith_changed }})
           - Harness: ${{ steps.plan.outputs.harness_tag }} (changed: ${{ steps.plan.outputs.harness_changed }})
 
@@ -445,6 +453,11 @@ jobs:
             tags+=("${{ needs.prepare.outputs.app_tag }}")
           fi
 
+          if [[ "${{ needs.prepare.outputs.docs_changed }}" == "true" ]]; then
+            git tag -a "${{ needs.prepare.outputs.docs_tag }}" -m "${{ needs.prepare.outputs.docs_tag }}"
+            tags+=("${{ needs.prepare.outputs.docs_tag }}")
+          fi
+
           if [[ "${{ needs.prepare.outputs.modulith_changed }}" == "true" ]]; then
             git tag -a "${{ needs.prepare.outputs.modulith_tag }}" -m "${{ needs.prepare.outputs.modulith_tag }}"
             tags+=("${{ needs.prepare.outputs.modulith_tag }}")
@@ -468,6 +481,11 @@ jobs:
           if [[ "${{ needs.prepare.outputs.app_changed }}" == "true" ]]; then
             gh release create "${{ needs.prepare.outputs.app_tag }}" \
               --title "${{ needs.prepare.outputs.app_tag }}" \
+              --generate-notes
+          fi
+          if [[ "${{ needs.prepare.outputs.docs_changed }}" == "true" ]]; then
+            gh release create "${{ needs.prepare.outputs.docs_tag }}" \
+              --title "${{ needs.prepare.outputs.docs_tag }}" \
               --generate-notes
           fi
           if [[ "${{ needs.prepare.outputs.modulith_changed }}" == "true" ]]; then
@@ -661,6 +679,10 @@ jobs:
           APP_TAG: ${{ needs.prepare.outputs.app_tag }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: app-v${{ needs.prepare.outputs.app_version }}
+          DOCS_VERSION: ${{ needs.prepare.outputs.docs_version }}
+          DOCS_TAG: ${{ needs.prepare.outputs.docs_tag }}
+          DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
+          DOCS_IMAGE_TAG: docs-v${{ needs.prepare.outputs.docs_version }}
           MODULITH_VERSION: ${{ needs.prepare.outputs.modulith_version }}
           MODULITH_TAG: ${{ needs.prepare.outputs.modulith_tag }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
@@ -684,6 +706,10 @@ jobs:
             --arg app_tag "$APP_TAG" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
+            --arg docs_version "$DOCS_VERSION" \
+            --arg docs_tag "$DOCS_TAG" \
+            --arg docs_image_repository "$DOCS_IMAGE_REPOSITORY" \
+            --arg docs_image_tag "$DOCS_IMAGE_TAG" \
             --arg modulith_version "$MODULITH_VERSION" \
             --arg modulith_tag "$MODULITH_TAG" \
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
@@ -711,6 +737,12 @@ jobs:
                   tag: $app_tag,
                   image_repository: $app_image_repository,
                   image_tag: $app_image_tag
+                },
+                docs: {
+                  version: $docs_version,
+                  tag: $docs_tag,
+                  image_repository: $docs_image_repository,
+                  image_tag: $docs_image_tag
                 },
                 modulith: {
                   version: $modulith_version,
@@ -776,6 +808,79 @@ jobs:
             digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}:app-v${{ needs.prepare.outputs.app_version }}" | awk '/^Digest:/ { print $2; exit }')"
           fi
           echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
+
+  build-docs:
+    name: Resolve docs image
+    runs-on: ubuntu-latest
+    needs: [prepare, tag]
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+        if: needs.prepare.outputs.docs_changed == 'true'
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        if: needs.prepare.outputs.docs_changed == 'true'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: turbo-repo/package-lock.json
+
+      - name: Install dependencies
+        if: needs.prepare.outputs.docs_changed == 'true'
+        run: npm ci
+        working-directory: turbo-repo
+
+      - name: Build docs
+        if: needs.prepare.outputs.docs_changed == 'true'
+        run: npx turbo run build --filter=@modulariot/docs
+        working-directory: turbo-repo
+
+      - name: Stage docs artifact
+        if: needs.prepare.outputs.docs_changed == 'true'
+        run: |
+          mkdir -p build-context/.next
+          cp -r turbo-repo/apps/docs/.next/standalone build-context/.next/standalone
+          cp -r turbo-repo/apps/docs/.next/static build-context/.next/static
+          cp -r turbo-repo/apps/docs/public build-context/public
+          cp turbo-repo/docker/nextjs.standalone-docs.Dockerfile build-context/
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        if: needs.prepare.outputs.docs_changed == 'true'
+        id: docker
+        uses: docker/build-push-action@v6
+        with:
+          context: build-context/
+          file: build-context/nextjs.standalone-docs.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:${{ needs.prepare.outputs.docs_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+          provenance: true
+          sbom: true
+
+      - name: Export image ref
+        id: image
+        run: |
+          if [[ "${{ needs.prepare.outputs.docs_changed }}" == "true" ]]; then
+            digest="${{ steps.docker.outputs.digest }}"
+          else
+            digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}" | awk '/^Digest:/ { print $2; exit }')"
+          fi
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
 
   build-modulith:
     name: Resolve modulith image
@@ -891,7 +996,7 @@ jobs:
   deploy:
     name: Dispatch configured environment deploys
     runs-on: ubuntu-latest
-    needs: [prepare, tag, build-app, build-modulith, build-harness]
+    needs: [prepare, tag, build-app, build-docs, build-modulith, build-harness]
     environment:
       name: app-deploy
     steps:
@@ -907,12 +1012,18 @@ jobs:
           SHORT_SHA: ${{ needs.tag.outputs.short_sha }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           APP_TAG: ${{ needs.prepare.outputs.app_tag }}
+          DOCS_TAG: ${{ needs.prepare.outputs.docs_tag }}
           MODULITH_TAG: ${{ needs.prepare.outputs.modulith_tag }}
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: app-v${{ needs.prepare.outputs.app_version }}
           APP_IMAGE_REF: ${{ needs.build-app.outputs.image }}
           APP_CHANGED: ${{ needs.prepare.outputs.app_changed }}
           APP_VERSION: ${{ needs.prepare.outputs.app_version }}
+          DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
+          DOCS_IMAGE_TAG: docs-v${{ needs.prepare.outputs.docs_version }}
+          DOCS_IMAGE_REF: ${{ needs.build-docs.outputs.image }}
+          DOCS_CHANGED: ${{ needs.prepare.outputs.docs_changed }}
+          DOCS_VERSION: ${{ needs.prepare.outputs.docs_version }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: modulith-v${{ needs.prepare.outputs.modulith_version }}
           MODULITH_IMAGE_REF: ${{ needs.build-modulith.outputs.image }}
@@ -945,12 +1056,18 @@ jobs:
             --arg app_tag "$APP_TAG" \
             --arg app_changed "$APP_CHANGED" \
             --arg app_version "$APP_VERSION" \
+            --arg docs_tag "$DOCS_TAG" \
+            --arg docs_changed "$DOCS_CHANGED" \
+            --arg docs_version "$DOCS_VERSION" \
             --arg modulith_tag "$MODULITH_TAG" \
             --arg modulith_changed "$MODULITH_CHANGED" \
             --arg modulith_version "$MODULITH_VERSION" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
             --arg app_image_ref "$APP_IMAGE_REF" \
+            --arg docs_image_repository "$DOCS_IMAGE_REPOSITORY" \
+            --arg docs_image_tag "$DOCS_IMAGE_TAG" \
+            --arg docs_image_ref "$DOCS_IMAGE_REF" \
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
@@ -980,6 +1097,14 @@ jobs:
                     image_repository: $app_image_repository,
                     image_tag: $app_image_tag,
                     image_ref: $app_image_ref
+                  },
+                  docs: {
+                    changed: ($docs_changed == "true"),
+                    version: $docs_version,
+                    tag: $docs_tag,
+                    image_repository: $docs_image_repository,
+                    image_tag: $docs_image_tag,
+                    image_ref: $docs_image_ref
                   },
                   modulith: {
                     changed: ($modulith_changed == "true"),
@@ -1013,12 +1138,18 @@ jobs:
             --arg app_tag "$APP_TAG" \
             --arg app_changed "$APP_CHANGED" \
             --arg app_version "$APP_VERSION" \
+            --arg docs_tag "$DOCS_TAG" \
+            --arg docs_changed "$DOCS_CHANGED" \
+            --arg docs_version "$DOCS_VERSION" \
             --arg modulith_tag "$MODULITH_TAG" \
             --arg modulith_changed "$MODULITH_CHANGED" \
             --arg modulith_version "$MODULITH_VERSION" \
             --arg app_image_repository "$APP_IMAGE_REPOSITORY" \
             --arg app_image_tag "$APP_IMAGE_TAG" \
             --arg app_image_ref "$APP_IMAGE_REF" \
+            --arg docs_image_repository "$DOCS_IMAGE_REPOSITORY" \
+            --arg docs_image_tag "$DOCS_IMAGE_TAG" \
+            --arg docs_image_ref "$DOCS_IMAGE_REF" \
             --arg modulith_image_repository "$MODULITH_IMAGE_REPOSITORY" \
             --arg modulith_image_tag "$MODULITH_IMAGE_TAG" \
             --arg modulith_image_ref "$MODULITH_IMAGE_REF" \
@@ -1040,11 +1171,15 @@ jobs:
               workflow_run_url: $workflow_run_url,
               manifest_version: 1,
               app_tag: $app_tag,
+              docs_tag: $docs_tag,
               modulith_tag: $modulith_tag,
               harness_tag: $harness_tag,
               app_image_repository: $app_image_repository,
               app_image_tag: $app_image_tag,
               app_image_ref: $app_image_ref,
+              docs_image_repository: $docs_image_repository,
+              docs_image_tag: $docs_image_tag,
+              docs_image_ref: $docs_image_ref,
               modulith_image_repository: $modulith_image_repository,
               modulith_image_tag: $modulith_image_tag,
               modulith_image_ref: $modulith_image_ref,
@@ -1059,6 +1194,14 @@ jobs:
                   image_repository: $app_image_repository,
                   image_tag: $app_image_tag,
                   image_ref: $app_image_ref
+                },
+                docs: {
+                  changed: ($docs_changed == "true"),
+                  version: $docs_version,
+                  tag: $docs_tag,
+                  image_repository: $docs_image_repository,
+                  image_tag: $docs_image_tag,
+                  image_ref: $docs_image_ref
                 },
                 modulith: {
                   changed: ($modulith_changed == "true"),


### PR DESCRIPTION
## Summary
- restore the docs image build in nightly and release-train stack flows
- add docs to stack release planning, component tags, build metadata, dispatch payloads, and release manifests
- publish `ghcr.io/microboxlabs/miot-docs` with nightly, `sha-*`, and `docs-v*` tags

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/app-nightly.yml .github/workflows/app-release-train.yml`\n- `node --check .github/scripts/resolve-stack-release-plan.js`\n- `git diff --check`\n\nCloses #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added docs as a releaseable component in nightly and release-train workflows.
  * Docs images are now built, tagged, and published alongside app releases.
  * Release metadata and deploy payloads now include docs version, tag, and image references.

* **Bug Fixes**
  * Release plans now consistently surface docs-related change status and outputs for downstream automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->