### PR TITLE
feat(harness): miot-search skill — agentic spotlight search over app pages

### DIFF
--- a/.github/workflows/harness.yaml
+++ b/.github/workflows/harness.yaml
@@ -37,6 +37,9 @@ on:
     paths:
       - 'miot-harness/**'
       - '.github/workflows/harness.yaml'
+      # apps/app nav registry — the miot-search skill's page inventory is
+      # parity-tested against it (tests/context_skills/test_miot_search_pages_parity.py)
+      - 'turbo-repo/apps/app/src/features/layout/models/pages-config.json'
     branches: [trunk, main]
     tags:
       - 'v*'
@@ -44,6 +47,7 @@ on:
     paths:
       - 'miot-harness/**'
       - '.github/workflows/harness.yaml'
+      - 'turbo-repo/apps/app/src/features/layout/models/pages-config.json'
     branches: [trunk, main]
   workflow_dispatch:
 

--- a/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
+++ b/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: miot-search
+description: >
+  Resolve a free-text query typed into the ModularIoT app search box into a
+  direct answer, a deep link to the right page, or a build request. Use when
+  the user searches for a page or section, looks up an entity (truck, trailer,
+  driver, task, service, expedition, booking, conversation), or asks a data
+  question from the spotlight search.
+when_to_use: >
+  A run arrives from the apps/app spotlight search box (skill_id=miot-search).
+  The user typed a short free-text query and expects an answer row and/or
+  "Go to" links rendered in the palette.
+---
+
+# MIOT Search
+
+You resolve one short search-box query. The result renders inside a compact
+spotlight palette row in the ModularIoT web app, so be brief, precise, and
+always machine-parseable.
+
+## 1. Classify the intent
+
+Classify the query as exactly one of:
+
+- `navigate` — the user wants a place in the app. Examples: "flota",
+  "where do I see trucks?", "camion ABC-123", "conversaciones whatsapp",
+  "tareas pendientes".
+- `ask` — the user wants information or an answer derived from data.
+  Examples: "¿cuántas entregas atrasadas hoy?", "how many services finished
+  this week?", "estado del camión ABC-123".
+- `build` — the user wants to create or configure something. Examples:
+  "crea un dashboard de cumplimiento", "add a widget for late deliveries".
+  Building is **not supported yet**: reply with a single short markdown block
+  saying so (in the user's language), plus the intent block. Do not attempt
+  the build.
+
+Queries that name an entity identifier (a license plate, RUT, expedition
+code, service id…) are usually `navigate` (take me to it) unless the phrasing
+clearly asks a question about it.
+
+## 2. Output contract
+
+The run always uses `answer_format=json`: your entire answer is a JSON array
+of typed blocks (no prose outside the array). On top of the generic block
+contract, follow these rules:
+
+1. The **first** block declares the intent:
+   `{"type": "intent", "value": "ask" | "navigate" | "build"}`
+2. Include **exactly one** `markdown` block: a one-line summary in the user's
+   language (it becomes the palette row label — keep it under ~100 chars).
+   For `ask`, this carries the answer; add at most one more short paragraph
+   inside the same block if truly needed.
+3. For `navigate` (and for `ask` answers that reference app entities), add one
+   `url` block per destination, most relevant first, at most 5:
+   `{"type": "url", "value": {"url": "/fleet-management?licensePlate=ABC123", "name": "Fleet — ABC-123"}}`
+
+URL rules — never break these:
+
+- URLs are **app-relative paths** exactly as listed in the page inventory
+  below: they start with a single `/`, never include a locale prefix (the app
+  injects `es`/`en` itself), never include a host, and never use a scheme
+  (`https:`, `javascript:`, `data:` are all wrong).
+- Only link routes from the inventory. Never invent a route or a query
+  parameter that is not listed.
+- `name` is a short human label in the user's language.
+
+Example — query "camion ABC-123":
+
+```json
+[
+  {"type": "intent", "value": "navigate"},
+  {"type": "markdown", "value": "Camión ABC-123 en gestión de flota"},
+  {"type": "url", "value": {"url": "/fleet-management?licensePlate=ABC123", "name": "Flota — ABC-123"}},
+  {"type": "url", "value": {"url": "/geographic-view?licensePlate=ABC123", "name": "Mapa — ABC-123"}}
+]
+```
+
+## 3. Page inventory
+
+Filter parameters are plain query-string keys on the route
+(`?key=value&key2=value2`). Date filters use ISO dates in a `_from`/`_to`
+pair. Dynamic segments are written `{like_this}` — replace them with a real
+value you have confirmed; never emit a literal placeholder.
+
+| Route | Names / synonyms | What it shows | Filter params |
+|---|---|---|---|
+| `/home` | home, inicio, dashboards, tableros | User dashboards (each dashboard at `/home/{slug}`) | — |
+| `/calendar` | calendar, calendario, agenda, reservas, bookings | Calendar services overview; planning at `/calendar/planning` and per-calendar `/calendar/{calendarId}/planning` | — |
+| `/planning` | planning, planificación (kanban) | Services being planned (kanban board) | kanban params (below) |
+| `/shipping` | shipping, embarque, despacho (kanban) | Services in shipping | kanban params |
+| `/delivery` | delivery, entrega, reparto (kanban) | Services in delivery | kanban params |
+| `/finished` | finished, finalizados, completados (kanban) | Completed services | kanban params |
+| `/mytasks` | my tasks, mis tareas, tareas | The user's tasks | `status=pending\|finished` + kanban params; a task opens at `/task/edit/{taskId}` |
+| `/geographic-view` | map, mapa, geographic view, posición, GPS | Live map of assets/vehicles | `licensePlate` |
+| `/symptoms` | symptoms, síntomas, alerts, alertas | Alerts on assets/trips (control tower); list at `/symptoms/symptoms-list` | `asset_id`, `trip_id`, `driver_id`, `carrier_id`, `origin`, `destination`, `symptom_name`, `date_from`/`date_to` |
+| `/signal-history` | signal history, historial de señales, telemetría | Device signal/telemetry history | — |
+| `/whatsapp/conversations` | whatsapp, conversations, conversaciones, chat, inbox | WhatsApp inbox conversations | — |
+| `/live-streams/facility-scl` | live stream, cámaras, facility SCL | Facility SCL camera streams | — |
+| `/live-streams/truck-beds` | truck beds, tolvas, camas de camión | Truck-bed camera streams | — |
+| `/live-streams/devices` | devices, dispositivos, cámaras | All streaming devices | — |
+| `/collaborators-management` | collaborators, colaboradores, drivers, conductores, choferes | Drivers/collaborators (detail at `/collaborators-management/{codDriver}`) | `name` or `rut` (one at a time) |
+| `/fleet-management` | fleet, flota, trucks, camiones, trailers, remolques | Fleet vehicles (detail at `/fleet-management/{plate}`) | `licensePlate`, `client`, `state=active\|maintenance\|alert\|inactive` |
+| `/where-is-my-load` | where is my load, dónde está mi carga, expedición, expedition | Load/expedition tracking | `expeditionCode` or `expeditionNumber` (one at a time) |
+| `/notifications` | notifications, notificaciones | User notifications | — |
+| `/users/settings` | settings, configuración, ajustes | User settings; organizations at `/users/settings/organizations`, data sources at `/users/settings/data-sources` | — |
+| `/admin/console/logs` | admin logs, logs, registros (admins only) | Operational logs | — |
+| `/admin/console/message-templates` | message templates, plantillas de mensaje (admins only) | Message templates | — |
+
+Kanban params (for `/planning`, `/shipping`, `/delivery`, `/finished`,
+`/mytasks`): `service`, `licensePlate`, `driverId`, `carrierId`, `origin`,
+`destination`, `customer`, `originType=INTERNAL|EXTERNAL`,
+`date_range_from`/`date_range_to`.
+
+## 4. Entity lookups (datasource connections)
+
+When the query names an identifier or an entity — a license plate, driver
+name/RUT, expedition code, service id, a count or status question — use the
+datasource connection tools available in this run to ground the answer before
+linking. Tools are named `<connection>_<primitive>` after whichever
+connections booted (for example `coordinador_select` or `nexo_grep`); do not
+assume any specific connection exists.
+
+1. Orient first: `<connection>_knowledge` (curated schema cards) or
+   `<connection>_list_tables`, then `<connection>_describe` on a candidate
+   table.
+2. Look up: `<connection>_grep` to find the identifier across a table's text
+   columns, or `<connection>_select` with a narrow `where` and a small
+   `limit`.
+3. Answer + link: put the confirmed facts in the markdown block and emit the
+   deep link from the inventory with the matching filter param (e.g. a
+   confirmed plate → `/fleet-management?licensePlate=<plate>` and, if
+   position matters, `/geographic-view?licensePlate=<plate>`).
+
+If no datasource connection tools are registered, or the lookup finds
+nothing, still answer: say (in the user's language) that you could not
+confirm the entity, and link the most relevant page with the user's raw term
+as the filter value when the param fits, or unfiltered otherwise.
+
+## 5. Guardrails
+
+- Read-only: never call tools that create, modify, or delete anything.
+- Never fabricate data, routes, or query parameters. Unconfirmed = say so.
+- Keep it short: this renders in a palette row, not a report.
+- Answer in the user's language (Spanish queries get Spanish labels and
+  summaries).
+- Links may point to pages the user's permission groups cannot open; that is
+  acceptable — the app guards each page. Prefer non-admin routes when both
+  fit.
+- If the query is empty or gibberish, return intent `ask` with a single
+  markdown block asking for a more specific query.

--- a/miot-harness/tests/context_skills/test_miot_search_pages_parity.py
+++ b/miot-harness/tests/context_skills/test_miot_search_pages_parity.py
@@ -1,0 +1,118 @@
+"""Parity tests for the packaged `miot-search` skill.
+
+The skill body embeds a page inventory of the apps/app frontend (routes +
+filter params) so the harness can answer spotlight searches with deep links.
+That inventory must stay in lockstep with the app's navigation registry
+(`pages-config.json`) and the actual Next.js pages:
+
+- every navigable registry entry must be covered by the skill body, and
+- every route the skill teaches must exist as a real page.
+
+The checks read the frontend sources from the monorepo checkout and are
+skipped when they are absent (e.g. running the tests from an installed
+wheel/sdist) — only monorepo CI enforces parity.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import miot_harness.context_skills as context_skills_pkg
+from miot_harness.context_skills.file_source import FileSkillSource
+from miot_harness.context_skills.skill_models import PlaybookSkill
+
+_DEFAULT_SKILLS_DIR = Path(context_skills_pkg.__file__).parent / "defaults" / "skills"
+_SKILL_MD = _DEFAULT_SKILLS_DIR / "miot-search" / "SKILL.md"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_APP_ROOT = _REPO_ROOT / "turbo-repo" / "apps" / "app"
+_PAGES_CONFIG = _APP_ROOT / "src" / "features" / "layout" / "models" / "pages-config.json"
+_SECURED_PAGES_DIR = _APP_ROOT / "src" / "app" / "[lang]" / "(secured)"
+
+# Backticked app-relative routes in the skill body, e.g. `/fleet-management`
+# or `/mytasks?status=...`. Captures the static path prefix only: the capture
+# stops at `?` (query) and `{` (dynamic-segment placeholder).
+_ROUTE_RE = re.compile(r"`(/[a-z0-9\-/]+)[^`]*`")
+
+requires_frontend_sources = pytest.mark.skipif(
+    not (_PAGES_CONFIG.is_file() and _SECURED_PAGES_DIR.is_dir()),
+    reason="apps/app sources not present (not a monorepo checkout)",
+)
+
+
+def _skill_body() -> str:
+    return _SKILL_MD.read_text(encoding="utf-8")
+
+
+def _body_routes() -> set[str]:
+    """Static route paths the skill body references in inline code."""
+    routes: set[str] = set()
+    for match in _ROUTE_RE.finditer(_skill_body()):
+        route = match.group(1).rstrip("/")
+        if route:
+            routes.add(route)
+    return routes
+
+
+def _registry_hrefs() -> set[str]:
+    """Static hrefs from the app nav registry (sections + nested items)."""
+    sections = json.loads(_PAGES_CONFIG.read_text(encoding="utf-8"))
+    hrefs: set[str] = set()
+    for section in sections:
+        for entry in (section, *(section.get("items") or ())):
+            href = entry.get("href")
+            if href:
+                hrefs.add(href.split("?")[0].rstrip("/"))
+    hrefs.discard("")
+    return hrefs
+
+
+def _page_exists(route: str) -> bool:
+    """True when a page.tsx exists at `route` or under it (dynamic details)."""
+    base = _SECURED_PAGES_DIR / route.lstrip("/")
+    return base.is_dir() and any(base.rglob("page.tsx"))
+
+
+def test_packaged_miot_search_skill_loads() -> None:
+    result = FileSkillSource(_DEFAULT_SKILLS_DIR).load()
+
+    assert not [d for d in result.diagnostics if d.level == "error"]
+    loaded = next(s for s in result.skills if s.skill.id == "miot-search")
+    assert isinstance(loaded.skill, PlaybookSkill)
+    assert loaded.skill.scope.kind == "global"
+    assert loaded.skill.description
+    assert loaded.playbook_body
+    # The body must carry the spotlight output contract.
+    for marker in ('"intent"', '"markdown"', '"url"'):
+        assert marker in loaded.playbook_body
+
+
+@requires_frontend_sources
+def test_registry_pages_are_in_skill_inventory() -> None:
+    """Every navigable nav-registry href must appear in the skill body.
+
+    Registry hrefs without a real page (e.g. section-header stubs like
+    `/reports`) are exempt — the skill must not teach dead routes.
+    """
+    body_routes = _body_routes()
+    navigable = {href for href in _registry_hrefs() if _page_exists(href)}
+
+    missing = sorted(navigable - body_routes)
+    assert not missing, (
+        "pages-config.json hrefs missing from the miot-search page inventory "
+        f"({_SKILL_MD}): {missing}"
+    )
+
+
+@requires_frontend_sources
+def test_skill_inventory_routes_exist_as_pages() -> None:
+    """Every route the skill teaches must resolve to a real app page."""
+    dead = sorted(route for route in _body_routes() if not _page_exists(route))
+    assert not dead, (
+        "miot-search page inventory references routes with no page.tsx under "
+        f"{_SECURED_PAGES_DIR}: {dead}"
+    )

--- a/turbo-repo/apps/app/src/app/api/harness/search/route.ts
+++ b/turbo-repo/apps/app/src/app/api/harness/search/route.ts
@@ -13,10 +13,14 @@ const MIOT_HARNESS_HOST = process.env.MIOT_HARNESS_URL ?? "";
 // org slugs for the same tenant. Falls back to dynamic scope resolution.
 const MIOT_HARNESS_ORG = process.env.MIOT_HARNESS_ORG ?? "";
 
-/** ms before we abort a run that hasn't completed */
-const HARNESS_SEARCH_TIMEOUT_MS = 12_000;
+/** ms before we abort a run that hasn't completed — entity lookups on the
+ * agentic path (planner → datasource tools → verify gate) need headroom */
+const HARNESS_SEARCH_TIMEOUT_MS = 30_000;
+
+export type HarnessIntent = "ask" | "navigate" | "build";
 
 export type HarnessBlock =
+  | { type: "intent"; value: HarnessIntent }
   | { type: "markdown"; value: string }
   | { type: "url"; value: { url: string; name: string } };
 
@@ -24,19 +28,31 @@ export interface HarnessSearchResult {
   id: string;
   label: string;
   sublabel?: string;
+  intent?: HarnessIntent;
   blocks: HarnessBlock[];
+}
+
+const HARNESS_INTENTS: readonly string[] = ["ask", "navigate", "build"];
+
+/** Absolute http(s), or an app-relative path (single leading slash — a
+ * protocol-relative `//host` is rejected). */
+function isSafeHref(url: string): boolean {
+  return /^https?:\/\//i.test(url) || (url.startsWith("/") && !url.startsWith("//"));
 }
 
 function isValidBlock(item: unknown): item is HarnessBlock {
   if (!item || typeof item !== "object") return false;
   const b = item as Record<string, unknown>;
+  if (b.type === "intent") {
+    return typeof b.value === "string" && HARNESS_INTENTS.includes(b.value);
+  }
   if (b.type === "markdown") return typeof b.value === "string";
   if (b.type === "url") {
     if (!b.value || typeof b.value !== "object") return false;
     const v = b.value as Record<string, unknown>;
     return (
       typeof v.url === "string" &&
-      /^https?:\/\//i.test(v.url) &&
+      isSafeHref(v.url) &&
       typeof v.name === "string"
     );
   }
@@ -129,10 +145,17 @@ export async function POST(request: Request) {
 
     if (!answer) return NextResponse.json({ results: [] });
 
-    const blocks = parseAnswerBlocks(answer);
+    const parsed = parseAnswerBlocks(answer);
+    // The skill emits the intent as a leading typed block — surface it as a
+    // field and keep only renderable blocks.
+    const intent = parsed.find(
+      (b): b is Extract<HarnessBlock, { type: "intent" }> => b.type === "intent",
+    )?.value;
+    const blocks = parsed.filter((b) => b.type !== "intent");
     const result: HarnessSearchResult = {
       id: `harness:${run_id}`,
       label: buildLabel(blocks),
+      ...(intent && { intent }),
       blocks,
     };
 

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-results.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-results.tsx
@@ -61,9 +61,10 @@ function MarkdownBlock({ value }: Readonly<{ value: string }>) {
   );
 }
 
-function HarnessAnswerItem({ item, onHover, navigateHeading, selectedItemId }: Readonly<{
+function HarnessAnswerItem({ item, onHover, onOpenUrl, navigateHeading, selectedItemId }: Readonly<{
   item: SpotlightItem;
   onHover: (id: string | null) => void;
+  onOpenUrl: (url: string) => void;
   navigateHeading: string;
   selectedItemId: string | null;
 }>) {
@@ -112,7 +113,7 @@ function HarnessAnswerItem({ item, onHover, navigateHeading, selectedItemId }: R
                   label: block.value.name,
                   kind: "harness-goto",
                   keywords: [],
-                  onSelect: () => globalThis.open(block.value.url, "_blank", "noopener,noreferrer"),
+                  onSelect: () => onOpenUrl(block.value.url),
                 }}
                 isSelected={id === selectedItemId}
                 onSelect={(it) => it.onSelect()}
@@ -135,6 +136,7 @@ interface SpotlightResultsProps {
   selectedItemId: string | null;
   onSelect: (item: SpotlightItem) => void;
   onHover: (id: string | null) => void;
+  onOpenUrl: (url: string) => void;
   navigateHeading: string;
   harnessEmptyLabel: string;
 }
@@ -148,6 +150,7 @@ export const SpotlightResults = memo(function SpotlightResults({
   selectedItemId,
   onSelect,
   onHover,
+  onOpenUrl,
   navigateHeading,
   harnessEmptyLabel,
 }: Readonly<SpotlightResultsProps>) {
@@ -191,6 +194,7 @@ export const SpotlightResults = memo(function SpotlightResults({
                   key={item.id}
                   item={item}
                   onHover={onHover}
+                  onOpenUrl={onOpenUrl}
                   navigateHeading={navigateHeading}
                   selectedItemId={selectedItemId}
                 />

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx
@@ -58,18 +58,17 @@ const KIND_ICONS: Record<SpotlightResultKind, IconConfig> = {
   },
 };
 
-function urlBlockToItem(block: HarnessBlock & { type: "url" }, i: number): SpotlightItem {
+function urlBlockToItem(
+  block: HarnessBlock & { type: "url" },
+  i: number,
+  openUrl: (url: string) => void,
+): SpotlightItem {
   return {
     id: `harness-url-${i}`,
     label: block.value.name,
     kind: "harness-goto" as const,
     keywords: [],
-    onSelect: () => {
-      const { url } = block.value;
-      if (/^https?:\/\//i.test(url)) {
-        globalThis.open(url, "_blank", "noopener,noreferrer");
-      }
-    },
+    onSelect: () => openUrl(block.value.url),
   };
 }
 
@@ -138,6 +137,22 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
     onEnterSelect: handleEnterSelect,
   });
 
+  // ── Harness url opener — relative paths navigate in-app (locale-aware),
+  //    absolute http(s) urls open a new tab ──────────────────────────────────
+  const onOpenHarnessUrl = useCallback(
+    (url: string) => {
+      if (/^https?:\/\//i.test(url)) {
+        globalThis.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      if (url.startsWith("/") && !url.startsWith("//")) {
+        router.push(url);
+        close();
+      }
+    },
+    [router, close],
+  );
+
   // ── Committed query — only set when user explicitly asks Harness ─────────
   const [committedQuery, setCommittedQuery] = useState("");
 
@@ -176,9 +191,9 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
     harnessResults.flatMap((result) =>
       (result.blocks ?? [])
         .filter((b): b is HarnessBlock & { type: "url" } => b.type === "url")
-        .map((block, i) => urlBlockToItem(block, i))
+        .map((block, i) => urlBlockToItem(block, i, onOpenHarnessUrl))
     ),
-    [harnessResults],
+    [harnessResults, onOpenHarnessUrl],
   );
 
   // ── Flat selectable list (no group headers) ───────────────────────────────
@@ -296,6 +311,7 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
                   selectedItemId={selectableItems[selectedIndex]?.id ?? null}
                   onSelect={handleSelectAction}
                   onHover={setHoveredId}
+                  onOpenUrl={onOpenHarnessUrl}
                   navigateHeading={navigateHeading}
                   harnessEmptyLabel={harnessEmptyLabel}
                 />

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/types.ts
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/types.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from "react";
-import type { HarnessBlock } from "@/app/api/harness/search/route";
+import type { HarnessBlock, HarnessIntent } from "@/app/api/harness/search/route";
 
-export type { HarnessBlock };
+export type { HarnessBlock, HarnessIntent };
 
 export type SpotlightResultKind = "navigate" | "harness" | "harness-goto";
 
@@ -19,6 +19,8 @@ export interface SpotlightItem {
   isGroupHeader?: boolean;
   /** Structured answer blocks — harness items only */
   blocks?: HarnessBlock[];
+  /** Query intent declared by the miot-search skill — harness items only */
+  intent?: HarnessIntent;
   /** Marks the synthetic "Ask Harness" prompt row — selecting it fires the search, does not close modal */
   isHarnessPrompt?: boolean;
 }

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/use-harness-search.ts
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/use-harness-search.ts
@@ -11,6 +11,7 @@ function toSpotlightItem(r: HarnessSearchResult): SpotlightItem {
     label: r.label,
     sublabel: r.sublabel,
     blocks: r.blocks,
+    intent: r.intent,
     kind: "harness" as const,
     icon: BsStars,
     keywords: [],


### PR DESCRIPTION
## Summary

Implements the `miot-search` harness context skill that the spotlight search (#876) already dispatches (`skill_id: "miot-search"`) but which did not exist — runs degraded to generic answers with no knowledge of the app's pages or entities.

> **Stacked on #876** (`based/new_searchbar_definition`) — merge that first; this PR should retarget to `trunk` automatically once it lands. Closes #880.

### Harness (packaged defaults)

- `context_skills/defaults/skills/miot-search/SKILL.md` — Anthropic Agent-Skills standard. Classifies each query as `ask` / `navigate` / `build` (build answers *not supported yet*), leads the JSON answer with an `{"type": "intent"}` block on top of the typed-blocks contract (#854), embeds the apps/app page inventory (routes, ES/EN synonyms, filter query-params from `pages-config.json` + `navegation_params.ts`), and teaches entity lookups via the connection-prefixed datasource primitives (`<connection>_knowledge/grep/select…`) without assuming any specific connection.
- Parity tests (`tests/context_skills/test_miot_search_pages_parity.py`): every navigable `pages-config.json` href must appear in the skill body, and every route the skill teaches must resolve to a real `page.tsx` (dead registry hrefs like `/reports` are exempt). Skipped outside a monorepo checkout.
- `.github/workflows/harness.yaml` now also triggers on `pages-config.json`, so renaming/adding an app page fails harness CI until the skill inventory is updated.

### Frontend (apps/app)

- `/api/harness/search`: accepts the `intent` block and app-relative `url` blocks (both previously dropped by validation), surfaces `intent` on the result, timeout 12s → 30s for datasource-backed lookups.
- Spotlight: relative `url` blocks navigate in-app via `router.push` (locale-aware, closes the palette); absolute urls keep opening a new tab.

## Verification

- `miot-harness`: 913 passed / 4 skipped (full suite); parity tests proven to fail on a simulated page rename.
- `apps/app`: `check-types` + 640 vitest tests green.
- Live E2E against a locally booted harness with the Coordinador datasource (tools registered as `coordinador_*`, validating the connection-agnostic design). Query `donde veo el camión ABC-123` via the `meta` route returns the full contract: `intent: navigate`, one-line summary, and deep links `/geographic-view?licensePlate=ABC123` + `/fleet-management?licensePlate=ABC123`. `auto` → `data_meta` behaves identically for page queries.

### Known follow-ups (documented in #880)

- The intent router sends entity-flavored queries to the canned data path, whose fixed pipeline ignores the block contract (degrades to plain markdown, no links).
- `build` queries route to `storytelling_run`, which returns an empty answer → spotlight empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)