### PR TITLE
feat(harness): json answer_format — skill-driven typed blocks

### DIFF
--- a/miot-harness/src/miot_harness/runtime/answer_blocks.py
+++ b/miot-harness/src/miot_harness/runtime/answer_blocks.py
@@ -6,6 +6,10 @@ block types are validated strictly — `markdown` (value is a string) and `url`
 (value is an object with string `url` and `name`); any other `type` is accepted
 unchanged (passthrough). `to_json_blocks` never raises: on any failure it wraps
 the raw text as a single markdown block so a formatting glitch can't fail a run.
+
+Note: `url` block values are NOT scheme-validated — the schema only checks they
+are strings — so downstream consumers must sanitize urls as hrefs (reject
+`javascript:`, `data:`, etc.).
 """
 
 from __future__ import annotations
@@ -28,7 +32,7 @@ class AnswerBlock(BaseModel):
     value: Any
 
     @model_validator(mode="after")
-    def _validate_known_types(self) -> "AnswerBlock":
+    def _validate_known_types(self) -> AnswerBlock:
         if self.type == "markdown":
             if not isinstance(self.value, str):
                 raise ValueError("markdown block value must be a string")
@@ -81,6 +85,6 @@ def to_json_blocks(text: str) -> str:
     try:
         blocks = parse_blocks(text)
         return json.dumps([b.model_dump() for b in blocks], ensure_ascii=False)
-    except Exception:  # noqa: BLE001 — formatting must never fail a run
-        logger.exception("answer json-blocks parse failed; using markdown fallback")
+    except Exception as exc:  # noqa: BLE001 — formatting must never fail a run
+        logger.warning("answer json-blocks parse failed; using markdown fallback: %s", exc)
         return json.dumps([{"type": "markdown", "value": text}], ensure_ascii=False)

--- a/miot-harness/src/miot_harness/runtime/answer_blocks.py
+++ b/miot-harness/src/miot_harness/runtime/answer_blocks.py
@@ -1,0 +1,86 @@
+"""Typed-block schema for the `json` answer format.
+
+The `json` answer format returns the run's answer as an array of typed blocks
+so clients can render multiple, differently-typed pieces of one answer. Two
+block types are validated strictly — `markdown` (value is a string) and `url`
+(value is an object with string `url` and `name`); any other `type` is accepted
+unchanged (passthrough). `to_json_blocks` never raises: on any failure it wraps
+the raw text as a single markdown block so a formatting glitch can't fail a run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from pydantic import BaseModel, TypeAdapter, ValidationError, model_validator
+
+logger = logging.getLogger(__name__)
+
+# Match a fenced block: ```json\n...\n``` or ```\n...\n``` (whole string).
+_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```$", re.DOTALL)
+
+
+class AnswerBlock(BaseModel):
+    type: str
+    value: Any
+
+    @model_validator(mode="after")
+    def _validate_known_types(self) -> "AnswerBlock":
+        if self.type == "markdown":
+            if not isinstance(self.value, str):
+                raise ValueError("markdown block value must be a string")
+        elif self.type == "url":
+            v = self.value
+            if (
+                not isinstance(v, dict)
+                or not isinstance(v.get("url"), str)
+                or not isinstance(v.get("name"), str)
+            ):
+                raise ValueError(
+                    "url block value must be an object with string 'url' and 'name'"
+                )
+        # Any other type passes through unchanged.
+        return self
+
+
+_BLOCKS_ADAPTER = TypeAdapter(list[AnswerBlock])
+
+
+def _strip_fence(raw: str) -> str:
+    match = _FENCE_RE.match(raw.strip())
+    return match.group(1) if match else raw
+
+
+def parse_blocks(raw: str) -> list[AnswerBlock]:
+    """Parse agent text into a validated list of blocks.
+
+    Strips an optional ```json fence, requires a JSON array, and validates
+    known block types. Raises `ValueError` on any failure.
+    """
+    text = _strip_fence(raw)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"answer is not valid JSON: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError("answer JSON must be an array of blocks")
+    try:
+        return _BLOCKS_ADAPTER.validate_python(data)
+    except ValidationError as exc:
+        raise ValueError(f"invalid blocks: {exc}") from exc
+
+
+def to_json_blocks(text: str) -> str:
+    """Return a clean JSON array string of blocks. Never raises.
+
+    On any parse/validate failure, wrap the raw text as a single markdown block.
+    """
+    try:
+        blocks = parse_blocks(text)
+        return json.dumps([b.model_dump() for b in blocks], ensure_ascii=False)
+    except Exception:  # noqa: BLE001 — formatting must never fail a run
+        logger.exception("answer json-blocks parse failed; using markdown fallback")
+        return json.dumps([{"type": "markdown", "value": text}], ensure_ascii=False)

--- a/miot-harness/src/miot_harness/runtime/answer_render.py
+++ b/miot-harness/src/miot_harness/runtime/answer_render.py
@@ -18,6 +18,8 @@ from xml.sax.saxutils import escape as _xml_escape
 import markdown as _markdown  # type: ignore[import-untyped]
 import yaml as _yaml
 
+from miot_harness.runtime.answer_blocks import to_json_blocks
+
 logger = logging.getLogger(__name__)
 
 _TAG_RE = re.compile(r"<[^>]+>")
@@ -60,6 +62,11 @@ def render_answer_with_format(markdown_text: str | None, fmt: str) -> tuple[str 
     """
     if markdown_text is None:
         return None, fmt
+    if fmt == "json":
+        # `json` is not a re-render of Markdown: the agent emits a block array
+        # as its answer text. to_json_blocks parses+validates it (markdown-block
+        # fallback on failure) and never raises. Effective format is always json.
+        return to_json_blocks(markdown_text), "json"
     if fmt == "markdown":
         return markdown_text, "markdown"
     renderer = _RENDERERS.get(fmt)

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -1,8 +1,9 @@
+import re
 from datetime import UTC, datetime
 from typing import Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from miot_harness.runtime.approvals import ApprovalRegistry
 from miot_harness.runtime.permissions import (
@@ -20,7 +21,12 @@ RunMode = Literal["auto", "canned", "meta", "agentic"]
 # The output format for the run's `answer` string. The JSON response envelope
 # never changes; only the encoding of `answer` does. "markdown" is canonical
 # (what the agents emit) and the default when a caller omits the field.
-AnswerFormat = Literal["markdown", "plain", "html", "xml", "yaml"]
+AnswerFormat = Literal["markdown", "plain", "html", "xml", "yaml", "json"]
+
+# A leading "/slug" in a request message selects a skill (e.g.
+# "/fleet-report how is the fleet?"). The slug must be followed by whitespace
+# or end-of-string, so path-like text ("/runs/status") is not matched.
+_SKILL_SLUG_RE = re.compile(r"^/(?P<slug>[A-Za-z0-9_-]+)(?:\s+(?P<rest>.*))?$", re.DOTALL)
 
 
 class HarnessContext(BaseModel):
@@ -98,6 +104,20 @@ class UserRequest(BaseModel):
     rules: list[PermissionRule] = Field(default_factory=list)
     # Output format for the response `answer` string (default markdown).
     answer_format: AnswerFormat = "markdown"
+
+    @model_validator(mode="after")
+    def _extract_skill_slug(self) -> "UserRequest":
+        """Pull a leading "/slug" out of `message` into `skill_id` when empty.
+
+        An explicit `skill_id` always wins (message left untouched). Unknown
+        slugs resolve to no skill downstream and the run proceeds normally.
+        """
+        if not self.skill_id:
+            match = _SKILL_SLUG_RE.match(self.message)
+            if match is not None:
+                self.skill_id = match.group("slug")
+                self.message = match.group("rest") or ""
+        return self
 
     def to_context(self) -> HarnessContext:
         # NOTE: the policy built here is UNGATED — the bypass policy gate

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -67,6 +67,16 @@ from miot_harness.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
+_JSON_BLOCKS_INSTRUCTION = (
+    "# Output format: JSON blocks\n\n"
+    "Return ONLY a JSON array of typed blocks as your entire answer — no prose "
+    "outside the array and no code fence. Each block is an object "
+    '{"type": <string>, "value": <...>}. Known types:\n'
+    '- "markdown": value is a Markdown string.\n'
+    '- "url": value is an object {"url": <string>, "name": <string>}.\n'
+    "Emit multiple blocks to convey different parts of the answer."
+)
+
 
 class HarnessSupervisor:
     def __init__(
@@ -219,6 +229,7 @@ class HarnessSupervisor:
         # list when no store, no conversation_id, or no prior history.
         prior_messages = self._hydrate_history(request)
         prior_messages = self._inject_skill(request, ctx, prior_messages)
+        prior_messages = self._inject_json_blocks_instruction(ctx, prior_messages)
 
         try:
             if route.route == HarnessRoute.DATA_QUERY:
@@ -386,6 +397,22 @@ class HarnessSupervisor:
             )
         )
         return [guidance, *prior_messages]
+
+    def _inject_json_blocks_instruction(
+        self,
+        ctx: HarnessContext,
+        prior_messages: list[BaseMessage],
+    ) -> list[BaseMessage]:
+        """Prepend the JSON-block output contract when json output is requested.
+
+        For ``answer_format == "json"`` the agent must emit a JSON array of
+        typed blocks instead of prose; this generic instruction supplies the
+        schema contract (any active skill supplies the domain content). For all
+        other formats this is a no-op.
+        """
+        if ctx.answer_format != "json":
+            return prior_messages
+        return [SystemMessage(content=_JSON_BLOCKS_INSTRUCTION), *prior_messages]
 
     def _hydrate_history(self, request: UserRequest) -> list[BaseMessage]:
         """Read prior turns from `ConversationStore` and trim them to fit the

--- a/miot-harness/tests/api/test_runs_json_format.py
+++ b/miot-harness/tests/api/test_runs_json_format.py
@@ -56,6 +56,7 @@ def test_json_format_returns_a_block_array_string(client: TestClient) -> None:
     # `answer` is a STRING containing a JSON array of blocks.
     blocks = json.loads(body["answer"])
     assert isinstance(blocks, list)
+    assert len(blocks) >= 1
     assert all("type" in b and "value" in b for b in blocks)
 
 

--- a/miot-harness/tests/api/test_runs_json_format.py
+++ b/miot-harness/tests/api/test_runs_json_format.py
@@ -1,0 +1,81 @@
+"""End-to-end FastAPI tests for the json answer_format on POST /runs.
+
+Drives the real FastAPI app (via TestClient) with the same env-isolation and
+workspace setup used by tests/api/test_runs_answer_format.py.  No production-
+code stubs are introduced.
+
+Realistic no-LLM behavior: the direct agent returns fallback prose, so the
+json finalize path wraps it in a single markdown block.  The multi-block valid
+path is covered by Tasks 1, 3, and 4.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from miot_harness.api.server import create_app
+from miot_harness.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clean_settings_and_workspace(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Per-test isolation: scrub datasource env vars, pin workspace to tmp."""
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
+    monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
+    monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    """A TestClient wired to a fresh app instance with no auth or datasource."""
+    app = create_app()
+    with TestClient(app) as tc:
+        yield tc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_json_format_returns_a_block_array_string(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "json"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer_format"] == "json"
+    # `answer` is a STRING containing a JSON array of blocks.
+    blocks = json.loads(body["answer"])
+    assert isinstance(blocks, list)
+    assert all("type" in b and "value" in b for b in blocks)
+
+
+def test_json_fallback_wraps_prose_as_single_markdown_block(client: TestClient) -> None:
+    # No LLM in tests → the agent returns fallback prose → single markdown block.
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "json"})
+    assert resp.status_code == 200
+    blocks = json.loads(resp.json()["answer"])
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "markdown"
+    assert isinstance(blocks[0]["value"], str) and blocks[0]["value"]
+
+
+def test_invalid_format_still_422(client: TestClient) -> None:
+    resp = client.post("/runs", json={"message": "hi", "answer_format": "pdf"})
+    assert resp.status_code == 422
+
+
+def test_slug_in_message_is_accepted(client: TestClient) -> None:
+    # A leading /slug must not break the request (skill simply unresolved here).
+    resp = client.post("/runs", json={"message": "/some-skill hi", "answer_format": "json"})
+    assert resp.status_code == 200
+    assert resp.json()["answer_format"] == "json"

--- a/miot-harness/tests/runtime/test_answer_blocks.py
+++ b/miot-harness/tests/runtime/test_answer_blocks.py
@@ -1,0 +1,69 @@
+import json
+
+import pytest
+
+from miot_harness.runtime.answer_blocks import (
+    AnswerBlock,
+    parse_blocks,
+    to_json_blocks,
+)
+
+
+def test_parse_clean_array_of_known_blocks():
+    raw = json.dumps([
+        {"type": "markdown", "value": "hello **world**"},
+        {"type": "url", "value": {"url": "https://x.com", "name": "X"}},
+    ])
+    blocks = parse_blocks(raw)
+    assert [b.type for b in blocks] == ["markdown", "url"]
+    assert blocks[1].value == {"url": "https://x.com", "name": "X"}
+
+
+def test_parse_strips_json_code_fence():
+    raw = '```json\n[{"type": "markdown", "value": "hi"}]\n```'
+    blocks = parse_blocks(raw)
+    assert blocks[0].value == "hi"
+
+
+def test_parse_allows_unknown_type_passthrough():
+    raw = json.dumps([{"type": "chart", "value": {"series": [1, 2, 3]}}])
+    blocks = parse_blocks(raw)
+    assert blocks[0].type == "chart"
+    assert blocks[0].value == {"series": [1, 2, 3]}
+
+
+def test_parse_rejects_non_array():
+    with pytest.raises(ValueError):
+        parse_blocks('{"type": "markdown", "value": "hi"}')
+
+
+def test_parse_rejects_non_json():
+    with pytest.raises(ValueError):
+        parse_blocks("just some prose, not json")
+
+
+def test_parse_rejects_markdown_block_with_non_string_value():
+    with pytest.raises(ValueError):
+        parse_blocks(json.dumps([{"type": "markdown", "value": {"oops": 1}}]))
+
+
+def test_parse_rejects_url_block_missing_name():
+    with pytest.raises(ValueError):
+        parse_blocks(json.dumps([{"type": "url", "value": {"url": "https://x.com"}}]))
+
+
+def test_to_json_blocks_roundtrips_valid_input():
+    raw = json.dumps([{"type": "markdown", "value": "hi"}])
+    out = to_json_blocks(raw)
+    assert json.loads(out) == [{"type": "markdown", "value": "hi"}]
+
+
+def test_to_json_blocks_falls_back_to_single_markdown_block():
+    out = to_json_blocks("not json at all")
+    assert json.loads(out) == [{"type": "markdown", "value": "not json at all"}]
+
+
+def test_answer_block_model_validates_known_types_directly():
+    AnswerBlock(type="markdown", value="ok")  # no raise
+    with pytest.raises(ValueError):
+        AnswerBlock(type="url", value="not-an-object")

--- a/miot-harness/tests/runtime/test_answer_blocks.py
+++ b/miot-harness/tests/runtime/test_answer_blocks.py
@@ -25,6 +25,12 @@ def test_parse_strips_json_code_fence():
     assert blocks[0].value == "hi"
 
 
+def test_parse_strips_bare_code_fence():
+    raw = '```\n[{"type": "markdown", "value": "hi"}]\n```'
+    blocks = parse_blocks(raw)
+    assert blocks[0].value == "hi"
+
+
 def test_parse_allows_unknown_type_passthrough():
     raw = json.dumps([{"type": "chart", "value": {"series": [1, 2, 3]}}])
     blocks = parse_blocks(raw)
@@ -50,6 +56,11 @@ def test_parse_rejects_markdown_block_with_non_string_value():
 def test_parse_rejects_url_block_missing_name():
     with pytest.raises(ValueError):
         parse_blocks(json.dumps([{"type": "url", "value": {"url": "https://x.com"}}]))
+
+
+def test_parse_rejects_url_block_missing_url():
+    with pytest.raises(ValueError):
+        parse_blocks(json.dumps([{"type": "url", "value": {"name": "X"}}]))
 
 
 def test_to_json_blocks_roundtrips_valid_input():

--- a/miot-harness/tests/runtime/test_answer_render.py
+++ b/miot-harness/tests/runtime/test_answer_render.py
@@ -94,3 +94,30 @@ def test_render_answer_with_format_none_preserves_requested_fmt():
     result, effective_fmt = render_answer_with_format(None, "yaml")
     assert result is None
     assert effective_fmt == "yaml"
+
+
+def test_json_format_passes_through_valid_block_array():
+    import json as _json
+
+    from miot_harness.runtime.answer_render import render_answer_with_format
+
+    raw = '[{"type": "markdown", "value": "hi"}]'
+    out, effective = render_answer_with_format(raw, "json")
+    assert effective == "json"
+    assert _json.loads(out) == [{"type": "markdown", "value": "hi"}]
+
+
+def test_json_format_falls_back_to_single_markdown_block():
+    import json as _json
+
+    from miot_harness.runtime.answer_render import render_answer_with_format
+
+    out, effective = render_answer_with_format("just prose", "json")
+    assert effective == "json"
+    assert _json.loads(out) == [{"type": "markdown", "value": "just prose"}]
+
+
+def test_json_format_none_input_preserves_none_and_format():
+    from miot_harness.runtime.answer_render import render_answer_with_format
+
+    assert render_answer_with_format(None, "json") == (None, "json")

--- a/miot-harness/tests/runtime/test_context_json_and_slug.py
+++ b/miot-harness/tests/runtime/test_context_json_and_slug.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from miot_harness.runtime.context import UserRequest
+
+
+def test_answer_format_accepts_json():
+    assert UserRequest(message="hi", answer_format="json").answer_format == "json"
+
+
+def test_answer_format_still_rejects_invalid():
+    with pytest.raises(ValidationError):
+        UserRequest(message="hi", answer_format="pdf")
+
+
+def test_leading_slug_sets_skill_id_and_strips_message():
+    req = UserRequest(message="/fleet-report how is the fleet?")
+    assert req.skill_id == "fleet-report"
+    assert req.message == "how is the fleet?"
+
+
+def test_slug_only_message_leaves_empty_message():
+    req = UserRequest(message="/fleet-report")
+    assert req.skill_id == "fleet-report"
+    assert req.message == ""
+
+
+def test_explicit_skill_id_wins_over_slug():
+    req = UserRequest(message="/other do it", skill_id="explicit")
+    assert req.skill_id == "explicit"
+    assert req.message == "/other do it"  # message untouched when skill_id present
+
+
+def test_non_slug_message_is_untouched():
+    req = UserRequest(message="how is the fleet?")
+    assert req.skill_id is None
+    assert req.message == "how is the fleet?"
+
+
+def test_path_like_message_is_not_treated_as_slug():
+    # "/runs/status" has no whitespace boundary after the first segment.
+    req = UserRequest(message="/runs/status please")
+    assert req.skill_id is None
+    assert req.message == "/runs/status please"

--- a/miot-harness/tests/runtime/test_supervisor_json_instruction.py
+++ b/miot-harness/tests/runtime/test_supervisor_json_instruction.py
@@ -1,0 +1,32 @@
+from langchain_core.messages import SystemMessage
+
+from miot_harness.runtime.supervisor import HarnessSupervisor
+
+
+def _ctx(fmt):
+    class _C:
+        answer_format = fmt
+
+    return _C()
+
+
+def test_injects_instruction_when_format_is_json():
+    sup = object.__new__(HarnessSupervisor)
+    out = sup._inject_json_blocks_instruction(_ctx("json"), [])
+    assert len(out) == 1
+    assert isinstance(out[0], SystemMessage)
+    assert "JSON array" in out[0].content
+
+
+def test_no_injection_for_other_formats():
+    sup = object.__new__(HarnessSupervisor)
+    existing = ["x"]
+    assert sup._inject_json_blocks_instruction(_ctx("markdown"), existing) == existing
+
+
+def test_instruction_is_prepended_before_existing_messages():
+    sup = object.__new__(HarnessSupervisor)
+    existing = [SystemMessage(content="skill body")]
+    out = sup._inject_json_blocks_instruction(_ctx("json"), existing)
+    assert out[0].content != "skill body"  # json instruction is first
+    assert out[1].content == "skill body"

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/api/HarnessProxyResourcePostTest.java
@@ -190,4 +190,35 @@ class HarnessProxyResourcePostTest {
                 .body("answer_format", is("yaml"))
                 .body("answer", is("answer: hi\n"));
     }
+
+    @Test
+    void postRunsForwardsJsonAnswerFormatAndEchoesBlocks() {
+        // Arrange: stub the Python backend to match answer_format:"json" in the request
+        // body and return a response with answer as a serialized JSON block array.
+        // Registered after @BeforeEach's default /runs stub so WireMock
+        // (last-in-first-tried) evaluates this more specific body-matching stub first.
+        String token = TestTokenFactory.signWebToken(StubAlfrescoMembershipClient.MEMBER_EMAIL);
+        WireMockLifecycle.server().stubFor(WireMock.post(WireMock.urlEqualTo("/runs"))
+                .withRequestBody(
+                        WireMock.matchingJsonPath("$.answer_format", WireMock.equalTo("json")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"run_id\":\"run_x\",\"status\":\"completed\","
+                                + "\"answer\":\"[{\\\"type\\\":\\\"markdown\\\",\\\"value\\\":\\\"hi\\\"}]\","
+                                + "\"answer_format\":\"json\"}")));
+
+        // Act + Assert: proxy forwards answer_format:"json" to the backend and returns
+        // the echoed answer_format and the serialized block-array string.
+        given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body("{\"message\":\"hi\",\"answer_format\":\"json\"}")
+                .when()
+                .post(RUNS_PATH)
+                .then()
+                .statusCode(200)
+                .body("answer_format", is("json"))
+                .body("answer", org.hamcrest.Matchers.containsString("\"type\":\"markdown\""));
+    }
 }


### PR DESCRIPTION
Closes #855

> **Stacked on #846** (answer-formats). Base is the answer-formats branch so this shows only the json commits; retarget to `trunk` after #846 merges.

## What

Adds `answer_format: "json"` to the harness API. Unlike `markdown`/`plain`/`html`/`xml`/`yaml` (deterministic re-renders of the Markdown answer), `json` makes the agent **produce a typed-block array**, guided by a **skill**, so a client can receive several differently-typed pieces of one answer.

The response is still the JSON `HarnessRunRecord`; `answer` stays a **string** (non-polymorphic) holding the serialized block array, and `answer_format` echoes `"json"`.

```jsonc
// request
{ "message": "/fleet-report how is the fleet?", "answer_format": "json" }

// HarnessRunRecord.answer (a STRING containing this JSON array)
[
  { "type": "markdown", "value": "Fleet **OK**: 3 of 4 online." },
  { "type": "url", "value": { "url": "https://example.com", "name": "Ir a Ejemplo" } }
]
```

## How

- **`runtime/answer_blocks.py`** — `AnswerBlock {type, value}` with strict validation for `markdown` (value=string) and `url` (value={url,name}); any other `type` passes through. `parse_blocks` strips a ```json fence, requires a JSON array, validates. `to_json_blocks` **never raises** — on any failure it falls back to a single `{type:"markdown"}` block.
- **`runtime/context.py`** — `AnswerFormat += "json"`; a `UserRequest` validator extracts a leading `/slug` in `message` into `skill_id` when empty (explicit `skill_id` wins; path-like `/a/b` not matched).
- **`runtime/answer_render.py`** — `render_answer_with_format` special-cases `json` **before** the markdown renderers.
- **`runtime/supervisor.py`** — injects a JSON-block output instruction (the schema contract) when `answer_format == "json"`, alongside any active skill's `SKILL.md` guidance. `json` works with **and** without a skill (degenerate single block).
- **Quarkus proxy** — no production change; forwards the field and passes the response through (test added).

## Skill-driven

A skill's `SKILL.md` supplies the domain content and which block types to emit; the harness supplies the strict schema contract and the never-fail parsing. Select the skill via `skill_id` or a leading `/slug` in the message.

## Notes

- `url` block values are **not** scheme-validated (only checked to be strings) — downstream consumers rendering a `url` as an href must sanitize (`javascript:`/`data:`).
- The `json` finalize is idempotent and never raises, so a run can never fail on formatting.

## Tests

- Block schema/parser, `/slug` + format validation, render branch, supervisor instruction injection, end-to-end `POST /runs` (realistic no-LLM fallback path), Quarkus proxy pass-through.
- Harness suites **276 passed / 1 skipped**; mypy strict `Success (117 files)`; ruff clean; Quarkus `HarnessProxyResourcePostTest` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)