### PR TITLE
feat: show assignment accreditation on planning services

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/assignment-accreditation.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/assignment-accreditation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Coverage for the assignment-accreditation aggregate the calendar card/chip
+ * render: weakest-link level across the assigned resources, skipping slots
+ * whose level is unknown (legacy bookings / row not on the loaded page).
+ */
+import { describe, it, expect } from "vitest";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import {
+  getAssignmentAccreditation,
+  assignmentAccreditationTooltip,
+} from "./assignment-accreditation";
+import type { SelectedService } from "./planning-selection-types";
+
+function makeService(overrides: Partial<SelectedService> = {}): SelectedService {
+  return {
+    id: "1626876-v",
+    cliente: "Cliente",
+    origen: "SCL",
+    lugarCarguio: "SCL",
+    destino: "ANF",
+    tipoViaje: "Sider",
+    ocupacion: 0,
+    permanencia: "",
+    leadTime: {
+      total_lineasoc_cumplen: 0,
+      total_lineasoc_incumplen: 0,
+      lineasoc_pctn_cumplimiento: null,
+    },
+    eta: "",
+    incidencias: [],
+    observaciones: "",
+    prioridad: 0,
+    ...overrides,
+  };
+}
+
+const dict = {
+  pages: {
+    planning: {
+      sidebar: {
+        assignment: {
+          carrier: "Transportista",
+          driver: "Conductor",
+          secondDriver: "Segundo Conductor",
+          truck: "Camión",
+          trailer: "Remolque",
+          enabled: "Acreditado",
+          notEnabled: "No Acreditado",
+          superAccredited: "Súper Acreditado",
+        },
+      },
+    },
+  },
+} as unknown as I18nRecord;
+
+describe("getAssignmentAccreditation", () => {
+  it("returns null when nothing is assigned", () => {
+    expect(getAssignmentAccreditation(makeService())).toBeNull();
+  });
+
+  it("returns null for legacy bookings that persisted ids but no levels", () => {
+    const service = makeService({
+      assignedCarrier: "carrier-1",
+      assignedDriver: "driver-1",
+      assignedTruck: "truck-1",
+    });
+    expect(getAssignmentAccreditation(service)).toBeNull();
+  });
+
+  it("skips slots whose level is null (row not on the loaded page)", () => {
+    const service = makeService({
+      assignedCarrier: "carrier-1",
+      assignedCarrierAccreditation: null,
+      assignedDriver: "driver-1",
+      assignedDriverAccreditation: "superAccredited",
+    });
+    const result = getAssignmentAccreditation(service);
+    expect(result?.level).toBe("superAccredited");
+    expect(result?.entries).toHaveLength(1);
+  });
+
+  it("ignores stale levels on slots that are no longer assigned", () => {
+    const service = makeService({
+      assignedCarrierAccreditation: "notAccredited",
+    });
+    expect(getAssignmentAccreditation(service)).toBeNull();
+  });
+
+  it("is superAccredited only when every assigned resource is", () => {
+    const service = makeService({
+      assignedCarrier: "carrier-1",
+      assignedCarrierAccreditation: "superAccredited",
+      assignedDriver: "driver-1",
+      assignedDriverAccreditation: "superAccredited",
+      assignedTruck: "truck-1",
+      assignedTruckAccreditation: "superAccredited",
+    });
+    expect(getAssignmentAccreditation(service)?.level).toBe("superAccredited");
+  });
+
+  it("degrades to the weakest level across resources, including driver2/trailer", () => {
+    const service = makeService({
+      assignedCarrier: "carrier-1",
+      assignedCarrierAccreditation: "superAccredited",
+      assignedDriver: "driver-1",
+      assignedDriverAccreditation: "accredited",
+      assignedDriver2: "driver-2",
+      assignedDriver2Accreditation: "superAccredited",
+      assignedTrailer: "trailer-1",
+      assignedTrailerAccreditation: "superAccredited",
+    });
+    expect(getAssignmentAccreditation(service)?.level).toBe("accredited");
+
+    const withNotAccredited = makeService({
+      ...service,
+      assignedTrailerAccreditation: "notAccredited",
+    });
+    expect(getAssignmentAccreditation(withNotAccredited)?.level).toBe(
+      "notAccredited"
+    );
+  });
+});
+
+describe("assignmentAccreditationTooltip", () => {
+  it("renders one translated '<slot>: <level>' line per known resource", () => {
+    const service = makeService({
+      assignedCarrier: "carrier-1",
+      assignedCarrierAccreditation: "superAccredited",
+      assignedTruck: "truck-1",
+      assignedTruckAccreditation: "notAccredited",
+    });
+    const summary = getAssignmentAccreditation(service);
+    expect(summary).not.toBeNull();
+    expect(assignmentAccreditationTooltip(summary!, dict)).toBe(
+      "Transportista: Súper Acreditado\nCamión: No Acreditado"
+    );
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/assignment-accreditation.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/assignment-accreditation.ts
@@ -1,0 +1,103 @@
+// Aggregates the per-resource accreditation levels persisted on a planned
+// service's assignment tuple into the single "weakest link" level the
+// calendar surfaces (service card, planned chip) render.
+
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import {
+  accreditationLabel,
+  type AccreditationLevel,
+} from "./sidebar-tabs/assignment/accreditation";
+import type { SelectedService } from "./planning-selection-types";
+
+/** Ordering used to pick the weakest level across the assigned resources. */
+const LEVEL_RANK: Record<AccreditationLevel, number> = {
+  notAccredited: 0,
+  accredited: 1,
+  superAccredited: 2,
+};
+
+export interface AssignmentAccreditationEntry {
+  /** i18n key of the resource slot label (Transportista, Conductor, …). */
+  labelKey: string;
+  level: AccreditationLevel;
+}
+
+export interface AssignmentAccreditation {
+  /**
+   * Weakest level across the assigned resources — a service is only as
+   * accredited as its least-accredited resource, so `superAccredited` means
+   * every assigned resource is super accredited.
+   */
+  level: AccreditationLevel;
+  /** Per-resource breakdown, in carrier → driver → truck → trailer order. */
+  entries: AssignmentAccreditationEntry[];
+}
+
+/**
+ * Collect the accreditation levels persisted on a service's assignment tuple.
+ * Slots that are unassigned — or assigned before the level was captured
+ * (legacy bookings persist ids only, and `null` means the row wasn't on the
+ * loaded feed page at selection time) — are skipped rather than treated as
+ * `notAccredited`, so "unknown" never masquerades as a real state. Returns
+ * null when nothing is known and no badge should render.
+ */
+export function getAssignmentAccreditation(
+  service: SelectedService
+): AssignmentAccreditation | null {
+  const entries: AssignmentAccreditationEntry[] = [];
+  const collect = (
+    assignedId: string | undefined,
+    level: AccreditationLevel | null | undefined,
+    labelKey: string
+  ) => {
+    if (assignedId && level != null) entries.push({ labelKey, level });
+  };
+  collect(
+    service.assignedCarrier,
+    service.assignedCarrierAccreditation,
+    "pages.planning.sidebar.assignment.carrier"
+  );
+  collect(
+    service.assignedDriver,
+    service.assignedDriverAccreditation,
+    "pages.planning.sidebar.assignment.driver"
+  );
+  collect(
+    service.assignedDriver2,
+    service.assignedDriver2Accreditation,
+    "pages.planning.sidebar.assignment.secondDriver"
+  );
+  collect(
+    service.assignedTruck,
+    service.assignedTruckAccreditation,
+    "pages.planning.sidebar.assignment.truck"
+  );
+  collect(
+    service.assignedTrailer,
+    service.assignedTrailerAccreditation,
+    "pages.planning.sidebar.assignment.trailer"
+  );
+  if (entries.length === 0) return null;
+  let weakest = entries[0].level;
+  for (const entry of entries) {
+    if (LEVEL_RANK[entry.level] < LEVEL_RANK[weakest]) weakest = entry.level;
+  }
+  return { level: weakest, entries };
+}
+
+/**
+ * Per-resource breakdown for the badge tooltip — one "<slot>: <level>" line
+ * per assigned resource with a known level.
+ */
+export function assignmentAccreditationTooltip(
+  summary: AssignmentAccreditation,
+  dict: I18nRecord
+): string {
+  return summary.entries
+    .map(
+      (entry) =>
+        `${tr(entry.labelKey, dict)}: ${accreditationLabel(entry.level, dict)}`
+    )
+    .join("\n");
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -5,6 +5,11 @@ import { IoPerson, IoPeople } from "react-icons/io5";
 import type { PlannedService } from "./planning-selection-context";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
+import {
+  getAssignmentAccreditation,
+  assignmentAccreditationTooltip,
+} from "./assignment-accreditation";
+import { AccreditationBadge } from "./sidebar-tabs/assignment/accreditation";
 import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 /**
@@ -83,6 +88,11 @@ export function PlannedServiceChip({
   const hasUrgencia = hasUrgenciaIncidencia(plannedService.service);
   const driverCount = getDriverCount(plannedService.service);
   const { origen, destino } = plannedService.service;
+  // Weakest accreditation level across the assigned resources — rendered with
+  // the same labelled badge the service card and sidebar show (icon + text),
+  // with the per-resource breakdown as tooltip. Unknown levels (legacy
+  // bookings) render nothing.
+  const accreditation = getAssignmentAccreditation(plannedService.service);
 
   return (
     <button
@@ -147,6 +157,14 @@ export function PlannedServiceChip({
             variant="ghost"
             className="shrink-0 px-1 text-[9px] font-semibold leading-none"
           />
+          {accreditation && (
+            <AccreditationBadge
+              level={accreditation.level}
+              dict={dict}
+              title={assignmentAccreditationTooltip(accreditation, dict)}
+              className="cursor-help px-1 py-0 text-[9px] leading-none"
+            />
+          )}
         </div>
       </div>
       {/* Right: Driver icon centered vertically */}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-types.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-types.ts
@@ -3,6 +3,7 @@
 // are injected into the generic planning provider via planning-selection-wrapper.
 
 import { type LeadTimeData } from "@/features/common/components/kpi-display";
+import type { AccreditationLevel } from "./sidebar-tabs/assignment/accreditation";
 
 // Re-export the lead-time helpers so existing planning imports keep resolving.
 export type { LeadTimeData };
@@ -90,4 +91,17 @@ export interface SelectedService {
   assignedDriver2ExternalId?: string | null;
   assignedTruckExternalId?: string | null;
   assignedTrailerExternalId?: string | null;
+  /**
+   * Accreditation level of each assigned resource, captured from the
+   * accredited-resources row at selection time (same lifecycle as the
+   * external-id slots) and persisted on the booking so the calendar card /
+   * chip can show the assignment's accreditation without re-querying the
+   * feed. `null` = unknown (row wasn't on the loaded page when selected);
+   * absent = booking written before this field existed.
+   */
+  assignedCarrierAccreditation?: AccreditationLevel | null;
+  assignedDriverAccreditation?: AccreditationLevel | null;
+  assignedDriver2Accreditation?: AccreditationLevel | null;
+  assignedTruckAccreditation?: AccreditationLevel | null;
+  assignedTrailerAccreditation?: AccreditationLevel | null;
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -66,6 +66,15 @@ import type { SelectedService, TaskStage } from "./planning-selection-types";
 import { ServiceEvent } from "./service-event";
 
 /**
+ * Persisted accreditation level of an assigned resource — mirrors the
+ * `AccreditationLevel` union; `null` = unknown at selection time.
+ */
+const AccreditationLevelSchema = z
+  .enum(["accredited", "notAccredited", "superAccredited"])
+  .nullable()
+  .optional();
+
+/**
  * Zod schema for data stored inside booking.resource.data. All SelectedService
  * fields are optional (defaults applied on merge). `_anden` is stored here
  * because SlotData has no andén field.
@@ -119,6 +128,11 @@ const StoredServiceSchema = z
     assignedDriver2ExternalId: z.string().nullable().optional(),
     assignedTruckExternalId: z.string().nullable().optional(),
     assignedTrailerExternalId: z.string().nullable().optional(),
+    assignedCarrierAccreditation: AccreditationLevelSchema,
+    assignedDriverAccreditation: AccreditationLevelSchema,
+    assignedDriver2Accreditation: AccreditationLevelSchema,
+    assignedTruckAccreditation: AccreditationLevelSchema,
+    assignedTrailerAccreditation: AccreditationLevelSchema,
     _anden: z.number().optional(),
   })
   .optional();
@@ -496,7 +510,7 @@ export function PlanningSelectionProvider({
       // canonical item's raw service. The package's generic SidebarShell calls
       // this seam (falling back to its default ItemCard when unset).
       renderItemCard: (item) => (
-        <ServiceEvent service={item.raw as SelectedService} />
+        <ServiceEvent service={item.raw as SelectedService} dict={dict} />
       ),
       bookingApi: {
         createBooking,
@@ -633,6 +647,11 @@ export function PlanningSelectionProvider({
             assignedDriver2: undefined,
             assignedTruck: undefined,
             assignedTrailer: undefined,
+            assignedCarrierAccreditation: undefined,
+            assignedDriverAccreditation: undefined,
+            assignedDriver2Accreditation: undefined,
+            assignedTruckAccreditation: undefined,
+            assignedTrailerAccreditation: undefined,
           };
         },
       },

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -57,14 +57,25 @@ function assignmentOverrides(
     // `null` is a real value (carrier with no upstream code on file) and
     // must be preserved — don't gate this on truthiness.
     out.assignedCarrierExternalId = data.carrierExternalId;
+    // Same lifecycle for the accreditation level the calendar card renders:
+    // `null` (unknown) is a real value too.
+    out.assignedCarrierAccreditation = data.carrierAccreditation;
   }
-  if (data.driver) out.assignedDriver = data.driver;
+  if (data.driver) {
+    out.assignedDriver = data.driver;
+    out.assignedDriverAccreditation = data.driverAccreditation;
+  }
   if (data.hasSecondDriver && data.secondDriver) {
     out.assignedDriver2 = data.secondDriver;
+    out.assignedDriver2Accreditation = data.secondDriverAccreditation;
   }
-  if (data.truck) out.assignedTruck = data.truck;
+  if (data.truck) {
+    out.assignedTruck = data.truck;
+    out.assignedTruckAccreditation = data.truckAccreditation;
+  }
   if (data.hasTrailer && data.trailer) {
     out.assignedTrailer = data.trailer;
+    out.assignedTrailerAccreditation = data.trailerAccreditation;
   }
   return out;
 }
@@ -85,11 +96,16 @@ function assignmentDataFromService(
     // carrier row falls off the current accredited-resources page or the
     // carrier has been deactivated upstream since the prior confirm.
     carrierExternalId: service?.assignedCarrierExternalId ?? null,
+    carrierAccreditation: service?.assignedCarrierAccreditation ?? null,
     driver: service?.assignedDriver ?? "",
+    driverAccreditation: service?.assignedDriverAccreditation ?? null,
     secondDriver: service?.assignedDriver2 ?? "",
+    secondDriverAccreditation: service?.assignedDriver2Accreditation ?? null,
     hasSecondDriver: Boolean(service?.assignedDriver2),
     truck: service?.assignedTruck ?? "",
+    truckAccreditation: service?.assignedTruckAccreditation ?? null,
     trailer: service?.assignedTrailer ?? "",
+    trailerAccreditation: service?.assignedTrailerAccreditation ?? null,
     hasTrailer: Boolean(service?.assignedTrailer),
   };
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-event.tsx
@@ -12,6 +12,12 @@ import {
   getLeadTimeStatus,
 } from "./planning-selection-types";
 import { getDisplayIncidencias } from "./incidencias.types";
+import {
+  getAssignmentAccreditation,
+  assignmentAccreditationTooltip,
+} from "./assignment-accreditation";
+import { AccreditationBadge } from "./sidebar-tabs/assignment/accreditation";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 // Set Spanish locale for dayjs
@@ -20,6 +26,7 @@ dayjs.locale("es");
 export interface ServiceEventProps {
   readonly service: SelectedService;
   readonly className?: string;
+  readonly dict: I18nRecord;
 }
 
 /**
@@ -73,12 +80,15 @@ function getOccupancyColor(percentage: number): string {
  * 2. KPIs (Lead Time, Ocupación)
  * 3. Static (Cliente, Origen → Destino)
  */
-export function ServiceEvent({ service, className }: ServiceEventProps) {
+export function ServiceEvent({ service, className, dict }: ServiceEventProps) {
   const { selectedService, selectService } =
     usePlanningSelection<SelectedService>();
 
   const isSelected = selectedService?.id === service.id;
   const leadTimeStyles = getLeadTimeStyles(service.leadTime);
+  // Weakest accreditation level across the assigned resources; null until an
+  // assignment with a known level is persisted (no badge for legacy bookings).
+  const accreditation = getAssignmentAccreditation(service);
 
   // Extract incident codes and create code-to-label map for tooltips
   const codeToLabelMap = new Map<string, string>();
@@ -141,7 +151,7 @@ export function ServiceEvent({ service, className }: ServiceEventProps) {
         </h4>
 
         {/* Flags row */}
-        {(hasFlags || service.serviceCategory) && (
+        {(hasFlags || service.serviceCategory || accreditation) && (
           <div className="flex flex-wrap items-center gap-1 pointer-events-auto">
             {/* Service category - shown alongside incidencia flags */}
             <ServiceCategoryBadge
@@ -149,6 +159,16 @@ export function ServiceEvent({ service, className }: ServiceEventProps) {
               variant="soft"
               className="px-2 py-0.5 text-xs cursor-help"
             />
+
+            {/* Assignment accreditation — tooltip breaks it down per resource */}
+            {accreditation && (
+              <AccreditationBadge
+                level={accreditation.level}
+                dict={dict}
+                title={assignmentAccreditationTooltip(accreditation, dict)}
+                className="cursor-help"
+              />
+            )}
 
             {/* Sort-relevant incidencias, in tier order */}
             {displayIncidencias.map(({ key, config }) => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
@@ -75,6 +75,8 @@ interface AccreditationBadgeProps {
   readonly dict: I18nRecord;
   /** Extra classes merged onto the badge wrapper (e.g. layout tweaks). */
   readonly className?: string;
+  /** Native tooltip (e.g. the per-resource breakdown on calendar cards). */
+  readonly title?: string;
 }
 
 /**
@@ -87,6 +89,7 @@ export function AccreditationBadge({
   level,
   dict,
   className,
+  title,
 }: AccreditationBadgeProps) {
   const base =
     "text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 inline-flex items-center gap-1";
@@ -94,7 +97,7 @@ export function AccreditationBadge({
 
   if (level === "notAccredited") {
     return (
-      <span className={twMerge(base, BADGE_TONE[level], className)}>
+      <span className={twMerge(base, BADGE_TONE[level], className)} title={title}>
         {label}
       </span>
     );
@@ -103,7 +106,7 @@ export function AccreditationBadge({
   const Icon = level === "superAccredited" ? HiStar : HiCheck;
 
   return (
-    <span className={twMerge(base, BADGE_TONE[level], className)}>
+    <span className={twMerge(base, BADGE_TONE[level], className)} title={title}>
       <span
         className={twMerge(
           "flex items-center justify-center w-3.5 h-3.5 rounded-full",

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -11,19 +11,13 @@ import {
   useAccreditedResources,
   type AccreditedResource,
 } from "@/features/calendar/services/accredited-resources.service";
-import {
-  toAccreditationLevel,
-  type AccreditationLevel,
-} from "./accreditation";
+import { toAccreditationLevel, type AccreditationLevel } from "./accreditation";
 import { DriverSearchDropdown } from "./driver-search-dropdown";
 import {
   CarrierSearchDropdown,
   type CarrierOption,
 } from "./carrier-search-dropdown";
-import {
-  TruckSearchDropdown,
-  type TruckOption,
-} from "./truck-search-dropdown";
+import { TruckSearchDropdown, type TruckOption } from "./truck-search-dropdown";
 import {
   TrailerSearchDropdown,
   type TrailerOption,
@@ -252,6 +246,93 @@ export interface AssignmentFormData {
   truck: string;
   trailer: string;
   hasTrailer: boolean;
+  /**
+   * Accreditation level of each selected resource, captured from the
+   * accredited-resources row on every change (same lifecycle as
+   * `carrierExternalId`). Travels up to `assignmentOverrides` so the booking
+   * carries the levels the calendar card renders. `null` when the slot is
+   * empty or the row wasn't on the loaded feed page.
+   */
+  carrierAccreditation: AccreditationLevel | null;
+  driverAccreditation: AccreditationLevel | null;
+  secondDriverAccreditation: AccreditationLevel | null;
+  truckAccreditation: AccreditationLevel | null;
+  trailerAccreditation: AccreditationLevel | null;
+}
+
+/**
+ * Look up the accreditation level of the row backing a just-selected resource
+ * id. `null` when the selection was cleared or the row is not on the
+ * currently loaded page (same "not yet in the page" caveat as the
+ * carrier external-id capture).
+ */
+function accreditationFromRows(
+  rows: AccreditedResource[],
+  resourceId: string | boolean
+): AccreditationLevel | null {
+  if (typeof resourceId !== "string" || resourceId.length === 0) return null;
+  const row = rows.find((r) => r.resource_id === resourceId);
+  return row ? toAccreditationLevel(row.is_acredited) : null;
+}
+
+function carrierExternalIdFromRows(
+  rows: AccreditedResource[],
+  resourceId: string | boolean
+): string | null {
+  if (typeof resourceId !== "string" || resourceId.length === 0) return null;
+  return (
+    rows.find((row) => row.resource_id === resourceId)?.external_id ?? null
+  );
+}
+
+function clearCarrierScopedAssignment(updated: AssignmentFormData): void {
+  updated.driver = "";
+  updated.secondDriver = "";
+  updated.truck = "";
+  updated.trailer = "";
+  updated.driverAccreditation = null;
+  updated.secondDriverAccreditation = null;
+  updated.truckAccreditation = null;
+  updated.trailerAccreditation = null;
+}
+
+function updateSelectedResourceAccreditation(
+  updated: AssignmentFormData,
+  field: keyof AssignmentFormData,
+  fieldValue: string | boolean,
+  resources: {
+    drivers: AccreditedResource[];
+    trucks: AccreditedResource[];
+    trailers: AccreditedResource[];
+  }
+): void {
+  if (field === "driver") {
+    updated.driverAccreditation = accreditationFromRows(
+      resources.drivers,
+      fieldValue
+    );
+    return;
+  }
+  if (field === "secondDriver") {
+    updated.secondDriverAccreditation = accreditationFromRows(
+      resources.drivers,
+      fieldValue
+    );
+    return;
+  }
+  if (field === "truck") {
+    updated.truckAccreditation = accreditationFromRows(
+      resources.trucks,
+      fieldValue
+    );
+    return;
+  }
+  if (field === "trailer") {
+    updated.trailerAccreditation = accreditationFromRows(
+      resources.trailers,
+      fieldValue
+    );
+  }
 }
 
 interface AssignmentFormProps {
@@ -513,39 +594,45 @@ export function AssignmentForm({
     // row (or null when the new value is empty / row not yet in the page) so
     // the upstream prve_codigo travels with the UUID.
     if (field === "carrier" && fieldValue !== value.carrier) {
-      updated.driver = "";
-      updated.secondDriver = "";
-      updated.truck = "";
-      updated.trailer = "";
+      clearCarrierScopedAssignment(updated);
       setDriverQuery("");
       setTruckQuery("");
       setTrailerQuery("");
-      updated.carrierExternalId =
-        typeof fieldValue === "string" && fieldValue.length > 0
-          ? accreditedCarriers.find((row) => row.resource_id === fieldValue)
-              ?.external_id ?? null
-          : null;
+      updated.carrierExternalId = carrierExternalIdFromRows(
+        accreditedCarriers,
+        fieldValue
+      );
+      updated.carrierAccreditation = accreditationFromRows(
+        accreditedCarriers,
+        fieldValue
+      );
     }
+
+    updateSelectedResourceAccreditation(updated, field, fieldValue, {
+      drivers: accreditedDrivers,
+      trucks: accreditedTrucks,
+      trailers: accreditedTrailers,
+    });
 
     // When changing driver, clear secondDriver if it matches the new value
     // or if the second driver section is disabled
     if (field === "driver" && typeof fieldValue === "string") {
-      if (
-        updated.secondDriver === fieldValue ||
-        !updated.hasSecondDriver
-      ) {
+      if (updated.secondDriver === fieldValue || !updated.hasSecondDriver) {
         updated.secondDriver = "";
+        updated.secondDriverAccreditation = null;
       }
     }
 
     // When disabling second driver section, clear the selection
     if (field === "hasSecondDriver" && fieldValue === false) {
       updated.secondDriver = "";
+      updated.secondDriverAccreditation = null;
     }
 
     // When disabling trailer section, clear the selection and search.
     if (field === "hasTrailer" && fieldValue === false) {
       updated.trailer = "";
+      updated.trailerAccreditation = null;
       setTrailerQuery("");
     }
 
@@ -576,10 +663,7 @@ export function AssignmentForm({
         drivers={driverOptions}
         selectedDriverId={value.driver}
         onSelect={(v: string) => handleChange("driver", v)}
-        placeholder={tr(
-          "pages.planning.sidebar.assignment.selectDriver",
-          dict
-        )}
+        placeholder={tr("pages.planning.sidebar.assignment.selectDriver", dict)}
         dict={dict}
         disabled={!value.carrier}
         onQueryChange={setDriverQuery}
@@ -588,10 +672,7 @@ export function AssignmentForm({
         labelRightElement={
           <label className="flex items-center gap-1 cursor-pointer">
             <span className="text-[10px] text-gray-500 dark:text-gray-400">
-              {tr(
-                "pages.planning.sidebar.assignment.secondDriverLabel",
-                dict
-              )}
+              {tr("pages.planning.sidebar.assignment.secondDriverLabel", dict)}
             </span>
             <Checkbox
               id="segundo-driver-check"


### PR DESCRIPTION
Closes #882

## Summary

- persist accreditation levels for each assigned planning resource on booking data
- aggregate the weakest known assigned accreditation level for calendar service cards and planned-service chips
- add tooltip details for the per-resource accreditation breakdown
- cover legacy/unknown assignment states with focused Vitest tests

## Validation

- npm --prefix turbo-repo/apps/app run test:run -- src/features/calendar/components/planning/assignment-accreditation.test.ts
- npm --prefix turbo-repo/apps/app run check-types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accreditation indicators to planning and calendar views for selected services.
  * Show per-resource accreditation details in tooltips, with localized labels.
  * Preserved accreditation values when editing assignments, including optional second driver and trailer fields.

* **Bug Fixes**
  * Improved handling of unknown or legacy accreditation data so only valid assigned resources affect the displayed overall level.
  * Cleared accreditation values when unassigning resources to keep booking data in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->