### PR TITLE
fix(harness): surface ground-or-flag assumptions on the agent_loop path

### DIFF
--- a/miot-harness/src/miot_harness/agents/synthesizer.py
+++ b/miot-harness/src/miot_harness/agents/synthesizer.py
@@ -263,15 +263,17 @@ def harden_answer(answer: str) -> str:
     return json.dumps(blocks, ensure_ascii=False)
 
 
-def _extract_assumptions(answer: str) -> list[dict[str, Any]]:
+def extract_assumptions(answer: str) -> list[dict[str, Any]]:
     """Pull self-reported ground-or-flag assumptions out of a JSON-blocks answer.
 
-    The synthesizer (guided by the miot-search skill's assumptions contract)
-    emits one `{"type":"assumption","value":{term,interpretation,predicate}}`
-    block per business term it could not ground in an authoritative card. A
-    non-JSON or block-less answer yields nothing — this is a NO-OP for every
-    other synthesis path (prose answers, nexo, refusals), so the shared
-    synthesizer behaviour is unchanged unless a skill opts in."""
+    The answering agent (guided by the miot-search skill's assumptions
+    contract) emits one `{"type":"assumption","value":{term,interpretation,
+    predicate}}` block per business term it could not ground in an
+    authoritative card. A non-JSON or block-less answer yields nothing — this
+    is a NO-OP for every other synthesis path (prose answers, nexo, refusals),
+    so the shared behaviour is unchanged unless a skill opts in. Shared by the
+    synthesizer node and the supervisor's agent_loop branch: every agentic
+    path must surface assumptions or the learning loop never sees them."""
     try:
         parsed = json.loads(answer)
     except (ValueError, TypeError):
@@ -296,7 +298,7 @@ def _extract_assumptions(answer: str) -> list[dict[str, Any]]:
     return assumptions
 
 
-def _emit_grounding_gap(
+def emit_grounding_gap(
     progress: Progress, run_id: str, assumption: dict[str, Any]
 ) -> None:
     progress(
@@ -393,7 +395,7 @@ async def synthesizer_node(
     # Ground-or-flag: surface any self-reported assumption as a structured
     # record + one grounding.gap event per ungrounded term (no-op unless the
     # answer carried assumption blocks).
-    assumptions = _extract_assumptions(answer)
+    assumptions = extract_assumptions(answer)
     for assumption in assumptions:
-        _emit_grounding_gap(progress, ctx.run_id, assumption)
+        emit_grounding_gap(progress, ctx.run_id, assumption)
     return {"answer": answer, "assumptions": assumptions}

--- a/miot-harness/src/miot_harness/runtime/supervisor.py
+++ b/miot-harness/src/miot_harness/runtime/supervisor.py
@@ -37,6 +37,11 @@ from miot_harness.agents.meta_agent import (
     MetaAgentCatalogEntry,
     meta_agent_node,
 )
+from miot_harness.agents.synthesizer import (
+    emit_grounding_gap,
+    extract_assumptions,
+    harden_answer,
+)
 from miot_harness.config import HarnessSettings, get_settings
 from miot_harness.context_skills.registry import ContextSkillsBundle
 from miot_harness.datasource.provider import DataSourceProfile
@@ -721,7 +726,15 @@ class HarnessSupervisor:
                     prior_messages=prior_messages or [],
                     progress=progress,
                 )
-            record.answer = delta.get("answer") or "(no answer produced by agent loop)"
+            answer = delta.get("answer") or "(no answer produced by agent loop)"
+            record.answer = harden_answer(answer)
+            # Ground-or-flag: the loop path bypasses the synthesizer, so the
+            # assumption blocks must be surfaced here too — otherwise this
+            # route feeds nothing to the capture/distill loop.
+            assumptions = extract_assumptions(record.answer)
+            for assumption in assumptions:
+                emit_grounding_gap(progress, ctx.run_id, assumption)
+            record.assumptions = self._stamp_connection(assumptions)
             return
 
         if self.agentic_graph is None:

--- a/miot-harness/tests/runtime/test_supervisor_agent_loop.py
+++ b/miot-harness/tests/runtime/test_supervisor_agent_loop.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -41,6 +42,55 @@ async def test_agentic_route_prefers_agent_loop(tmp_path):
     assert record.answer == "loop answer"
     assert record.status == "completed"
     assert loop.calls[0]["user_message"] == "explore this"
+    # Prose answer → nothing to flag.
+    assert record.assumptions == []
+
+
+class _AssumingLoop:
+    """Loop double whose answer carries a ground-or-flag assumption block."""
+
+    async def run(self, *, user_message, ctx, prior_messages, progress):
+        answer = json.dumps(
+            [
+                {"type": "markdown", "value": "Hay 11 servicios en entregas."},
+                {
+                    "type": "assumption",
+                    "value": {
+                        "term": "entregas",
+                        "interpretation": "confirmDelivery+receiveDelivery+confirmArrival",
+                        "predicate": "task_def_key IN (...)",
+                    },
+                },
+            ],
+            ensure_ascii=False,
+        )
+        return {"answer": answer, "evidence": [], "usage_log": []}
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_answer_surfaces_assumptions(tmp_path):
+    """The loop path must honor ground-or-flag like the graph path: the
+    assumption lands on the record (feeds capture/distill) and a
+    grounding.gap event is emitted."""
+    sup = HarnessSupervisor(
+        router=_AgenticRouter(),
+        tools=ToolRegistry(),
+        stories=StorytellingModule(),
+        run_store=JsonRunStore(tmp_path),
+        agentic_graph=object(),  # would explode if invoked
+        agent_loop=_AssumingLoop(),
+    )
+    record = await sup.run(
+        UserRequest(
+            message="cuántos servicios en entregas",
+            tenant_id="demo-tenant",
+            mode="agentic",
+        )
+    )
+    assert record.status == "completed"
+    assert [a["term"] for a in record.assumptions] == ["entregas"]
+    assert record.assumptions[0]["grounded"] is False
+    assert "grounding.gap" in [e.type for e in record.events]
 
 
 @pytest.mark.asyncio

--- a/miot-harness/tests/test_synthesizer_harden.py
+++ b/miot-harness/tests/test_synthesizer_harden.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 
 from miot_harness.agents.synthesizer import (
-    _extract_assumptions,
+    extract_assumptions,
     harden_answer,
 )
 
@@ -33,7 +33,7 @@ _CLEAN = json.dumps(
 def _assert_valid_blocks_with_assumption(answer: str) -> None:
     parsed = json.loads(answer)  # must be valid JSON now
     assert isinstance(parsed, list)
-    assumptions = _extract_assumptions(answer)
+    assumptions = extract_assumptions(answer)
     assert [a["term"] for a in assumptions] == ["entregas"]
 
 


### PR DESCRIPTION
Closes #905

## Problem

With `MIOT_HARNESS_AGENTS_AGENT_LOOP_ENABLED=true`, `DATA_AGENTIC` runs take the `agent_loop` branch of `HarnessSupervisor._run_data_agentic`, which returned early setting only `record.answer`. The ground-or-flag machinery lives in the synthesizer node — which the loop never calls — so these runs emitted **no `grounding.gap` events** and persisted **empty `assumptions`**, even when the model declared an assumption in prose. Net effect: no spotlight chip, no signal in the interaction episode, nothing for the distiller — the continual-learning loop got no seed from this path (observed live on the canonical `confirmArrival` case).

## Fix

- `runtime/supervisor.py` — the `agent_loop` branch now mirrors the graph path: `harden_answer` → `extract_assumptions` → one `grounding.gap` event per ungrounded term → `record.assumptions = _stamp_connection(...)`.
- `agents/synthesizer.py` — `_extract_assumptions` / `_emit_grounding_gap` promoted to public `extract_assumptions` / `emit_grounding_gap`: they are now the shared contract for both agentic engines. No behavior change.
- Tests: new `test_agent_loop_answer_surfaces_assumptions` (assumption block → record stamped `grounded: false` + `grounding.gap` emitted) and prose-answer-stays-empty assertion; renamed imports in `test_synthesizer_harden.py`.

## Verification

- Suite: **1018 passed** · ruff clean · mypy strict clean.
- Live (dev stack, `acs` connection, agent_loop enabled):
  - *"¿cuántos servicios en etapas de entrega?"* → **9**, grounded by the approved `pendientes-de-entrega` card, `assumptions: []` (correct silence — the loop's own earlier learning).
  - *"¿cuántos servicios están atrasados?"* (no card) → 1 `grounding.gap` + `search.result.assumptions = [{term: "atrasados", interpretation: …, predicate: …, grounded: false, connection: "acs"}]` — chip renders in the spotlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169P2qL3VXjL9KdtejfUto4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-loop answers now identify assumptions and associate them with the run’s primary connection.
  * Grounding-gap events are emitted when assumptions cannot be grounded.

* **Bug Fixes**
  * Plain-text agent-loop responses no longer produce unintended assumptions.
  * Hardened answers consistently preserve assumption and grounding information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->