### PR TITLE
feat(harness): miot-search skill + backend-resolved harness org

### DIFF
--- a/turbo-repo/apps/app/.env.example
+++ b/turbo-repo/apps/app/.env.example
@@ -94,13 +94,10 @@ MIOT_DEFAULT_ORG_ID=your_organization_id
 
 # ─── Harness (AI assistant / spotlight search) ──────────────────
 # Base host of the Quarkus gateway (no path). The code appends
-# /api/v1/orgs/{MIOT_HARNESS_ORG}/harness automatically.
+# /api/v1/orgs/{active-org-slug}/harness automatically — the org (and tenant)
+# are resolved by the backend from the authenticated session, never pinned here.
 # Leave unset to disable harness results in the spotlight search.
 MIOT_HARNESS_URL=https://your-quarkus-host.com
-# Org slug on the harness deployment. Set this when the harness is on a
-# separate host from the resource API and uses a different slug for the tenant.
-# If unset, falls back to the active org from resolveTenantScope().
-MIOT_HARNESS_ORG=your-harness-org-slug
 
 # ─── Dashlet ingestion ───────────────────────────────────────────
 # Audit metadata stamped on every imported row by the batch_import dashlet.

--- a/turbo-repo/apps/app/src/app/api/harness/search/route.ts
+++ b/turbo-repo/apps/app/src/app/api/harness/search/route.ts
@@ -8,10 +8,6 @@ import { resolveTenantScope } from "../../utils/tenant-scope";
 import { logger } from "@/lib/logger";
 
 const MIOT_HARNESS_HOST = process.env.MIOT_HARNESS_URL ?? "";
-// Org slug on the harness proxy. May differ from MIOT_DEFAULT_ORG_ID when the
-// harness and resource API are hosted on separate deployments with different
-// org slugs for the same tenant. Falls back to dynamic scope resolution.
-const MIOT_HARNESS_ORG = process.env.MIOT_HARNESS_ORG ?? "";
 
 /** ms before we abort a run that hasn't completed — entity lookups on the
  * agentic path (planner → datasource tools → verify gate) need headroom */
@@ -90,15 +86,13 @@ export async function POST(request: Request) {
   const query = body.query?.trim() ?? "";
   if (!query) return NextResponse.json({ results: [] });
 
-  // Use MIOT_HARNESS_ORG if set (harness slug may differ from the resource API
-  // slug when the two services run in separate deployments). Fall back to
-  // resolveTenantScope() only when no override is configured.
-  let orgSlug = MIOT_HARNESS_ORG;
-  if (!orgSlug) {
-    const scopeResult = await resolveTenantScope();
-    if (!scopeResult.resolved) return scopeResult.response;
-    orgSlug = scopeResult.scope.activeOrg.slug;
-  }
+  // The org (and therefore the tenant) is always resolved by the backend from
+  // the authenticated session — never pinned by env. resolveTenantScope() reads
+  // the active org via Quarkus /me/scopes; the harness proxy at
+  // /api/v1/orgs/{slug}/harness injects the tenant client id from membership.
+  const scopeResult = await resolveTenantScope();
+  if (!scopeResult.resolved) return scopeResult.response;
+  const orgSlug = scopeResult.scope.activeOrg.slug;
 
   const harnessUrl = `${MIOT_HARNESS_HOST}/api/v1/orgs/${orgSlug}/harness`;
 


### PR DESCRIPTION
Re-established after the branch was removed from the remote. Two logically-separate commits:

1. **feat(harness): miot-search skill** — the Agent-Skills `SKILL.md` for spotlight search (intent classification, page inventory, connection-agnostic entity lookups), the CI parity test, and the frontend changes (intent block, relative-url in-app navigation, 30s timeout). Details as in the original #881.

2. **refactor(app): remove MIOT_HARNESS_ORG** — the search route pinned the org slug via `MIOT_HARNESS_ORG`, bypassing `resolveTenantScope()` and letting the tenant fall back to the harness `UserRequest` default (`demo-tenant`). The org — and the tenant the Quarkus proxy injects — must always be backend-resolved from the authenticated session. The env var is dropped from `route.ts` and `.env.example`; the route now always calls `resolveTenantScope()`.

Stacked on `based/new_searchbar_definition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #880
