### PR TITLE
feat(harness): single-agent cached tool-calling loop (replaces agentic expert panel, flag-gated)

### DIFF
--- a/miot-harness/src/miot_harness/agents/chat_models.py
+++ b/miot-harness/src/miot_harness/agents/chat_models.py
@@ -55,6 +55,7 @@ def get_chat_model(
     *,
     thinking_budget_tokens: int | None = None,
     effort: Effort | None = None,
+    timeout: int | None = None,
 ) -> BaseChatModel:
     """Multi-provider chat-model factory.
 
@@ -96,7 +97,10 @@ def get_chat_model(
         kwargs: dict[str, object] = {
             "model_name": name,
             "api_key": SecretStr(settings.anthropic_api_key),
-            "timeout": 60,
+            # 60s suits single-shot seats; the agent loop passes a longer
+            # budget because an adaptive-thinking turn that plans several
+            # tool calls can legitimately exceed a minute.
+            "timeout": timeout if timeout is not None else 60,
             "stop": None,
         }
         if effort is not None:

--- a/miot-harness/src/miot_harness/agents/native_tools.py
+++ b/miot-harness/src/miot_harness/agents/native_tools.py
@@ -1,0 +1,34 @@
+"""Anthropic-format tool definitions for the single-agent loop.
+
+The tool list is part of the prompt-cache prefix (tools render before
+system), so it must be byte-stable across requests: same scope rules as
+the legacy planner catalog (curated `tool_prefix` functions + exploration
+primitives), sorted by name, schemas derived deterministically from the
+pydantic input models.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miot_harness.datasource.provider import DataSourceProfile
+from miot_harness.tools.registry import ToolRegistry
+
+
+def build_native_tools(
+    registry: ToolRegistry, *, profile: DataSourceProfile
+) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for name in registry.names():  # .names() is already sorted
+        tool = registry.get(name)
+        in_scope = name.startswith(profile.tool_prefix) or tool.kind == "primitive"
+        if not in_scope:
+            continue
+        tools.append(
+            {
+                "name": name,
+                "description": tool.description,
+                "input_schema": tool.input_model.model_json_schema(),
+            }
+        )
+    return tools

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -479,6 +479,7 @@ def _make_lifespan(
                         model=get_chat_model(
                             settings.agents_planner_model,
                             effort=settings.agents_planner_effort,
+                            timeout=settings.agents_agent_loop_llm_timeout_seconds,
                         ),
                         registry=harness.tools,
                         settings=settings,

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -39,6 +39,7 @@ from miot_harness.datasource.provider import BootResult, DataSourceProvider
 from miot_harness.datasource.registry import resolve as resolve_datasource
 from miot_harness.observability.otel import configure_tracing, shutdown_tracing
 from miot_harness.observability.provenance import ProvenanceLog
+from miot_harness.runtime.agent_loop import AgentLoopRunner
 from miot_harness.runtime.agentic_graph import build_agentic_graph
 from miot_harness.runtime.context import UserRequest
 from miot_harness.runtime.data_graph import build_data_graph
@@ -470,6 +471,23 @@ def _make_lifespan(
                     profile=effective_profile,
                     registry=harness.tools,
                 )
+                # Single-agent loop (flag-gated). Reuses the planner seat's
+                # model/effort; the runner freezes prompt + tool list at boot
+                # so every request shares one prompt-cache prefix.
+                if settings.agents_agent_loop_enabled:
+                    harness.agent_loop = AgentLoopRunner(
+                        model=get_chat_model(
+                            settings.agents_planner_model,
+                            effort=settings.agents_planner_effort,
+                        ),
+                        registry=harness.tools,
+                        settings=settings,
+                        profile=effective_profile,
+                        provenance_log=ProvenanceLog(
+                            settings.provenance_log_dir,
+                            enabled=settings.provenance_log_enabled,
+                        ),
+                    )
                 harness.meta_model = get_chat_model(
                     settings.intent_router_model,
                     thinking_budget_tokens=synth_thinking_budget,
@@ -525,6 +543,7 @@ def _make_lifespan(
                 app.state.datasource_freshness = {}
                 harness.data_graph = None
                 harness.agentic_graph = None
+                harness.agent_loop = None
                 harness.meta_model = None
                 harness.meta_primer = ""  # meta path gates on meta_model
                 harness.meta_catalog = []

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -81,6 +81,10 @@ class HarnessSettings(BaseSettings):
     # Per-tool-result cap on the JSON fed back to the model. Bounds context
     # growth (and cache-write size) when a tool returns a large row set.
     agents_agent_loop_tool_result_max_chars: int = Field(default=6000, gt=0)
+    # LLM timeout for the agent loop (seconds). The loop's final turn writes
+    # the full user-facing answer and adaptive-thinking turns can exceed the
+    # current hard 60s default. 300s (5 minutes) suits multi-step planning.
+    agents_agent_loop_llm_timeout_seconds: int = Field(default=300, gt=0)
     # Small "did we answer it?" judge. Held separate from the synthesizer so it
     # can stay cheap. Empty string disables the LLM judge (rules-only verify).
     agents_verifier_model: str = "claude-haiku-4-5"

--- a/miot-harness/src/miot_harness/config.py
+++ b/miot-harness/src/miot_harness/config.py
@@ -73,6 +73,14 @@ class HarnessSettings(BaseSettings):
     # so they exercise the rules-only path.
     agents_agentic_verify_enabled: bool = True
     agents_agentic_max_replans: int = Field(default=2, ge=0)
+    # Single-agent tool-calling loop (spec 2026-07-02). When enabled, the
+    # DATA_AGENTIC route runs one cached native tool-use loop instead of the
+    # planner/verifier/synthesizer/critic panel. Default off until golden
+    # evals show parity with the legacy agentic graph.
+    agents_agent_loop_enabled: bool = False
+    # Per-tool-result cap on the JSON fed back to the model. Bounds context
+    # growth (and cache-write size) when a tool returns a large row set.
+    agents_agent_loop_tool_result_max_chars: int = Field(default=6000, gt=0)
     # Small "did we answer it?" judge. Held separate from the synthesizer so it
     # can stay cheap. Empty string disables the LLM judge (rules-only verify).
     agents_verifier_model: str = "claude-haiku-4-5"

--- a/miot-harness/src/miot_harness/observability/callbacks.py
+++ b/miot-harness/src/miot_harness/observability/callbacks.py
@@ -82,7 +82,15 @@ def _extract_usage(response: LLMResult) -> TokenUsage:
                 continue
             details = usage_metadata.get("input_token_details") or {}
             cache_read = int(details.get("cache_read", 0) or 0)
-            cache_creation = int(details.get("cache_creation", 0) or 0)
+            # langchain_anthropic maps ephemeral cache writes to
+            # ephemeral_5m_input_tokens / ephemeral_1h_input_tokens and sets
+            # cache_creation=0. Sum all three so telemetry captures ephemeral
+            # writes at the correct 1.25× pricing rate.
+            cache_creation = (
+                int(details.get("cache_creation", 0) or 0)
+                + int(details.get("ephemeral_5m_input_tokens", 0) or 0)
+                + int(details.get("ephemeral_1h_input_tokens", 0) or 0)
+            )
             total_input = int(usage_metadata.get("input_tokens", 0) or 0)
             return TokenUsage(
                 input_tokens=max(total_input - cache_read - cache_creation, 0),

--- a/miot-harness/src/miot_harness/runtime/agent_loop.py
+++ b/miot-harness/src/miot_harness/runtime/agent_loop.py
@@ -1,0 +1,106 @@
+"""Single-agent native tool-calling loop (replaces the agentic seat panel).
+
+Cache layout per request (Anthropic renders tools → system → messages):
+
+    [tools: sorted, static]                      ─┐ cached prefix,
+    [system: frozen prompt, cache_control here]  ─┘ breakpoint 1
+    [prior turns + this run's growing loop tail]
+    [last block: request-time cache_control]      ← breakpoint 2
+
+Invariants (spec 2026-07-02): the prefix is byte-stable per (profile,
+registry); dynamic content (skill bodies, JSON-block contracts) rides in
+the user turn as <system-reminder> blocks; markers are applied on a COPY at
+request time so history never accumulates breakpoints.
+
+Known limit (spec §component 5): the API's cache lookback is 20 content
+blocks — a single turn with >8 parallel tool calls could out-run it and
+silently miss the tail cache for that request (prefix cache unaffected).
+Accepted for v1; revisit if usage_log shows cache_read collapsing on
+fan-out turns.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any
+
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+_EPHEMERAL_CACHE = {"type": "ephemeral"}
+
+
+def _split_prior(
+    prior: list[BaseMessage],
+) -> tuple[list[BaseMessage], list[str]]:
+    """Separate supervisor-injected SystemMessages from real history.
+
+    langchain_anthropic folds every SystemMessage into the single top-level
+    `system` param — a per-request skill body appended there would change
+    the cached prefix bytes and silently zero the cache. So injected system
+    texts are demoted to <system-reminder> blocks in the user turn instead.
+    """
+    history: list[BaseMessage] = []
+    reminders: list[str] = []
+    for msg in prior:
+        if isinstance(msg, SystemMessage):
+            reminders.append(
+                msg.content if isinstance(msg.content, str) else json.dumps(msg.content)
+            )
+        else:
+            history.append(msg)
+    return history, reminders
+
+
+def _compose_human(user_message: str, reminders: list[str]) -> HumanMessage:
+    if not reminders:
+        return HumanMessage(content=user_message)
+    blocks = "\n\n".join(
+        f"<system-reminder>\n{text}\n</system-reminder>" for text in reminders
+    )
+    return HumanMessage(content=f"{blocks}\n\n{user_message}")
+
+
+def _with_tail_marker(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Copy of `messages` with `cache_control` on the last markable block.
+
+    Applied per request; the caller's list is never mutated (asserted by
+    tests) so breakpoints can't accumulate past the API's 4-marker cap.
+    """
+    if not messages:
+        return messages
+    last = messages[-1]
+    marked = _mark_message(last)
+    if marked is None:
+        return list(messages)
+    return [*messages[:-1], marked]
+
+
+def _mark_message(msg: BaseMessage) -> BaseMessage | None:
+    content = msg.content
+    if isinstance(content, str):
+        blocks: list[Any] = [
+            {"type": "text", "text": content, "cache_control": _EPHEMERAL_CACHE}
+        ]
+    elif isinstance(content, list) and content:
+        blocks = copy.deepcopy(content)
+        tail = blocks[-1]
+        if not isinstance(tail, dict):
+            return None
+        if tail.get("type") not in ("text", "tool_result", "tool_use"):
+            # thinking / redacted blocks are not valid cache anchors — skip
+            # marking rather than 400 the request.
+            return None
+        tail["cache_control"] = _EPHEMERAL_CACHE
+    else:
+        return None
+    return msg.model_copy(update={"content": blocks})

--- a/miot-harness/src/miot_harness/runtime/agent_loop.py
+++ b/miot-harness/src/miot_harness/runtime/agent_loop.py
@@ -27,11 +27,9 @@ import logging
 from typing import Any
 
 from langchain_core.messages import (
-    AIMessage,
     BaseMessage,
     HumanMessage,
     SystemMessage,
-    ToolMessage,
 )
 
 logger = logging.getLogger(__name__)
@@ -77,7 +75,7 @@ def _with_tail_marker(messages: list[BaseMessage]) -> list[BaseMessage]:
     tests) so breakpoints can't accumulate past the API's 4-marker cap.
     """
     if not messages:
-        return messages
+        return list(messages)
     last = messages[-1]
     marked = _mark_message(last)
     if marked is None:

--- a/miot-harness/src/miot_harness/runtime/agent_loop.py
+++ b/miot-harness/src/miot_harness/runtime/agent_loop.py
@@ -24,17 +24,48 @@ from __future__ import annotations
 import copy
 import json
 import logging
+from time import monotonic
 from typing import Any
 
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     BaseMessage,
     HumanMessage,
     SystemMessage,
+    ToolMessage,
 )
+
+from miot_harness.agents.chat_models import response_text
+from miot_harness.agents.data_fetcher import invoke_step
+from miot_harness.agents.freshness_judge import freshness_judge_node
+from miot_harness.agents.native_tools import build_native_tools
+from miot_harness.config import HarnessSettings
+from miot_harness.datasource.provider import DataSourceProfile
+from miot_harness.observability.provenance import ProvenanceLog
+from miot_harness.runtime.agent_prompt import (
+    build_agent_system_prompt,
+    cached_system_message,
+)
+from miot_harness.runtime.agentic_graph import _provenance_entry
+from miot_harness.runtime.context import HarnessContext
+from miot_harness.runtime.data_graph import instrument_model
+from miot_harness.runtime.events import HarnessEvent
+from miot_harness.runtime.plan import DataEvidence, DataStep
+from miot_harness.runtime.router import HarnessRoute
+from miot_harness.runtime.tenancy import tenancy_gate_decision
+from miot_harness.runtime.tool import Progress
+from miot_harness.tools.registry import ToolRegistry
+from miot_harness.utils.truncation import truncate_for_trace
 
 logger = logging.getLogger(__name__)
 
 _EPHEMERAL_CACHE = {"type": "ephemeral"}
+
+_TURN_CAP_NUDGE = (
+    "Turn cap reached. Answer now from the evidence you already collected; "
+    "do not call more tools. If the evidence is insufficient, say what is "
+    "missing."
+)
 
 
 def _split_prior(
@@ -102,3 +133,202 @@ def _mark_message(msg: BaseMessage) -> BaseMessage | None:
     else:
         return None
     return msg.model_copy(update={"content": blocks})
+
+
+class AgentLoopRunner:
+    """One cached tool-calling agent for the DATA_AGENTIC route.
+
+    Prefix (system prompt + native tool list) is built ONCE here and never
+    varies per request — that is the prompt-cache contract. Per-request
+    dynamics (skill bodies, JSON-block contract) arrive via prior_messages
+    and are demoted into the user turn by _split_prior/_compose_human.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: BaseChatModel,
+        registry: ToolRegistry,
+        settings: HarnessSettings,
+        profile: DataSourceProfile,
+        provenance_log: ProvenanceLog | None = None,
+    ) -> None:
+        self.registry = registry
+        self.settings = settings
+        self.profile = profile
+        self.provenance_log = provenance_log
+        self.native_tools = build_native_tools(registry, profile=profile)
+        self.system_message = cached_system_message(build_agent_system_prompt(profile))
+        # Bind once — adding/removing/reordering tools mid-conversation
+        # invalidates the whole cache (tools render at position 0).
+        self.bound_model = model.bind_tools(self.native_tools)
+
+    async def run(
+        self,
+        *,
+        user_message: str,
+        ctx: HarnessContext,
+        prior_messages: list[BaseMessage],
+        progress: Progress,
+    ) -> dict[str, Any]:
+        decision = tenancy_gate_decision(
+            ctx=ctx,
+            route=HarnessRoute.DATA_AGENTIC,
+            settings=self.settings,
+            profile=self.profile,
+        )
+        if not decision.allowed:
+            return {
+                "answer": decision.refusal_message,
+                "evidence": [],
+                "usage_log": [],
+            }
+
+        model = instrument_model(
+            self.bound_model,  # type: ignore[arg-type]  # RunnableBinding also has .with_config
+            "agent_loop",
+            ctx,
+            progress=progress,
+            span_prefix=self.profile.name,
+        )
+        history, reminders = _split_prior(prior_messages)
+        messages: list[BaseMessage] = [
+            self.system_message,
+            *history,
+            _compose_human(user_message, reminders),
+        ]
+        evidence: list[DataEvidence] = []
+        usage_log: list[dict[str, Any]] = []
+        answer: str | None = None
+        max_turns = self.settings.agents_agentic_max_turns
+
+        for turn in range(max_turns + 1):
+            capped = turn >= max_turns
+            if capped:
+                messages.append(HumanMessage(content=_TURN_CAP_NUDGE))
+            progress(
+                HarnessEvent(
+                    run_id=ctx.run_id,
+                    type="agent.started",
+                    message="Entering agent_loop turn",
+                    data={"agent": "agent_loop", "graph": "agent_loop", "turn": turn},
+                )
+            )
+            start = monotonic()
+            response = await model.ainvoke(_with_tail_marker(messages))
+            usage_log.append(dict(getattr(response, "usage_metadata", None) or {}))
+            messages.append(response)
+            tool_calls = list(getattr(response, "tool_calls", None) or [])
+            progress(
+                HarnessEvent(
+                    run_id=ctx.run_id,
+                    type="agent.completed",
+                    message="Completed agent_loop turn",
+                    data={
+                        "agent": "agent_loop",
+                        "graph": "agent_loop",
+                        "turn": turn,
+                        "duration_ms": int((monotonic() - start) * 1000),
+                        "exit_reason": "tool_calls" if tool_calls else "answer",
+                    },
+                )
+            )
+            if not tool_calls or capped:
+                answer = response_text(response).strip()
+                break
+            for call in tool_calls:
+                messages.append(
+                    await self._execute_tool_call(
+                        call, ctx=ctx, user_message=user_message,
+                        evidence=evidence, progress=progress,
+                    )
+                )
+
+        if not answer:
+            answer = (
+                "The investigation could not produce an answer within the "
+                "turn limit."
+            )
+        progress(
+            HarnessEvent(
+                run_id=ctx.run_id,
+                type="answer.completed",
+                message="Agent loop answered",
+                data={"length": len(answer), "turns": len(usage_log)},
+            )
+        )
+        return {"answer": answer, "evidence": evidence, "usage_log": usage_log}
+
+    async def _execute_tool_call(
+        self,
+        call: dict[str, Any],
+        *,
+        ctx: HarnessContext,
+        user_message: str,
+        evidence: list[DataEvidence],
+        progress: Progress,
+    ) -> ToolMessage:
+        step = DataStep(
+            intent=str(call.get("name", "")),
+            tool=str(call.get("name", "")),
+            args=dict(call.get("args") or {}),
+            rationale="agent_loop",
+        )
+        call_id = str(call.get("id", ""))
+        delta = await invoke_step(
+            step,
+            ctx=ctx,
+            registry=self.registry,
+            settings=self.settings,
+            progress=progress,
+            profile=self.profile,
+        )
+        if "failure" in delta:
+            # Feedback, not a dead end: the model sees the error and adapts
+            # (retry with fixed args, another tool, or answer without it).
+            return ToolMessage(
+                content=json.dumps({"error": delta["failure"]}, default=str),
+                tool_call_id=call_id,
+                status="error",
+            )
+        ev: DataEvidence = delta["evidence"][0]
+        evidence.append(ev)
+        # Deterministic freshness classification (emits freshness.warning).
+        # REFUSE-zone `failure` is intentionally dropped — agentic parity:
+        # the evidence is already stamped stale and the system prompt makes
+        # the answer caveat it (see runtime/agentic_graph.freshness_judge).
+        freshness_judge_node(
+            {"ctx": ctx, "evidence": evidence},
+            settings=self.settings,
+            progress=progress,
+            profile=self.profile,
+        )
+        if self.provenance_log is not None:
+            self.provenance_log.append(
+                _provenance_entry(
+                    ctx=ctx, user_message=user_message, step=step, evidence=ev
+                )
+            )
+        return ToolMessage(
+            content=self._render_tool_result(ev), tool_call_id=call_id
+        )
+
+    def _render_tool_result(self, ev: DataEvidence) -> str:
+        payload, _info = truncate_for_trace(
+            {
+                "tool": ev.tool,
+                "source": ev.source,
+                "rows_returned": ev.sample_size,
+                "refreshed_at": ev.refreshed_at,
+                "is_stale": ev.is_stale,
+                "freshness_status": ev.freshness_status,
+                "is_sample": ev.is_sample,
+                "executed_sql": ev.executed_sql,
+                "output": ev.output,
+            }
+        )
+        text = json.dumps(payload, default=str)
+        cap = self.settings.agents_agent_loop_tool_result_max_chars
+        if len(text) > cap:
+            text = text[:cap] + '... [truncated]"}'
+        return text

--- a/miot-harness/src/miot_harness/runtime/agent_prompt.py
+++ b/miot-harness/src/miot_harness/runtime/agent_prompt.py
@@ -15,8 +15,6 @@ from langchain_core.messages import SystemMessage
 
 from miot_harness.datasource.provider import DataSourceProfile
 
-_EPHEMERAL_CACHE = {"type": "ephemeral"}
-
 _AGENT_SYSTEM_TEMPLATE = """\
 You are the {display_name} data agent ({tenant_display} fleet operations).
 You investigate the user's question by calling tools, then write the final
@@ -76,5 +74,5 @@ def cached_system_message(text: str) -> SystemMessage:
     the API renders tools before system, so one breakpoint covers both.
     """
     return SystemMessage(
-        content=[{"type": "text", "text": text, "cache_control": _EPHEMERAL_CACHE}]
+        content=[{"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}]
     )

--- a/miot-harness/src/miot_harness/runtime/agent_prompt.py
+++ b/miot-harness/src/miot_harness/runtime/agent_prompt.py
@@ -1,0 +1,80 @@
+"""Frozen system prompt for the single-agent loop.
+
+This text is the prompt-cache prefix (together with the tool list), so it
+must be a pure function of the datasource profile: no clock, no per-request
+tenant, no uuids, no counters. Dynamic per-run context never goes here —
+it rides in the user turn (see agent_loop._compose_human).
+
+The rules merge the two seats the loop replaces: the agentic planner's
+investigation-rigor rules and the synthesizer's answer rules.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import SystemMessage
+
+from miot_harness.datasource.provider import DataSourceProfile
+
+_EPHEMERAL_CACHE = {"type": "ephemeral"}
+
+_AGENT_SYSTEM_TEMPLATE = """\
+You are the {display_name} data agent ({tenant_display} fleet operations).
+You investigate the user's question by calling tools, then write the final
+answer yourself from the evidence those tools returned.
+
+{primer}
+
+Investigation rules:
+- Prefer curated tools (the `{tool_prefix}*` functions); exploration
+  primitives are a fallback for questions the curated catalog cannot answer.
+- Never repeat a tool call you already made with identical arguments.
+- Read any knowledge card at most once, then ACT on what it says.
+
+Rigor — do not answer from incomplete or fuzzy evidence:
+- A grep / ILIKE result is a FUZZY sample, never an authoritative count or
+  list. Do not report a total or enumerate items from a grep — run a precise
+  query with an explicit WHERE; use COUNT(*) for totals.
+- "List / give me / show me <items>" means ENUMERATE the actual rows — run a
+  query that returns one row per item with its business attributes. A COUNT
+  is not a list; never substitute a count, a sample, or an offer for the rows
+  asked.
+- If the items' attributes live in a related table (e.g. process variables,
+  node properties), run the join/pivot query that returns the actual
+  attributes (codes, names, references) before answering.
+- Never state a number or list you have not obtained from a real tool result.
+- Do not answer while a query you already identified as needed is still
+  unrun, and do not defer it ("I can run it if you want") — run it now.
+
+Answer rules (write in the same language as the question; be concise,
+<= 200 words):
+- Quote what is in the evidence; do not invent rows or numbers.
+- If the evidence is empty or insufficient, say what you don't know.
+- When asked what query you ran, quote the tool result's `executed_sql`
+  verbatim.
+- If a tool result is marked stale (`is_stale` / `freshness_status`), caveat
+  the answer and cite its `refreshed_at` timestamp.
+- Do not mention the internal pipeline or raw tool names in the answer.
+- Prior assistant turns in this conversation were produced by real curated
+  tools. Treat their numbers, tables, and claims as authoritative evidence —
+  do NOT claim you fabricated them.
+"""
+
+
+def build_agent_system_prompt(profile: DataSourceProfile) -> str:
+    return _AGENT_SYSTEM_TEMPLATE.format(
+        display_name=profile.display_name,
+        tenant_display=(profile.tenant_lock or profile.display_name).capitalize(),
+        primer=profile.primer,
+        tool_prefix=profile.tool_prefix,
+    )
+
+
+def cached_system_message(text: str) -> SystemMessage:
+    """System message with the prefix cache breakpoint.
+
+    Marking the last (only) system block caches `tools + system` together —
+    the API renders tools before system, so one breakpoint covers both.
+    """
+    return SystemMessage(
+        content=[{"type": "text", "text": text, "cache_control": _EPHEMERAL_CACHE}]
+    )

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -89,6 +89,7 @@ class HarnessSupervisor:
         *,
         llm_router: LLMIntentRouter | None = None,
         agentic_graph: Any | None = None,
+        agent_loop: Any | None = None,
         meta_model: BaseChatModel | None = None,
         meta_primer: str = "",
         meta_catalog: list[MetaAgentCatalogEntry] | None = None,
@@ -111,6 +112,10 @@ class HarnessSupervisor:
         self.data_graph = data_graph
         self.llm_router = llm_router
         self.agentic_graph = agentic_graph
+        # Single-agent loop (spec 2026-07-02). When set, DATA_AGENTIC runs
+        # this instead of agentic_graph. Both stay wire-able so the flag can
+        # flip per deployment while golden evals compare the two.
+        self.agent_loop = agent_loop
         self.meta_model = meta_model
         self.meta_primer = meta_primer
         self.meta_catalog: list[MetaAgentCatalogEntry] = meta_catalog or []
@@ -609,6 +614,17 @@ class HarnessSupervisor:
         route: HarnessRoute | None = None,
         prior_messages: list[BaseMessage] | None = None,
     ) -> None:
+        if self.agent_loop is not None:
+            with agent_span("run", **self._root_span_kwargs(ctx, route)):
+                delta = await self.agent_loop.run(
+                    user_message=request.message,
+                    ctx=ctx,
+                    prior_messages=prior_messages or [],
+                    progress=progress,
+                )
+            record.answer = delta.get("answer") or "(no answer produced by agent loop)"
+            return
+
         if self.agentic_graph is None:
             answer = (
                 "Agentic exploration is currently disabled "

--- a/miot-harness/tests/agents/test_chat_models_loop.py
+++ b/miot-harness/tests/agents/test_chat_models_loop.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from miot_harness.agents.chat_models import get_chat_model
+from miot_harness.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _api_key_and_cache(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_default_timeout_unchanged():
+    model = get_chat_model("claude-sonnet-4-6")
+    assert model.default_request_timeout == 60
+
+
+def test_loop_timeout_override():
+    model = get_chat_model("claude-sonnet-4-6", timeout=300)
+    assert model.default_request_timeout == 300

--- a/miot-harness/tests/integration/conftest.py
+++ b/miot-harness/tests/integration/conftest.py
@@ -1,0 +1,37 @@
+"""Per-directory pytest configuration for live integration tests.
+
+The root conftest strips ANTHROPIC_API_KEY (and other provider keys) from
+the environment so that unit tests run in a clean, deterministic state.
+This conftest re-injects those keys for the integration directory so live
+API tests can actually call the real providers.
+
+Key values are captured at module import time (before the root autouse
+fixture runs per-test) and restored by a function-scoped autouse fixture
+that runs AFTER the root fixture has cleared them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Capture at collection time, before the root conftest's autouse fixture
+# strips them for each test.
+_SAVED_ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY")
+_SAVED_RUN_LIVE = os.environ.get("MIOT_HARNESS_RUN_LIVE_TESTS")
+
+
+@pytest.fixture(autouse=True)
+def _restore_live_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-inject provider API keys stripped by the root conftest.
+
+    The root _isolate_settings_from_env fixture (autouse, function-scoped)
+    deletes ANTHROPIC_API_KEY so unit tests can't accidentally call the real
+    API. For live integration tests we undo that deletion here so
+    HarnessSettings picks the key up from the environment.
+    """
+    if _SAVED_ANTHROPIC_KEY:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", _SAVED_ANTHROPIC_KEY)
+    if _SAVED_RUN_LIVE:
+        monkeypatch.setenv("MIOT_HARNESS_RUN_LIVE_TESTS", _SAVED_RUN_LIVE)

--- a/miot-harness/tests/integration/test_agent_loop_cache_live.py
+++ b/miot-harness/tests/integration/test_agent_loop_cache_live.py
@@ -1,0 +1,456 @@
+"""LIVE test — talks to the Anthropic API. Skipped unless both
+ANTHROPIC_API_KEY and MIOT_HARNESS_RUN_LIVE_TESTS=1 are set.
+
+Asserts the agent loop's cache contract:
+- call 1 writes the prefix cache (cache_creation_input_tokens > 0). If this
+  is 0, the frozen prefix is below the model's minimum cacheable size
+  (2048 tokens on Sonnet 4.6) or a marker is misplaced.
+- call 2 reads it (cache_read_input_tokens > 0). If this is 0 while call 1
+  wrote, a silent invalidator is injecting unstable bytes into the prefix.
+
+Usage-key verification (run once, result recorded in task-8-report.md):
+    grep cache_read .venv/lib/python3.*/site-packages/langchain_core/messages/ai.py
+    # Found: cache_creation / cache_read inside input_token_details — matches
+    # the keys used in _cache_tokens() below.
+
+Minimum-size note: FAKE_PROFILE's short primer + 4 tiny tools is far below
+Sonnet 4.6's 2048-token minimum. _big_registry() pads the prefix with 25
+fake tools whose descriptions are ~500 characters each (~125 tokens/tool),
+bringing the prefix comfortably above the 2048-token threshold.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from miot_harness.agents.chat_models import get_chat_model
+from miot_harness.config import HarnessSettings
+from miot_harness.runtime.agent_loop import AgentLoopRunner
+from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.permissions import PermissionResult
+from miot_harness.runtime.tool import HarnessTool
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+pytestmark = pytest.mark.skipif(
+    not (os.getenv("ANTHROPIC_API_KEY") and os.getenv("MIOT_HARNESS_RUN_LIVE_TESTS")),
+    reason="live Anthropic test; set ANTHROPIC_API_KEY and MIOT_HARNESS_RUN_LIVE_TESTS=1",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_tokens(usage: dict) -> tuple[int, int]:  # type: ignore[type-arg]
+    """Return (cache_created, cache_read) token counts from a usage_log entry.
+
+    langchain_anthropic maps Anthropic's prompt-cache usage as follows:
+
+    Standard (1-hour+) cache:
+      cache_creation_input_tokens  → input_token_details["cache_creation"]
+      cache_read_input_tokens      → input_token_details["cache_read"]
+
+    Ephemeral (5-minute) cache — the type used by cached_system_message():
+      cache_creation.ephemeral_5m_input_tokens  → input_token_details["ephemeral_5m_input_tokens"]
+      cache_creation.ephemeral_1h_input_tokens  → input_token_details["ephemeral_1h_input_tokens"]
+      When either ephemeral field is > 0, langchain_anthropic EXPLICITLY sets
+      input_token_details["cache_creation"] = 0 (so checking only "cache_creation"
+      misses ephemeral writes).
+
+    Cache READS from the ephemeral cache are still returned by the Anthropic API
+    in cache_read_input_tokens, so input_token_details["cache_read"] covers both
+    standard and ephemeral reads.
+    """
+    details = usage.get("input_token_details") or {}
+    # Cache CREATED: standard path + ephemeral 5-min + ephemeral 1-hour
+    created = (
+        int(details.get("cache_creation") or 0)
+        + int(details.get("ephemeral_5m_input_tokens") or 0)
+        + int(details.get("ephemeral_1h_input_tokens") or 0)
+    )
+    # Cache READ: single field covers both standard and ephemeral reads
+    read = int(details.get("cache_read") or 0)
+    return created, read
+
+
+class _In(BaseModel):
+    limit: int = 10
+
+
+class _Out(BaseModel):
+    rows: list[dict] = []  # type: ignore[type-arg]
+
+
+def _fat_tool(name: str, description: str) -> HarnessTool:
+    """Create a fake curated tool with a long description to pad the prefix."""
+
+    async def _allow(ctx, parsed):  # type: ignore[no-untyped-def]
+        return PermissionResult.allow("test")
+
+    async def _call(ctx, parsed, progress):  # type: ignore[no-untyped-def]
+        return _Out()
+
+    return HarnessTool(
+        name=name,
+        description=description,
+        input_model=_In,
+        output_model=_Out,
+        kind="curated",
+        check_permission=_allow,
+        call=_call,
+    )
+
+
+def _big_registry() -> ToolRegistry:
+    """Return a ToolRegistry whose prefix far exceeds the 2048-token minimum.
+
+    Sonnet 4.6 requires >=2048 tokens in the frozen prefix before it will
+    write a cache entry. FAKE_PROFILE's 4-tool registry is far too small.
+    Each tool below has a ~500-character description (~125 tokens), so 25
+    tools contribute ~3 125 tokens of tool payload alone — comfortably above
+    the threshold when combined with the system-prompt text (~350 tokens) and
+    JSON-schema boilerplate (~30 tokens/tool * 25 = 750 tokens).
+    """
+    reg = ToolRegistry.__new__(ToolRegistry)
+    reg._tools = {}
+
+    _TOOLS = [
+        (
+            "fake_asset_health_summary",
+            (
+                "[Layer L1] Returns a summary of asset health metrics for the tenant's fleet. "
+                "Aggregates fault codes, downtime hours, and maintenance events across all "
+                "registered devices. Use this tool when the user asks about overall fleet "
+                "health, aggregate fault rates, or a high-level operational summary. "
+                "Returns one row per asset class with columns: asset_class, fault_count, "
+                "downtime_hours, last_maintenance_date. Filter by date range using `limit`."
+            ),
+        ),
+        (
+            "fake_device_uptime_report",
+            (
+                "[Layer L1] Computes per-device uptime percentage over a rolling window. "
+                "Queries the telemetry event log to calculate the ratio of reported-online "
+                "intervals to total wall-clock time. Use when the user asks which devices "
+                "are most or least available, or wants an uptime SLA report. Returns one "
+                "row per device_id with columns: device_id, device_name, uptime_pct, "
+                "total_hours_sampled, last_seen_at. Ordered by uptime_pct ascending."
+            ),
+        ),
+        (
+            "fake_fault_code_histogram",
+            (
+                "[Layer L1] Returns a frequency histogram of fault codes raised in the "
+                "specified period. Each row is one distinct fault code with its occurrence "
+                "count, affected device count, and most recent trigger timestamp. Use this "
+                "tool when the user asks which faults are most common, recurring, or "
+                "trending. Columns: fault_code, fault_description, occurrence_count, "
+                "device_count, latest_at. Ordered by occurrence_count descending."
+            ),
+        ),
+        (
+            "fake_maintenance_schedule",
+            (
+                "[Layer L1] Retrieves upcoming and overdue preventive maintenance tasks "
+                "for the tenant fleet. Joins the maintenance calendar with the asset "
+                "register to return tasks enriched with asset identifiers and location. "
+                "Use when the user asks about scheduled maintenance, overdue tasks, or "
+                "which assets are approaching their service interval. Columns: task_id, "
+                "asset_id, asset_name, scheduled_date, status, technician_assigned."
+            ),
+        ),
+        (
+            "fake_energy_consumption_daily",
+            (
+                "[Layer L1] Returns daily energy consumption totals by asset or asset "
+                "group. Sums kWh readings from the meter telemetry stream, normalized to "
+                "calendar days in the tenant timezone. Use for energy-cost analysis, "
+                "carbon-footprint reporting, or identifying high-consumption outliers. "
+                "Columns: date, asset_id, asset_group, kwh_consumed, co2_kg_equivalent. "
+                "Ordered by date descending, then asset_id ascending."
+            ),
+        ),
+        (
+            "fake_alarm_event_log",
+            (
+                "[Layer L1] Fetches raw alarm events from the operational event bus for "
+                "the specified look-back window. Each row is one alarm activation or "
+                "clearance event with severity, source device, and acknowledgement state. "
+                "Use for incident investigation, SLA breach analysis, or identifying "
+                "noisy-alarm sources. Columns: event_id, device_id, alarm_code, severity, "
+                "triggered_at, cleared_at, acknowledged_by, duration_seconds."
+            ),
+        ),
+        (
+            "fake_production_output_kpi",
+            (
+                "[Layer L1] Returns production output KPIs aggregated by shift, line, or "
+                "product SKU. Joins the production order table with the telemetry counter "
+                "feed to compute units produced, reject rate, and OEE score. Use when the "
+                "user asks about throughput, quality metrics, or overall equipment "
+                "effectiveness. Columns: period, line_id, sku, units_produced, "
+                "reject_count, reject_pct, oee_score."
+            ),
+        ),
+        (
+            "fake_sensor_anomaly_detection",
+            (
+                "[Layer L1] Queries the anomaly-detection result table for sensor readings "
+                "that deviated beyond the configured z-score threshold in the look-back "
+                "window. Use when the user reports unexpected sensor behavior or wants to "
+                "know which sensors triggered anomaly alerts. Returns one row per anomaly "
+                "event: sensor_id, sensor_name, anomaly_score, observed_value, "
+                "expected_value, detected_at, asset_id."
+            ),
+        ),
+        (
+            "fake_spare_parts_inventory",
+            (
+                "[Layer L1] Returns current spare-parts inventory levels for the tenant "
+                "warehouse. Joins the parts catalog with stock movements to compute "
+                "on-hand quantity, reorder point, and days-of-supply remaining. Use when "
+                "the user asks about parts availability, stockout risk, or upcoming "
+                "procurement needs. Columns: part_number, part_name, on_hand_qty, "
+                "reorder_point, days_of_supply, supplier_id."
+            ),
+        ),
+        (
+            "fake_work_order_status",
+            (
+                "[Layer L1] Retrieves open and recently closed work orders for the tenant "
+                "fleet. Each row is one work order with its priority, assigned technician, "
+                "estimated vs. actual completion time, and linked asset. Use when the user "
+                "asks about outstanding repairs, mean-time-to-repair, or work-order backlog. "
+                "Columns: wo_id, asset_id, priority, status, created_at, closed_at, "
+                "technician_id, labor_hours_actual."
+            ),
+        ),
+        (
+            "fake_connectivity_status",
+            (
+                "[Layer L1] Returns real-time and historical connectivity status for all "
+                "registered IoT gateways and edge devices. Includes last-heartbeat "
+                "timestamp, packet-loss rate, and signal quality index. Use when the user "
+                "asks which devices are offline, experiencing connectivity issues, or have "
+                "not reported recently. Columns: device_id, gateway_id, status, "
+                "last_heartbeat_at, packet_loss_pct, signal_quality."
+            ),
+        ),
+        (
+            "fake_throughput_trend",
+            (
+                "[Layer L1] Computes a rolling throughput trend (units/hour) for each "
+                "production line over the specified period, compared against the target "
+                "rate and the same period in the prior year. Use for trend analysis, "
+                "capacity planning, or identifying lines trending below target. Columns: "
+                "line_id, line_name, period, actual_units_per_hour, target_units_per_hour, "
+                "prior_year_units_per_hour, pct_vs_target, pct_vs_prior_year."
+            ),
+        ),
+        (
+            "fake_environmental_readings",
+            (
+                "[Layer L1] Returns environmental sensor readings (temperature, humidity, "
+                "pressure, particulate matter) for the specified zone and time range. "
+                "Useful for compliance reporting, root-cause analysis of quality deviations, "
+                "and cold-chain verification. Columns: reading_id, zone_id, sensor_type, "
+                "value, unit, recorded_at, within_spec. Ordered by recorded_at descending."
+            ),
+        ),
+        (
+            "fake_operator_activity_log",
+            (
+                "[Layer L1] Returns a log of operator interactions with the SCADA / HMI "
+                "system, including parameter changes, manual overrides, and setpoint "
+                "adjustments. Use for audit trails, change management, or correlating "
+                "process deviations with operator actions. Columns: log_id, operator_id, "
+                "operator_name, action_type, target_device, old_value, new_value, "
+                "performed_at."
+            ),
+        ),
+        (
+            "fake_batch_quality_results",
+            (
+                "[Layer L1] Fetches quality-control results for completed production "
+                "batches, including lab test outcomes, in-process inspection pass/fail "
+                "counts, and final disposition (released, quarantined, scrapped). Use "
+                "when the user asks about batch quality, first-pass yield, or quarantine "
+                "rates. Columns: batch_id, sku, start_time, end_time, units_produced, "
+                "units_passed, units_failed, disposition, qa_approved_by."
+            ),
+        ),
+        (
+            "fake_predictive_maintenance_scores",
+            (
+                "[Layer L1] Returns machine-learning–derived predictive maintenance risk "
+                "scores for each asset in the fleet, computed from vibration, temperature, "
+                "and runtime telemetry. A score above 0.7 indicates elevated failure risk "
+                "within the next 14 days. Use when the user wants to proactively identify "
+                "at-risk assets. Columns: asset_id, asset_name, risk_score, risk_level, "
+                "predicted_failure_date, top_contributing_factor."
+            ),
+        ),
+        (
+            "fake_shift_performance_report",
+            (
+                "[Layer L1] Aggregates operator and line performance metrics by shift "
+                "(morning, afternoon, night). Computes units produced, fault events raised, "
+                "average cycle time, and shift OEE. Use for shift-comparison analysis, "
+                "identifying which shifts underperform, or benchmarking against targets. "
+                "Columns: shift_date, shift_name, line_id, units_produced, fault_count, "
+                "avg_cycle_time_s, oee_score, supervisor_id."
+            ),
+        ),
+        (
+            "fake_customer_order_pipeline",
+            (
+                "[Layer L1] Returns open customer orders and their production-readiness "
+                "status, linking sales order lines to scheduled production runs and "
+                "available inventory. Use when the user asks about order fulfilment risk, "
+                "late orders, or production-to-order alignment. Columns: order_id, "
+                "customer_id, sku, quantity_ordered, quantity_ready, scheduled_ship_date, "
+                "days_until_due, at_risk."
+            ),
+        ),
+        (
+            "fake_raw_material_consumption",
+            (
+                "[Layer L1] Returns raw material consumption per production run, comparing "
+                "actual vs. standard bill-of-materials quantities to compute yield loss and "
+                "material efficiency. Use for cost variance analysis, waste reduction "
+                "initiatives, or identifying over-consumption patterns. Columns: run_id, "
+                "material_code, material_name, standard_qty, actual_qty, variance_qty, "
+                "variance_pct, unit_of_measure."
+            ),
+        ),
+        (
+            "fake_safety_incident_log",
+            (
+                "[Layer L1] Retrieves safety incident and near-miss records for the "
+                "tenant site, including severity classification, affected area, root-cause "
+                "category, and corrective action status. Use for safety KPI dashboards, "
+                "trend analysis, or regulatory compliance reporting. Columns: incident_id, "
+                "incident_date, severity, area_id, affected_employees, root_cause_category, "
+                "corrective_action_status, days_since_last_incident."
+            ),
+        ),
+        (
+            "fake_downtime_pareto",
+            (
+                "[Layer L1] Computes a Pareto ranking of downtime causes for the fleet "
+                "or a specific line over the specified period. Joins stop-event records "
+                "with the downtime-reason catalog to return cumulative downtime minutes "
+                "and percentage contribution per cause code. Use for loss analysis and "
+                "prioritising improvement projects. Columns: reason_code, reason_description, "
+                "total_downtime_min, pct_of_total, cumulative_pct."
+            ),
+        ),
+        (
+            "fake_calibration_due_report",
+            (
+                "[Layer L1] Returns instruments and measurement devices whose calibration "
+                "certificates are expired or due within the next 30 days. Use for "
+                "calibration planning, audit preparation, or identifying out-of-tolerance "
+                "measurement risk. Columns: instrument_id, instrument_name, location, "
+                "last_calibration_date, next_due_date, days_overdue, calibration_status, "
+                "responsible_technician."
+            ),
+        ),
+        (
+            "fake_water_usage_report",
+            (
+                "[Layer L1] Returns daily water consumption totals from the site's flow "
+                "meters, segmented by process area and compared against permitted discharge "
+                "limits and sustainability targets. Use for environmental reporting, ISO "
+                "14001 audits, or water-efficiency projects. Columns: date, area_id, "
+                "area_name, cubic_meters_consumed, target_cubic_meters, variance_pct, "
+                "within_permit."
+            ),
+        ),
+        (
+            "fake_iot_firmware_versions",
+            (
+                "[Layer L1] Returns the current firmware version for every managed IoT "
+                "device in the tenant fleet, alongside the latest available version and "
+                "a flag indicating whether an update is pending or blocked. Use when "
+                "the user asks about firmware currency, update campaign progress, or "
+                "devices running vulnerable versions. Columns: device_id, device_model, "
+                "current_version, latest_version, update_status, last_updated_at."
+            ),
+        ),
+        (
+            "fake_cost_center_allocation",
+            (
+                "[Layer L1] Returns actual vs. budgeted cost allocations by cost centre "
+                "for the current fiscal period, broken down by cost category (labour, "
+                "materials, energy, maintenance). Use for variance reporting, budget "
+                "review preparation, or identifying overspending cost centres. Columns: "
+                "cost_centre_id, cost_centre_name, category, budgeted_amount, "
+                "actual_amount, variance_amount, variance_pct, period."
+            ),
+        ),
+    ]
+
+    for name, description in _TOOLS:
+        reg.register(_fat_tool(name, description))
+
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefix_caches_across_two_runs() -> None:
+    runner = AgentLoopRunner(
+        model=get_chat_model("claude-sonnet-4-6"),
+        registry=_big_registry(),
+        settings=HarnessSettings(agents_agentic_max_turns=2),
+        profile=FAKE_PROFILE,
+    )
+    ctx = UserRequest(message="hola", tenant_id="acme", mode="agentic").to_context()
+
+    first = await runner.run(
+        user_message="Say hello, do not call tools.",
+        ctx=ctx,
+        prior_messages=[],
+        progress=lambda e: None,
+    )
+    second = await runner.run(
+        user_message="Say hello again, do not call tools.",
+        ctx=ctx,
+        prior_messages=[],
+        progress=lambda e: None,
+    )
+
+    assert first["usage_log"], "first run returned no usage_log entries"
+    assert second["usage_log"], "second run returned no usage_log entries"
+
+    first_created, first_read = _cache_tokens(first["usage_log"][0])
+    second_created, second_read = _cache_tokens(second["usage_log"][0])
+
+    # Call 1: the prefix must be EITHER newly cached (cold start) OR already cached
+    # from a very recent prior run still within the 5-minute TTL window.
+    # Either outcome proves the prefix exceeds the 2048-token minimum.
+    # Cold start: first_created > 0, first_read == 0
+    # Warm cache: first_read > 0, first_created == 0 (prior run's cache still live)
+    assert first_created + first_read > 0, (
+        f"call 1 saw zero cache activity — prefix is likely below the 2048-token "
+        f"minimum or a cache_control marker is misplaced. "
+        f"usage_log[0]={first['usage_log'][0]}"
+    )
+    # Call 2: must read from cache regardless of whether call 1 created or hit it.
+    # A silent invalidator (unstable bytes in the prefix) would cause a fresh
+    # cache WRITE here instead of a read, making second_read == 0.
+    assert second_read > 0, (
+        f"second run missed the cache — silent invalidator may be injecting "
+        f"unstable bytes into the prefix between calls. "
+        f"usage_log[0]={second['usage_log'][0]}"
+    )

--- a/miot-harness/tests/integration/test_agent_loop_cache_live.py
+++ b/miot-harness/tests/integration/test_agent_loop_cache_live.py
@@ -454,3 +454,72 @@ async def test_prefix_caches_across_two_runs() -> None:
         f"unstable bytes into the prefix between calls. "
         f"usage_log[0]={second['usage_log'][0]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_tool_result_turn_accepts_cache_marker() -> None:
+    """Live-verify that the Anthropic API accepts cache_control on tool-result turns.
+
+    _mark_message wraps a ToolMessage's string content into
+    [{"type":"text",...,"cache_control":{...}}] and langchain_anthropic hoists
+    that marker onto the surrounding tool_result block.  If the API ever rejects
+    this placement with "invalid cache_control location", the ainvoke() call
+    will raise and this test will fail — that is the regression it guards.
+
+    Assertions:
+    - evidence is non-empty  → a tool actually executed (not just a text reply)
+    - len(usage_log) >= 2    → at least one tool round-trip (turn 0: tool_call,
+                               turn 1: answer after tool_result) was accepted by
+                               the API with the tool_result cache marker in place
+    - usage_log[1] cache_read > 0 → the frozen prefix (system + tools) was read
+                               from cache on the second API call, confirming the
+                               prefix is still stable through the tool-result turn
+    """
+    runner = AgentLoopRunner(
+        model=get_chat_model("claude-sonnet-4-6"),
+        registry=_big_registry(),
+        settings=HarnessSettings(agents_agentic_max_turns=3),
+        profile=FAKE_PROFILE,
+    )
+    ctx = UserRequest(
+        message="tool-result-cache", tenant_id="acme", mode="agentic"
+    ).to_context()
+
+    result = await runner.run(
+        user_message=(
+            "Call the fake_production_output_kpi tool exactly once with default "
+            "arguments, then summarize its result in one sentence."
+        ),
+        ctx=ctx,
+        prior_messages=[],
+        progress=lambda e: None,
+    )
+
+    assert result["answer"], "run returned an empty answer"
+
+    # evidence is populated only when at least one tool executed successfully;
+    # an empty list means the model answered without calling any tool.
+    assert result["evidence"], (
+        "no evidence collected — the model did not call a tool; "
+        "the prompt may need strengthening or max_turns may be too low"
+    )
+
+    # At minimum: turn 0 (tool_call request) + turn 1 (answer after tool_result).
+    # Fewer entries means the loop exited before the tool round-trip completed.
+    assert len(result["usage_log"]) >= 2, (
+        f"expected >=2 usage_log entries for a tool round-trip, "
+        f"got {len(result['usage_log'])}"
+    )
+
+    # The second API call's request carries the same frozen prefix (system +
+    # tools) as the first call.  That prefix must be read from the ephemeral
+    # cache — a miss here means either the prefix invalidated between turns or
+    # the tool_result cache_control marker caused the API to reject/ignore the
+    # cache entirely.
+    _second_created, second_read = _cache_tokens(result["usage_log"][1])
+    assert second_read > 0, (
+        f"second API call (after tool_result turn) saw zero cache_read — "
+        f"the tool_result cache_control marker may have been rejected or the "
+        f"frozen prefix invalidated between turns. "
+        f"usage_log[1]={result['usage_log'][1]}"
+    )

--- a/miot-harness/tests/observability/test_callbacks.py
+++ b/miot-harness/tests/observability/test_callbacks.py
@@ -8,7 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from miot_harness.observability.callbacks import AgentTelemetryCallback
+from miot_harness.observability.callbacks import AgentTelemetryCallback, _extract_usage
 
 
 def _serialized_anthropic(model: str = "claude-haiku-4-5") -> dict[str, object]:
@@ -154,3 +154,58 @@ def test_callback_span_prefix_overrides_default(
     assert span.name == "fake.filter_expert"
     attrs = dict(span.attributes)
     assert attrs["gen_ai.operation.name"] == "fake.filter_expert"
+
+
+def _llm_result_with_details(
+    *,
+    input_tokens: int = 6100,
+    output_tokens: int = 20,
+    input_token_details: dict,
+) -> LLMResult:
+    """Build an LLMResult with arbitrary input_token_details (for ephemeral tests)."""
+    usage_metadata = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "input_token_details": input_token_details,
+    }
+    message = AIMessage(content="ok", usage_metadata=usage_metadata)
+    generation = ChatGeneration(message=message)
+    return LLMResult(generations=[[generation]], llm_output={"model_name": "claude-haiku-4-5"})
+
+
+def test_extract_usage_counts_ephemeral_5m_as_cache_creation() -> None:
+    """langchain_anthropic sets cache_creation=0 and stores ephemeral writes in
+    ephemeral_5m_input_tokens; _extract_usage must count those as cache-creation
+    so telemetry is accurate and pricing uses the 1.25× write rate.
+    """
+    result = _llm_result_with_details(
+        input_tokens=5100,
+        output_tokens=20,
+        input_token_details={
+            "cache_read": 100,
+            "cache_creation": 0,
+            "ephemeral_5m_input_tokens": 5000,
+        },
+    )
+    usage = _extract_usage(result)
+    assert usage.cache_creation_input_tokens == 5000
+    assert usage.cache_read_input_tokens == 100
+
+
+def test_extract_usage_sums_ephemeral_5m_and_1h_as_cache_creation() -> None:
+    """Both ephemeral_5m_input_tokens and ephemeral_1h_input_tokens contribute
+    to the cache-creation bucket so all ephemeral write costs are captured.
+    cache_creation=0 + ephemeral_5m=5000 + ephemeral_1h=200 → 5200
+    """
+    result = _llm_result_with_details(
+        input_tokens=5200,
+        output_tokens=20,
+        input_token_details={
+            "cache_creation": 0,
+            "ephemeral_5m_input_tokens": 5000,
+            "ephemeral_1h_input_tokens": 200,
+        },
+    )
+    usage = _extract_usage(result)
+    assert usage.cache_creation_input_tokens == 5200

--- a/miot-harness/tests/runtime/test_agent_loop.py
+++ b/miot-harness/tests/runtime/test_agent_loop.py
@@ -1,0 +1,190 @@
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+import miot_harness.runtime.agent_loop as agent_loop_mod
+from miot_harness.config import HarnessSettings
+from miot_harness.runtime.agent_loop import AgentLoopRunner
+from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.plan import DataEvidence
+from tests.fixtures.fake_provider import FAKE_PROFILE
+from tests.test_native_tools import _registry
+
+
+class ScriptedModel:
+    """Stands in for ChatAnthropic: bind_tools returns self; ainvoke pops
+    scripted AIMessages and records the exact message lists it was sent."""
+
+    def __init__(self, responses: list[AIMessage]) -> None:
+        self.responses = list(responses)
+        self.calls: list[list[Any]] = []
+        self.bound_tools: list[dict] | None = None
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> "ScriptedModel":
+        self.bound_tools = list(tools)
+        return self
+
+    def with_config(self, **kwargs: Any) -> "ScriptedModel":
+        return self
+
+    async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+        self.calls.append(list(messages))
+        return self.responses.pop(0)
+
+
+def _evidence(tool: str = "fake_kpi_summary") -> DataEvidence:
+    return DataEvidence(
+        step_id="s1", tool=tool, source="FakeSource", refreshed_at=None,
+        output={"rows": [{"k": 1}]}, sample_size=1,
+    )
+
+
+def _ctx():
+    return UserRequest(message="q", tenant_id="acme", mode="agentic").to_context()
+
+
+def _settings() -> HarnessSettings:
+    return HarnessSettings(agents_agentic_max_turns=3)
+
+
+def _runner(model: ScriptedModel) -> AgentLoopRunner:
+    return AgentLoopRunner(
+        model=model, registry=_registry(), settings=_settings(),
+        profile=FAKE_PROFILE, provenance_log=None,
+    )
+
+
+def _tool_call_msg(name: str = "fake_kpi_summary", call_id: str = "c1") -> AIMessage:
+    return AIMessage(
+        content="", tool_calls=[{"name": name, "args": {}, "id": call_id, "type": "tool_call"}]
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_answer_no_tools():
+    model = ScriptedModel([AIMessage(content="the answer")])
+    delta = await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=lambda e: None
+    )
+    assert delta["answer"] == "the answer"
+    assert delta["evidence"] == []
+    # tools bound once, sorted
+    assert [t["name"] for t in model.bound_tools] == sorted(
+        t["name"] for t in model.bound_tools
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_call_produces_evidence_and_tool_message(monkeypatch):
+    async def fake_invoke_step(step, **kwargs):
+        assert step.tool == "fake_kpi_summary"
+        return {"evidence": [_evidence()]}
+
+    monkeypatch.setattr(agent_loop_mod, "invoke_step", fake_invoke_step)
+    model = ScriptedModel([_tool_call_msg(), AIMessage(content="done: 1 row")])
+    delta = await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=lambda e: None
+    )
+    assert delta["answer"] == "done: 1 row"
+    assert len(delta["evidence"]) == 1
+    # 2nd call saw: system, human, ai(tool_call), tool_result
+    second = model.calls[1]
+    assert isinstance(second[-1], ToolMessage)
+    assert second[-1].tool_call_id == "c1"
+    assert "rows" in str(second[-1].content)
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_becomes_error_tool_message(monkeypatch):
+    async def fake_invoke_step(step, **kwargs):
+        return {"failure": "boom", "error": "boom", "error_type": "RuntimeError"}
+
+    monkeypatch.setattr(agent_loop_mod, "invoke_step", fake_invoke_step)
+    model = ScriptedModel([_tool_call_msg(), AIMessage(content="could not fetch")])
+    delta = await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=lambda e: None
+    )
+    assert delta["answer"] == "could not fetch"
+    tm = model.calls[1][-1]
+    assert isinstance(tm, ToolMessage)
+    assert tm.status == "error"
+    assert "boom" in str(tm.content)
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_calls_all_executed(monkeypatch):
+    seen: list[str] = []
+
+    async def fake_invoke_step(step, **kwargs):
+        seen.append(step.tool)
+        return {"evidence": [_evidence(step.tool)]}
+
+    monkeypatch.setattr(agent_loop_mod, "invoke_step", fake_invoke_step)
+    multi = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "fake_kpi_summary", "args": {}, "id": "c1", "type": "tool_call"},
+            {"name": "fake_alpha_query", "args": {}, "id": "c2", "type": "tool_call"},
+        ],
+    )
+    model = ScriptedModel([multi, AIMessage(content="both done")])
+    delta = await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=lambda e: None
+    )
+    assert seen == ["fake_kpi_summary", "fake_alpha_query"]
+    assert len(delta["evidence"]) == 2
+    tool_messages = [m for m in model.calls[1] if isinstance(m, ToolMessage)]
+    assert {m.tool_call_id for m in tool_messages} == {"c1", "c2"}
+
+
+@pytest.mark.asyncio
+async def test_turn_cap_forces_final_answer(monkeypatch):
+    async def fake_invoke_step(step, **kwargs):
+        return {"evidence": [_evidence()]}
+
+    monkeypatch.setattr(agent_loop_mod, "invoke_step", fake_invoke_step)
+    # max_turns=3: three tool rounds, then the forced no-more-tools turn.
+    model = ScriptedModel(
+        [
+            _tool_call_msg(call_id="c1"),
+            _tool_call_msg(call_id="c2"),
+            _tool_call_msg(call_id="c3"),
+            AIMessage(content="partial answer from evidence"),
+        ]
+    )
+    delta = await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=lambda e: None
+    )
+    assert delta["answer"] == "partial answer from evidence"
+    # The forced turn told the model to stop calling tools.
+    final_call = model.calls[-1]
+    assert "Turn cap reached" in str(final_call[-1].content)
+
+
+@pytest.mark.asyncio
+async def test_tenancy_refusal_short_circuits():
+    ctx = UserRequest(message="q", tenant_id="intruder", mode="agentic").to_context()
+    model = ScriptedModel([])  # must never be called
+    delta = await _runner(model).run(
+        user_message="q", ctx=ctx, prior_messages=[], progress=lambda e: None
+    )
+    assert "acme" in delta["answer"].lower() or "only" in delta["answer"].lower()
+    assert model.calls == []
+
+
+@pytest.mark.asyncio
+async def test_events_emitted(monkeypatch):
+    async def fake_invoke_step(step, **kwargs):
+        return {"evidence": [_evidence()]}
+
+    monkeypatch.setattr(agent_loop_mod, "invoke_step", fake_invoke_step)
+    events: list[Any] = []
+    model = ScriptedModel([_tool_call_msg(), AIMessage(content="ok")])
+    await _runner(model).run(
+        user_message="q", ctx=_ctx(), prior_messages=[], progress=events.append
+    )
+    types = [e.type for e in events]
+    assert "agent.started" in types
+    assert "agent.completed" in types
+    assert "answer.completed" in types

--- a/miot-harness/tests/runtime/test_agent_loop_payload.py
+++ b/miot-harness/tests/runtime/test_agent_loop_payload.py
@@ -88,3 +88,13 @@ def test_stored_history_stays_unmarked():
     messages = [cached_system_message("s"), _compose_human("q", [])]
     _with_tail_marker(messages)
     assert "cache_control" not in json.dumps(messages[-1].content)
+
+
+def test_stored_history_stays_unmarked_list_content():
+    tail = HumanMessage(content=[{"type": "text", "text": "q"}])
+    messages = [cached_system_message("s"), tail]
+    marked = _with_tail_marker(messages)
+    # the returned copy carries the marker...
+    assert "cache_control" in json.dumps(marked[-1].content)
+    # ...but the caller's stored message object must stay untouched
+    assert "cache_control" not in json.dumps(tail.content)

--- a/miot-harness/tests/runtime/test_agent_loop_payload.py
+++ b/miot-harness/tests/runtime/test_agent_loop_payload.py
@@ -1,0 +1,90 @@
+import json
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from miot_harness.agents.native_tools import build_native_tools
+from miot_harness.runtime.agent_loop import (
+    _compose_human,
+    _split_prior,
+    _with_tail_marker,
+)
+from miot_harness.runtime.agent_prompt import (
+    build_agent_system_prompt,
+    cached_system_message,
+)
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+def _payload(messages, tools):
+    from langchain_anthropic import ChatAnthropic
+
+    model = ChatAnthropic(model_name="claude-sonnet-4-6", api_key="test-key")
+    bound = model.bind_tools(tools)
+    # _get_request_payload builds the wire dict without any network call.
+    return bound.bound._get_request_payload(messages, **bound.kwargs)
+
+
+def _count_markers(payload) -> int:
+    return json.dumps(payload).count('"cache_control"')
+
+
+def test_split_prior_extracts_system_messages():
+    prior = [
+        SystemMessage(content="# Active skill: x\nbody"),
+        HumanMessage(content="q1"),
+        AIMessage(content="a1"),
+    ]
+    history, reminders = _split_prior(prior)
+    assert [type(m) for m in history] == [HumanMessage, AIMessage]
+    assert reminders == ["# Active skill: x\nbody"]
+
+
+def test_compose_human_wraps_reminders():
+    msg = _compose_human("the question", ["do X"])
+    text = json.dumps(msg.content)
+    assert "<system-reminder>" in text
+    assert "the question" in text
+
+
+def test_request_has_exactly_two_breakpoints_and_stable_prefix():
+    from tests.test_native_tools import _registry
+
+    tools = build_native_tools(_registry(), profile=FAKE_PROFILE)
+    system = cached_system_message(build_agent_system_prompt(FAKE_PROFILE))
+    messages = [system, _compose_human("q", [])]
+    payload = _payload(_with_tail_marker(messages), tools)
+
+    assert _count_markers(payload) == 2  # system block + tail marker, never more
+    # Prefix layout: tools first, then system with the ephemeral marker.
+    assert [t["name"] for t in payload["tools"]] == sorted(
+        t["name"] for t in payload["tools"]
+    )
+    assert payload["system"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_tail_marker_lands_on_valid_top_level_block():
+    from tests.test_native_tools import _registry
+
+    tools = build_native_tools(_registry(), profile=FAKE_PROFILE)
+    system = cached_system_message(build_agent_system_prompt(FAKE_PROFILE))
+    messages = [
+        system,
+        _compose_human("q", []),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "fake_kpi_summary", "args": {}, "id": "c1", "type": "tool_call"}],
+        ),
+        ToolMessage(content='{"rows": []}', tool_call_id="c1"),
+    ]
+    payload = _payload(_with_tail_marker(messages), tools)
+    assert _count_markers(payload) == 2
+    last_block = payload["messages"][-1]["content"][-1]
+    # The marker must sit ON a top-level content block (tool_result / text),
+    # never nested inside tool_result.content (the API rejects that).
+    assert last_block.get("cache_control") == {"type": "ephemeral"}
+
+
+def test_stored_history_stays_unmarked():
+    messages = [cached_system_message("s"), _compose_human("q", [])]
+    _with_tail_marker(messages)
+    assert "cache_control" not in json.dumps(messages[-1].content)

--- a/miot-harness/tests/runtime/test_agent_prompt.py
+++ b/miot-harness/tests/runtime/test_agent_prompt.py
@@ -15,9 +15,21 @@ def test_prompt_carries_rigor_and_answer_rules():
     text = build_agent_system_prompt(FAKE_PROFILE)
     assert "FakeSource" in text
     assert FAKE_PROFILE.primer in text
-    assert "FUZZY sample" in text          # planner rigor rule survives
-    assert "do not invent rows" in text.lower()  # synthesizer rule survives
     assert "fake_" in text                 # curated prefix guidance
+
+    # Planner rigor rules
+    assert "FUZZY sample" in text
+    assert "ENUMERATE the actual rows" in text
+    assert "join/pivot query" in text
+    assert "identified as needed" in text
+
+    # Synthesizer answer rules
+    assert "do not invent rows" in text
+    assert "executed_sql" in text
+    assert "refreshed_at" in text
+    assert "same language as the question" in text
+    assert "200 words" in text
+    assert "do NOT claim you fabricated them" in text
 
 
 def test_prompt_has_no_dynamic_markers():

--- a/miot-harness/tests/runtime/test_agent_prompt.py
+++ b/miot-harness/tests/runtime/test_agent_prompt.py
@@ -1,0 +1,39 @@
+from miot_harness.runtime.agent_prompt import (
+    build_agent_system_prompt,
+    cached_system_message,
+)
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+def test_prompt_is_byte_stable():
+    assert build_agent_system_prompt(FAKE_PROFILE) == build_agent_system_prompt(
+        FAKE_PROFILE
+    )
+
+
+def test_prompt_carries_rigor_and_answer_rules():
+    text = build_agent_system_prompt(FAKE_PROFILE)
+    assert "FakeSource" in text
+    assert FAKE_PROFILE.primer in text
+    assert "FUZZY sample" in text          # planner rigor rule survives
+    assert "do not invent rows" in text.lower()  # synthesizer rule survives
+    assert "fake_" in text                 # curated prefix guidance
+
+
+def test_prompt_has_no_dynamic_markers():
+    import re
+
+    text = build_agent_system_prompt(FAKE_PROFILE)
+    # No interpolated clock/uuid/request state — these would silently
+    # invalidate the prompt-cache prefix on every request.
+    assert not re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:", text)
+    assert "{" not in text.replace("{}", "")  # no unrendered placeholders
+
+
+def test_cached_system_message_has_single_ephemeral_breakpoint():
+    msg = cached_system_message("hello")
+    assert isinstance(msg.content, list) and len(msg.content) == 1
+    block = msg.content[0]
+    assert block["type"] == "text"
+    assert block["text"] == "hello"
+    assert block["cache_control"] == {"type": "ephemeral"}

--- a/miot-harness/tests/runtime/test_supervisor_agent_loop.py
+++ b/miot-harness/tests/runtime/test_supervisor_agent_loop.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import pytest
+
+from miot_harness.runtime.context import UserRequest
+from miot_harness.runtime.router import HarnessRoute, IntentRouter, RouteResult
+from miot_harness.runtime.run_store import JsonRunStore
+from miot_harness.runtime.supervisor import HarnessSupervisor
+from miot_harness.storytelling.module import StorytellingModule
+from miot_harness.tools.registry import ToolRegistry
+
+
+class _AgenticRouter(IntentRouter):
+    def route(self, message: str) -> RouteResult:
+        return RouteResult(route=HarnessRoute.DATA_AGENTIC, reason="test")
+
+
+class _FakeLoop:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, *, user_message, ctx, prior_messages, progress):
+        self.calls.append({"user_message": user_message, "ctx": ctx})
+        return {"answer": "loop answer", "evidence": [], "usage_log": []}
+
+
+@pytest.mark.asyncio
+async def test_agentic_route_prefers_agent_loop(tmp_path):
+    loop = _FakeLoop()
+    sup = HarnessSupervisor(
+        router=_AgenticRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        agentic_graph=object(),  # would explode if invoked
+        agent_loop=loop,
+    )
+    record = await sup.run(UserRequest(message="explore this", mode="agentic"))
+    assert record.answer == "loop answer"
+    assert record.status == "completed"
+    assert loop.calls[0]["user_message"] == "explore this"
+
+
+@pytest.mark.asyncio
+async def test_agentic_route_falls_back_to_graph_when_no_loop(tmp_path):
+    sup = HarnessSupervisor(
+        router=_AgenticRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        agentic_graph=None,
+        agent_loop=None,
+    )
+    record = await sup.run(UserRequest(message="explore this", mode="agentic"))
+    assert "disabled" in (record.answer or "")

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -285,3 +285,19 @@ def test_load_dotenv_multi_file_later_wins(tmp_path, monkeypatch):
 
     assert os.environ["MIOT_HARNESS_A_T"] == "over"  # later file wins
     assert os.environ["MIOT_HARNESS_B_T"] == "base"
+
+
+def test_agent_loop_settings_defaults(monkeypatch):
+    monkeypatch.delenv("MIOT_HARNESS_AGENTS_AGENT_LOOP_ENABLED", raising=False)
+    from miot_harness.config import HarnessSettings
+
+    s = HarnessSettings()
+    assert s.agents_agent_loop_enabled is False
+    assert s.agents_agent_loop_tool_result_max_chars == 6000
+
+
+def test_agent_loop_settings_env_override(monkeypatch):
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_AGENT_LOOP_ENABLED", "true")
+    from miot_harness.config import HarnessSettings
+
+    assert HarnessSettings().agents_agent_loop_enabled is True

--- a/miot-harness/tests/test_config.py
+++ b/miot-harness/tests/test_config.py
@@ -301,3 +301,18 @@ def test_agent_loop_settings_env_override(monkeypatch):
     from miot_harness.config import HarnessSettings
 
     assert HarnessSettings().agents_agent_loop_enabled is True
+
+
+def test_agent_loop_llm_timeout_default(monkeypatch):
+    monkeypatch.delenv("MIOT_HARNESS_AGENTS_AGENT_LOOP_LLM_TIMEOUT_SECONDS", raising=False)
+    from miot_harness.config import HarnessSettings
+
+    s = HarnessSettings()
+    assert s.agents_agent_loop_llm_timeout_seconds == 300
+
+
+def test_agent_loop_llm_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("MIOT_HARNESS_AGENTS_AGENT_LOOP_LLM_TIMEOUT_SECONDS", "600")
+    from miot_harness.config import HarnessSettings
+
+    assert HarnessSettings().agents_agent_loop_llm_timeout_seconds == 600

--- a/miot-harness/tests/test_native_tools.py
+++ b/miot-harness/tests/test_native_tools.py
@@ -1,0 +1,67 @@
+import json
+
+from pydantic import BaseModel
+
+from miot_harness.agents.native_tools import build_native_tools
+from miot_harness.runtime.permissions import PermissionResult
+from miot_harness.runtime.tool import HarnessTool
+from miot_harness.tools.registry import ToolRegistry
+from tests.fixtures.fake_provider import FAKE_PROFILE
+
+
+class _In(BaseModel):
+    limit: int = 10
+
+
+class _Out(BaseModel):
+    rows: list[dict] = []
+
+
+def _tool(name: str, kind: str) -> HarnessTool:
+    async def _allow(ctx, parsed):
+        return PermissionResult.allow("test")
+
+    async def _call(ctx, parsed, progress):
+        return _Out()
+
+    return HarnessTool(
+        name=name,
+        description=f"{name} description",
+        input_model=_In,
+        output_model=_Out,
+        kind=kind,
+        check_permission=_allow,
+        call=_call,
+    )
+
+
+def _registry() -> ToolRegistry:
+    reg = ToolRegistry.__new__(ToolRegistry)  # skip built-in tool auto-registration
+    reg._tools = {}
+    for name, kind in [
+        ("fake_kpi_summary", "curated"),
+        ("fake_alpha_query", "curated"),
+        ("pg_explore", "primitive"),
+        ("create_story_draft", "general"),  # must be excluded
+    ]:
+        reg.register(_tool(name, kind))
+    return reg
+
+
+def test_native_tools_scope_and_order():
+    tools = build_native_tools(_registry(), profile=FAKE_PROFILE)
+    names = [t["name"] for t in tools]
+    assert names == ["fake_alpha_query", "fake_kpi_summary", "pg_explore"]
+    assert all(set(t) == {"name", "description", "input_schema"} for t in tools)
+
+
+def test_native_tools_schema_comes_from_input_model():
+    tools = build_native_tools(_registry(), profile=FAKE_PROFILE)
+    schema = tools[0]["input_schema"]
+    assert schema["properties"]["limit"]["default"] == 10
+
+
+def test_native_tools_byte_stable():
+    a = json.dumps(build_native_tools(_registry(), profile=FAKE_PROFILE), sort_keys=True)
+    b = json.dumps(build_native_tools(_registry(), profile=FAKE_PROFILE), sort_keys=True)
+    assert a == b


### PR DESCRIPTION
## Summary

Replaces the agentic expert-panel pipeline (planner → verifier → synthesizer → critic seats, 5-10+ sequential full-context LLM calls per question) with **one cached native tool-calling agent loop**, behind a feature flag (`MIOT_HARNESS_AGENTS_AGENT_LOOP_ENABLED`, default **off** — flag-off behavior is verified identical to trunk).

Root causes addressed (Console showed zero prompt-cache usage):
1. **No `cache_control` anywhere** — every LLM call paid full input price and full prefill latency.
2. **Panel shape defeats caching** — each seat built a different system prompt, so the static context (primer + tool catalogs) could never be shared across seats.

## Architecture

- **`runtime/agent_loop.py` — `AgentLoopRunner`**: one model, tools bound once at boot, append-only conversation looping `tool_use → invoke_step → tool_result` until the model answers. Replaces the planner/verifier/synthesizer/critic seats; reuses `invoke_step`, the rule-based `freshness_judge`, and provenance logging unchanged.
- **Cache layout** (Anthropic renders tools → system → messages): frozen byte-stable prefix (sorted native tool defs + static system prompt with an `ephemeral` breakpoint) + one request-time tail marker applied on a copy — exactly 2 breakpoints per request, wire-verified via `_get_request_payload` tests.
- **Deterministic safety gates kept as code**: tenancy pre-gate before any LLM call; freshness classification per step (same annotate-don't-refuse semantics as the legacy agentic graph). Anti-fabrication/citation rules moved into the cached prompt (all 10 rule phrases pinned by tests).
- **Dynamic content never touches the prefix**: skill bodies / JSON-blocks contract / conversation history are demoted to `<system-reminder>` blocks in the user turn.
- Telemetry now records ephemeral cache-write tokens (langchain maps them to `input_token_details["ephemeral_5m_input_tokens"]` and zeroes `cache_creation`), so the Console/Langfuse cache panels report real numbers.

## Verification

- **Live cache test passed against the real Anthropic API**: ~5011-token prefix written on call 1, 5012 tokens read from cache on call 2 (`tests/integration/test_agent_loop_cache_live.py`, skip-gated behind `MIOT_HARNESS_RUN_LIVE_TESTS=1`).
- 901 tests pass, 3 skipped; ruff + mypy clean on new modules.
- Each task passed an independent spec+quality review; final whole-branch review found one blocker (telemetry cache accounting) — fixed in the last commit.

## Rollout plan (not in this PR)

Golden-eval parity run (legacy agentic graph vs loop) → review latency/cost/cache metrics → flip the flag default and delete the legacy agentic seats in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional single-agent tool-calling loop for data requests, configurable via new settings for enabling the mode, capping tool-result context size, and setting an LLM timeout.
  * Improved native tool-calling and prompt-cache stability for agent interactions.

* **Bug Fixes**
  * Fixed Anthropic model timeout handling to respect a caller-provided timeout when set.
  * Updated Anthropic usage tracking so ephemeral cache creation is reflected correctly.

* **Tests**
  * Added unit and live integration coverage for the agent loop, prompt caching, native tool generation, configuration defaults, and timeout overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #878
