### PR TITLE
feat(miot-chat): real answer streaming, inline loading, no truncation, markdown

### DIFF
--- a/miot-harness/src/miot_harness/agents/llm_streaming.py
+++ b/miot-harness/src/miot_harness/agents/llm_streaming.py
@@ -46,6 +46,7 @@ async def stream_llm_with_thinking(
     thinking_parts: list[str] = []
     text_parts: list[str] = []
     thinking_index = 0
+    answer_index = 0
     thinking_emitted = False
 
     async for event in model.astream_events(messages, version="v2"):
@@ -58,6 +59,19 @@ async def stream_llm_with_thinking(
             if isinstance(content, str):
                 if content:
                     text_parts.append(content)
+                    progress(
+                        HarnessEvent(
+                            run_id=run_id,
+                            type="answer.delta",
+                            message="",
+                            data={
+                                "agent": agent_name,
+                                "delta": content,
+                                "index": answer_index,
+                            },
+                        )
+                    )
+                    answer_index += 1
                 continue
             if not isinstance(content, list):
                 continue
@@ -87,6 +101,19 @@ async def stream_llm_with_thinking(
                     delta = block.get("text") or ""
                     if delta:
                         text_parts.append(delta)
+                        progress(
+                            HarnessEvent(
+                                run_id=run_id,
+                                type="answer.delta",
+                                message="",
+                                data={
+                                    "agent": agent_name,
+                                    "delta": delta,
+                                    "index": answer_index,
+                                },
+                            )
+                        )
+                        answer_index += 1
         elif kind == "on_chat_model_end" and thinking_parts and not thinking_emitted:
             full_thinking = "".join(thinking_parts)
             progress(

--- a/miot-harness/src/miot_harness/runtime/event_types.json
+++ b/miot-harness/src/miot_harness/runtime/event_types.json
@@ -19,6 +19,7 @@
     "usage.recorded",
     "freshness.warning",
     "verification.completed",
+    "answer.delta",
     "answer.completed",
     "run.completed",
     "run.failed"

--- a/miot-harness/src/miot_harness/runtime/events.py
+++ b/miot-harness/src/miot_harness/runtime/events.py
@@ -26,6 +26,7 @@ HarnessEventType = Literal[
     "usage.recorded",
     "freshness.warning",
     "verification.completed",
+    "answer.delta",
     "answer.completed",
     "run.completed",
     "run.failed",

--- a/miot-harness/tests/test_events.py
+++ b/miot-harness/tests/test_events.py
@@ -52,6 +52,7 @@ def test_event_type_full_set_is_pinned():
         "usage.recorded",
         "freshness.warning",
         "verification.completed",
+        "answer.delta",
         "answer.completed",
         "run.completed",
         "run.failed",

--- a/miot-harness/tests/test_llm_streaming.py
+++ b/miot-harness/tests/test_llm_streaming.py
@@ -1,0 +1,80 @@
+"""Verifies stream_llm_with_thinking emits answer.delta for each text
+chunk (in order) and still returns the joined, stripped answer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from miot_harness.agents.llm_streaming import stream_llm_with_thinking
+from miot_harness.runtime.events import HarnessEvent
+
+
+class _FakeChunk:
+    def __init__(self, content: list[dict[str, Any]] | str) -> None:
+        self.content = content
+
+
+class _FakeStreamingModel:
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self._events = events
+
+    async def astream_events(
+        self, _messages, *, version: str = "v2"
+    ) -> AsyncIterator[dict[str, Any]]:
+        assert version == "v2"
+        for evt in self._events:
+            yield evt
+
+
+def _events() -> list[dict[str, Any]]:
+    return [
+        {"event": "on_chat_model_stream",
+         "data": {"chunk": _FakeChunk([{"type": "thinking", "thinking": "hmm "}])}},
+        {"event": "on_chat_model_stream",
+         "data": {"chunk": _FakeChunk([{"type": "text", "text": "Hello "}])}},
+        {"event": "on_chat_model_stream",
+         "data": {"chunk": _FakeChunk([{"type": "text", "text": "world."}])}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emits_answer_delta_per_text_chunk() -> None:
+    emitted: list[HarnessEvent] = []
+    model = _FakeStreamingModel(_events())
+
+    answer = await stream_llm_with_thinking(
+        model=model,  # type: ignore[arg-type]
+        messages=[],
+        progress=emitted.append,
+        run_id="r1",
+        agent_name="synthesizer",
+    )
+
+    deltas = [e for e in emitted if e.type == "answer.delta"]
+    assert [d.data["delta"] for d in deltas] == ["Hello ", "world."]
+    assert [d.data["index"] for d in deltas] == [0, 1]
+    assert all(d.data["agent"] == "synthesizer" for d in deltas)
+    assert answer == "Hello world."
+
+
+@pytest.mark.asyncio
+async def test_string_content_also_emits_answer_delta() -> None:
+    emitted: list[HarnessEvent] = []
+    model = _FakeStreamingModel(
+        [{"event": "on_chat_model_stream",
+          "data": {"chunk": _FakeChunk("plain text")}}]
+    )
+    answer = await stream_llm_with_thinking(
+        model=model,  # type: ignore[arg-type]
+        messages=[],
+        progress=emitted.append,
+        run_id="r1",
+        agent_name="meta",
+    )
+    deltas = [e for e in emitted if e.type == "answer.delta"]
+    assert [d.data["delta"] for d in deltas] == ["plain text"]
+    assert answer == "plain text"

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -28474,7 +28474,7 @@
     },
     "packages/miot-chat": {
       "name": "@microboxlabs/miot-chat",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@microboxlabs/miot-auth": "*",

--- a/turbo-repo/packages/miot-chat/package.json
+++ b/turbo-repo/packages/miot-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microboxlabs/miot-chat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/AssistantTurn.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/AssistantTurn.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render } from "ink-testing-library";
+import { AssistantTurn } from "../../transcript/AssistantTurn.js";
+import type { TranscriptItem } from "../../session/types.js";
+
+function assistant(
+  text: string,
+  status: "streaming" | "complete" | "failed",
+): Extract<TranscriptItem, { kind: "assistant" }> {
+  return { kind: "assistant", id: "a-1", runId: "r1", text, status, ts: "t" };
+}
+
+describe("<AssistantTurn />", () => {
+  it("renders a markdown list bullet when complete", () => {
+    const { lastFrame } = render(
+      <AssistantTurn item={assistant("- one\n- two", "complete")} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("•");
+    expect(frame).toContain("one");
+  });
+
+  it("renders raw text (no bullet) while streaming", () => {
+    const { lastFrame } = render(
+      <AssistantTurn item={assistant("- one\n- two", "streaming")} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("- one");
+    expect(frame).not.toContain("•");
+  });
+});

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/TopLine.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/TopLine.test.tsx
@@ -25,9 +25,11 @@ describe("<TopLine />", () => {
     expect(frame).toContain("conv abcdef01");
   });
 
-  it("renders a spinner glyph when streaming", () => {
+  it("renders no spinner even while streaming (loading stays inline)", () => {
     const { lastFrame } = render(<TopLine meta={meta()} streaming={true} />);
-    expect(lastFrame() ?? "").toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("demo-tenant");
+    expect(frame).not.toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
   });
 
   it("does not render the spinner when idle", () => {

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Transcript.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Transcript.test.tsx
@@ -90,6 +90,21 @@ describe("<Transcript />", () => {
     expect(frame).toContain("partial answer");
   });
 
+  it("preserves original order during streaming (completed tool does not float above an active route row)", () => {
+    const items: TranscriptItem[] = [
+      user("q", "u-ord"),
+      { kind: "route", id: "rt", route: "ROUTEX", ts: "t" },
+      tool("TOOLX", "ok", "tl"),
+    ];
+    const { lastFrame } = render(
+      <Transcript items={items} isStreaming={true} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("ROUTEX");
+    expect(frame).toContain("TOOLX");
+    expect(frame.indexOf("ROUTEX")).toBeLessThan(frame.indexOf("TOOLX"));
+  });
+
   it("keeps a streaming assistant out of Static, then commits it on completion", () => {
     const streamingItems: TranscriptItem[] = [
       user("hi", "u-9"),

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Transcript.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/Transcript.test.tsx
@@ -90,6 +90,26 @@ describe("<Transcript />", () => {
     expect(frame).toContain("partial answer");
   });
 
+  it("keeps a streaming assistant out of Static, then commits it on completion", () => {
+    const streamingItems: TranscriptItem[] = [
+      user("hi", "u-9"),
+      assistant("partial", "streaming", "a-9"),
+    ];
+    const { rerender, lastFrame } = render(
+      <Transcript items={streamingItems} isStreaming={true} />,
+    );
+    expect(lastFrame() ?? "").toContain("partial");
+
+    const doneItems: TranscriptItem[] = [
+      user("hi", "u-9"),
+      assistant("partial complete answer", "complete", "a-9"),
+    ];
+    rerender(<Transcript items={doneItems} isStreaming={false} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("hi");
+    expect(frame).toContain("partial complete answer");
+  });
+
   it("flushes the live tail back into the static section when streaming ends", () => {
     const items: TranscriptItem[] = [
       user("hi"),

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
@@ -239,6 +239,43 @@ describe("transcript projector — answer.completed precedence", () => {
   });
 });
 
+describe("transcript projector — answer.delta streaming", () => {
+  it("accumulates answer.delta into one streaming assistant item", () => {
+    const ctx = mkCtx();
+    let s = applyHarnessEvent(
+      emptySlice(),
+      evt("answer.delta", { data: { delta: "Hola " } }),
+      "r1",
+      ctx,
+    );
+    s = applyHarnessEvent(
+      s,
+      evt("answer.delta", { data: { delta: "mundo" } }),
+      "r1",
+      ctx,
+    );
+    expect(s.transcript).toHaveLength(1);
+    expect(s.transcript[0]).toMatchObject({
+      kind: "assistant",
+      text: "Hola mundo",
+      status: "streaming",
+    });
+    expect(s.currentAssistantItemId).not.toBeNull();
+  });
+
+  it("ignores answer.delta with an empty delta", () => {
+    const ctx = mkCtx();
+    const s = applyHarnessEvent(
+      emptySlice(),
+      evt("answer.delta", { data: { delta: "" } }),
+      "r1",
+      ctx,
+    );
+    expect(s.transcript).toHaveLength(0);
+    expect(s.currentAssistantItemId).toBeNull();
+  });
+});
+
 describe("transcript projector — tool name normalization", () => {
   it("strips 'Starting <name>' / 'Completed <name>' so paired events collapse", () => {
     const ctx = mkCtx();

--- a/turbo-repo/packages/miot-chat/src/tui/chrome/TopLine.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/chrome/TopLine.tsx
@@ -1,10 +1,12 @@
 import { Box, Text } from "ink";
 import type { SessionMeta } from "../session/types.js";
-import { Spinner } from "../transcript/Spinner.js";
 import { useTheme } from "../theme/ThemeProvider.js";
 
 export interface TopLineProps {
   meta: SessionMeta;
+  // Kept for API compatibility with App. Loading is now signalled
+  // inline in the transcript (the active chain row / AssistantTurn
+  // spinner) so it sits with the conversation, not detached up here.
   streaming: boolean;
 }
 
@@ -19,12 +21,6 @@ export function TopLine(props: TopLineProps): React.ReactElement {
       <Text color={theme.dim}>
         ⎇ {props.meta.tenantId} · {props.meta.userId} · conv {shortConv}
       </Text>
-      {props.streaming ? (
-        <>
-          <Text color={theme.dim}> </Text>
-          <Spinner color={theme.spinner} />
-        </>
-      ) : null}
     </Box>
   );
 }

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/AssistantTurn.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/AssistantTurn.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from "ink";
 import { Spinner } from "./Spinner.js";
+import { Markdown } from "./markdown.js";
+import { useTheme } from "../theme/ThemeProvider.js";
 import type { TranscriptItem } from "../session/types.js";
 
 export interface AssistantTurnProps {
@@ -9,6 +11,7 @@ export interface AssistantTurnProps {
 export function AssistantTurn(
   props: AssistantTurnProps,
 ): React.ReactElement {
+  const { theme } = useTheme();
   const { text, status } = props.item;
   const color =
     status === "failed"
@@ -18,21 +21,31 @@ export function AssistantTurn(
         : "white";
 
   return (
-    <Box flexDirection="row" marginTop={1}>
-      {status === "streaming" ? (
-        <>
-          <Spinner color="cyan" />
+    <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="row">
+        {status === "streaming" ? (
+          <>
+            <Spinner color="cyan" />
+            <Text color={color} bold>
+              {" "}
+              miot
+            </Text>
+          </>
+        ) : (
           <Text color={color} bold>
-            {" "}
-            miot{" "}
+            {status === "failed" ? "✗ " : "✓ "}miot
           </Text>
-        </>
-      ) : (
-        <Text color={color} bold>
-          {status === "failed" ? "✗ " : "✓ "}miot{" "}
-        </Text>
-      )}
-      <Text color={color}>{text}</Text>
+        )}
+      </Box>
+      <Box marginLeft={2}>
+        {status === "complete" ? (
+          // Plain text while streaming (fast, flicker-free, no partial
+          // markdown); render formatted once the turn is final.
+          <Markdown text={text} theme={theme} />
+        ) : (
+          <Text color={color}>{text}</Text>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/Transcript.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/Transcript.tsx
@@ -43,28 +43,33 @@ function isTerminalItem(
 }
 
 /**
- * Render committed (terminal) turns via Ink's <Static> so they flush to
- * native terminal scrollback and escape Ink's viewport-height
- * truncation (the cause of long answers being cut with "…"). Only the
- * in-flight tail renders in the dynamic <Box>.
+ * Render the settled prefix via Ink's <Static> so it flushes to native
+ * terminal scrollback and escapes Ink's viewport-height truncation (the
+ * cause of long answers being cut with "…"). Only the in-flight tail
+ * renders in the dynamic <Box>.
  *
- * `committed` and `live` are derived by a pure per-render filter on
- * `isTerminalItem`, so they are always disjoint — an item is never
- * painted in both regions (no ghost line). The filter returns a fresh
- * array each render, which is required for Ink's <Static> to detect and
- * emit newly-committed items: <Static> only re-renders when its `items`
- * prop reference changes (a same-reference mutation is silently
- * dropped). `isTerminalItem` is monotonic — status only advances
- * (streaming→complete) and a run only ends (isStreaming true→false) — so
- * an item never oscillates back out of `committed`.
+ * The split is a single point — the index of the first non-terminal
+ * (in-flight) item — NOT two independent filters. A filter-based split
+ * would float a later terminal item (e.g. a finished tool) above an
+ * earlier still-active chain row, reordering the transcript. Slicing at
+ * the first live item keeps both regions in their original relative
+ * order: `committed` is the leading prefix, `live` the trailing tail.
+ *
+ * `slice` returns a fresh array each render, which is required for Ink's
+ * <Static> to detect and emit newly-committed items: <Static> only
+ * re-renders when its `items` prop reference changes (a same-reference
+ * mutation is silently dropped). The split point is monotonic during a
+ * run — items only append at the tail and `isTerminalItem` only advances
+ * (streaming→complete, run ends true→false) — so the committed prefix
+ * only ever grows and no item oscillates back out of <Static>.
  */
 export function Transcript(props: TranscriptProps): React.ReactElement {
-  const committed = props.items.filter((item) =>
-    isTerminalItem(item, props.isStreaming),
-  );
-  const live = props.items.filter(
+  const firstLive = props.items.findIndex(
     (item) => !isTerminalItem(item, props.isStreaming),
   );
+  const splitPoint = firstLive === -1 ? props.items.length : firstLive;
+  const committed = props.items.slice(0, splitPoint);
+  const live = props.items.slice(splitPoint);
   // When a run is in flight, the most recent "chain" item (route /
   // plan / agent / artifact / freshness) in the live tail gets a
   // spinner instead of the static "·" prefix to signal "this is the

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/Transcript.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/Transcript.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "ink";
+import { Box, Static, Text } from "ink";
 import { AssistantTurn } from "./AssistantTurn.js";
 import { Spinner } from "./Spinner.js";
 import { ToolCall } from "./ToolCall.js";
@@ -11,44 +11,84 @@ export interface TranscriptProps {
 }
 
 /**
- * Render the full transcript on every state change.
+ * An item is terminal when it will no longer mutate and is safe to
+ * commit to Ink's <Static> (rendered once, flushed to native terminal
+ * scrollback, never re-painted). When the run is over, every item is
+ * terminal. While a run is in flight, only finished items commit; the
+ * in-flight tail stays in the live region.
+ */
+function isTerminalItem(
+  item: TranscriptItem,
+  isStreaming: boolean,
+): boolean {
+  if (!isStreaming) return true;
+  switch (item.kind) {
+    case "assistant":
+      return item.status !== "streaming";
+    case "tool":
+      return item.status !== "running";
+    case "thinking":
+      return item.status !== "streaming";
+    case "route":
+    case "agent":
+    case "plan":
+    case "freshness":
+    case "artifact":
+      // May still be the spinning active step; keep live until run ends.
+      return false;
+    case "user":
+    case "system":
+      return true;
+  }
+}
+
+/**
+ * Render committed (terminal) turns via Ink's <Static> so they flush to
+ * native terminal scrollback and escape Ink's viewport-height
+ * truncation (the cause of long answers being cut with "…"). Only the
+ * in-flight tail renders in the dynamic <Box>.
  *
- * Earlier versions split items into Ink's <Static> (committed turns) +
- * a live <Box> (the in-flight turn) so completed turns scrolled into
- * terminal scrollback. The trade-off bit us: when an item migrates
- * from live → static AND its status flips in the same render,
- * real-terminal Ink doesn't reliably clear the live region's prior
- * paint, so a "… miot" line printed during streaming stayed on screen
- * even after END_TURN flipped the item to "complete". ink-testing-
- * library captures both regions as one frame and didn't catch it.
- *
- * Trade-off accepted: every state change re-paints every item. For
- * typical sessions (≤20 turns visible) the reconciliation cost is
- * negligible. Long-running sessions lose true scrollback; users can
- * still scroll the terminal manually.
- *
- * `isStreaming` is kept in the prop signature for the Header / spinner
- * gating but is no longer needed here.
+ * `committed` and `live` are derived by a pure per-render filter on
+ * `isTerminalItem`, so they are always disjoint — an item is never
+ * painted in both regions (no ghost line). The filter returns a fresh
+ * array each render, which is required for Ink's <Static> to detect and
+ * emit newly-committed items: <Static> only re-renders when its `items`
+ * prop reference changes (a same-reference mutation is silently
+ * dropped). `isTerminalItem` is monotonic — status only advances
+ * (streaming→complete) and a run only ends (isStreaming true→false) — so
+ * an item never oscillates back out of `committed`.
  */
 export function Transcript(props: TranscriptProps): React.ReactElement {
+  const committed = props.items.filter((item) =>
+    isTerminalItem(item, props.isStreaming),
+  );
+  const live = props.items.filter(
+    (item) => !isTerminalItem(item, props.isStreaming),
+  );
   // When a run is in flight, the most recent "chain" item (route /
-  // plan / agent / artifact / freshness) gets a spinner instead of
-  // the static "·" prefix to signal "this is the step the harness is
-  // working on right now". Tool items already self-animate via
-  // status=running; assistant items animate via status=streaming.
+  // plan / agent / artifact / freshness) in the live tail gets a
+  // spinner instead of the static "·" prefix to signal "this is the
+  // step the harness is working on right now".
   const activeChainIdx = props.isStreaming
-    ? findActiveChainIndex(props.items)
+    ? findActiveChainIndex(live)
     : -1;
 
   return (
     <Box flexDirection="column">
-      {props.items.map((item, i) => (
-        <TranscriptItemView
-          key={item.id}
-          item={item}
-          isActive={i === activeChainIdx}
-        />
-      ))}
+      <Static items={committed}>
+        {(item) => (
+          <TranscriptItemView key={item.id} item={item} isActive={false} />
+        )}
+      </Static>
+      <Box flexDirection="column">
+        {live.map((item, i) => (
+          <TranscriptItemView
+            key={item.id}
+            item={item}
+            isActive={i === activeChainIdx}
+          />
+        ))}
+      </Box>
     </Box>
   );
 }

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
@@ -45,6 +45,13 @@ export function applyHarnessEvent(
       // race the projector against END_TURN.
       return slice;
 
+    case "answer.delta": {
+      const delta =
+        typeof event.data.delta === "string" ? event.data.delta : "";
+      if (!delta) return slice;
+      return appendAnswerDelta(slice, delta, runId, ctx);
+    }
+
     case "answer.completed":
       return upsertAssistantItem(slice, event, runId, ctx);
 
@@ -267,6 +274,46 @@ function extractAnswerText(event: HarnessEvent): string | null {
     return data.answer;
   }
   return null;
+}
+
+/**
+ * Append a streamed answer.delta to the live assistant item, creating
+ * it on the first delta. Mirrors the thinking.delta accumulation so the
+ * assistant bubble grows token-by-token instead of popping in whole at
+ * END_TURN. END_TURN still reconciles against the authoritative run
+ * record, keeping the streamed text if the record answer is empty.
+ */
+function appendAnswerDelta(
+  slice: TranscriptSlice,
+  delta: string,
+  runId: string,
+  ctx: ProjectionContext,
+): TranscriptSlice {
+  const existingId = slice.currentAssistantItemId;
+  if (existingId) {
+    return {
+      ...slice,
+      transcript: slice.transcript.map((item) =>
+        item.kind === "assistant" && item.id === existingId
+          ? { ...item, text: item.text + delta, status: "streaming" as const }
+          : item,
+      ),
+    };
+  }
+  const id = ctx.uuid();
+  const item: TranscriptItem = {
+    kind: "assistant",
+    id,
+    runId,
+    text: delta,
+    status: "streaming",
+    ts: ctx.now(),
+  };
+  return {
+    ...slice,
+    currentAssistantItemId: id,
+    transcript: [...slice.transcript, item],
+  };
 }
 
 function upsertAssistantItem(

--- a/turbo-repo/packages/miot-harness-client/src/types.ts
+++ b/turbo-repo/packages/miot-harness-client/src/types.ts
@@ -50,6 +50,7 @@ export const HARNESS_EVENT_TYPES = [
   "usage.recorded",
   "freshness.warning",
   "verification.completed",
+  "answer.delta",
   "answer.completed",
   "run.completed",
   "run.failed",
@@ -110,6 +111,12 @@ export interface ThinkingCompletedData {
   agent: "synthesizer";
   tokens: number;
   length: number;
+}
+
+export interface AnswerDeltaData {
+  agent: string;
+  delta: string;
+  index: number;
 }
 
 export interface UsageRecordedData {


### PR DESCRIPTION
## What & why

Addresses three TUI complaints from the dev team about `@microboxlabs/miot-chat`:

> "Streaming no está funcionando del todo bien, los loading fuera de la conversa (arriba de todo); respuestas muy largas truncadas, no las pinta completa, ponen `...` cuando son mucho texto."

Each traced to a concrete root cause (diagnosis below), fixed across the harness, the TS client, and the TUI.

## Root causes & fixes

| Symptom | Root cause | Fix |
|---|---|---|
| **Streaming doesn't really work** | Every `answer.completed` event carried only `{length}`, never the answer text — so the TUI showed nothing until a separate, sometimes-hanging `GET /runs/{id}` after the stream ended. | Harness now emits **`answer.delta`** events (the answer text the model already streams), mirroring `thinking.delta`. The TUI accumulates them so the bubble grows token-by-token; the GET is now reconciliation-only. |
| **Loading indicator detached at top** | `TopLine` rendered a spinner pinned to the top of the screen. | Removed it — loading stays inline at the active turn / `AssistantTurn` spinner. |
| **Long responses truncated with `…`** | `Transcript` had removed Ink's `<Static>` and re-painted the whole transcript in the live region every render; content taller than the terminal gets truncated by Ink. | Reintroduced `<Static>` for finished turns so they flush to native scrollback and escape viewport-height truncation. |
| **Markdown not rendered** (bonus) | The `Markdown` component existed but was orphaned; `AssistantTurn` printed raw text. | Completed assistant turns now render through `Markdown` (plain text while streaming, formatted on finish). |

## How `<Static>` is done safely

`committed` (terminal turns) and `live` (in-flight tail) are derived by a pure per-render filter on `isTerminalItem`, so they're always disjoint — no double-paint / ghost line. The filter returns a **fresh array each render**, which is required for Ink's `<Static>` to emit newly-committed items (it only re-renders on a new `items` reference — a same-reference mutation is silently dropped; this was caught and fixed during development via a frame probe).

## Stack touched

- `miot-harness` (Python): `answer.delta` literal + emission in `stream_llm_with_thinking`
- `@microboxlabs/miot-harness-client` (TS): literal + `AnswerDeltaData`
- `@microboxlabs/miot-chat` (TS): projector, `Transcript`, `TopLine`, `AssistantTurn`

The event literal stays in lockstep across `events.py`, `event_types.json`, and the TS `HARNESS_EVENT_TYPES` (parity-tested both sides).

## Tests

All green, TDD throughout (failing test → fix → pass per task):
- Harness: 14 passed (new `test_llm_streaming.py` + event parity + existing streaming suites)
- `miot-harness-client`: 24 passed
- `miot-chat`: 408 passed; `check-types` + `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming assistant responses now update incrementally, producing “delta” events as text arrives.
  * Completed assistant messages now render as markdown (including proper list formatting).
* **Bug Fixes**
  * Empty streaming deltas are ignored, preventing blank/stray transcript updates.
  * Top status line no longer shows a spinner while streaming; transcript rendering now preserves correct ordering during active streaming.
* **Tests**
  * Added coverage for incremental assistant delta emission and transcript projector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->