### PR TITLE
fix(harness): fail loud when nexo tenant lock is unconfigured (no slug fallback)

### DIFF
--- a/miot-harness/src/miot_harness/integrations/nexo/provider.py
+++ b/miot-harness/src/miot_harness/integrations/nexo/provider.py
@@ -106,12 +106,26 @@ class NexoProvider(DataSourceProvider):
         # The schema / EXPLAIN cost knobs are honestly Nexo's (Postgres
         # concepts), so they stay in NexoSettings (MIOT_HARNESS_NEXO_* prefix).
         nexo_settings = NexoSettings()
-        tenant_lock = (
-            opts.get("tenant_lock")
-            or settings.datasource_tenant_lock
-            or self.profile.tenant_lock
-        )
-        assert tenant_lock is not None  # NEXO_PROFILE.tenant_lock is "mintral"
+        # Tenant lock: the connection option (validated non-empty above) wins
+        # over the legacy MIOT_HARNESS_DATASOURCE_TENANT_LOCK env. There is
+        # deliberately NO fallback to the profile's slug default
+        # (NEXO_PROFILE.tenant_lock == "mintral"): the tenant that reaches the
+        # harness is the org's tenant_client_id (injected as
+        # X-Miot-Tenant-Client-Id by the proxy), so a profile slug would never
+        # match a real request and would silently refuse every query. Require an
+        # explicit lock and fail loud — mirrors the tenant_id fail-fast in
+        # UserRequest.to_context and the empty-option check above.
+        tenant_lock = opts.get("tenant_lock") or settings.datasource_tenant_lock
+        if not tenant_lock:
+            return BootResult(
+                enabled=False,
+                registered=(),
+                reason=(
+                    f"connection {conn_name!r}: tenant_lock is not configured "
+                    "(set the connection's tenant_lock option or "
+                    "MIOT_HARNESS_DATASOURCE_TENANT_LOCK)"
+                ),
+            )
         # Non-numeric freshness options (e.g. `freshness_warn_minutes: "abc"`)
         # would make `_resolve_minutes` raise `int(...)` out of boot(), violating
         # the "boot must not raise" contract. Catch and degrade to disabled with

--- a/miot-harness/tests/integrations/nexo/test_provider.py
+++ b/miot-harness/tests/integrations/nexo/test_provider.py
@@ -63,7 +63,11 @@ async def test_boot_registers_composable_primitives(
     provider = NexoProvider()
     registry = ToolRegistry()
     result = await provider.boot(
-        registry, HarnessSettings(datasource_dsn="postgresql://u:p@h:5/db")
+        registry,
+        HarnessSettings(
+            datasource_dsn="postgresql://u:p@h:5/db",
+            datasource_tenant_lock="mintral",
+        ),
     )
     assert result.enabled is True
     for name in ("nexo_describe", "nexo_select", "nexo_grep", "nexo_explain"):
@@ -86,6 +90,23 @@ async def test_boot_empty_tenant_lock_option_returns_disabled() -> None:
         options={"tenant_lock": ""},
     )
     result = await provider.boot(ToolRegistry(), HarnessSettings(), conn)
+    assert result.enabled is False
+    assert "tenant_lock" in (result.reason or "")
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_boot_without_tenant_lock_returns_disabled() -> None:
+    """No tenant lock anywhere (no connection option, no
+    MIOT_HARNESS_DATASOURCE_TENANT_LOCK env) must fail loud: the tenant that
+    reaches the harness is the org's tenant_client_id, so silently falling back
+    to the profile slug ("mintral") would refuse every real request. Boot must
+    return disabled with a tenant_lock reason instead."""
+    provider = NexoProvider()
+    settings = HarnessSettings(
+        datasource_dsn="postgresql://u:p@h:5/db", datasource_tenant_lock=None
+    )
+    result = await provider.boot(ToolRegistry(), settings)
     assert result.enabled is False
     assert "tenant_lock" in (result.reason or "")
     await provider.close()
@@ -122,7 +143,11 @@ async def test_boot_pool_failure_returns_disabled_and_no_leak(
     )
     provider = NexoProvider()
     result = await provider.boot(
-        ToolRegistry(), HarnessSettings(datasource_dsn="postgresql://u:p@h:5/db")
+        ToolRegistry(),
+        HarnessSettings(
+            datasource_dsn="postgresql://u:p@h:5/db",
+            datasource_tenant_lock="mintral",
+        ),
     )
     assert result.enabled is False
     assert "connection refused" in (result.reason or "")

--- a/miot-harness/tests/test_server_lifespan.py
+++ b/miot-harness/tests/test_server_lifespan.py
@@ -39,6 +39,8 @@ def test_app_boots_without_nexo_when_dsn_unset(monkeypatch, tmp_path):
 
 def test_app_boots_with_nexo_when_load_succeeds(monkeypatch, tmp_path):
     monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
+    # Nexo boot now requires an explicit tenant lock (no profile-slug fallback).
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "mintral")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
     # Provider keys required by the chat-model factory once Nexo enables
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
@@ -75,6 +77,7 @@ def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
     """ACL leak / stale snapshot — load_nexo_tools returns enabled=False
     with a reason. The app must still boot and the pool must close."""
     monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "mintral")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
 
     fake_pool = MagicMock()
@@ -102,6 +105,7 @@ def test_app_boots_when_load_nexo_returns_disabled(monkeypatch, tmp_path):
 def test_app_boots_when_pool_creation_raises(monkeypatch, tmp_path):
     """Tunnel down — asyncpg.create_pool raises. App still boots."""
     monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "mintral")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
 
     with patch(
@@ -121,6 +125,7 @@ def test_graph_build_failure_tears_down_partial_wiring(monkeypatch, tmp_path):
     disabled /health would silently keep serving) and the provider's
     pool must be closed immediately, not at app shutdown."""
     monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_DSN", "postgresql://u:p@localhost:5432/d")
+    monkeypatch.setenv("MIOT_HARNESS_DATASOURCE_TENANT_LOCK", "mintral")
     monkeypatch.setenv("MIOT_HARNESS_WORKSPACE_DIR", str(tmp_path / "ws"))
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
 


### PR DESCRIPTION
Closes #890

## Problem

`NexoProvider.boot()` resolved the tenant lock with a silent fallback to the profile **slug** default (a hardcoded placeholder). The tenant identity that actually reaches the harness is the org's **`tenant_client_id`** — the Quarkus proxy sets `TenantContext.clientId = organization.tenantClientId` and forwards it as `X-Miot-Tenant-Client-Id` (`OrganizationRequestFilter` → `HarnessProxyResource`); `tenancy_gate_decision` and `mode_resolver` compare `request.tenant_id` against the lock.

So a deployment that sets a datasource DSN but forgets the lock silently falls back to the slug placeholder, which no real request (a client id) can match. The datasource boots "successfully" and then refuses every data query — a silent failure. Datasource-side twin of the `UserRequest.tenant_id` fail-fast.

## Change

- Drop the profile-slug fallback in `boot()`. Require an explicit lock (connection `tenant_lock` option or `MIOT_HARNESS_DATASOURCE_TENANT_LOCK`); return a disabled `BootResult` with a clear reason otherwise. Removed the stale `assert`.
- The profile slug placeholder is kept only as a display identity / test fixture, no longer a silent boot fallback.

## Tests

- New `test_boot_without_tenant_lock_returns_disabled` (fail-loud).
- Boot-success paths now pass an explicit lock. Full suite green; `mypy` + `ruff check` clean.

## Related

The dev deployment was pinning the lock to the org slug; fixed in miot-deployments (lock → the org `tenant_client_id`).