### PR TITLE
[codex] fix release train harness version floor

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -25,10 +25,33 @@ const latestVersion = (pattern, prefix) => {
   return tags.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))[tags.length - 1];
 };
 
+const semverPattern = /^(\d+)\.(\d+)\.(\d+)$/;
+
+const assertSemver = (version, source) => {
+  if (!semverPattern.test(version)) {
+    throw new Error(`Invalid semver version from ${source}: ${version}`);
+  }
+  return version;
+};
+
+const maxVersion = (...versions) => {
+  const validVersions = versions.filter(Boolean).map((version) => assertSemver(version, "version source"));
+  if (validVersions.length === 0) return "";
+  return validVersions.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).at(-1);
+};
+
+const projectVersion = (path) => {
+  const content = fs.readFileSync(path, "utf8");
+  const match = content.match(/^version = "([^"]+)"$/m);
+  if (!match) {
+    throw new Error(`Could not read project.version from ${path}`);
+  }
+  return assertSemver(match[1], path);
+};
+
 const bumpPatch = (version) => {
   if (!version) return "0.1.0";
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) throw new Error(`Invalid semver tag version: ${version}`);
+  const match = assertSemver(version, "tag").match(semverPattern);
   return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
 };
 
@@ -106,10 +129,12 @@ const modulithChanged = pathStarts(["quarkus-srv/"]);
 
 const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
 const latestHarnessVersion = latestVersion("harness@v*", "harness@v");
+const currentHarnessVersion = projectVersion("miot-harness/pyproject.toml");
+const harnessBaseVersion = maxVersion(latestHarnessVersion, currentHarnessVersion);
 const harnessChanged = pathStarts(["miot-harness/"]) || !latestHarnessVersion;
 const appVersion = stackVersion;
 const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : latestModulithVersion;
-const harnessVersion = harnessChanged ? bumpPatch(latestHarnessVersion) : latestHarnessVersion;
+const harnessVersion = harnessChanged ? bumpPatch(harnessBaseVersion) : harnessBaseVersion;
 const docsVersion = stackVersion;
 
 if (!appVersion) {

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -189,16 +189,32 @@ jobs:
         run: |
           node - <<'NODE'
           const fs = require("fs");
-          const path = "miot-harness/pyproject.toml";
           const version = "${{ steps.plan.outputs.harness_version }}";
-          const content = fs.readFileSync(path, "utf8");
-          const match = content.match(/^version = "([^"]+)"$/m);
+
+          const updateFile = (path, pattern, replacement) => {
+            const content = fs.readFileSync(path, "utf8");
+            if (!pattern.test(content)) {
+              throw new Error(`Could not update harness version in ${path}`);
+            }
+            const next = content.replace(pattern, replacement);
+            if (next !== content) {
+              fs.writeFileSync(path, next);
+            }
+          };
+
+          const pyprojectPath = "miot-harness/pyproject.toml";
+          const pyprojectContent = fs.readFileSync(pyprojectPath, "utf8");
+          const match = pyprojectContent.match(/^version = "([^"]+)"$/m);
           if (!match) {
-            throw new Error(`Could not update project.version in ${path}`);
+            throw new Error(`Could not update project.version in ${pyprojectPath}`);
           }
-          if (match[1] !== version) {
-            fs.writeFileSync(path, content.replace(/^version = ".*"$/m, `version = "${version}"`));
-          }
+          updateFile(pyprojectPath, /^version = ".*"$/m, `version = "${version}"`);
+
+          updateFile(
+            "miot-harness/uv.lock",
+            /(\[\[package\]\]\nname = "miot-harness"\nversion = ")[^"]+(")/,
+            (_match, prefix, suffix) => `${prefix}${version}${suffix}`
+          );
           NODE
 
       - name: Resolve release date
@@ -278,7 +294,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml
+          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml miot-harness/uv.lock
           if git diff --cached --quiet; then
             echo "No release prep changes to commit."
           else
@@ -416,8 +432,14 @@ jobs:
 
           if [[ "${{ needs.prepare.outputs.harness_changed }}" == "true" ]]; then
             harness_version="$(node -p "require('fs').readFileSync('miot-harness/pyproject.toml', 'utf8').match(/^version = \\\"([^\\\"]+)\\\"$/m)?.[1] || process.exit(1)")"
+            harness_lock_version="$(node -p "require('fs').readFileSync('miot-harness/uv.lock', 'utf8').match(/\\[\\[package\\]\\]\\nname = \\\"miot-harness\\\"\\nversion = \\\"([^\\\"]+)\\\"/)?.[1] || process.exit(1)")"
             if [[ "$harness_version" != "${{ needs.prepare.outputs.harness_version }}" ]]; then
               echo "trunk harness version is $harness_version, expected ${{ needs.prepare.outputs.harness_version }}." >&2
+              echo "Merge the release PR before approving/tagging." >&2
+              exit 1
+            fi
+            if [[ "$harness_lock_version" != "${{ needs.prepare.outputs.harness_version }}" ]]; then
+              echo "trunk harness lock version is $harness_lock_version, expected ${{ needs.prepare.outputs.harness_version }}." >&2
               echo "Merge the release PR before approving/tagging." >&2
               exit 1
             fi


### PR DESCRIPTION
## Summary

- Use the current `miot-harness/pyproject.toml` version as a floor when resolving the next harness release version.
- Keep `miot-harness/uv.lock` in sync when the release train bumps harness metadata.
- Stage and verify both harness metadata files during release prep/tag validation.

## Root Cause

The release train previously derived the next harness version only from the latest `harness@v*` tag. If package metadata had already advanced beyond the latest tag, the release prep step could rewrite `pyproject.toml` downward.

## Validation

- `node --check .github/scripts/resolve-stack-release-plan.js`
- YAML parse for `.github/workflows/app-release-train.yml`
- `git diff --check -- .github/scripts/resolve-stack-release-plan.js .github/workflows/app-release-train.yml`

Closes #859