### PR TITLE
feat(harness): selectable answer formats (markdown/plain/html/xml/yaml)

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "langchain-anthropic>=1.4.6",
   "langchain-openai>=0.3",
   "langgraph>=1.1",
+  "markdown>=3.9",
   "opentelemetry-api>=1.27",
   "opentelemetry-sdk>=1.27",
   "opentelemetry-exporter-otlp>=1.27",

--- a/miot-harness/src/miot_harness/runtime/answer_render.py
+++ b/miot-harness/src/miot_harness/runtime/answer_render.py
@@ -1,0 +1,70 @@
+"""Render the canonical Markdown answer into a caller-selected format.
+
+The harness response is always JSON; only the `answer` string's content is
+transformed here. Markdown is the canonical source produced by the agents.
+All functions are pure and deterministic (no LLM, no network) so they are
+fully unit-testable. `render_answer` never raises: on any renderer error it
+returns the raw Markdown so a formatting glitch can never fail a run.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import logging
+import re
+from collections.abc import Callable
+from xml.sax.saxutils import escape as _xml_escape
+
+import markdown as _markdown
+import yaml as _yaml
+
+logger = logging.getLogger(__name__)
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _to_html(text: str) -> str:
+    return _markdown.markdown(text)
+
+
+def _to_plain(text: str) -> str:
+    stripped = _TAG_RE.sub("", _markdown.markdown(text))
+    return _html.unescape(stripped).strip()
+
+
+def _to_xml(text: str) -> str:
+    return f'<answer format="markdown">{_xml_escape(text)}</answer>'
+
+
+def _to_yaml(text: str) -> str:
+    return _yaml.safe_dump({"answer": text}, allow_unicode=True, sort_keys=False)
+
+
+# Markdown is the identity case and is handled inline in render_answer.
+_RENDERERS: dict[str, Callable[[str], str]] = {
+    "html": _to_html,
+    "plain": _to_plain,
+    "xml": _to_xml,
+    "yaml": _to_yaml,
+}
+
+
+def render_answer(markdown_text: str | None, fmt: str) -> str | None:
+    """Return `markdown_text` rendered as `fmt`.
+
+    `None` passes through as `None`. `markdown` and any unrecognised format
+    return the input unchanged. Renderer exceptions fall back to the raw
+    Markdown (logged), never propagating.
+    """
+    if markdown_text is None:
+        return None
+    if fmt == "markdown":
+        return markdown_text
+    renderer = _RENDERERS.get(fmt)
+    if renderer is None:
+        return markdown_text
+    try:
+        return renderer(markdown_text)
+    except Exception:  # noqa: BLE001 — rendering must never fail a run
+        logger.exception("answer render failed for format=%s; using raw markdown", fmt)
+        return markdown_text

--- a/miot-harness/src/miot_harness/runtime/answer_render.py
+++ b/miot-harness/src/miot_harness/runtime/answer_render.py
@@ -49,6 +49,29 @@ _RENDERERS: dict[str, Callable[[str], str]] = {
 }
 
 
+def render_answer_with_format(markdown_text: str | None, fmt: str) -> tuple[str | None, str]:
+    """Render `markdown_text` as `fmt`, returning (result, effective_fmt).
+
+    `effective_fmt` is `fmt` only when the result is genuinely in that format.
+    It is "markdown" whenever the result is the raw Markdown string — an
+    unknown format or a renderer-error fallback — so callers can echo a format
+    that actually matches the bytes they return. A None answer preserves the
+    requested `fmt` (there is no string to mislabel).
+    """
+    if markdown_text is None:
+        return None, fmt
+    if fmt == "markdown":
+        return markdown_text, "markdown"
+    renderer = _RENDERERS.get(fmt)
+    if renderer is None:
+        return markdown_text, "markdown"
+    try:
+        return renderer(markdown_text), fmt
+    except Exception:  # noqa: BLE001 — rendering must never fail a run
+        logger.exception("answer render failed for format=%s; using raw markdown", fmt)
+        return markdown_text, "markdown"
+
+
 def render_answer(markdown_text: str | None, fmt: str) -> str | None:
     """Return `markdown_text` rendered as `fmt`.
 
@@ -56,15 +79,4 @@ def render_answer(markdown_text: str | None, fmt: str) -> str | None:
     return the input unchanged. Renderer exceptions fall back to the raw
     Markdown (logged), never propagating.
     """
-    if markdown_text is None:
-        return None
-    if fmt == "markdown":
-        return markdown_text
-    renderer = _RENDERERS.get(fmt)
-    if renderer is None:
-        return markdown_text
-    try:
-        return renderer(markdown_text)
-    except Exception:  # noqa: BLE001 — rendering must never fail a run
-        logger.exception("answer render failed for format=%s; using raw markdown", fmt)
-        return markdown_text
+    return render_answer_with_format(markdown_text, fmt)[0]

--- a/miot-harness/src/miot_harness/runtime/answer_render.py
+++ b/miot-harness/src/miot_harness/runtime/answer_render.py
@@ -15,7 +15,7 @@ import re
 from collections.abc import Callable
 from xml.sax.saxutils import escape as _xml_escape
 
-import markdown as _markdown
+import markdown as _markdown  # type: ignore[import-untyped]
 import yaml as _yaml
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ _TAG_RE = re.compile(r"<[^>]+>")
 
 
 def _to_html(text: str) -> str:
-    return _markdown.markdown(text)
+    return str(_markdown.markdown(text))
 
 
 def _to_plain(text: str) -> str:
@@ -37,7 +37,7 @@ def _to_xml(text: str) -> str:
 
 
 def _to_yaml(text: str) -> str:
-    return _yaml.safe_dump({"answer": text}, allow_unicode=True, sort_keys=False)
+    return str(_yaml.safe_dump({"answer": text}, allow_unicode=True, sort_keys=False))
 
 
 # Markdown is the identity case and is handled inline in render_answer.

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -17,6 +17,11 @@ from miot_harness.runtime.permissions import (
 # operator debugging.
 RunMode = Literal["auto", "canned", "meta", "agentic"]
 
+# The output format for the run's `answer` string. The JSON response envelope
+# never changes; only the encoding of `answer` does. "markdown" is canonical
+# (what the agents emit) and the default when a caller omits the field.
+AnswerFormat = Literal["markdown", "plain", "html", "xml", "yaml"]
+
 
 class HarnessContext(BaseModel):
     # ApprovalRegistry is a process-local handle, not a serializable
@@ -32,6 +37,9 @@ class HarnessContext(BaseModel):
     # Phase E (plan 13): the mode the caller requested. Set from
     # `UserRequest.mode` so per-mode cost can split in Langfuse panels.
     mode: RunMode = "auto"
+    # The caller-requested output format for the final answer string. Read by
+    # HarnessSupervisor._finalize_answer to render record.answer before save.
+    answer_format: AnswerFormat = "markdown"
     # Phase E10 (plan 13): the multi-turn conversation id, if any.
     # Used as the Langfuse `session_id` (falls back to `thread_id`).
     conversation_id: str | None = None
@@ -88,6 +96,8 @@ class UserRequest(BaseModel):
     # policy, then the tenant default.
     permission_mode: PermissionMode | None = None
     rules: list[PermissionRule] = Field(default_factory=list)
+    # Output format for the response `answer` string (default markdown).
+    answer_format: AnswerFormat = "markdown"
 
     def to_context(self) -> HarnessContext:
         # NOTE: the policy built here is UNGATED — the bypass policy gate
@@ -110,5 +120,6 @@ class UserRequest(BaseModel):
             mode=self.mode,
             conversation_id=self.conversation_id,
             debug=self.debug,
+            answer_format=self.answer_format,
             permission_policy=policy,
         )

--- a/miot-harness/src/miot_harness/runtime/run_store.py
+++ b/miot-harness/src/miot_harness/runtime/run_store.py
@@ -16,6 +16,8 @@ class HarnessRunRecord(BaseModel):
     # The format `answer` was rendered in (see runtime.answer_render). Echoed so
     # callers know how to interpret the string. Default keeps legacy persisted
     # records (written before this field existed) loadable.
+    # Security note: the "html" format is unsanitized Markdown-to-HTML;
+    # consumers that inject it into a DOM must sanitize to prevent XSS.
     answer_format: str = "markdown"
     # Phase E (plan 13): the conversation this run belongs to. None for
     # one-shot requests; set when the caller passes `conversation_id`.

--- a/miot-harness/src/miot_harness/runtime/run_store.py
+++ b/miot-harness/src/miot_harness/runtime/run_store.py
@@ -13,6 +13,10 @@ class HarnessRunRecord(BaseModel):
     events: list[HarnessEvent] = Field(default_factory=list)
     artifacts: list[dict[str, Any]] = Field(default_factory=list)
     answer: str | None = None
+    # The format `answer` was rendered in (see runtime.answer_render). Echoed so
+    # callers know how to interpret the string. Default keeps legacy persisted
+    # records (written before this field existed) loadable.
+    answer_format: str = "markdown"
     # Phase E (plan 13): the conversation this run belongs to. None for
     # one-shot requests; set when the caller passes `conversation_id`.
     # Langfuse groups runs by this attribute.

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -40,7 +40,7 @@ from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.context_skills.registry import ContextSkillsBundle
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.spans import agent_span
-from miot_harness.runtime.answer_render import render_answer
+from miot_harness.runtime.answer_render import render_answer_with_format
 from miot_harness.runtime.approvals import ApprovalRegistry
 from miot_harness.runtime.context import HarnessContext, UserRequest
 from miot_harness.runtime.conversation import (
@@ -307,10 +307,15 @@ class HarnessSupervisor:
 
         Must be called AFTER any ConversationStore append (history stores the
         canonical Markdown) and immediately BEFORE persisting the record.
-        None-safe; render_answer never raises.
+        None-safe; render_answer_with_format never raises.
+
+        Must be called exactly once per run: it mutates `record.answer` in
+        place, so re-finalizing a non-markdown answer would double-render and
+        corrupt it.
         """
-        record.answer_format = ctx.answer_format
-        record.answer = render_answer(record.answer, ctx.answer_format)
+        rendered, effective_fmt = render_answer_with_format(record.answer, ctx.answer_format)
+        record.answer = rendered
+        record.answer_format = effective_fmt
 
     def _emit(self, record: HarnessRunRecord, event: HarnessEvent) -> None:
         """Single funnel for landing a `HarnessEvent` on a run record.

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -40,6 +40,7 @@ from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.context_skills.registry import ContextSkillsBundle
 from miot_harness.datasource.provider import DataSourceProfile
 from miot_harness.observability.spans import agent_span
+from miot_harness.runtime.answer_render import render_answer
 from miot_harness.runtime.approvals import ApprovalRegistry
 from miot_harness.runtime.context import HarnessContext, UserRequest
 from miot_harness.runtime.conversation import (
@@ -199,6 +200,7 @@ class HarnessSupervisor:
                     },
                 )
             )
+            self._finalize_answer(record, ctx)
             self.run_store.save(record)
             self._close_bus(ctx.run_id)
             return record
@@ -256,6 +258,7 @@ class HarnessSupervisor:
                     data={"error": "cancelled", "reason": "cancelled"},
                 )
             )
+            self._finalize_answer(record, ctx)
             self.run_store.save(record)
             self._close_bus(ctx.run_id)
             raise
@@ -277,6 +280,7 @@ class HarnessSupervisor:
                     data={"error": str(exc)},
                 )
             )
+            self._finalize_answer(record, ctx)
             self.run_store.save(record)
             self._close_bus(ctx.run_id)
             return record
@@ -293,9 +297,20 @@ class HarnessSupervisor:
 
         record.status = "completed"
         progress(HarnessEvent(run_id=ctx.run_id, type="run.completed", message="Run completed"))
+        self._finalize_answer(record, ctx)
         self.run_store.save(record)
         self._close_bus(ctx.run_id)
         return record
+
+    def _finalize_answer(self, record: HarnessRunRecord, ctx: HarnessContext) -> None:
+        """Render `record.answer` into the caller-requested format in place.
+
+        Must be called AFTER any ConversationStore append (history stores the
+        canonical Markdown) and immediately BEFORE persisting the record.
+        None-safe; render_answer never raises.
+        """
+        record.answer_format = ctx.answer_format
+        record.answer = render_answer(record.answer, ctx.answer_format)
 
     def _emit(self, record: HarnessRunRecord, event: HarnessEvent) -> None:
         """Single funnel for landing a `HarnessEvent` on a run record.

--- a/miot-harness/tests/api/test_runs_answer_format.py
+++ b/miot-harness/tests/api/test_runs_answer_format.py
@@ -1,0 +1,86 @@
+"""End-to-end FastAPI tests for the answer_format feature on POST /runs.
+
+Drives the real FastAPI app (via TestClient) with the same env-isolation and
+supervisor setup used by tests/api/test_runs_stream.py.  No production-code
+stubs are introduced — the renderer (answer_render.py) and supervisor wiring
+from Tasks 1-4 are exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from miot_harness.api.server import create_app
+from miot_harness.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clean_settings_and_workspace(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Per-test isolation: scrub datasource env vars, pin workspace to tmp."""
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
+    monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    """A TestClient wired to a fresh app instance with no auth or datasource."""
+    app = create_app()
+    with TestClient(app) as tc:
+        yield tc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_format_defaults_to_markdown(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer_format"] == "markdown"
+    assert isinstance(body["answer"], str)
+
+
+def test_invalid_format_is_rejected_422(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "pdf"})
+    assert resp.status_code == 422
+
+
+def test_yaml_format_round_trips(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "yaml"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer_format"] == "yaml"
+    loaded = yaml.safe_load(body["answer"])
+    assert isinstance(loaded, dict)
+    assert set(loaded.keys()) == {"answer"}
+
+
+def test_xml_format_is_well_formed(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "xml"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer_format"] == "xml"
+    root = ET.fromstring(body["answer"])
+    assert root.tag == "answer"
+
+
+def test_html_format_contains_markup(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "html"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer_format"] == "html"
+    assert "<" in body["answer"]

--- a/miot-harness/tests/runtime/test_answer_render.py
+++ b/miot-harness/tests/runtime/test_answer_render.py
@@ -1,3 +1,4 @@
+import re
 import xml.etree.ElementTree as ET
 
 import yaml
@@ -30,7 +31,7 @@ def test_plain_strips_markup_and_unescapes_entities():
     out = render_answer(MD, "plain")
     assert "Title" in out
     assert "Use A & B when x < y" in out
-    assert "</" not in out and "#" not in out
+    assert not re.search(r"<[a-zA-Z/]", out) and "#" not in out
 
 
 def test_yaml_round_trips_to_the_markdown_string():

--- a/miot-harness/tests/runtime/test_answer_render.py
+++ b/miot-harness/tests/runtime/test_answer_render.py
@@ -1,0 +1,56 @@
+import xml.etree.ElementTree as ET
+
+import yaml
+
+from miot_harness.runtime.answer_render import render_answer
+
+MD = "# Title\n\nUse A & B when x < y"
+
+
+def test_markdown_is_passthrough():
+    assert render_answer(MD, "markdown") == MD
+
+
+def test_unknown_format_returns_input_unchanged():
+    assert render_answer(MD, "totally-bogus") == MD
+
+
+def test_none_input_returns_none():
+    assert render_answer(None, "html") is None
+
+
+def test_html_renders_markdown_and_escapes():
+    out = render_answer(MD, "html")
+    assert "<h1>Title</h1>" in out
+    assert "A &amp; B" in out
+    assert "x &lt; y" in out
+
+
+def test_plain_strips_markup_and_unescapes_entities():
+    out = render_answer(MD, "plain")
+    assert "Title" in out
+    assert "Use A & B when x < y" in out
+    assert "</" not in out and "#" not in out
+
+
+def test_yaml_round_trips_to_the_markdown_string():
+    out = render_answer(MD, "yaml")
+    assert yaml.safe_load(out) == {"answer": MD}
+
+
+def test_xml_round_trips_to_the_markdown_string():
+    out = render_answer(MD, "xml")
+    root = ET.fromstring(out)
+    assert root.tag == "answer"
+    assert root.attrib == {"format": "markdown"}
+    assert root.text == MD
+
+
+def test_renderer_error_falls_back_to_raw_markdown(monkeypatch):
+    import miot_harness.runtime.answer_render as mod
+
+    def boom(_text):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setitem(mod._RENDERERS, "html", boom)
+    assert render_answer(MD, "html") == MD

--- a/miot-harness/tests/runtime/test_answer_render.py
+++ b/miot-harness/tests/runtime/test_answer_render.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 
 import yaml
 
-from miot_harness.runtime.answer_render import render_answer
+from miot_harness.runtime.answer_render import render_answer, render_answer_with_format
 
 MD = "# Title\n\nUse A & B when x < y"
 
@@ -55,3 +55,42 @@ def test_renderer_error_falls_back_to_raw_markdown(monkeypatch):
 
     monkeypatch.setitem(mod._RENDERERS, "html", boom)
     assert render_answer(MD, "html") == MD
+
+
+# --- render_answer_with_format tests ---
+
+
+def test_render_answer_with_format_yaml_success():
+    result, effective_fmt = render_answer_with_format(MD, "yaml")
+    assert effective_fmt == "yaml"
+    assert yaml.safe_load(result) == {"answer": MD}
+
+
+def test_render_answer_with_format_html_success():
+    result, effective_fmt = render_answer_with_format(MD, "html")
+    assert effective_fmt == "html"
+    assert "<h1>Title</h1>" in result
+
+
+def test_render_answer_with_format_unknown_returns_markdown():
+    result, effective_fmt = render_answer_with_format(MD, "totally-bogus")
+    assert result == MD
+    assert effective_fmt == "markdown"
+
+
+def test_render_answer_with_format_renderer_error_returns_markdown(monkeypatch):
+    import miot_harness.runtime.answer_render as mod
+
+    def boom(_text):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setitem(mod._RENDERERS, "yaml", boom)
+    result, effective_fmt = render_answer_with_format(MD, "yaml")
+    assert result == MD
+    assert effective_fmt == "markdown"
+
+
+def test_render_answer_with_format_none_preserves_requested_fmt():
+    result, effective_fmt = render_answer_with_format(None, "yaml")
+    assert result is None
+    assert effective_fmt == "yaml"

--- a/miot-harness/tests/runtime/test_context_answer_format.py
+++ b/miot-harness/tests/runtime/test_context_answer_format.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from miot_harness.runtime.context import UserRequest
+
+
+def test_answer_format_defaults_to_markdown():
+    req = UserRequest(message="hi")
+    assert req.answer_format == "markdown"
+
+
+@pytest.mark.parametrize("fmt", ["markdown", "plain", "html", "xml", "yaml"])
+def test_answer_format_accepts_valid_values(fmt):
+    assert UserRequest(message="hi", answer_format=fmt).answer_format == fmt
+
+
+def test_answer_format_rejects_invalid_value():
+    with pytest.raises(ValidationError):
+        UserRequest(message="hi", answer_format="pdf")
+
+
+def test_to_context_carries_answer_format():
+    ctx = UserRequest(message="hi", answer_format="yaml").to_context()
+    assert ctx.answer_format == "yaml"

--- a/miot-harness/tests/runtime/test_run_record_answer_format.py
+++ b/miot-harness/tests/runtime/test_run_record_answer_format.py
@@ -1,0 +1,13 @@
+from miot_harness.runtime.run_store import HarnessRunRecord
+
+
+def test_record_defaults_answer_format_to_markdown():
+    rec = HarnessRunRecord(run_id="run_x")
+    assert rec.answer_format == "markdown"
+
+
+def test_legacy_record_without_answer_format_still_loads():
+    # Pre-existing persisted JSON has no answer_format key.
+    rec = HarnessRunRecord.model_validate({"run_id": "run_x", "answer": "hi"})
+    assert rec.answer_format == "markdown"
+    assert rec.answer == "hi"

--- a/miot-harness/tests/runtime/test_supervisor_answer_format.py
+++ b/miot-harness/tests/runtime/test_supervisor_answer_format.py
@@ -1,0 +1,39 @@
+"""Task 4 — HarnessSupervisor._finalize_answer wires render_answer into run().
+
+Tests drive the _finalize_answer helper directly (unit) rather than
+spinning up a full run, so they are fast and deterministic.
+"""
+
+from __future__ import annotations
+
+from miot_harness.runtime.run_store import HarnessRunRecord
+
+
+def test_finalize_answer_renders_record_and_sets_format():
+    from miot_harness.runtime.supervisor import HarnessSupervisor
+
+    rec = HarnessRunRecord(run_id="run_1", answer="# Hi\n\nthere")
+
+    class _Ctx:
+        answer_format = "yaml"
+
+    # _finalize_answer is a pure method (no instance state used); call unbound.
+    HarnessSupervisor._finalize_answer(object.__new__(HarnessSupervisor), rec, _Ctx())
+
+    import yaml
+
+    assert rec.answer_format == "yaml"
+    assert yaml.safe_load(rec.answer) == {"answer": "# Hi\n\nthere"}
+
+
+def test_finalize_answer_is_none_safe():
+    from miot_harness.runtime.supervisor import HarnessSupervisor
+
+    rec = HarnessRunRecord(run_id="run_2", answer=None)
+
+    class _Ctx:
+        answer_format = "html"
+
+    HarnessSupervisor._finalize_answer(object.__new__(HarnessSupervisor), rec, _Ctx())
+    assert rec.answer is None
+    assert rec.answer_format == "html"

--- a/miot-harness/tests/runtime/test_supervisor_answer_format.py
+++ b/miot-harness/tests/runtime/test_supervisor_answer_format.py
@@ -6,6 +6,9 @@ spinning up a full run, so they are fast and deterministic.
 
 from __future__ import annotations
 
+import pytest
+import yaml
+
 from miot_harness.runtime.run_store import HarnessRunRecord
 
 
@@ -19,8 +22,6 @@ def test_finalize_answer_renders_record_and_sets_format():
 
     # _finalize_answer is a pure method (no instance state used); call unbound.
     HarnessSupervisor._finalize_answer(object.__new__(HarnessSupervisor), rec, _Ctx())
-
-    import yaml
 
     assert rec.answer_format == "yaml"
     assert yaml.safe_load(rec.answer) == {"answer": "# Hi\n\nthere"}
@@ -37,3 +38,78 @@ def test_finalize_answer_is_none_safe():
     HarnessSupervisor._finalize_answer(object.__new__(HarnessSupervisor), rec, _Ctx())
     assert rec.answer is None
     assert rec.answer_format == "html"
+
+
+def test_finalize_answer_echo_is_effective_format_on_unknown(monkeypatch):
+    """When the requested format is unknown the effective format echoed back
+    is 'markdown' (the actual content), not the caller-supplied value."""
+    from miot_harness.runtime.supervisor import HarnessSupervisor
+
+    rec = HarnessRunRecord(run_id="run_3", answer="# MD")
+
+    class _Ctx:
+        answer_format = "totally-bogus"
+
+    HarnessSupervisor._finalize_answer(object.__new__(HarnessSupervisor), rec, _Ctx())
+    assert rec.answer == "# MD"
+    assert rec.answer_format == "markdown"
+
+
+# --- Finding 2: ModeAccessDenied terminal path regression guard ---
+
+
+@pytest.mark.asyncio
+async def test_mode_access_denied_answer_is_finalized_as_yaml(tmp_path):
+    """When _resolve_route raises ModeAccessDenied the supervisor must still
+    run _finalize_answer, so the persisted record's answer is rendered in the
+    requested format and answer_format is echoed correctly.
+
+    Trigger: llm_router wired + tenant_lock set + request mode="canned" with a
+    different tenant_id → mode_resolver.resolve_mode raises ModeAccessDenied
+    before any LLM call is made (the mode check is first).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from miot_harness.runtime.context import UserRequest
+    from miot_harness.runtime.intent_router import LLMIntentRouter
+    from miot_harness.runtime.router import IntentRouter
+    from miot_harness.runtime.run_store import JsonRunStore
+    from miot_harness.runtime.supervisor import HarnessSupervisor
+    from miot_harness.storytelling.module import StorytellingModule
+    from miot_harness.tools.registry import ToolRegistry
+
+    # Minimal stub model — ModeAccessDenied fires before any LLM call.
+    mock_model = MagicMock()
+    mock_model.ainvoke = AsyncMock(
+        return_value=MagicMock(content='{"route": "DIRECT", "confidence": 0.9, "reasoning": "x"}')
+    )
+    llm_router = LLMIntentRouter(model=mock_model)
+
+    sup = HarnessSupervisor(
+        router=IntentRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        llm_router=llm_router,
+        tenant_lock="locked-tenant",  # request's tenant_id will not match
+    )
+
+    request = UserRequest(
+        message="show me the data",
+        mode="canned",
+        tenant_id="other-tenant",   # != tenant_lock → ModeAccessDenied
+        answer_format="yaml",
+    )
+
+    record = await sup.run(request)
+
+    # The run must complete (not raise)
+    assert record.status == "completed"
+    # answer must be non-null — it is set from str(exc) before finalize
+    assert record.answer is not None
+    # answer_format must be echoed as "yaml" since str(exc) is Markdown-ish text
+    assert record.answer_format == "yaml"
+    # answer must be valid YAML and parse successfully
+    parsed = yaml.safe_load(record.answer)
+    assert isinstance(parsed, dict)
+    assert "answer" in parsed

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1322,6 +1322,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1408,6 +1417,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "markdown" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -1442,6 +1452,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.6" },
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=1.1" },
+    { name = "markdown", specifier = ">=3.9" },
     { name = "opentelemetry-api", specifier = ">=1.27" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.48b0" },

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
@@ -161,4 +161,33 @@ class HarnessProxyResourcePostTest {
                 .statusCode();
         assertThat(status, is(401));
     }
+
+    @Test
+    void postRunsForwardsAnswerFormatAndEchoesItBack() {
+        // Arrange: stub the Python backend to assert it received answer_format
+        // and to return a record echoing it back. Registered after @BeforeEach's
+        // default /runs stub so WireMock (last-in-first-tried) evaluates this
+        // more specific body-matching stub first.
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        WireMockLifecycle.server().stubFor(WireMock.post(WireMock.urlEqualTo("/runs"))
+                .withRequestBody(
+                        WireMock.matchingJsonPath("$.answer_format", WireMock.equalTo("yaml")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"run_id\":\"run_x\",\"status\":\"completed\","
+                                + "\"answer\":\"answer: hi\\n\",\"answer_format\":\"yaml\"}")));
+
+        // Act + Assert: proxy forwards answer_format to the backend and returns the echo.
+        given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{\"message\":\"hi\",\"answer_format\":\"yaml\"}")
+                .when()
+                .post(RUNS_PATH)
+                .then()
+                .statusCode(200)
+                .body("answer_format", is("yaml"))
+                .body("answer", is("answer: hi\n"));
+    }
 }


### PR DESCRIPTION
Closes #848

## What

Lets a harness API client choose the format the run's `answer` comes back in. The response is **always JSON** (`HarnessRunRecord`) — that envelope never changes; only the content/encoding of the `answer` **string** varies. The client selects it with an `answer_format` field on the `POST /runs` request; omitted → `markdown` (fully backward compatible).

Supported formats: `markdown` (default), `plain`, `html`, `xml`, `yaml`.

## How

- **`runtime/answer_render.py`** — pure, deterministic, LLM-free renderer. Markdown is canonical (what the agents already emit); `html`/`plain` go through the `markdown` lib, `xml` via stdlib escaping, `yaml` via `yaml.safe_dump`. Never raises — on a renderer error it falls back to the raw Markdown.
- **`runtime/context.py`** — `AnswerFormat` literal; `answer_format` on `UserRequest` and `HarnessContext`, threaded through `to_context()`. Invalid values are rejected with `422`.
- **`runtime/supervisor.py`** — a single `_finalize_answer` chokepoint renders `record.answer` before each terminal save. It runs **after** the conversation-history append, so multi-turn history keeps canonical Markdown; the echoed `answer_format` reflects the **effective** format (so a render fallback reports `markdown`, never a lie).
- **`runtime/run_store.py`** — `answer_format` echo field on `HarnessRunRecord` (plain `str`, so legacy persisted records still load).
- **Quarkus proxy** — no production change; it already forwards the body and passes the response through. Added a pass-through/echo test.

## Backward compatibility

`answer` stays `str | None` (never polymorphic). Default `markdown` is a passthrough, so existing clients see no change. New request/response fields are additive.

## Security note

`html` output is unsanitized Markdown→HTML; downstream consumers that inject it into a DOM must sanitize (documented on the field and in error handling).

## Tests

- Renderer unit tests (all formats + fallback + effective-format)
- Context validation, run-record legacy-load, supervisor finalize (incl. mode-denied terminal path), end-to-end `POST /runs` per format, Quarkus proxy pass-through
- Harness suites: **247 passed / 1 skipped**; Quarkus `HarnessProxyResourcePostTest` 6/6; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing the answer output format, including Markdown, plain text, HTML, XML, and YAML.
  * Responses now echo the selected format alongside the generated answer.

* **Bug Fixes**
  * Improved handling so answers still return successfully even if formatting can’t be applied.
  * Preserved backward compatibility for existing records without a stored format.

* **Tests**
  * Added end-to-end and runtime coverage for format selection, validation, rendering, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->