### PR TITLE
ci: resolve docs images in stack pipelines

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -124,21 +124,32 @@ const pathStarts = (prefixes) => [...changedFiles].some((file) => prefixes.some(
 // Stack release notes are bundled into the Next.js app, so the app package,
 // tag, and image intentionally stay in sync with the stack version.
 const appChanged = true;
-const docsChanged = true;
+const docsChanged = pathStarts([
+  "turbo-repo/apps/docs/",
+  "turbo-repo/packages/ui/",
+  "turbo-repo/packages/typescript-config/",
+  "turbo-repo/packages/eslint-config/",
+  "turbo-repo/package-lock.json",
+  "turbo-repo/docker/nextjs.standalone-docs.Dockerfile",
+]);
 const modulithChanged = pathStarts(["quarkus-srv/"]);
 
+const latestDocsVersion = latestVersion("docs@v*", "docs@v");
 const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
 const latestHarnessVersion = latestVersion("harness@v*", "harness@v");
 const currentHarnessVersion = projectVersion("miot-harness/pyproject.toml");
 const harnessBaseVersion = maxVersion(latestHarnessVersion, currentHarnessVersion);
 const harnessChanged = pathStarts(["miot-harness/"]) || !latestHarnessVersion;
 const appVersion = stackVersion;
+const docsVersion = docsChanged ? stackVersion : latestDocsVersion;
 const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : latestModulithVersion;
 const harnessVersion = harnessChanged ? bumpPatch(harnessBaseVersion) : harnessBaseVersion;
-const docsVersion = stackVersion;
 
 if (!appVersion) {
   throw new Error("No app@v* tag exists and the app did not change in this milestone.");
+}
+if (!docsVersion) {
+  throw new Error("No docs@v* tag exists and the docs did not change in this milestone.");
 }
 if (!modulithVersion) {
   throw new Error("No modulith@v* tag exists and the modulith did not change in this milestone.");

--- a/.github/workflows/app-nightly.yml
+++ b/.github/workflows/app-nightly.yml
@@ -10,20 +10,20 @@ on:
       - main
     paths:
       - 'turbo-repo/apps/app/**'
-      - 'turbo-repo/apps/docs/**'
       - 'turbo-repo/packages/ui/**'
       - 'turbo-repo/packages/db/**'
       - 'turbo-repo/packages/typescript-config/**'
       - 'turbo-repo/package-lock.json'
-      - 'turbo-repo/docker/**'
-  # The modulith and harness images are built by their OWN workflows (Quarkus CI
-  # / Harness CI) and only *retagged* here. Triggering on `push` for
-  # `quarkus-srv/**` / `miot-harness/**` raced those builds: the resolve step
+      - 'turbo-repo/docker/nextjs.standalone.Dockerfile'
+  # The docs, modulith, and harness images are built by their OWN workflows
+  # (Docs CI / Quarkus CI / Harness CI) and only *retagged* here. Triggering on
+  # `push` for those component paths raced those builds: the resolve step
   # could check for `:sha-<short>` before the build pushed it and silently
   # promote a stale `:latest` (#764). Instead, run AFTER the build workflow
   # completes so the commit-pinned `sha-<short>` image is guaranteed to exist.
   workflow_run:
     workflows:
+      - Docs CI
       - Quarkus CI
       - Harness CI
     types:
@@ -63,6 +63,7 @@ jobs:
       short_sha: ${{ steps.vars.outputs.short_sha }}
       head_sha: ${{ steps.vars.outputs.head_sha }}
       nightly_date: ${{ steps.vars.outputs.nightly_date }}
+      expect_docs_sha: ${{ steps.vars.outputs.expect_docs_sha }}
       expect_modulith_sha: ${{ steps.vars.outputs.expect_modulith_sha }}
       expect_harness_sha: ${{ steps.vars.outputs.expect_harness_sha }}
     steps:
@@ -86,10 +87,12 @@ jobs:
           # Require a commit-pinned source image ONLY for the component whose
           # build just completed. Everything else is resolved opportunistically
           # and may legitimately fall back to :latest (unchanged this run).
+          expect_docs_sha=false
           expect_modulith_sha=false
           expect_harness_sha=false
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             case "$WORKFLOW_RUN_NAME" in
+              "Docs CI") expect_docs_sha=true ;;
               "Quarkus CI") expect_modulith_sha=true ;;
               "Harness CI") expect_harness_sha=true ;;
             esac
@@ -99,6 +102,7 @@ jobs:
             echo "short_sha=${head_sha:0:7}"
             echo "head_sha=$head_sha"
             echo "nightly_date=$(date -u +'%Y%m%d')"
+            echo "expect_docs_sha=$expect_docs_sha"
             echo "expect_modulith_sha=$expect_modulith_sha"
             echo "expect_harness_sha=$expect_harness_sha"
           } >> "$GITHUB_OUTPUT"
@@ -286,7 +290,7 @@ jobs:
           APP_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.APP_IMAGE_NAME }}
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
-          DOCS_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
+          DOCS_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
           HARNESS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.HARNESS_IMAGE_NAME }}
@@ -407,8 +411,8 @@ jobs:
             echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`sha-${{ needs.metadata.outputs.short_sha }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  build-docs:
-    name: Build and publish nightly docs image
+  resolve-docs:
+    name: Resolve nightly docs image
     runs-on: ubuntu-latest
     needs: metadata
     permissions:
@@ -417,34 +421,9 @@ jobs:
       id-token: write
     outputs:
       image: ${{ steps.image.outputs.image }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+      source_tag: ${{ steps.resolve.outputs.source_tag }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          ref: ${{ needs.metadata.outputs.head_sha }}
-          fetch-depth: 0
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: turbo-repo/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: turbo-repo
-
-      - name: Build docs
-        run: npx turbo run build --filter=@modulariot/docs
-        working-directory: turbo-repo
-
-      - name: Prepare Docker context
-        run: |
-          mkdir -p /tmp/build-docs/.next
-          cp -r turbo-repo/apps/docs/.next/standalone /tmp/build-docs/.next/standalone
-          cp -r turbo-repo/apps/docs/.next/static /tmp/build-docs/.next/static
-          cp -r turbo-repo/apps/docs/public /tmp/build-docs/public
-          cp turbo-repo/docker/nextjs.standalone-docs.Dockerfile /tmp/build-docs/
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
@@ -455,30 +434,67 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        id: docker
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
-        with:
-          context: /tmp/build-docs/
-          file: /tmp/build-docs/nextjs.standalone-docs.Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.metadata.outputs.short_sha }}
-          labels: |
-            org.opencontainers.image.title=${{ env.DOCS_IMAGE_NAME }}
-            org.opencontainers.image.description=ModularIoT docs nightly build
-            org.opencontainers.image.vendor=MicroboxLabs
-            org.opencontainers.image.revision=${{ needs.metadata.outputs.head_sha }}
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          provenance: true
-          sbom: true
+      - name: Resolve source image
+        id: resolve
+        env:
+          SHA_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.metadata.outputs.short_sha }}
+          LATEST_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:latest
+          SHORT_SHA: ${{ needs.metadata.outputs.short_sha }}
+          EXPECT_SHA: ${{ needs.metadata.outputs.expect_docs_sha }}
+        run: |
+          max_attempts=30
+          delay=10
+
+          source_image=""
+          source_tag=""
+          for attempt in $(seq 1 "$max_attempts"); do
+            if docker buildx imagetools inspect "$SHA_IMAGE" >/dev/null 2>&1; then
+              source_image="$SHA_IMAGE"
+              source_tag="sha-${SHORT_SHA}"
+              break
+            fi
+            if [[ "$EXPECT_SHA" != "true" ]]; then
+              break
+            fi
+            echo "Attempt ${attempt}/${max_attempts}: ${SHA_IMAGE} not in registry yet; retrying in ${delay}s..."
+            sleep "$delay"
+          done
+
+          if [[ -z "$source_image" ]]; then
+            if [[ "$EXPECT_SHA" == "true" ]]; then
+              echo "::error::${SHA_IMAGE} never became available after ~$((max_attempts * delay))s even though its build reported success; refusing to promote a stale :latest." >&2
+              exit 1
+            fi
+            echo "::notice::${SHA_IMAGE} not found (docs unchanged this commit); falling back to ${LATEST_IMAGE}."
+            source_image="$LATEST_IMAGE"
+            source_tag="latest"
+          fi
+
+          docker buildx imagetools inspect "$source_image" >/dev/null
+          {
+            echo "source_image=$source_image"
+            echo "source_tag=$source_tag"
+            echo "image_tag=nightly-${{ needs.metadata.outputs.nightly_date }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Promote nightly tags
+        env:
+          SOURCE_IMAGE: ${{ steps.resolve.outputs.source_image }}
+          NIGHTLY_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly
+          DATED_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}
+          SHA_NIGHTLY_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$NIGHTLY_IMAGE" \
+            --tag "$DATED_IMAGE" \
+            --tag "$SHA_NIGHTLY_IMAGE" \
+            "$SOURCE_IMAGE"
 
       - name: Resolve immutable image reference
         id: image
-        run: echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}@${{ steps.docker.outputs.digest }}" >> "$GITHUB_OUTPUT"
+        run: |
+          digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}" | awk '/^Digest:/ { print $2; exit }')"
+          echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Nightly summary
         run: |
@@ -486,7 +502,8 @@ jobs:
             echo "# MIOT Docs Nightly"
             echo ""
             echo "- Image: \`${{ steps.image.outputs.image }}\`"
-            echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`sha-${{ needs.metadata.outputs.short_sha }}\`"
+            echo "- Source tag: \`${{ steps.resolve.outputs.source_tag }}\`"
+            echo "- Tags: \`nightly\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}\`, \`nightly-${{ needs.metadata.outputs.nightly_date }}-${{ needs.metadata.outputs.short_sha }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   resolve-modulith:
@@ -696,7 +713,7 @@ jobs:
   deploy:
     name: Dispatch development environment deploys
     runs-on: ubuntu-latest
-    needs: [metadata, build-app, build-docs, resolve-modulith, resolve-harness]
+    needs: [metadata, build-app, resolve-docs, resolve-modulith, resolve-harness]
     permissions:
       contents: read
     environment:
@@ -721,8 +738,8 @@ jobs:
           APP_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
           APP_IMAGE_REF: ${{ needs.build-app.outputs.image }}
           DOCS_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}
-          DOCS_IMAGE_TAG: sha-${{ needs.metadata.outputs.short_sha }}
-          DOCS_IMAGE_REF: ${{ needs.build-docs.outputs.image }}
+          DOCS_IMAGE_TAG: nightly-${{ needs.metadata.outputs.nightly_date }}
+          DOCS_IMAGE_REF: ${{ needs.resolve-docs.outputs.image }}
           MODULITH_IMAGE_REPOSITORY: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.MODULITH_IMAGE_NAME }}
           MODULITH_IMAGE_TAG: ${{ needs.resolve-modulith.outputs.image_tag }}
           MODULITH_IMAGE_REF: ${{ needs.resolve-modulith.outputs.image }}

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -179,6 +179,31 @@ jobs:
         if: steps.plan.outputs.app_changed == 'true'
         run: bash turbo-repo/generative_ai/tools/sh/bump-app-version.sh "${{ steps.plan.outputs.app_version }}"
 
+      - name: Bump docs package version
+        if: steps.plan.outputs.docs_changed == 'true'
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const version = "${{ steps.plan.outputs.docs_version }}";
+
+          const updateJsonFile = (path, updater) => {
+            const data = JSON.parse(fs.readFileSync(path, "utf8"));
+            updater(data);
+            fs.writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+          };
+
+          updateJsonFile("turbo-repo/apps/docs/package.json", (data) => {
+            data.version = version;
+          });
+          updateJsonFile("turbo-repo/package-lock.json", (data) => {
+            const docsPackage = data.packages?.["apps/docs"];
+            if (!docsPackage) {
+              throw new Error("Could not find apps/docs in turbo-repo/package-lock.json");
+            }
+            docsPackage.version = version;
+          });
+          NODE
+
       - name: Bump modulith Maven version
         if: steps.plan.outputs.modulith_changed == 'true'
         run: ./mvnw versions:set -DnewVersion="${{ steps.plan.outputs.modulith_version }}" -DgenerateBackupPoms=false -DprocessAllModules=true
@@ -294,7 +319,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml miot-harness/uv.lock
+          git add "${{ steps.plan.outputs.stack_plan_file }}" releases/notes/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/src/releases/v${{ steps.version.outputs.release_notes_version }}.mdx turbo-repo/apps/app/package.json turbo-repo/apps/docs/package.json turbo-repo/package-lock.json quarkus-srv miot-harness/pyproject.toml miot-harness/uv.lock
           if git diff --cached --quiet; then
             echo "No release prep changes to commit."
           else
@@ -838,38 +863,6 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     steps:
-      - uses: actions/checkout@v5
-        if: needs.prepare.outputs.docs_changed == 'true'
-        with:
-          ref: ${{ needs.tag.outputs.sha }}
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v6
-        if: needs.prepare.outputs.docs_changed == 'true'
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: turbo-repo/package-lock.json
-
-      - name: Install dependencies
-        if: needs.prepare.outputs.docs_changed == 'true'
-        run: npm ci
-        working-directory: turbo-repo
-
-      - name: Build docs
-        if: needs.prepare.outputs.docs_changed == 'true'
-        run: npx turbo run build --filter=@modulariot/docs
-        working-directory: turbo-repo
-
-      - name: Stage docs artifact
-        if: needs.prepare.outputs.docs_changed == 'true'
-        run: |
-          mkdir -p build-context/.next
-          cp -r turbo-repo/apps/docs/.next/standalone build-context/.next/standalone
-          cp -r turbo-repo/apps/docs/.next/static build-context/.next/static
-          cp -r turbo-repo/apps/docs/public build-context/public
-          cp turbo-repo/docker/nextjs.standalone-docs.Dockerfile build-context/
-
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -878,30 +871,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Wait for release docs image
         if: needs.prepare.outputs.docs_changed == 'true'
-        id: docker
-        uses: docker/build-push-action@v6
-        with:
-          context: build-context/
-          file: build-context/nextjs.standalone-docs.Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:${{ needs.prepare.outputs.docs_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
-          provenance: true
-          sbom: true
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+        run: |
+          for attempt in {1..60}; do
+            if docker buildx imagetools inspect "$SOURCE_IMAGE" >/dev/null; then
+              echo "Promoting release docs image $SOURCE_IMAGE."
+              exit 0
+            fi
+
+            echo "Waiting for Docs CI to publish release image... ($attempt/60)"
+            sleep 60
+          done
+
+          echo "::error::Timed out waiting for Docs CI to publish release image."
+          exit 1
+
+      - name: Promote image tags
+        if: needs.prepare.outputs.docs_changed == 'true'
+        env:
+          SOURCE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:sha-${{ needs.tag.outputs.short_sha }}
+          RELEASE_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:${{ needs.prepare.outputs.docs_version }}
+          COMPONENT_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$RELEASE_IMAGE" \
+            --tag "$COMPONENT_IMAGE" \
+            "$SOURCE_IMAGE"
 
       - name: Export image ref
         id: image
         run: |
-          if [[ "${{ needs.prepare.outputs.docs_changed }}" == "true" ]]; then
-            digest="${{ steps.docker.outputs.digest }}"
-          else
-            digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}" | awk '/^Digest:/ { print $2; exit }')"
-          fi
+          digest="$(docker buildx imagetools inspect "${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}:docs-v${{ needs.prepare.outputs.docs_version }}" | awk '/^Digest:/ { print $2; exit }')"
           echo "image=${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.DOCS_IMAGE_NAME }}@${digest}" >> "$GITHUB_OUTPUT"
 
   build-modulith:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,109 @@
+name: Docs CI
+
+on:
+  push:
+    paths:
+      - 'turbo-repo/apps/docs/**'
+      - 'turbo-repo/packages/ui/**'
+      - 'turbo-repo/packages/typescript-config/**'
+      - 'turbo-repo/packages/eslint-config/**'
+      - 'turbo-repo/package-lock.json'
+      - 'turbo-repo/docker/nextjs.standalone-docs.Dockerfile'
+      - '.github/workflows/docs.yml'
+    branches: [trunk, main]
+  pull_request:
+    paths:
+      - 'turbo-repo/apps/docs/**'
+      - 'turbo-repo/packages/ui/**'
+      - 'turbo-repo/packages/typescript-config/**'
+      - 'turbo-repo/packages/eslint-config/**'
+      - 'turbo-repo/package-lock.json'
+      - 'turbo-repo/docker/nextjs.standalone-docs.Dockerfile'
+      - '.github/workflows/docs.yml'
+    branches: [trunk, main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: "24"
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_OWNER: microboxlabs
+  IMAGE_NAME: miot-docs
+
+jobs:
+  build:
+    name: Build and publish docs image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+    outputs:
+      image-digest: ${{ steps.docker.outputs.digest }}
+      short-sha: ${{ steps.vars.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: turbo-repo/package-lock.json
+
+      - name: Resolve image metadata
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: turbo-repo
+
+      - name: Build docs
+        run: npx turbo run build --filter=@modulariot/docs
+        working-directory: turbo-repo
+
+      - name: Prepare Docker context
+        run: |
+          mkdir -p /tmp/build-docs/.next
+          cp -r turbo-repo/apps/docs/.next/standalone /tmp/build-docs/.next/standalone
+          cp -r turbo-repo/apps/docs/.next/static /tmp/build-docs/.next/static
+          cp -r turbo-repo/apps/docs/public /tmp/build-docs/public
+          cp turbo-repo/docker/nextjs.standalone-docs.Dockerfile /tmp/build-docs/
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/build-docs/
+          file: /tmp/build-docs/nextjs.standalone-docs.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.description=ModularIoT docs site
+            org.opencontainers.image.vendor=MicroboxLabs
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          provenance: true
+          sbom: true
+
+      - name: Image summary
+        run: |
+          {
+            echo "# Docs Image"
+            echo ""
+            echo "- Digest: \`${{ steps.docker.outputs.digest }}\`"
+            echo "- Tags: \`latest\`, \`sha-${{ steps.vars.outputs.short_sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add a dedicated Docs CI workflow that builds and publishes the `miot-docs` image with `latest` and commit SHA tags.
- Change nightly to resolve and promote docs images instead of rebuilding docs in the stack workflow.
- Make release planning mark docs changed only when docs build inputs changed, and have release train promote the Docs CI image like harness/modulith.

## Why

Docs was being rebuilt every time the nightly and release train stack pipelines ran. Harness and modulith already publish their own component images and the stack pipelines only resolve/promote those images, so this brings docs into the same model.

## Validation

- `node --check .github/scripts/resolve-stack-release-plan.js`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/app-nightly.yml .github/workflows/app-release-train.yml .github/workflows/docs.yml`
- `git diff --cached --check` before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Docs CI workflow to build and publish the docs site as a Docker image.
  * Nightly and release workflows now reuse published docs images instead of rebuilding them every time, improving consistency.

* **Bug Fixes**
  * Docs versioning now only updates when docs actually change, reducing unnecessary version bumps.
  * Release and nightly processes now fail clearly if a required docs image isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->