### PR TITLE
feat(whatsapp): WhatsApp-style delivery ticks in the conversation panel

### DIFF
--- a/turbo-repo/apps/app/src/features/whatsapp-inbox/components/message-thread.tsx
+++ b/turbo-repo/apps/app/src/features/whatsapp-inbox/components/message-thread.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect } from "react";
 import { Spinner } from "flowbite-react";
-import { HiCheck, HiOutlineExclamationCircle } from "react-icons/hi";
-import { HiMiniCheckCircle } from "react-icons/hi2";
+import { HiOutlineExclamationCircle } from "react-icons/hi";
+import { BsCheck, BsCheckAll } from "react-icons/bs";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import type { Conversation, Message, MessageStatus } from "../conversation.types";
@@ -128,18 +128,14 @@ function StatusTicks({
 }) {
   switch (status) {
     case "READ":
-      return (
-        <HiMiniCheckCircle className="h-3.5 w-3.5 text-blue-500" title={tr("statusRead", dict)} />
-      );
+      // Double tick, blue — read (WhatsApp semantics).
+      return <BsCheckAll className="h-4 w-4 text-blue-500" title={tr("statusRead", dict)} />;
     case "DELIVERED":
-      return (
-        <HiMiniCheckCircle
-          className="h-3.5 w-3.5 text-gray-400"
-          title={tr("statusDelivered", dict)}
-        />
-      );
+      // Double tick, gray — delivered to the device.
+      return <BsCheckAll className="h-4 w-4 text-gray-400" title={tr("statusDelivered", dict)} />;
     case "SENT":
-      return <HiCheck className="h-3.5 w-3.5 text-gray-400" title={tr("statusSent", dict)} />;
+      // Single tick, gray — accepted by Meta, not yet delivered.
+      return <BsCheck className="h-4 w-4 text-gray-400" title={tr("statusSent", dict)} />;
     case "FAILED":
       return (
         <HiOutlineExclamationCircle


### PR DESCRIPTION
Part of #852 (Phase 2b — WhatsApp conversation module enhancements), Slice 1.

## What
Outbound message status now renders like WhatsApp instead of single mixed icons:

| status | before | after |
|---|---|---|
| SENT | single check | **✓** single, gray |
| DELIVERED | filled circle-check, gray | **✓✓** double, gray |
| READ | filled circle-check, blue | **✓✓** double, blue |
| FAILED | ⚠ | ⚠ (unchanged) |

Uses `react-icons/bs` `BsCheck` / `BsCheckAll` (already-available package). Titles keep the existing
i18n tooltips (`statusSent/Delivered/Read/Failed`).

## Why
Matches the id-auto CRM / WhatsApp look the team expects — the single tick read as "not delivered".

## Validation
`apps/app` `check-types` green. Pure FE render change; status data (SENT/DELIVERED/READ) already flows
from the status-callback webhook (confirmed DELIVERED end-to-end on dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated WhatsApp message status icons and sizing for a more consistent in-chat appearance.
  * Kept the failed-message indicator unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->