### PR TITLE
fix(whatsapp): inbound webhook 401 on dev — serve off /api/* + fail-closed config defaults

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -73,12 +73,13 @@ miot.auth.client-id-claims=azp,aud
 
 # --- WhatsApp inbound webhook (Meta Cloud API) ---
 # Meta cannot present our JWT, so the inbound webhook is public and verified by its own
-# X-Hub-Signature-256 HMAC (POST) + verify-token handshake (GET). This permission targets the
-# exact path and is therefore MORE SPECIFIC than /api/* above, so Quarkus applies it instead of
-# the blanket `authenticated` policy for just this endpoint. The path carries no {org}; the org is
-# resolved from the payload's phone_number_id, so OrganizationRequestFilter (/api/v1/orgs/**) is
-# never in play.
-quarkus.http.auth.permission.whatsapp-webhook.paths=/api/v1/whatsapp/webhook
+# X-Hub-Signature-256 HMAC (POST) + verify-token handshake (GET). It lives at /webhooks/whatsapp —
+# OUTSIDE /api/* — because a more-specific permit under /api/* did NOT override the blanket
+# `authenticated` policy on Quarkus 3.32.4 (the endpoint returned 401 even with a valid token).
+# Keeping it off /api/* removes the precedence question; this explicit permit is belt-and-braces in
+# case a catch-all policy is ever added. The path carries no {org}; the org is resolved from the
+# payload's phone_number_id, so OrganizationRequestFilter (/api/v1/orgs/**) is never in play.
+quarkus.http.auth.permission.whatsapp-webhook.paths=/webhooks/*
 quarkus.http.auth.permission.whatsapp-webhook.policy=permit
 # Handshake verify token + Meta App secret (Meta App dashboard). Real values via env/secret. The
 # defaults are EMPTY (not a placeholder string): the signature verifier and handshake both bail on

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/WhatsAppWebhookResource.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/WhatsAppWebhookResource.java
@@ -25,19 +25,21 @@ import org.jboss.logging.Logger;
  * callbacks. Meta cannot present our JWT, so this path is deliberately outside both auth regimes:
  *
  * <ul>
- *   <li>It sits under {@code /api/v1/whatsapp/webhook} (no {@code {organizationId}}), so the
- *       org-scoped {@code OrganizationRequestFilter} — which only matches
- *       {@code /api/v1/orgs/**} — never runs. The owning org is resolved later from the payload's
- *       {@code phone_number_id} (slice 3), not from the path.</li>
- *   <li>A more-specific {@code permit} HTTP permission (see {@code application.properties}) lifts
- *       just this path out of the blanket {@code /api/* → authenticated} policy.</li>
+ *   <li>It sits under {@code /webhooks/whatsapp} — a prefix the blanket {@code /api/* →
+ *       authenticated} policy does not match at all, so the request is never challenged. (The
+ *       original {@code /api/v1/whatsapp/webhook} placement plus a more-specific {@code permit}
+ *       rule returned 401 in practice: Quarkus 3.32.4 did not let the narrower {@code permit}
+ *       override {@code /api/*}. Living off {@code /api/*} sidesteps that precedence entirely.)</li>
+ *   <li>It carries no {@code {organizationId}}, so the org-scoped {@code OrganizationRequestFilter}
+ *       — which only matches {@code /api/v1/orgs/**} — never runs. The owning org is resolved later
+ *       from the payload's {@code phone_number_id}, not from the path.</li>
  * </ul>
  *
  * <p>Trust is established instead by Meta's own signals: a verify-token handshake on
  * {@code GET} and an {@code X-Hub-Signature-256} HMAC over the raw body on {@code POST}. Both
  * are fail-closed — a mismatch returns 403/401 and the body is never processed.
  */
-@Path("/api/v1/whatsapp/webhook")
+@Path("/webhooks/whatsapp")
 @Tag(name = "WhatsApp Webhook", description = "Inbound Meta WhatsApp Cloud API webhook (public, signature-verified)")
 @IfBuildProperty(name = "miot.component.conversational.enabled", stringValue = "true")
 public class WhatsAppWebhookResource {
@@ -51,8 +53,8 @@ public class WhatsAppWebhookResource {
 
     @Inject
     public WhatsAppWebhookResource(
-            @ConfigProperty(name = "miot.whatsapp.webhook.verify-token") String verifyToken,
-            @ConfigProperty(name = "miot.whatsapp.app-secret") String appSecret,
+            @ConfigProperty(name = "miot.whatsapp.webhook.verify-token", defaultValue = "") String verifyToken,
+            @ConfigProperty(name = "miot.whatsapp.app-secret", defaultValue = "") String appSecret,
             WhatsAppInboundService inboundService) {
         this.verifyToken = verifyToken;
         this.appSecret = appSecret;

--- a/quarkus-srv/scripts/simulate-meta-inbound.sh
+++ b/quarkus-srv/scripts/simulate-meta-inbound.sh
@@ -52,10 +52,10 @@ esac
 # Sign the EXACT bytes we send (printf '%s' = no trailing newline; curl --data sends them verbatim).
 SIG="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$APP_SECRET" -hex | sed 's/^.*= //')"
 
-echo "POST ${BASE_URL}/api/v1/whatsapp/webhook  (${KIND}, wamid=${WAMID})"
+echo "POST ${BASE_URL}/webhooks/whatsapp  (${KIND}, wamid=${WAMID})"
 curl -sS -i -X POST \
   -H "Content-Type: application/json" \
   -H "X-Hub-Signature-256: ${SIG}" \
   --data "$PAYLOAD" \
-  "${BASE_URL}/api/v1/whatsapp/webhook"
+  "${BASE_URL}/webhooks/whatsapp"
 echo


### PR DESCRIPTION
Closes #849

## Problem

The Phase 2a inbound webhook (#843) is **unreachable** as deployed on `coordinador-dev`: a `GET …/api/v1/whatsapp/webhook` with the **correct** verify token returns **HTTP 401**, so Meta's verification handshake fails.

**Root cause (O-permit):** the more-specific `permit` rule does not override `quarkus.http.auth.permission.api.paths=/api/*` (`authenticated`) in Quarkus 3.32.4. Verified on dev — image contains #843, env secrets are wired and non-empty, yet the request is rejected at the auth layer before JAX-RS (`currentRoutePath=/`, 401, even with a valid token).

**Secondary bug:** `@ConfigProperty` for the verify-token / app-secret had no `defaultValue`, so an unset env (which expands to empty via `${VAR:}`) throws `Failed to load config value` during bean construction instead of the intended fail-closed-on-blank behaviour.

## Fix

- **Relocate** the resource to `@Path("/webhooks/whatsapp")` and repoint the permit to `/webhooks/*`. The `/api/*→authenticated` policy never matches the new prefix, so there is no precedence battle.
- **`defaultValue = ""`** on both `@ConfigProperty` → an unset env injects `""`, which the existing blank-token handshake guard and blank-secret HMAC verifier already reject (fail-closed) rather than crashing the bean.
- Update `simulate-meta-inbound.sh` to the new path.

The unit test (`isValidHandshake`, incl. the blank-token case) is unchanged and green (4/4).

## Companion

- `miot-deployments` PR #36 adds the `/webhooks` ingress route on the dev modulith.
- **New Meta callback URL:** `https://coordinador-dev.mintral.cl/webhooks/whatsapp`

## Validation (after deploy)

`GET …/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=<correct>&hub.challenge=x` must return **200** echoing `x` (**403** on a wrong token, **never 401**), then Meta's "Verify and save" succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the WhatsApp inbound webhook to use a new public `/webhooks/*` path, ensuring requests are accepted correctly.
  * Aligned the webhook endpoint used by the app and the simulation script so they match the new route.
  * Added safe default values for webhook configuration settings when they are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->