### PR TITLE
feat(harness): stop sharing agent $ cost with the client

### DIFF
--- a/miot-harness/src/miot_harness/observability/callbacks.py
+++ b/miot-harness/src/miot_harness/observability/callbacks.py
@@ -216,8 +216,9 @@ class AgentTelemetryCallback(BaseCallbackHandler):
                 "cache_read_input_tokens": usage.cache_read_input_tokens,
                 "cache_creation_input_tokens": usage.cache_creation_input_tokens,
             }
-            if cost_usd is not None:
-                data["cost_usd"] = cost_usd
+            # NOTE: cost_usd is deliberately NOT emitted to the client. The dollar
+            # cost stays server-side (span attribute above / eval + provenance logs)
+            # so we can track our own spend without exposing it to the tenant.
             # Fail open: the progress sink is an observability concern,
             # so a buggy or saturated event bus must NOT bubble up and
             # tear down the LLM call. Catch Exception (not BaseException)

--- a/miot-harness/tests/observability/test_usage_recorded_event.py
+++ b/miot-harness/tests/observability/test_usage_recorded_event.py
@@ -56,6 +56,8 @@ def test_callback_emits_usage_recorded_when_progress_wired(
     usage_events = [e for e in events if e.type == "usage.recorded"]
     assert len(usage_events) == 1
     payload = usage_events[0].data
+    # The dollar cost is NEVER shared with the client, even for a priced
+    # model — it stays server-side (span attribute + eval/provenance logs).
     # Total input (200) minus cache_read (5) minus cache_creation (3) = 192
     assert payload == {
         "agent": "filter_expert",
@@ -64,9 +66,8 @@ def test_callback_emits_usage_recorded_when_progress_wired(
         "output_tokens": 80,
         "cache_read_input_tokens": 5,
         "cache_creation_input_tokens": 3,
-        "cost_usd": payload["cost_usd"],
     }
-    assert payload["cost_usd"] > 0
+    assert "cost_usd" not in payload
     assert usage_events[0].run_id == "run_abc"
 
 

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/components/FooterLine.test.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/components/FooterLine.test.tsx
@@ -9,9 +9,7 @@ function usage(partial: Partial<UsageTotals> = {}): UsageTotals {
     outputTokens: 0,
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
-    costUsd: 0,
     lastAgent: null,
-    lastCostUsd: null,
     ...partial,
   };
 }
@@ -44,23 +42,22 @@ describe("<FooterLine />", () => {
     expect(lastFrame() ?? "").toContain("profile staging");
   });
 
-  it("shows a usage segment when usageTotals has any tokens", () => {
+  it("shows a token usage segment when usageTotals has any tokens", () => {
     const { lastFrame } = render(
       <FooterLine
         {...props({
           usageTotals: usage({
             inputTokens: 1234,
             outputTokens: 56,
-            costUsd: 0.0123,
             lastAgent: "synthesizer",
-            lastCostUsd: 0.0123,
           }),
         })}
       />,
     );
     const frame = lastFrame() ?? "";
     expect(frame).toContain("1234→56");
-    expect(frame).toContain("$0.0123");
+    // The dollar cost is never shown to the client.
+    expect(frame).not.toContain("$");
   });
 
   it("hides the usage segment when there are no tokens yet", () => {

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
@@ -30,9 +30,7 @@ function emptySlice(): TranscriptSlice {
       outputTokens: 0,
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
-      costUsd: 0,
       lastAgent: null,
-      lastCostUsd: null,
     },
   };
 }
@@ -434,7 +432,7 @@ describe("transcript projector — thinking + usage (plan: SSE rich events)", ()
     expect(s2.transcript[0]).toMatchObject({ kind: "thinking", status: "complete" });
   });
 
-  it("usage.recorded accumulates totals across calls", () => {
+  it("usage.recorded accumulates token totals across calls", () => {
     const ctx = mkCtx();
     const s1 = applyHarnessEvent(
       emptySlice(),
@@ -446,7 +444,6 @@ describe("transcript projector — thinking + usage (plan: SSE rich events)", ()
           output_tokens: 100,
           cache_read_input_tokens: 50,
           cache_creation_input_tokens: 25,
-          cost_usd: 0.0042,
         },
       }),
       "r1",
@@ -457,9 +454,7 @@ describe("transcript projector — thinking + usage (plan: SSE rich events)", ()
       outputTokens: 100,
       cacheReadTokens: 50,
       cacheCreationTokens: 25,
-      costUsd: 0.0042,
       lastAgent: "filter_expert",
-      lastCostUsd: 0.0042,
     });
 
     const s2 = applyHarnessEvent(
@@ -480,8 +475,8 @@ describe("transcript projector — thinking + usage (plan: SSE rich events)", ()
     expect(s2.usageTotals.inputTokens).toBe(3000);
     expect(s2.usageTotals.outputTokens).toBe(300);
     expect(s2.usageTotals.lastAgent).toBe("synthesizer");
-    expect(s2.usageTotals.lastCostUsd).toBeNull();
-    expect(s2.usageTotals.costUsd).toBeCloseTo(0.0042);
+    // Dollar cost is never carried on the client-side usage totals.
+    expect(s2.usageTotals).not.toHaveProperty("costUsd");
   });
 
   it("agent.completed is intentionally dropped from the transcript", () => {

--- a/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/__tests__/transcript.project.test.ts
@@ -477,6 +477,7 @@ describe("transcript projector — thinking + usage (plan: SSE rich events)", ()
     expect(s2.usageTotals.lastAgent).toBe("synthesizer");
     // Dollar cost is never carried on the client-side usage totals.
     expect(s2.usageTotals).not.toHaveProperty("costUsd");
+    expect(s2.usageTotals).not.toHaveProperty("lastCostUsd");
   });
 
   it("agent.completed is intentionally dropped from the transcript", () => {

--- a/turbo-repo/packages/miot-chat/src/tui/chrome/FooterLine.tsx
+++ b/turbo-repo/packages/miot-chat/src/tui/chrome/FooterLine.tsx
@@ -22,8 +22,7 @@ export function FooterLine(props: FooterLineProps): React.ReactElement {
   segments.push(`ctx≈${props.approxTokens}tok (${props.contextPercent}%)`);
   const u = props.usageTotals;
   if (u && (u.inputTokens > 0 || u.outputTokens > 0)) {
-    const cost = u.costUsd > 0 ? ` $${u.costUsd.toFixed(4)}` : "";
-    segments.push(`${u.inputTokens}→${u.outputTokens}${cost}`);
+    segments.push(`${u.inputTokens}→${u.outputTokens}`);
   }
   segments.push(props.baseUrl);
   if (props.profileName) {

--- a/turbo-repo/packages/miot-chat/src/tui/session/types.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/session/types.ts
@@ -43,17 +43,15 @@ export type TranscriptItem =
 
 /**
  * Running totals across the conversation. Reset by CLEAR /
- * RESET_CONVERSATION; accumulated turn-over-turn. `lastCostUsd` is
- * the cost of the most recent LLM call (chip footer uses it).
+ * RESET_CONVERSATION; accumulated turn-over-turn. Dollar cost is
+ * intentionally not tracked here — it is not shared with the client.
  */
 export interface UsageTotals {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreationTokens: number;
-  costUsd: number;
   lastAgent: string | null;
-  lastCostUsd: number | null;
 }
 
 export const ZERO_USAGE: UsageTotals = {
@@ -61,9 +59,7 @@ export const ZERO_USAGE: UsageTotals = {
   outputTokens: 0,
   cacheReadTokens: 0,
   cacheCreationTokens: 0,
-  costUsd: 0,
   lastAgent: null,
-  lastCostUsd: null,
 };
 
 export interface PendingApproval {

--- a/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
+++ b/turbo-repo/packages/miot-chat/src/tui/transcript/project.ts
@@ -193,8 +193,6 @@ export function applyHarnessEvent(
         typeof event.data.cache_creation_input_tokens === "number"
           ? event.data.cache_creation_input_tokens
           : 0;
-      const cost =
-        typeof event.data.cost_usd === "number" ? event.data.cost_usd : 0;
       const agent =
         typeof event.data.agent === "string" ? event.data.agent : null;
       return {
@@ -204,10 +202,7 @@ export function applyHarnessEvent(
           outputTokens: slice.usageTotals.outputTokens + outT,
           cacheReadTokens: slice.usageTotals.cacheReadTokens + cacheR,
           cacheCreationTokens: slice.usageTotals.cacheCreationTokens + cacheC,
-          costUsd: slice.usageTotals.costUsd + cost,
           lastAgent: agent,
-          lastCostUsd:
-            typeof event.data.cost_usd === "number" ? event.data.cost_usd : null,
         },
       };
     }

--- a/turbo-repo/packages/miot-harness-client/src/types.ts
+++ b/turbo-repo/packages/miot-harness-client/src/types.ts
@@ -119,7 +119,6 @@ export interface UsageRecordedData {
   output_tokens: number;
   cache_read_input_tokens: number;
   cache_creation_input_tokens: number;
-  cost_usd?: number;
 }
 
 export const TERMINAL_EVENT_TYPES = new Set<HarnessEventType>([


### PR DESCRIPTION
## What & why

The harness computed the LLM dollar cost (`cost_usd`) per turn and streamed it to the client in the `usage.recorded` SSE event, where miot-chat rendered it in the TUI footer as `$0.0123`. We don't want tenants to see how much each query costs us.

This stops the dollar cost from ever leaving the server, while keeping it tracked internally so we still measure our own spend.

## Changes

**Boundary fix (backend)**
- `miot-harness/.../observability/callbacks.py` — no longer attaches `cost_usd` to the `usage.recorded` event. The cost is still computed and kept as the server-side span attribute (`gen_ai.usage.cost_usd`), so eval reports and provenance logs are unchanged.

**Client cleanup (token counts untouched)**
- `miot-harness-client/src/types.ts` — dropped `cost_usd` from `UsageRecordedData`.
- `miot-chat/.../session/types.ts` — removed `costUsd` / `lastCostUsd` from `UsageTotals` + `ZERO_USAGE`.
- `miot-chat/.../transcript/project.ts` — removed cost accumulation.
- `miot-chat/.../chrome/FooterLine.tsx` — footer now shows `1234→56` with no `$` figure.

**Left intentionally untouched (internal-only):** `report.py`, `run_golden.py` eval totals, `provenance.py` `plan_cost`, and the Postgres `EXPLAIN` `total_cost` (a query-planner estimate, not dollars).

## Verification

- Harness: `test_usage_recorded_event.py` + `test_callbacks.py` → **10 passed** (event omits `cost_usd`; span attribute retained).
- TUI: `FooterLine.test.tsx` + `transcript.project.test.ts` → **29 passed** (footer shows tokens, no `$`).
- `tsc --noEmit` on `miot-chat` and `miot-harness-client` → **exit 0**.
- Grep confirms no `cost_usd`/`costUsd` references remain in `turbo-repo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed dollar-cost values from client-facing usage events and summaries.
  * Updated usage tracking to keep token counts and agent details without showing pricing information.
  * Simplified the TUI footer so usage now displays token totals only, with no dollar amount.
  * Adjusted related test coverage to reflect the new usage display and event payload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->