### PR TITLE
fix(whatsapp): boot the modulith when WhatsApp env is unset (Optional config)

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/WhatsAppWebhookResource.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/api/WhatsAppWebhookResource.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -53,11 +54,16 @@ public class WhatsAppWebhookResource {
 
     @Inject
     public WhatsAppWebhookResource(
-            @ConfigProperty(name = "miot.whatsapp.webhook.verify-token", defaultValue = "") String verifyToken,
-            @ConfigProperty(name = "miot.whatsapp.app-secret", defaultValue = "") String appSecret,
+            // Optional (not String + defaultValue): application.properties maps these from env as
+            // ${WHATSAPP_..:}, so when the env is unset the property is present-but-EMPTY, and SmallRye
+            // rejects an empty value for a required String — crashing the modulith at boot even though
+            // conversational is baked into every image. Optional tolerates the empty/absent value; a
+            // blank token/secret then fails closed via the handshake + signature guards below.
+            @ConfigProperty(name = "miot.whatsapp.webhook.verify-token") Optional<String> verifyToken,
+            @ConfigProperty(name = "miot.whatsapp.app-secret") Optional<String> appSecret,
             WhatsAppInboundService inboundService) {
-        this.verifyToken = verifyToken;
-        this.appSecret = appSecret;
+        this.verifyToken = verifyToken.orElse("");
+        this.appSecret = appSecret.orElse("");
         this.inboundService = inboundService;
     }
 


### PR DESCRIPTION
Closes #863.

## Problem
`miot-conversational` is baked into **every** `miot-srv` image (CI sets the build-time `miot.component.conversational.enabled=true` `@IfBuildProperty`), so `WhatsAppWebhookResource` always loads at boot and reads `miot.whatsapp.webhook.verify-token` / `miot.whatsapp.app-secret`. `application.properties` maps them from env with an empty default (`${WHATSAPP_WEBHOOK_VERIFY_TOKEN:}`), so an **unset** env leaves the property *present-but-empty* — and SmallRye rejects an empty value for a required `String`, crashing the modulith before HTTP opens:

```
Failed to load config value of type class java.lang.String for: miot.whatsapp.webhook.verify-token
```

`@ConfigProperty(defaultValue = "")` (#850) did **not** fix it — the default only applies when the property is ABSENT, but `${VAR:}` keeps it always present. Proven: v0.5.21 (which contains the defaultValue fix) still crashes on streamhub-dev.

## Fix
Inject `Optional<String>` + `.orElse("")`. SmallRye maps the empty/absent value to `Optional.empty()` without the failing `String` conversion, so the modulith boots with a **blank** token/secret — which then fails closed via the existing handshake (`isValidHandshake` rejects a blank configured token) and HMAC (`WhatsAppSignatureVerifier` rejects a blank secret) guards. No env wiring needed in environments that don't use WhatsApp.

## Affected envs
Any image with conversational baked in that doesn't wire NON-EMPTY `WHATSAPP_WEBHOOK_VERIFY_TOKEN` + `WHATSAPP_APP_SECRET`. coordinador-dev/prod boot today only because they wire the secret; **streamhub-dev/prod crash** — this removes that dependency.

## Validation
`miot-conversational` suite green (58 tests). The real proof is a boot on an env with no WhatsApp env set (e.g. streamhub-dev) after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)