### PR TITLE
fix(integrations): qualify async-job CLAIM key to avoid ambiguous "id" (42702)

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
@@ -43,7 +43,7 @@ public class AsyncJobRepository {
      */
     private static final String CLAIM = """
             WITH runnable AS (
-                SELECT j.id
+                SELECT j.id AS job_id
                 FROM miot_integrations.async_jobs j
                 WHERE j.tenant_code = $1
                   AND j.executor = $2
@@ -73,7 +73,7 @@ public class AsyncJobRepository {
                 attempts = a.attempts + 1,
                 updated_at = now()
             FROM runnable r
-            WHERE a.id = r.id
+            WHERE a.id = r.job_id
             RETURNING %s""".formatted(COLUMNS);
 
     /**

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/persistence/AsyncJobSqlIntegrityTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/persistence/AsyncJobSqlIntegrityTest.java
@@ -1,0 +1,41 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the async-job CLAIM query against the ambiguous-{@code id} regression.
+ *
+ * <p>The claim is an {@code UPDATE ... async_jobs a FROM runnable r}: because the
+ * {@code runnable} CTE and the target table both expose an {@code id}, a bare
+ * {@code id} in the join / {@code RETURNING} resolves to two relations and
+ * PostgreSQL raises {@code 42702 column reference "id" is ambiguous}. The CTE
+ * must therefore project its key under a distinct name ({@code job_id}). This is
+ * a query-analysis error that fires even with zero matching rows, yet never
+ * surfaces in stubbed unit tests — only against a real database.
+ */
+class AsyncJobSqlIntegrityTest {
+
+    @Test
+    void claimJoinsOnDistinctlyNamedKeyToAvoidAmbiguousId() throws Exception {
+        String claim = readStaticString("CLAIM");
+        assertTrue(
+                claim.contains("AS job_id"),
+                "CLAIM's runnable CTE must alias its key as job_id so RETURNING id is unambiguous:\n" + claim);
+        assertTrue(
+                claim.contains("r.job_id"),
+                "CLAIM must join the target table on r.job_id:\n" + claim);
+        assertFalse(
+                claim.contains("r.id"),
+                "CLAIM must not reference r.id — it is ambiguous with the target table's id:\n" + claim);
+    }
+
+    private static String readStaticString(String name) throws Exception {
+        Field field = AsyncJobRepository.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+}


### PR DESCRIPTION
## Problem

With the integration outbox enabled on coordinador-dev, the ECM worker's first `POST /api/v1/orgs/{org}/integrations/jobs/claim` failed with:

```
io.vertx.pgclient.PgException: ERROR: column reference "id" is ambiguous (42702)
```

## Cause

`AsyncJobRepository.CLAIM` is an `UPDATE miot_integrations.async_jobs a FROM runnable r ... RETURNING <COLUMNS>`. The `runnable` CTE projected `j.id`, so **both** the target table `a` and the FROM relation `r` exposed an `id`. The bare `id` in the join (`WHERE a.id = r.id`) and in `RETURNING` (COLUMNS starts with `id`) then resolves to two relations → 42702. This is a query-analysis error, so it fires even with zero matching rows — it just never ran against a real Postgres before (the outbox had not been claimed on dev until now).

## Fix

Project the CTE key under a distinct name and join on it:
- `SELECT j.id` → `SELECT j.id AS job_id`
- `WHERE a.id = r.id` → `WHERE a.id = r.job_id`

`RETURNING id` now unambiguously resolves to `a.id` (the CTE no longer exposes `id`).

## Test

No test exercised `CLAIM` against a real Postgres (only the mocked `AsyncJobServiceTest`), which is why this slipped through — same class of "only-surfaces-against-real-PG" bug as #836. Added `AsyncJobSqlIntegrityTest`, a reflection guard asserting the CTE aliases its key (`AS job_id`, join on `r.job_id`, no `r.id`). `miot-integrations` tests green (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async job claiming so the job identifier is handled consistently, reducing the risk of database query ambiguity.

* **Tests**
  * Added coverage to verify the async job claim query keeps its expected SQL structure and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #841
