### PR TITLE
fix(harness): apply MIOT_HARNESS_LOG_LEVEL to logging (was inert)

### DIFF
--- a/miot-harness/src/miot_harness/api/server.py
+++ b/miot-harness/src/miot_harness/api/server.py
@@ -53,6 +53,27 @@ from miot_harness.runtime.supervisor import HarnessSupervisor
 logger = logging.getLogger(__name__)
 
 
+def _configure_logging(settings: HarnessSettings) -> None:
+    """Apply ``MIOT_HARNESS_LOG_LEVEL`` to the package logger.
+
+    uvicorn configures its own loggers but not ours, and nothing else wires
+    ``settings.log_level`` into logging — so without this the harness's own
+    INFO/DEBUG records are dropped (only WARNING+ leak via ``logging``'s
+    last-resort handler) and the log-level setting is inert. Attach one stream
+    handler to the ``miot_harness`` logger at the requested level. Idempotent
+    (create_app may run more than once under the test suite); ``propagate``
+    stays on so pytest's ``caplog`` still captures records.
+    """
+    pkg_logger = logging.getLogger("miot_harness")
+    pkg_logger.setLevel(settings.log_level)
+    if not pkg_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+        pkg_logger.addHandler(handler)
+
+
 class ApprovalDecision(BaseModel):
     """Body schema for POST /runs/{run_id}/approvals/{approval_id}.
 
@@ -580,6 +601,7 @@ def _make_lifespan(
 
 def create_app() -> FastAPI:
     settings = get_settings()
+    _configure_logging(settings)
     harness = build_harness(Path(settings.workspace_dir))
     app = FastAPI(
         title="MIOT Harness",


### PR DESCRIPTION
Closes #888

## Why
`config` parsed `log_level` but nothing wired it into Python's logging, and the Dockerfile runs uvicorn with no `--log-level` — so the harness's own INFO/DEBUG records were dropped (only WARNING+ leaked via the last-resort handler). `MIOT_HARNESS_LOG_LEVEL=DEBUG` was a **no-op**; the dev pod (already set to DEBUG) emitted no application logs.

## What
`create_app` configures the `miot_harness` logger with a stream handler at `settings.log_level`. Idempotent (the test suite calls `create_app` repeatedly); `propagate` stays on so pytest `caplog` still captures.

## Verification
Booted locally at DEBUG — lifespan INFO/DEBUG lines now surface (e.g. `INFO miot_harness.api.server: Datasource nexo: disabled …`), which were previously dropped. `pytest` 917 passed, mypy + ruff clean.

## Note
No deployment change is needed — `dev-mintral-harness` is already `MIOT_HARNESS_LOG_LEVEL=DEBUG`; it takes effect once this ships in a nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior so the harness now respects the configured log level more consistently.
  * Reduced duplicate log output by only adding a default console handler when none already exists.
  * Kept log propagation intact, helping logs flow through existing setups as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->