### PR TITLE
feat(whatsapp): render outbound template body in the conversation panel

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingService.java
@@ -96,7 +96,7 @@ public class WhatsAppMessagingService {
                 MessageDirection.OUTBOUND,
                 request.roleOrDefault(),
                 request.isTemplate() ? MessageType.TEMPLATE : MessageType.TEXT,
-                request.isTemplate() ? null : request.body(),
+                renderedBody(request),
                 request.isTemplate() ? request.templateName() : null,
                 null,
                 null,
@@ -254,10 +254,24 @@ public class WhatsAppMessagingService {
         return metadata;
     }
 
+    /**
+     * Body persisted to the pool: the free-text body for TEXT, or the rendered template copy for
+     * TEMPLATE (so the panel shows the real message). Null for a template we don't have copy for —
+     * the UI then falls back to the template name.
+     */
+    private static String renderedBody(SendWhatsAppMessageRequest request) {
+        if (!request.isTemplate()) {
+            return request.body();
+        }
+        return WhatsAppTemplateRenderer.render(request.templateName(), request.templateParamsOrEmpty());
+    }
+
     private static String preview(SendWhatsAppMessageRequest request) {
-        String text = request.isTemplate()
-                ? "[template] " + request.templateName()
-                : request.body();
+        String text = renderedBody(request);
+        if (text == null) {
+            // Unknown template (no local copy) — fall back to its name so the list still shows something.
+            text = request.isTemplate() ? request.templateName() : null;
+        }
         if (text == null) {
             return null;
         }

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRenderer.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRenderer.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.conversational.service;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Renders the human-readable body of an outbound WhatsApp <em>template</em> message from its name and
@@ -17,33 +18,49 @@ import java.util.Map;
  */
 public final class WhatsAppTemplateRenderer {
 
-    private static final String FOOTER_TRANSPORT = "ModularIoT · Coordinación de transporte";
+    // Possessive quantifier ([^}]*+) — no backtracking, so this is safe to run over the rendered body
+    // (which carries caller-supplied param values). Precompiled once.
+    private static final Pattern UNFILLED_PLACEHOLDER = Pattern.compile("\\{\\{[^}]*+}}");
 
-    /** template name -> body copy with {{named}} placeholders (footer appended, as WhatsApp shows it). */
+    private static final String POD_REJECTED_V1 =
+            """
+            Hola {{driver_name}}. Tu comprobante del viaje {{trip_reference}} no pudo ser aceptado: {{reason}}. Por favor envía una nueva foto del documento para poder continuar. Gracias.
+
+            ModularIoT · Coordinación de transporte""";
+
+    private static final String POD_APPROVED_V1 =
+            """
+            Hola {{driver_name}}. Tu comprobante de entrega del viaje {{trip_reference}} fue validado correctamente. ¡Gracias! El viaje queda cerrado.
+
+            ModularIoT · Coordinación de transporte""";
+
+    private static final String POD_IMAGE_UNCLEAR_V1 =
+            """
+            Hola {{driver_name}}. Recibimos tu documento del viaje {{trip_reference}}, pero la imagen no se ve con claridad. Por favor envía una nueva foto, bien iluminada y enfocada, donde se lea la firma. Gracias.
+
+            ModularIoT · Coordinación de transporte""";
+
+    private static final String TRIP_DETENTION_ALERT_V1 =
+            """
+            Hola {{driver_name}}. Detectamos una detención no programada en el viaje {{trip_reference}}, cerca de {{location}}. ¿Está todo en orden? Por favor responde a este mensaje indicando el motivo o si necesitas apoyo.
+
+            ModularIoT · Torre de Control""";
+
+    private static final String TRIP_ARRIVAL_POD_REQUEST_V1 =
+            """
+            Hola {{driver_name}}, tu viaje {{trip_reference}} ha sido confirmado como arribado por la torre de Control. Por favor, sube la prueba de entrega (POD) firmada respondiendo a este mensaje con la imagen o el documento.
+
+            Si tienes dudas, responde a este mensaje y te ayudamos.
+
+            MicroBoxLabs · ModularIoT""";
+
+    /** template name -> body copy with {{named}} placeholders (footer included, as WhatsApp shows it). */
     private static final Map<String, String> BODIES = Map.of(
-            "pod_rejected_v1",
-            "Hola {{driver_name}}. Tu comprobante del viaje {{trip_reference}} no pudo ser aceptado: "
-                    + "{{reason}}. Por favor envía una nueva foto del documento para poder continuar. Gracias."
-                    + "\n\n" + FOOTER_TRANSPORT,
-            "pod_approved_v1",
-            "Hola {{driver_name}}. Tu comprobante de entrega del viaje {{trip_reference}} fue validado "
-                    + "correctamente. ¡Gracias! El viaje queda cerrado."
-                    + "\n\n" + FOOTER_TRANSPORT,
-            "pod_image_unclear_v1",
-            "Hola {{driver_name}}. Recibimos tu documento del viaje {{trip_reference}}, pero la imagen no "
-                    + "se ve con claridad. Por favor envía una nueva foto, bien iluminada y enfocada, donde se "
-                    + "lea la firma. Gracias."
-                    + "\n\n" + FOOTER_TRANSPORT,
-            "trip_detention_alert_v1",
-            "Hola {{driver_name}}. Detectamos una detención no programada en el viaje {{trip_reference}}, "
-                    + "cerca de {{location}}. ¿Está todo en orden? Por favor responde a este mensaje indicando "
-                    + "el motivo o si necesitas apoyo."
-                    + "\n\nModularIoT · Torre de Control",
-            "trip_arrival_pod_request_v1",
-            "Hola {{driver_name}}, tu viaje {{trip_reference}} ha sido confirmado como arribado por la torre "
-                    + "de Control. Por favor, sube la prueba de entrega (POD) firmada respondiendo a este mensaje "
-                    + "con la imagen o el documento.\n\nSi tienes dudas, responde a este mensaje y te ayudamos."
-                    + "\n\nMicroBoxLabs · ModularIoT");
+            "pod_rejected_v1", POD_REJECTED_V1,
+            "pod_approved_v1", POD_APPROVED_V1,
+            "pod_image_unclear_v1", POD_IMAGE_UNCLEAR_V1,
+            "trip_detention_alert_v1", TRIP_DETENTION_ALERT_V1,
+            "trip_arrival_pod_request_v1", TRIP_ARRIVAL_POD_REQUEST_V1);
 
     private WhatsAppTemplateRenderer() {}
 
@@ -65,6 +82,6 @@ public final class WhatsAppTemplateRenderer {
             body = body.replace("{{" + param.getKey() + "}}", value);
         }
         // Strip any placeholder a caller didn't supply, so we never render raw "{{reason}}".
-        return body.replaceAll("\\{\\{[^}]+}}", "").trim();
+        return UNFILLED_PLACEHOLDER.matcher(body).replaceAll("").trim();
     }
 }

--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRenderer.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRenderer.java
@@ -1,0 +1,70 @@
+package com.microboxlabs.miot.conversational.service;
+
+import java.util.Map;
+
+/**
+ * Renders the human-readable body of an outbound WhatsApp <em>template</em> message from its name and
+ * NAMED parameters, so the Conversations panel can show the real text the driver received instead of
+ * just the template id (e.g. "pod_rejected_v1").
+ *
+ * <p>Meta stores the approved template copy on the WABA, not here; this registry mirrors that copy
+ * (es_CL) so the pool has a faithful, self-contained rendering. The copy is the source-of-truth spec
+ * in {@code .cursor/plans/whatsapp-integration/whatsapp-templates.md}. If a template is unknown, we
+ * return {@code null} and the caller falls back to the template name — no guessing.
+ *
+ * <p>Placeholders are {@code {{param_name}}} (named, matching the send parameters). Any placeholder
+ * left unfilled (a missing param) is stripped rather than shown raw.
+ */
+public final class WhatsAppTemplateRenderer {
+
+    private static final String FOOTER_TRANSPORT = "ModularIoT · Coordinación de transporte";
+
+    /** template name -> body copy with {{named}} placeholders (footer appended, as WhatsApp shows it). */
+    private static final Map<String, String> BODIES = Map.of(
+            "pod_rejected_v1",
+            "Hola {{driver_name}}. Tu comprobante del viaje {{trip_reference}} no pudo ser aceptado: "
+                    + "{{reason}}. Por favor envía una nueva foto del documento para poder continuar. Gracias."
+                    + "\n\n" + FOOTER_TRANSPORT,
+            "pod_approved_v1",
+            "Hola {{driver_name}}. Tu comprobante de entrega del viaje {{trip_reference}} fue validado "
+                    + "correctamente. ¡Gracias! El viaje queda cerrado."
+                    + "\n\n" + FOOTER_TRANSPORT,
+            "pod_image_unclear_v1",
+            "Hola {{driver_name}}. Recibimos tu documento del viaje {{trip_reference}}, pero la imagen no "
+                    + "se ve con claridad. Por favor envía una nueva foto, bien iluminada y enfocada, donde se "
+                    + "lea la firma. Gracias."
+                    + "\n\n" + FOOTER_TRANSPORT,
+            "trip_detention_alert_v1",
+            "Hola {{driver_name}}. Detectamos una detención no programada en el viaje {{trip_reference}}, "
+                    + "cerca de {{location}}. ¿Está todo en orden? Por favor responde a este mensaje indicando "
+                    + "el motivo o si necesitas apoyo."
+                    + "\n\nModularIoT · Torre de Control",
+            "trip_arrival_pod_request_v1",
+            "Hola {{driver_name}}, tu viaje {{trip_reference}} ha sido confirmado como arribado por la torre "
+                    + "de Control. Por favor, sube la prueba de entrega (POD) firmada respondiendo a este mensaje "
+                    + "con la imagen o el documento.\n\nSi tienes dudas, responde a este mensaje y te ayudamos."
+                    + "\n\nMicroBoxLabs · ModularIoT");
+
+    private WhatsAppTemplateRenderer() {}
+
+    /**
+     * Fills {@code template}'s named placeholders with {@code params}. Returns {@code null} for an
+     * unknown template so the caller can fall back to the template name.
+     */
+    public static String render(String templateName, Map<String, String> params) {
+        if (templateName == null) {
+            return null;
+        }
+        String body = BODIES.get(templateName);
+        if (body == null) {
+            return null;
+        }
+        Map<String, String> safeParams = params == null ? Map.of() : params;
+        for (Map.Entry<String, String> param : safeParams.entrySet()) {
+            String value = param.getValue() == null ? "" : param.getValue();
+            body = body.replace("{{" + param.getKey() + "}}", value);
+        }
+        // Strip any placeholder a caller didn't supply, so we never render raw "{{reason}}".
+        return body.replaceAll("\\{\\{[^}]+}}", "").trim();
+    }
+}

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -68,8 +68,7 @@ class WhatsAppMessagingServiceTest {
 
     @Test
     void previewLabelsTemplateByName() throws Exception {
-        // A template with no local copy (see WhatsAppTemplateRenderer) falls back to its bare name;
-        // templates we do have copy for render their filled body (covered in WhatsAppTemplateRendererTest).
+        // An unknown template with no stored copy shows its bare name in the preview.
         String preview = (String) preview().invoke(null, request("+56900", "TEMPLATE", null, "trip_assigned"));
         assertEquals("trip_assigned", preview);
     }

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppMessagingServiceTest.java
@@ -68,8 +68,10 @@ class WhatsAppMessagingServiceTest {
 
     @Test
     void previewLabelsTemplateByName() throws Exception {
+        // A template with no local copy (see WhatsAppTemplateRenderer) falls back to its bare name;
+        // templates we do have copy for render their filled body (covered in WhatsAppTemplateRendererTest).
         String preview = (String) preview().invoke(null, request("+56900", "TEMPLATE", null, "trip_assigned"));
-        assertEquals("[template] trip_assigned", preview);
+        assertEquals("trip_assigned", preview);
     }
 
     @Test

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRendererTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/service/WhatsAppTemplateRendererTest.java
@@ -1,0 +1,60 @@
+package com.microboxlabs.miot.conversational.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WhatsAppTemplateRendererTest {
+
+    @Test
+    void fillsNamedParamsForKnownTemplate() {
+        String body = WhatsAppTemplateRenderer.render(
+                "pod_rejected_v1",
+                Map.of("driver_name", "Mike", "trip_reference", "1586405", "reason", "la firma no es legible"));
+
+        assertTrue(body.contains("Hola Mike."), body);
+        assertTrue(body.contains("viaje 1586405"), body);
+        assertTrue(body.contains("no pudo ser aceptado: la firma no es legible."), body);
+        assertFalse(body.contains("{{"), "no raw placeholders should remain:\n" + body);
+    }
+
+    @Test
+    void unknownTemplateReturnsNullSoCallerFallsBackToName() {
+        assertNull(WhatsAppTemplateRenderer.render("no_such_template_v9", Map.of("driver_name", "Mike")));
+    }
+
+    @Test
+    void nullTemplateNameReturnsNull() {
+        assertNull(WhatsAppTemplateRenderer.render(null, Map.of()));
+    }
+
+    @Test
+    void stripsPlaceholdersForMissingParams() {
+        // reason not supplied — the {{reason}} placeholder must be removed, never rendered raw.
+        String body = WhatsAppTemplateRenderer.render(
+                "pod_rejected_v1", Map.of("driver_name", "Ana", "trip_reference", "V-99"));
+
+        assertFalse(body.contains("{{reason}}"), body);
+        assertFalse(body.contains("{{"), body);
+        assertTrue(body.contains("Hola Ana."), body);
+    }
+
+    @Test
+    void toleratesNullParamsMap() {
+        // No params at all: still renders the static parts, all placeholders stripped.
+        String body = WhatsAppTemplateRenderer.render("pod_approved_v1", null);
+        assertFalse(body.contains("{{"), body);
+        assertTrue(body.contains("validado"), body);
+    }
+
+    @Test
+    void rendersEmptyValueWithoutPlaceholder() {
+        String body = WhatsAppTemplateRenderer.render(
+                "pod_approved_v1", Map.of("driver_name", "", "trip_reference", "V-1"));
+        assertEquals(false, body.contains("{{"), body);
+    }
+}


### PR DESCRIPTION
Part of #852 (Phase 2b), Slice 2.

## What
Template sends persisted only `template_name` (body NULL), so the panel showed `Plantilla: pod_rejected_v1`. This adds `WhatsAppTemplateRenderer` — a small registry of the approved **es_CL** template copy — and stores the **rendered** body (NAMED params `{{driver_name}}` / `{{trip_reference}}` / `{{reason}}` / `{{location}}` filled) on the outbound `wa_message` row and the conversation preview.

Covers the 5 known templates: `pod_rejected_v1`, `pod_approved_v1`, `pod_image_unclear_v1`, `trip_detention_alert_v1`, `trip_arrival_pod_request_v1`.

## Behavior
- The panel already renders `body` first, so **new** template sends show the real message — **no FE change**.
- **Legacy** rows (body NULL) still fall back to the template name.
- **Unknown** template (no local copy) → renderer returns null → name fallback (no guessing). Missing params are stripped, never rendered as raw `{{…}}`.

Copy source-of-truth: `.cursor/plans/whatsapp-integration/whatsapp-templates.md` (mirrors the WABA-approved text; Meta remains the actual send source).

## Validation
`miot-conversational` full suite green (58 tests, incl. new `WhatsAppTemplateRendererTest` 6/6). Updated one preview test that encoded the old `[template] <name>` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #858


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp template messages now render and store the full message body, including filled-in template text.
  * Preview text now shows the rendered message when available, with a simpler fallback to the template name if not.

* **Bug Fixes**
  * Improved handling of missing or partial template data so previews and saved messages no longer show incomplete placeholder text.
  * Updated expectations for unknown templates to display a cleaner name-only preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->