### PR TITLE
fix(harness): route primitives-only datasources to agentic, not canned

### DIFF
--- a/miot-harness/src/miot_harness/datasource/provider.py
+++ b/miot-harness/src/miot_harness/datasource/provider.py
@@ -72,6 +72,15 @@ class DataSourceProfile:
     # the freshness judge is a no-op — a live source with no `refreshed_at` is
     # not "stale", so the snapshot-age warning is suppressed.
     has_freshness_model: bool = True
+    # Whether this datasource exposes a curated catalog of named data functions
+    # (Nexo's L1/L2/L3/VT `fn_dx_*` seats do) vs. only composable SQL primitives
+    # (generic_pg: describe/select/grep/query). The canned DATA_QUERY seat
+    # (`filter_expert`) picks ONE curated tool; it has nothing to pick on a
+    # primitives-only source, so the router must never send such a datasource
+    # there — every data question is agentic (composable-primitive) exploration.
+    # When False, the intent router drops DATA_QUERY from its menu and the
+    # supervisor remaps any DATA_QUERY it still sees to DATA_AGENTIC.
+    has_curated_catalog: bool = True
 
 
 @dataclass(frozen=True)

--- a/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
+++ b/miot-harness/src/miot_harness/integrations/generic_pg/provider.py
@@ -58,6 +58,9 @@ _GENERIC_DEFAULT_PROFILE = DataSourceProfile(
     freshness_warn_minutes=0,
     freshness_refuse_minutes=0,
     has_freshness_model=False,
+    # generic_pg only ever exposes composable SQL primitives — no curated
+    # catalog — so its data questions are always agentic, never canned.
+    has_curated_catalog=False,
 )
 
 
@@ -169,6 +172,9 @@ class GenericPgProvider(DataSourceProvider):
             freshness_warn_minutes=0,
             freshness_refuse_minutes=0,
             has_freshness_model=False,
+            # Primitives-only connection: no curated catalog, so its data
+            # questions route agentic (never to the canned filter_expert seat).
+            has_curated_catalog=False,
         )
 
         application_name = (

--- a/miot-harness/src/miot_harness/runtime/intent_router.py
+++ b/miot-harness/src/miot_harness/runtime/intent_router.py
@@ -33,10 +33,10 @@ logger = logging.getLogger(__name__)
 _DEFAULT_DISPLAY_NAME = "the data source"
 _DEFAULT_KEYWORD_EXAMPLES = "operational status, KPIs, fleet metrics"
 
-_SYSTEM_PROMPT_TEMPLATE = """You are the intent router for the ModularIoT harness.
-
-Classify the user's message into EXACTLY ONE of these routes:
-
+# Data-route block for a datasource WITH a curated catalog (Nexo's L1/L2/L3/VT
+# `fn_dx_*` seats): DATA_QUERY maps a canned question to one curated function,
+# and DATA_AGENTIC is the escape hatch for what the catalog doesn't cover.
+_CURATED_DATA_ROUTES = """\
 - DATA_QUERY: A canned data question about {display_name} that maps
   cleanly to a curated data function. Examples are phrased around its
   vocabulary: {keyword_examples}.
@@ -46,7 +46,30 @@ Classify the user's message into EXACTLY ONE of these routes:
 - DATA_AGENTIC: A free-form exploration of {display_name} data that may
   need composable primitives (describe/select/grep) — the canned
   catalog doesn't cover it. Examples: "show me rows where some_metric
-  > 6", "tell me more about that", multi-turn drilldowns.
+  > 6", "tell me more about that", multi-turn drilldowns."""
+
+# Data-route block for a PRIMITIVES-ONLY datasource (generic_pg): there is NO
+# curated catalog, so DATA_QUERY is omitted entirely. Every data lookup —
+# including a concrete single-record lookup like "tell me about service
+# 1585735" — is DATA_AGENTIC. Offering DATA_QUERY here mis-primes the LLM into
+# inventing a curated function that doesn't exist, dead-ending the run in the
+# canned filter_expert seat.
+_PRIMITIVES_DATA_ROUTES = """\
+- DATA_META: A schema/primer/introspection question that needs no SQL.
+  Examples: "what data do you have?", "how is this field calculated?",
+  "what columns does this table have?".
+- DATA_AGENTIC: ANY data question about {display_name} — it has no canned
+  catalog and is queried only with composable primitives
+  (describe/select/grep/query), so every lookup, count, filter and
+  drilldown takes this route. Examples: "tell me about service 1585735",
+  "show me rows where some_metric > 6", "how many X last week", "tell me
+  more about that"."""
+
+_SYSTEM_PROMPT_TEMPLATE = """You are the intent router for the ModularIoT harness.
+
+Classify the user's message into EXACTLY ONE of these routes:
+
+{data_routes}
 - STORYTELLING_RUN: User wants a written narrative or dashboard draft.
   Examples: "write a story about", "draft a status update".
 - DIRECT: Greetings, small talk, simple chat where no data or narrative
@@ -67,11 +90,16 @@ def _render_system_prompt(profile: DataSourceProfile | None) -> str:
     The route vocabulary is profile-agnostic; only the example wording is
     parameterized via the profile's `display_name` and `router_keywords`
     so the prompt names the active datasource instead of hardcoding it.
+
+    A datasource with no curated catalog (`has_curated_catalog=False`) drops
+    the DATA_QUERY route from the menu — it has no canned functions, so every
+    data question is DATA_AGENTIC (composable-primitive) exploration.
     """
 
     if profile is None:
         display_name = _DEFAULT_DISPLAY_NAME
         keyword_examples = _DEFAULT_KEYWORD_EXAMPLES
+        has_curated_catalog = True
     else:
         display_name = profile.display_name
         # Sorted for deterministic rendering; the full keyword set keeps
@@ -79,9 +107,11 @@ def _render_system_prompt(profile: DataSourceProfile | None) -> str:
         keyword_examples = ", ".join(sorted(profile.router_keywords)) or (
             _DEFAULT_KEYWORD_EXAMPLES
         )
-    return _SYSTEM_PROMPT_TEMPLATE.format(
-        display_name=display_name, keyword_examples=keyword_examples
-    )
+        has_curated_catalog = profile.has_curated_catalog
+    data_routes = (
+        _CURATED_DATA_ROUTES if has_curated_catalog else _PRIMITIVES_DATA_ROUTES
+    ).format(display_name=display_name, keyword_examples=keyword_examples)
+    return _SYSTEM_PROMPT_TEMPLATE.format(data_routes=data_routes)
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -220,6 +220,8 @@ class HarnessSupervisor:
             self._close_bus(ctx.run_id)
             return record
 
+        route = self._apply_catalog_route_override(route)
+
         progress(
             HarnessEvent(
                 run_id=ctx.run_id,
@@ -534,6 +536,33 @@ class HarnessSupervisor:
         # Plan 12 default: keyword router on the message; explicit modes
         # are ignored because the keyword router doesn't know about them.
         return self.router.route(request.message)
+
+    def _apply_catalog_route_override(self, route: RouteResult) -> RouteResult:
+        """Force DATA_QUERY → DATA_AGENTIC on primitives-only datasources.
+
+        The canned DATA_QUERY seat (`filter_expert`) picks ONE curated data
+        function. A datasource with no curated catalog (generic_pg: only
+        composable SQL primitives) has nothing for it to pick, so `filter_expert`
+        dead-ends — it emits an off-contract step and the run falls to the
+        onboarding fallback. Every data question on such a source is agentic
+        (composable-primitive) exploration. The intent router already drops
+        DATA_QUERY from its menu for these datasources; this is the deterministic
+        safety net that also catches an explicit `mode=canned` request and any
+        keyword-fallback DATA_QUERY the LLM prompt can't prevent.
+        """
+        if (
+            route.route == HarnessRoute.DATA_QUERY
+            and self.profile is not None
+            and not self.profile.has_curated_catalog
+        ):
+            return RouteResult(
+                route=HarnessRoute.DATA_AGENTIC,
+                reason=(
+                    f"{route.reason} → remapped to DATA_AGENTIC "
+                    f"({self.profile.name} has no curated catalog)"
+                ),
+            )
+        return route
 
     async def _run_storytelling(
         self,

--- a/miot-harness/tests/runtime/test_intent_router.py
+++ b/miot-harness/tests/runtime/test_intent_router.py
@@ -214,3 +214,18 @@ def test_system_prompt_falls_back_without_profile() -> None:
     prompt = _render_system_prompt(None)
     assert "DATA_QUERY" in prompt
     assert "the data source" in prompt
+
+
+def test_system_prompt_omits_data_query_without_curated_catalog() -> None:
+    """A primitives-only datasource (no curated catalog) drops DATA_QUERY from
+    the menu so the LLM can't classify a question as canned — every data
+    question is DATA_AGENTIC (composable-primitive) exploration."""
+
+    from dataclasses import replace
+
+    prompt = _render_system_prompt(replace(FAKE_PROFILE, has_curated_catalog=False))
+    assert "DATA_QUERY" not in prompt
+    # The remaining data routes and the datasource name are still present.
+    assert "DATA_AGENTIC" in prompt
+    assert "DATA_META" in prompt
+    assert FAKE_PROFILE.display_name in prompt

--- a/miot-harness/tests/runtime/test_supervisor_phase_e.py
+++ b/miot-harness/tests/runtime/test_supervisor_phase_e.py
@@ -217,6 +217,68 @@ async def test_auto_mode_uses_llm_router_to_pick_route(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_data_query_remapped_to_agentic_without_curated_catalog(
+    tmp_path: Any,
+) -> None:
+    """A primitives-only datasource (no curated catalog) has nothing for the
+    canned filter_expert seat to pick, so a DATA_QUERY route — whether the LLM
+    misclassified it or the caller sent `mode=canned` — must be remapped to the
+    agentic graph. This is the regression guard for the "servicio 1585735"
+    onboarding-fallback dead-end."""
+
+    from dataclasses import replace
+
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "canned (should not run)"})
+    agentic_graph = AsyncMock()
+    agentic_graph.ainvoke = AsyncMock(
+        return_value={"answer": "servicio 1585735 encontrado", "_events": []}
+    )
+    supervisor = _build_supervisor(
+        tmp_path,
+        data_graph=data_graph,
+        agentic_graph=agentic_graph,
+        llm_router=_scripted_llm_router("DATA_QUERY"),
+    )
+    # The active datasource has no curated catalog (generic_pg / acs).
+    supervisor.profile = replace(FAKE_PROFILE, has_curated_catalog=False)
+
+    record = await supervisor.run(
+        UserRequest(message="que me puedes decir del servicio 1585735", tenant_id="mintral")
+    )
+
+    agentic_graph.ainvoke.assert_awaited_once()
+    data_graph.ainvoke.assert_not_awaited()
+    assert record.answer == "servicio 1585735 encontrado"
+
+
+@pytest.mark.asyncio
+async def test_data_query_kept_canned_with_curated_catalog(tmp_path: Any) -> None:
+    """The remap is scoped to no-catalog datasources: a curated profile still
+    sends DATA_QUERY to the canned data graph."""
+
+    data_graph = AsyncMock()
+    data_graph.ainvoke = AsyncMock(return_value={"answer": "canned answer", "_events": []})
+    agentic_graph = AsyncMock()
+    agentic_graph.ainvoke = AsyncMock(return_value={"answer": "should not run"})
+    supervisor = _build_supervisor(
+        tmp_path,
+        data_graph=data_graph,
+        agentic_graph=agentic_graph,
+        llm_router=_scripted_llm_router("DATA_QUERY"),
+    )
+    supervisor.profile = FAKE_PROFILE  # has_curated_catalog defaults to True
+
+    record = await supervisor.run(
+        UserRequest(message="dame KPIs", tenant_id="mintral")
+    )
+
+    data_graph.ainvoke.assert_awaited_once()
+    agentic_graph.ainvoke.assert_not_awaited()
+    assert record.answer == "canned answer"
+
+
+@pytest.mark.asyncio
 async def test_conversation_id_round_trips_via_store(tmp_path: Any) -> None:
     """When a request carries `conversation_id`, the supervisor must:
     1. Set `record.conversation_id` for downstream telemetry.


### PR DESCRIPTION
## What

Routes data questions on **primitives-only (`generic_pg`) datasources** to the agentic planner instead of the canned `filter_expert` seat.

Fixes #894.

## Why

On the `acs` (Alfresco / `generic_pg`) connection, `{"query":"que me puedes decir del servicio 1585735"}` returned the generic onboarding fallback instead of an answer. `generic_pg` exposes only composable SQL primitives (`acs_query`/`acs_grep`/`acs_select`/`acs_list_tables`/…) — **no curated catalog** — but with `mode="auto"` the LLM intent router classified the question as `DATA_QUERY` (canned) and dispatched it to `filter_expert`.

`filter_expert` is built to pick *one curated function* (Nexo's L1/L2/L3/VT `fn_dx_*` seats). Handed only primitives, Haiku went off-contract and emitted an answer-blocks array (`[{"type":"intent",…},{"type":"markdown",…}]`) instead of a `DataStep` → `_parse_step` returned `None` → `"filter_expert returned malformed step"` → onboarding fallback. (The `answer_blocks … markdown fallback` WARNING in the same trace is the *designed* fallback firing on the plain-text onboarding message — benign.)

A no-curated-catalog datasource should never reach `filter_expert`; every data question on it is agentic (composable-primitive) exploration.

## Changes

- **`DataSourceProfile.has_curated_catalog: bool = True`** (mirrors the existing `has_freshness_model` flag); set **`False`** on both `generic_pg` profiles.
- **Intent router** — drops `DATA_QUERY` from the prompt menu for no-catalog datasources and folds canned-style questions into `DATA_AGENTIC` (with concrete examples). Removes the mis-priming fake `"KPIs, fleet metrics"` fallback examples for empty-keyword datasources.
- **Supervisor** — deterministic safety-net remap `DATA_QUERY → DATA_AGENTIC` for no-catalog datasources. Also catches an explicit `mode=canned` request and any keyword-fallback `DATA_QUERY` the prompt can't prevent.

Result: `"servicio 1585735"` now flows through the agentic planner (`acs_list_tables` → `acs_grep`/`acs_query`) instead of dead-ending in `filter_expert`.

## Tests

- `test_system_prompt_omits_data_query_without_curated_catalog` — router prompt drops `DATA_QUERY` for a no-catalog profile.
- `test_data_query_remapped_to_agentic_without_curated_catalog` — regression guard for the exact "servicio 1585735" scenario (agentic graph runs, canned graph does not).
- `test_data_query_kept_canned_with_curated_catalog` — remap is scoped: curated datasources still use the canned graph.

Full suite green (923 passed, 4 skipped); `ruff` + `mypy` clean on changed files.

## Follow-up (not in this PR)

When the LLM router returns *low confidence* for a `generic_pg` question, it falls back to the keyword router which — with empty `router_keywords` — can't classify it as data and lands it in `DIRECT`/`OTHER`. Hardening the keyword fallback for no-keyword datasources is a separate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
