### PR TITLE
fix(harness): reject runs with an unresolved tenant instead of defaulting to demo-tenant

### DIFF
--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -640,9 +640,10 @@ def create_app() -> FastAPI:
     async def require_auth(request: Request) -> Mapping[str, Any]:
         """Auth0 RS256 verification gate for /runs* endpoints.
 
-        Short-circuits to a blank context when auth is disabled (the
-        legacy unauthenticated mode used by unit tests and local
-        dev). When enabled:
+        Skips JWT verification when auth is disabled (the legacy
+        unauthenticated mode used by unit tests and local dev), but still
+        resolves `X-Miot-Tenant-Client-Id` when the proxy supplies it. When
+        auth is enabled:
 
         - Enforces Bearer-token + JWKS RS256 sig/iss/aud/exp checks.
         - Resolves the caller's tenant from the

--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -657,7 +657,16 @@ def create_app() -> FastAPI:
         still depends on it.
         """
         if not settings.auth_enabled:
-            return {"claims": {}, "tenant_id": None}
+            # Auth disabled skips JWT verification, but the tenant is still the
+            # backend's to assign: honor the `X-Miot-Tenant-Client-Id` header
+            # (set by the Quarkus proxy) so a proxied dev deployment resolves the
+            # real tenant instead of silently falling back. Absent header → None,
+            # which `_apply_tenant_override` turns into a 400 unless the caller
+            # supplied a body tenant (the dev/test escape hatch).
+            header_tenant = (
+                request.headers.get("X-Miot-Tenant-Client-Id") or ""
+            ).strip() or None
+            return {"claims": {}, "tenant_id": header_tenant}
 
         auth_header = request.headers.get("Authorization") or ""
         if not auth_header.startswith("Bearer "):
@@ -725,23 +734,38 @@ def create_app() -> FastAPI:
     def _apply_tenant_override(
         user_request: UserRequest, auth: Mapping[str, Any]
     ) -> UserRequest:
-        """If the verified header carried a tenant, that value wins
-        over whatever the body declared. Body-only flow (auth
-        disabled, i.e. local dev / unit tests) keeps the body value.
-        The body field itself is deprecated; a future release will
-        delete it from the schema once staging soak confirms no
-        caller still depends on it.
+        """Resolve the run's tenant and enforce that one exists.
+
+        A verified ``X-Miot-Tenant-Client-Id`` header (set by the Quarkus
+        proxy) wins over the body; the body ``tenant_id`` is only an
+        auth-disabled dev/test escape hatch. The tenant is NEVER defaulted:
+        a run with neither a header nor an explicit body tenant is rejected
+        (400) instead of being silently attributed to a placeholder, since
+        a missing tenant means the request did not pass through the org
+        proxy — a misconfiguration, not a valid anonymous run. The body
+        field is deprecated; a future release will delete it from the schema.
         """
         header_tenant = auth.get("tenant_id")
-        if not header_tenant:
-            return user_request
-        if user_request.tenant_id != header_tenant:
+        if header_tenant and user_request.tenant_id != header_tenant:
             logger.info(
                 "Auth: overriding body tenant %r with header tenant %r",
                 user_request.tenant_id,
                 header_tenant,
             )
-        return user_request.model_copy(update={"tenant_id": header_tenant})
+            user_request = user_request.model_copy(
+                update={"tenant_id": header_tenant}
+            )
+        if not user_request.tenant_id:
+            logger.error(
+                "Run rejected: unresolved tenant — no X-Miot-Tenant-Client-Id "
+                "header and no tenant_id supplied. The tenant is required and is "
+                "never defaulted; verify the request is routed through the "
+                "Quarkus org proxy."
+            )
+            raise HTTPException(
+                status_code=400, detail="missing_required_tenant"
+            )
+        return user_request
 
     @app.get("/health")
     async def health() -> dict[str, object]:
@@ -1053,6 +1077,10 @@ def _enforce_debug_allowlist(request: UserRequest, settings: HarnessSettings) ->
     """
     if not request.debug:
         return
+    # tenant is guaranteed non-None here: every /runs* handler calls
+    # _apply_tenant_override first, which 400s a tenant-less request before
+    # this gate is reached.
+    assert request.tenant_id is not None
     if settings.debug_tenant_allowed(request.tenant_id):
         return
     raise HTTPException(

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from miot_harness.runtime.approvals import ApprovalRegistry
 from miot_harness.runtime.permissions import (
@@ -104,6 +104,13 @@ class UserRequest(BaseModel):
     # Output format for the response `answer` string (default markdown).
     answer_format: AnswerFormat = "markdown"
 
+    @field_validator("tenant_id")
+    @classmethod
+    def _normalize_tenant_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.strip() or None
+
     @model_validator(mode="after")
     def _extract_skill_slug(self) -> "UserRequest":
         """Pull a leading "/slug" out of `message` into `skill_id` when empty.
@@ -123,7 +130,8 @@ class UserRequest(BaseModel):
         # unresolved tenants (400) before reaching here; this guard turns a
         # direct caller's mistake into a clear error instead of an opaque
         # pydantic ValidationError on HarnessContext.tenant_id.
-        if not self.tenant_id:
+        tenant_id = self.tenant_id
+        if not tenant_id:
             raise ValueError(
                 "UserRequest.tenant_id is unresolved; a run requires a tenant "
                 "(from the X-Miot-Tenant-Client-Id header or an explicit body value)"
@@ -142,7 +150,7 @@ class UserRequest(BaseModel):
             )
         return HarnessContext(
             thread_id=self.thread_id,
-            tenant_id=self.tenant_id,
+            tenant_id=tenant_id,
             user_id=self.user_id,
             route_context=self.route_context,
             mode=self.mode,

--- a/miot-harness/src/miot_harness/runtime/context.py
+++ b/miot-harness/src/miot_harness/runtime/context.py
@@ -69,19 +69,18 @@ class UserRequest(BaseModel):
     message: str
     thread_id: str = "demo-thread"
     # Issue #522 R6: `tenant_id` and `user_id` are deprecated body
-    # fields. In production they are silently overridden in
-    # `api.server` from the `X-Miot-Tenant-Client-Id` header set by
-    # the Quarkus proxy — `api.server.require_auth` makes the header
-    # mandatory whenever `MIOT_HARNESS_AUTH_ENABLED=true`, so body
-    # values are inert in any deployment that has auth on. They
-    # remain on the schema only to keep the CLI demo, eval harness,
-    # and the existing unit-test fleet (~30 call sites) working
-    # while the dev escape hatch is being phased out. A follow-up
-    # release will remove both fields once staging soak confirms no
-    # remaining caller relies on them. Do NOT build new logic that
-    # trusts these values.
-    tenant_id: str = Field(
-        default="demo-tenant",
+    # fields. In production the tenant is set in `api.server` from the
+    # trusted `X-Miot-Tenant-Client-Id` header (Quarkus proxy); the
+    # body value is only an auth-disabled dev/test escape hatch.
+    #
+    # `tenant_id` has NO default. A run with no resolved tenant — no
+    # header and no explicit body value — is rejected at the API
+    # boundary (400) rather than silently attributed to a placeholder:
+    # a missing tenant means the request bypassed the org proxy, which
+    # is a misconfiguration, not a valid anonymous run. Do NOT build
+    # new logic that trusts these values.
+    tenant_id: str | None = Field(
+        default=None,
         json_schema_extra={"deprecated": True},
     )
     user_id: str = Field(
@@ -120,6 +119,15 @@ class UserRequest(BaseModel):
         return self
 
     def to_context(self) -> HarnessContext:
+        # A HarnessContext requires a concrete tenant. The API rejects
+        # unresolved tenants (400) before reaching here; this guard turns a
+        # direct caller's mistake into a clear error instead of an opaque
+        # pydantic ValidationError on HarnessContext.tenant_id.
+        if not self.tenant_id:
+            raise ValueError(
+                "UserRequest.tenant_id is unresolved; a run requires a tenant "
+                "(from the X-Miot-Tenant-Client-Id header or an explicit body value)"
+            )
         # NOTE: the policy built here is UNGATED — the bypass policy gate
         # (resolve_effective_mode) is NOT applied. HarnessSupervisor.run
         # overwrites ctx.permission_policy with the gated result of

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -504,6 +504,9 @@ class HarnessSupervisor:
         if requested is None:
             return PermissionPolicy(), False
 
+        # tenant is guaranteed non-None here: run() builds the HarnessContext
+        # (which requires a tenant) before resolving the policy.
+        assert request.tenant_id is not None
         effective, denied = resolve_effective_mode(
             requested, settings=settings, tenant_id=request.tenant_id
         )

--- a/miot-harness/tests/api/test_runs_answer_format.py
+++ b/miot-harness/tests/api/test_runs_answer_format.py
@@ -37,7 +37,7 @@ def _clean_settings_and_workspace(
 def client() -> Iterator[TestClient]:
     """A TestClient wired to a fresh app instance with no auth or datasource."""
     app = create_app()
-    with TestClient(app) as tc:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as tc:
         yield tc
 
 

--- a/miot-harness/tests/api/test_runs_json_format.py
+++ b/miot-harness/tests/api/test_runs_json_format.py
@@ -39,7 +39,7 @@ def _clean_settings_and_workspace(
 def client() -> Iterator[TestClient]:
     """A TestClient wired to a fresh app instance with no auth or datasource."""
     app = create_app()
-    with TestClient(app) as tc:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as tc:
         yield tc
 
 

--- a/miot-harness/tests/api/test_runs_stream.py
+++ b/miot-harness/tests/api/test_runs_stream.py
@@ -26,9 +26,7 @@ from miot_harness.runtime.events import HarnessEvent
 
 
 @pytest.fixture(autouse=True)
-def _clean_settings_and_workspace(
-    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[None]:
+def _clean_settings_and_workspace(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_DSN", raising=False)
     # Pin provider selection to the default kind for deterministic boots.
     monkeypatch.delenv("MIOT_HARNESS_DATASOURCE_KIND", raising=False)
@@ -70,7 +68,7 @@ def test_post_runs_start_returns_202_with_run_id() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         resp = client.post("/runs:start", json={"message": "hi"})
     assert resp.status_code == 202
     body = resp.json()
@@ -84,7 +82,7 @@ def test_post_runs_unchanged_returns_harness_run_record() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         resp = client.post("/runs", json={"message": "hi"})
     assert resp.status_code == 200
     body = resp.json()
@@ -101,7 +99,7 @@ def test_stream_replays_completed_run() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         post = client.post("/runs", json={"message": "hi"})
         run_id = post.json()["run_id"]
 
@@ -126,7 +124,7 @@ def test_stream_with_last_event_id_skips_replayed_events() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         post = client.post("/runs", json={"message": "hi"})
         run_id = post.json()["run_id"]
 
@@ -141,7 +139,7 @@ def test_stream_with_last_event_id_skips_replayed_events() -> None:
 
     # Resume with that id; expect events with seq > cursor_seq.
     app = create_app()  # fresh app, same workspace via env var
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         with client.stream(
             "GET",
             f"/runs/{run_id}/stream",
@@ -165,7 +163,7 @@ def test_cancel_unknown_run_id_returns_404() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         resp = client.post("/runs/run_never_started/cancel")
     assert resp.status_code == 404
 
@@ -179,7 +177,7 @@ def test_stream_unknown_run_id_emits_error_event() -> None:
     """
 
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         with client.stream("GET", "/runs/run_unknown_xyz/stream") as resp:
             assert resp.status_code == 200
             body = resp.read().decode()
@@ -221,7 +219,7 @@ async def test_stream_receives_live_events_during_in_flight(
 
     # Drive lifespan via TestClient, then run the actual stream test
     # against httpx.AsyncClient(transport=ASGITransport) on the same app.
-    with TestClient(app):
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}):
         # Force route to DATA_QUERY via a scripted llm_router, and inject
         # a slow graph that emits 2 events and blocks until released.
         gate = asyncio.Event()
@@ -253,6 +251,7 @@ async def test_stream_receives_live_events_during_in_flight(
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
             base_url="http://test",
+            headers={"X-Miot-Tenant-Client-Id": "demo-tenant"},
         ) as client:
             # Kick the slow run
             post = await client.post("/runs:start", json={"message": message})
@@ -261,9 +260,7 @@ async def test_stream_receives_live_events_during_in_flight(
 
             # Start streaming concurrently with the in-flight run
             async def consume() -> list[dict[str, Any]]:
-                async with client.stream(
-                    "GET", f"/runs/{run_id}/stream"
-                ) as resp:
+                async with client.stream("GET", f"/runs/{run_id}/stream") as resp:
                     buffer = b""
                     async for chunk in resp.aiter_bytes():
                         buffer += chunk

--- a/miot-harness/tests/api/test_server_auth.py
+++ b/miot-harness/tests/api/test_server_auth.py
@@ -152,6 +152,15 @@ def test_auth_disabled_missing_tenant_returns_400() -> None:
     assert resp.json()["detail"] == "missing_required_tenant"
 
 
+def test_auth_disabled_whitespace_body_tenant_returns_400() -> None:
+    """Whitespace-only body tenant_id is unresolved, not an escape hatch."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post("/runs", json={"message": "hi", "tenant_id": "   "})
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "missing_required_tenant"
+
+
 def test_auth_disabled_tenant_from_header_is_honored() -> None:
     """Auth off skips JWT verification, not tenant resolution: the
     X-Miot-Tenant-Client-Id header set by the proxy still resolves the
@@ -174,6 +183,17 @@ def test_auth_disabled_body_tenant_is_escape_hatch() -> None:
     with TestClient(app) as client:
         resp = client.post(
             "/runs", json={"message": "hi", "tenant_id": "tenant-from-body"}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tenant_id"] == "tenant-from-body"
+
+
+def test_auth_disabled_body_tenant_is_normalized() -> None:
+    """Body tenant_id is stripped before creating the run context."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/runs", json={"message": "hi", "tenant_id": "  tenant-from-body  "}
         )
     assert resp.status_code == 200, resp.text
     assert resp.json()["tenant_id"] == "tenant-from-body"

--- a/miot-harness/tests/api/test_server_auth.py
+++ b/miot-harness/tests/api/test_server_auth.py
@@ -135,8 +135,48 @@ def test_auth_disabled_runs_endpoint_open() -> None:
     and the demo CLI depend on)."""
     app = create_app()
     with TestClient(app) as client:
-        resp = client.post("/runs", json={"message": "hi"})
+        resp = client.post(
+            "/runs", json={"message": "hi", "tenant_id": "demo-tenant"}
+        )
     assert resp.status_code == 200, resp.text
+
+
+def test_auth_disabled_missing_tenant_returns_400() -> None:
+    """With auth off, a run carrying no tenant at all — no
+    X-Miot-Tenant-Client-Id header and no body tenant_id — is rejected
+    (400), not silently attributed to a placeholder tenant."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post("/runs", json={"message": "hi"})
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "missing_required_tenant"
+
+
+def test_auth_disabled_tenant_from_header_is_honored() -> None:
+    """Auth off skips JWT verification, not tenant resolution: the
+    X-Miot-Tenant-Client-Id header set by the proxy still resolves the
+    tenant for the run."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/runs",
+            json={"message": "hi"},
+            headers={"X-Miot-Tenant-Client-Id": "tenant-from-header"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tenant_id"] == "tenant-from-header"
+
+
+def test_auth_disabled_body_tenant_is_escape_hatch() -> None:
+    """With auth off and no header, the deprecated body tenant_id still
+    works as the local dev/test escape hatch."""
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/runs", json={"message": "hi", "tenant_id": "tenant-from-body"}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tenant_id"] == "tenant-from-body"
 
 
 # ---------------------------------------------------------------------------

--- a/miot-harness/tests/api/test_steering_modes.py
+++ b/miot-harness/tests/api/test_steering_modes.py
@@ -25,7 +25,7 @@ def test_bypass_in_prod_emits_mode_denied(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("MIOT_HARNESS_STEERING_BYPASS_POLICY", "dev_only")
     get_settings.cache_clear()
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         resp = client.post(
             "/runs", json={"message": "hola", "permission_mode": "bypass"}
         )
@@ -40,7 +40,7 @@ def test_bypass_in_local_does_not_emit_mode_denied(
     monkeypatch.setenv("MIOT_HARNESS_ENV", "local")
     get_settings.cache_clear()
     app = create_app()
-    with TestClient(app) as client:
+    with TestClient(app, headers={"X-Miot-Tenant-Client-Id": "demo-tenant"}) as client:
         resp = client.post(
             "/runs", json={"message": "hola", "permission_mode": "bypass"}
         )

--- a/miot-harness/tests/runtime/test_context_answer_format.py
+++ b/miot-harness/tests/runtime/test_context_answer_format.py
@@ -5,20 +5,22 @@ from miot_harness.runtime.context import UserRequest
 
 
 def test_answer_format_defaults_to_markdown():
-    req = UserRequest(message="hi")
+    req = UserRequest(message="hi", tenant_id="demo-tenant")
     assert req.answer_format == "markdown"
 
 
 @pytest.mark.parametrize("fmt", ["markdown", "plain", "html", "xml", "yaml"])
 def test_answer_format_accepts_valid_values(fmt):
-    assert UserRequest(message="hi", answer_format=fmt).answer_format == fmt
+    assert (
+        UserRequest(message="hi", tenant_id="demo-tenant", answer_format=fmt).answer_format == fmt
+    )
 
 
 def test_answer_format_rejects_invalid_value():
     with pytest.raises(ValidationError):
-        UserRequest(message="hi", answer_format="pdf")
+        UserRequest(message="hi", tenant_id="demo-tenant", answer_format="pdf")
 
 
 def test_to_context_carries_answer_format():
-    ctx = UserRequest(message="hi", answer_format="yaml").to_context()
+    ctx = UserRequest(message="hi", tenant_id="demo-tenant", answer_format="yaml").to_context()
     assert ctx.answer_format == "yaml"

--- a/miot-harness/tests/runtime/test_context_permission_policy.py
+++ b/miot-harness/tests/runtime/test_context_permission_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from miot_harness.runtime.context import HarnessContext, UserRequest
 from miot_harness.runtime.permissions import (
     PermissionDecision,
@@ -30,6 +32,17 @@ def test_user_request_carries_mode_and_rules_to_context() -> None:
 def test_user_request_without_mode_yields_no_policy() -> None:
     ctx = UserRequest(message="hi", tenant_id="demo-tenant").to_context()
     assert ctx.permission_policy is None
+
+
+def test_user_request_normalizes_tenant_id_to_context() -> None:
+    ctx = UserRequest(message="hi", tenant_id="  demo-tenant  ").to_context()
+    assert ctx.tenant_id == "demo-tenant"
+
+
+def test_user_request_whitespace_tenant_id_cannot_create_context() -> None:
+    req = UserRequest(message="hi", tenant_id="   ")
+    with pytest.raises(ValueError, match="tenant_id is unresolved"):
+        req.to_context()
 
 
 def test_permission_policy_excluded_from_context_dump() -> None:

--- a/miot-harness/tests/runtime/test_context_permission_policy.py
+++ b/miot-harness/tests/runtime/test_context_permission_policy.py
@@ -17,6 +17,7 @@ def test_context_defaults_permission_policy_to_none() -> None:
 def test_user_request_carries_mode_and_rules_to_context() -> None:
     req = UserRequest(
         message="hi",
+        tenant_id="demo-tenant",
         permission_mode=PermissionMode.AUTO_SAFE,
         rules=[PermissionRule(tool="run_sql", decision=PermissionDecision.ALLOW)],
     )
@@ -27,7 +28,7 @@ def test_user_request_carries_mode_and_rules_to_context() -> None:
 
 
 def test_user_request_without_mode_yields_no_policy() -> None:
-    ctx = UserRequest(message="hi").to_context()
+    ctx = UserRequest(message="hi", tenant_id="demo-tenant").to_context()
     assert ctx.permission_policy is None
 
 

--- a/miot-harness/tests/runtime/test_supervisor_agent_loop.py
+++ b/miot-harness/tests/runtime/test_supervisor_agent_loop.py
@@ -35,7 +35,9 @@ async def test_agentic_route_prefers_agent_loop(tmp_path):
         agentic_graph=object(),  # would explode if invoked
         agent_loop=loop,
     )
-    record = await sup.run(UserRequest(message="explore this", mode="agentic"))
+    record = await sup.run(
+        UserRequest(message="explore this", tenant_id="demo-tenant", mode="agentic")
+    )
     assert record.answer == "loop answer"
     assert record.status == "completed"
     assert loop.calls[0]["user_message"] == "explore this"
@@ -51,5 +53,7 @@ async def test_agentic_route_falls_back_to_graph_when_no_loop(tmp_path):
         agentic_graph=None,
         agent_loop=None,
     )
-    record = await sup.run(UserRequest(message="explore this", mode="agentic"))
+    record = await sup.run(
+        UserRequest(message="explore this", tenant_id="demo-tenant", mode="agentic")
+    )
     assert "disabled" in (record.answer or "")

--- a/miot-harness/tests/runtime/test_supervisor_policy.py
+++ b/miot-harness/tests/runtime/test_supervisor_policy.py
@@ -34,7 +34,9 @@ def _supervisor(**kw: object) -> HarnessSupervisor:
 
 def test_request_bypass_downgraded_in_prod_sets_denied_flag() -> None:
     sup = _supervisor()
-    req = UserRequest(message="hi", permission_mode=PermissionMode.BYPASS)
+    req = UserRequest(
+        message="hi", tenant_id="demo-tenant", permission_mode=PermissionMode.BYPASS
+    )
     policy, denied = _resolve(sup, req, env="prod")
     assert policy.mode is PermissionMode.DEFAULT
     assert denied is True
@@ -47,12 +49,15 @@ def test_sticky_policy_reused_when_request_omits_mode() -> None:
     sup = _supervisor(conversation_policy_store=store)
     first = UserRequest(
         message="hi",
+        tenant_id="demo-tenant",
         conversation_id="c1",
         permission_mode=PermissionMode.AUTO_SAFE,
         rules=[PermissionRule(tool="run_sql", decision=PermissionDecision.ALLOW)],
     )
     sup._resolve_policy(first, settings=HarnessSettings(datasource_dsn=None, env="local"))  # type: ignore[arg-type]
-    second = UserRequest(message="again", conversation_id="c1")  # no mode/rules
+    second = UserRequest(
+        message="again", tenant_id="demo-tenant", conversation_id="c1"
+    )  # no mode/rules
     policy, _ = sup._resolve_policy(
         second, settings=HarnessSettings(datasource_dsn=None, env="local")  # type: ignore[arg-type]
     )

--- a/miot-harness/tests/test_storytelling_module.py
+++ b/miot-harness/tests/test_storytelling_module.py
@@ -13,7 +13,8 @@ async def test_delivery_compliance_story_run_creates_story_artifact(tmp_path) ->
             message=(
                 "Tell me the story of delivery compliance this month "
                 "and suggest one dashboard widget."
-            )
+            ),
+            tenant_id="demo-tenant",
         )
     )
 

--- a/miot-harness/tests/test_supervisor_data_branch.py
+++ b/miot-harness/tests/test_supervisor_data_branch.py
@@ -67,7 +67,9 @@ async def test_storytelling_path_unchanged(tmp_path):
     """Existing storytelling flow must still work — no data keywords trigger
     the legacy path with the default tool registry."""
     sup = _supervisor(tmp_path, data_graph=None, registry=build_default_registry())
-    record = await sup.run(UserRequest(message="write a story about delivery"))
+    record = await sup.run(
+        UserRequest(message="write a story about delivery", tenant_id="demo-tenant")
+    )
     assert record.status == "completed"
     assert any(e.type == "artifact.created" for e in record.events)
 
@@ -109,7 +111,7 @@ async def test_meta_disabled_emits_answer_completed(tmp_path):
     sup = _supervisor(tmp_path, data_graph=None)
     sup.profile = FAKE_PROFILE  # meta_model stays None
 
-    request = UserRequest(message="what can you do?", mode="meta")
+    request = UserRequest(message="what can you do?", mode="meta", tenant_id="demo-tenant")
     ctx = request.to_context()
     record = HarnessRunRecord(run_id=ctx.run_id, status="running")
     events = []


### PR DESCRIPTION
Closes #887

## Why

`UserRequest.tenant_id` defaulted to `"demo-tenant"`, so a run that carried **no tenant at all** — no `X-Miot-Tenant-Client-Id` header and no body `tenant_id` — was silently attributed to that placeholder instead of failing. This is a design footgun: it masks real misconfigurations. We hit it live — a dev harness returned `tenant_id: demo-tenant` for every run, which hid the fact that the proxy-injected tenant wasn't reaching the harness.

## What

- **`context.py`** — `tenant_id` has no default (`str | None = None`). `to_context()` raises a clear error if the tenant is unresolved, instead of letting a `None` hit `HarnessContext.tenant_id`.
- **`server.py`** — `_apply_tenant_override` now *enforces* a resolved tenant: a missing tenant is **logged** (`logger.error`) and **rejected with 400 `missing_required_tenant`**, never defaulted. Additionally, `require_auth` now honors the `X-Miot-Tenant-Client-Id` header **even when auth is disabled** — auth-off skips JWT verification, not tenant resolution — so a proxied dev deployment resolves the real tenant instead of falling through to a placeholder.
- Tests updated to supply a tenant (via header or the deprecated body escape hatch); new coverage for the 400, the header-resolved path, and the body escape hatch.

Behavior matrix after this change:

| Auth | Header | Body `tenant_id` | Result |
|---|---|---|---|
| on | present | — | header tenant (unchanged) |
| on | absent | — | 401 (unchanged) |
| off | present | — | **header tenant (now honored)** |
| off | absent | present | body tenant (escape hatch) |
| off | absent | absent | **400 `missing_required_tenant` (was: `demo-tenant`)** |

## Verification

`uv run pytest` (913 passed), `mypy` clean (107 files), `ruff` clean.

Note: the deprecated body `user_id` still defaults to `demo-user` — left as a separate follow-up since it's an attribution field, not a data-scoping boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant identity can now be resolved from a request header when authentication is turned off, improving behavior for proxied development setups.

* **Bug Fixes**
  * Requests without a resolved tenant are now rejected earlier with a clear error instead of failing later.
  * Tenant handling is now stricter and more consistent when both header and body values are present.
  * Added broader coverage for run and streaming flows with tenant-aware requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->