### PR TITLE
feat(integrations): Gauss GPS v2 forwarder + privacy pin from env

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -35,9 +35,12 @@ miot.integrations.retransmit.pulsar.subscription=${MIOT_INTEGRATIONS_RETRANSMIT_
 #   raw   = post miot.gps.retransmit@1 JSON as-is (echo / debug)
 miot.integrations.retransmit.payload-format=${MIOT_INTEGRATIONS_RETRANSMIT_PAYLOAD_FORMAT:auto}
 # Gauss Control (APG2) — position upload auth + field defaults
-# Static bearer OR OAuth (Basic client + password grant / refresh_token):
+# Preferred: provider gateway headers (secret):
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_PROVIDER_API_KEY  → X-Provider-Api-Key
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_TARGET_TENANT     → X-Target-Tenant
+# Fallback: static bearer OR OAuth (Basic client + password grant / refresh_token):
 #   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_BEARER_TOKEN
-#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_OAUTH_TOKEN_URL  (e.g. https://…/oauth/token)
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_OAUTH_TOKEN_URL
 #   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_CLIENT_ID / _CLIENT_SECRET
 #   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_USERNAME / _PASSWORD
 miot.integrations.retransmit.gauss.tags=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_TAGS:;MEL;}

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -29,6 +29,25 @@ miot.integrations.retransmit.retry-max-seconds=${MIOT_INTEGRATIONS_RETRANSMIT_RE
 miot.integrations.retransmit.pulsar.service-url=${MIOT_INTEGRATIONS_RETRANSMIT_PULSAR_SERVICE_URL:pulsar://localhost:6650}
 miot.integrations.retransmit.pulsar.topic=${MIOT_INTEGRATIONS_RETRANSMIT_PULSAR_TOPIC:persistent://streamhub/tracking/asset-positions-enriched}
 miot.integrations.retransmit.pulsar.subscription=${MIOT_INTEGRATIONS_RETRANSMIT_PULSAR_SUBSCRIPTION:miot-retransmit-worker}
+# Payload: auto | gauss | raw
+#   auto  = Gauss v2 format when destination URL looks like GaussControl
+#   gauss = always map to Inyección puntos GPS v2 (JSON array + Bearer)
+#   raw   = post miot.gps.retransmit@1 JSON as-is (echo / debug)
+miot.integrations.retransmit.payload-format=${MIOT_INTEGRATIONS_RETRANSMIT_PAYLOAD_FORMAT:auto}
+# Gauss Control (APG2) — position upload auth + field defaults
+# Static bearer OR OAuth (Basic client + password grant / refresh_token):
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_BEARER_TOKEN
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_OAUTH_TOKEN_URL  (e.g. https://…/oauth/token)
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_CLIENT_ID / _CLIENT_SECRET
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_USERNAME / _PASSWORD
+miot.integrations.retransmit.gauss.tags=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_TAGS:;MEL;}
+miot.integrations.retransmit.gauss.device-type=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_DEVICE_TYPE:gps}
+miot.integrations.retransmit.gauss.event-provider=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_EVENT_PROVIDER:streamhub}
+miot.integrations.retransmit.gauss.device-model=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_DEVICE_MODEL:streamhub-miot}
+# Privacy pin for outside-MEL mode (env/secret only — do not commit real coords):
+#   MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LAT
+#   MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LON
+#   MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LABEL
 # Optional (env only; leave unset when worker off):
 #   MIOT_INTEGRATIONS_RETRANSMIT_DEFAULT_URL
 #   MIOT_INTEGRATIONS_RETRANSMIT_GPS_REACTIVE_URL / _USERNAME / _PASSWORD

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussAuthClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussAuthClient.java
@@ -1,0 +1,190 @@
+package com.microboxlabs.miot.integrations.retransmit;
+
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Gauss Control OAuth (Basic client + password / refresh_token) for position upload.
+ *
+ * <p>Docs: APG2 / Autenticación - API de Login. Optional static bearer overrides OAuth.
+ */
+@ApplicationScoped
+public class GaussAuthClient {
+
+    private static final Logger LOG = Logger.getLogger(GaussAuthClient.class);
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(15);
+    /** Refresh a minute before expiry when expires_in is known. */
+    private static final long SKEW_SECONDS = 60;
+
+    private final Optional<String> staticBearer;
+    private final Optional<String> tokenUrl;
+    private final Optional<String> clientId;
+    private final Optional<String> clientSecret;
+    private final Optional<String> username;
+    private final Optional<String> password;
+    private final HttpClient httpClient;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private String accessToken;
+    private String refreshToken;
+    private Instant accessExpiresAt = Instant.EPOCH;
+
+    GaussAuthClient(
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.bearer-token")
+                    Optional<String> staticBearer,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.oauth-token-url")
+                    Optional<String> tokenUrl,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.client-id")
+                    Optional<String> clientId,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.client-secret")
+                    Optional<String> clientSecret,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.username")
+                    Optional<String> username,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.password")
+                    Optional<String> password) {
+        this.staticBearer = staticBearer.filter(s -> s != null && !s.isBlank());
+        this.tokenUrl = tokenUrl.filter(s -> s != null && !s.isBlank());
+        this.clientId = clientId.filter(s -> s != null && !s.isBlank());
+        this.clientSecret = clientSecret.filter(s -> s != null && !s.isBlank());
+        this.username = username.filter(s -> s != null && !s.isBlank());
+        this.password = password.filter(s -> s != null && !s.isBlank());
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    /** Whether Gauss auth is configured (static bearer or full OAuth). */
+    public boolean isConfigured() {
+        if (staticBearer.isPresent()) {
+            return true;
+        }
+        return tokenUrl.isPresent()
+                && clientId.isPresent()
+                && clientSecret.isPresent()
+                && (username.isPresent() && password.isPresent() || refreshToken != null);
+    }
+
+    /**
+     * Returns a usable access token. Refreshes or re-authenticates as needed.
+     *
+     * @throws IllegalStateException if auth is not configured or login fails
+     */
+    public String getAccessToken() {
+        if (staticBearer.isPresent()) {
+            return staticBearer.get().trim();
+        }
+        lock.lock();
+        try {
+            if (accessToken != null && Instant.now().isBefore(accessExpiresAt.minusSeconds(SKEW_SECONDS))) {
+                return accessToken;
+            }
+            if (refreshToken != null && !refreshToken.isBlank()) {
+                try {
+                    return requestToken(formRefresh(refreshToken));
+                } catch (Exception e) {
+                    LOG.warnf(e, "Gauss refresh_token failed; falling back to password grant");
+                }
+            }
+            if (username.isEmpty() || password.isEmpty()) {
+                throw new IllegalStateException(
+                        "Gauss OAuth not configured (set bearer-token or oauth-token-url + client + user)");
+            }
+            return requestToken(formPassword(username.get(), password.get()));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Force next {@link #getAccessToken()} to re-login (e.g. after HTTP 401). */
+    public void invalidate() {
+        if (staticBearer.isPresent()) {
+            return;
+        }
+        lock.lock();
+        try {
+            accessToken = null;
+            accessExpiresAt = Instant.EPOCH;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private String requestToken(String formBody) {
+        if (tokenUrl.isEmpty() || clientId.isEmpty() || clientSecret.isEmpty()) {
+            throw new IllegalStateException("Gauss OAuth token URL / client credentials missing");
+        }
+        try {
+            String basic = Base64.getEncoder()
+                    .encodeToString((clientId.get() + ":" + clientSecret.get())
+                            .getBytes(StandardCharsets.UTF_8));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(tokenUrl.get().trim()))
+                    .timeout(HTTP_TIMEOUT)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .header("Authorization", "Basic " + basic)
+                    .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException(
+                        "Gauss OAuth HTTP " + response.statusCode() + ": " + truncate(response.body()));
+            }
+            JsonObject json = new JsonObject(response.body());
+            String token = json.getString("access_token");
+            if (token == null || token.isBlank()) {
+                throw new IllegalStateException("Gauss OAuth response missing access_token");
+            }
+            accessToken = token.trim();
+            String newRefresh = json.getString("refresh_token");
+            if (newRefresh != null && !newRefresh.isBlank()) {
+                refreshToken = newRefresh.trim();
+            }
+            long expiresIn = json.containsKey("expires_in") ? json.getLong("expires_in") : 3600L;
+            accessExpiresAt = Instant.now().plusSeconds(Math.max(expiresIn, 60));
+            LOG.debugf("Gauss OAuth token acquired expires_in=%ds", expiresIn);
+            return accessToken;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Gauss OAuth interrupted", e);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Gauss OAuth failed: " + e.getMessage(), e);
+        }
+    }
+
+    private static String formPassword(String user, String pass) {
+        return "grant_type=password"
+                + "&username=" + url(user)
+                + "&password=" + url(pass);
+    }
+
+    private static String formRefresh(String refresh) {
+        return "grant_type=refresh_token&refresh_token=" + url(refresh);
+    }
+
+    private static String url(String v) {
+        return URLEncoder.encode(v, StandardCharsets.UTF_8);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.length() > 300 ? s.substring(0, 300) : s;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussAuthClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussAuthClient.java
@@ -17,9 +17,11 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 /**
- * Gauss Control OAuth (Basic client + password / refresh_token) for position upload.
+ * Gauss Control auth for position upload.
  *
- * <p>Docs: APG2 / Autenticación - API de Login. Optional static bearer overrides OAuth.
+ * <p>Preferred (provider gateway): {@code X-Provider-Api-Key} + optional
+ * {@code X-Target-Tenant}. Fallback: static bearer or OAuth password/refresh
+ * (APG2 login docs).
  */
 @ApplicationScoped
 public class GaussAuthClient {
@@ -29,6 +31,8 @@ public class GaussAuthClient {
     /** Refresh a minute before expiry when expires_in is known. */
     private static final long SKEW_SECONDS = 60;
 
+    private final Optional<String> providerApiKey;
+    private final Optional<String> targetTenant;
     private final Optional<String> staticBearer;
     private final Optional<String> tokenUrl;
     private final Optional<String> clientId;
@@ -43,6 +47,10 @@ public class GaussAuthClient {
     private Instant accessExpiresAt = Instant.EPOCH;
 
     GaussAuthClient(
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.provider-api-key")
+                    Optional<String> providerApiKey,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.target-tenant")
+                    Optional<String> targetTenant,
             @ConfigProperty(name = "miot.integrations.retransmit.gauss.bearer-token")
                     Optional<String> staticBearer,
             @ConfigProperty(name = "miot.integrations.retransmit.gauss.oauth-token-url")
@@ -55,6 +63,8 @@ public class GaussAuthClient {
                     Optional<String> username,
             @ConfigProperty(name = "miot.integrations.retransmit.gauss.password")
                     Optional<String> password) {
+        this.providerApiKey = providerApiKey.filter(s -> s != null && !s.isBlank());
+        this.targetTenant = targetTenant.filter(s -> s != null && !s.isBlank());
         this.staticBearer = staticBearer.filter(s -> s != null && !s.isBlank());
         this.tokenUrl = tokenUrl.filter(s -> s != null && !s.isBlank());
         this.clientId = clientId.filter(s -> s != null && !s.isBlank());
@@ -67,8 +77,11 @@ public class GaussAuthClient {
                 .build();
     }
 
-    /** Whether Gauss auth is configured (static bearer or full OAuth). */
+    /** Whether any Gauss auth mode is configured. */
     public boolean isConfigured() {
+        if (providerApiKey.isPresent()) {
+            return true;
+        }
         if (staticBearer.isPresent()) {
             return true;
         }
@@ -79,11 +92,31 @@ public class GaussAuthClient {
     }
 
     /**
+     * Applies auth headers to a Gauss upload request.
+     * Prefer provider API key; else OAuth/bearer {@code Authorization}.
+     */
+    public void applyAuthHeaders(HttpRequest.Builder req) {
+        if (providerApiKey.isPresent()) {
+            req.header("X-Provider-Api-Key", providerApiKey.get().trim());
+            targetTenant.ifPresent(t -> req.header("X-Target-Tenant", t.trim()));
+            return;
+        }
+        if (!isConfigured()) {
+            LOG.warn("Gauss delivery without auth config — request will likely 401");
+            return;
+        }
+        req.header("Authorization", "bearer " + getAccessToken());
+    }
+
+    /**
      * Returns a usable access token. Refreshes or re-authenticates as needed.
      *
      * @throws IllegalStateException if auth is not configured or login fails
      */
     public String getAccessToken() {
+        if (providerApiKey.isPresent()) {
+            throw new IllegalStateException("Gauss provider API key mode does not use bearer tokens");
+        }
         if (staticBearer.isPresent()) {
             return staticBearer.get().trim();
         }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapper.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapper.java
@@ -22,6 +22,12 @@ public final class GaussPositionMapper {
     private static final DateTimeFormatter GAUSS_START =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
 
+    private static final String KEY_LATITUDE = "latitude";
+    private static final String KEY_LONGITUDE = "longitude";
+    private static final String KEY_ALTITUDE = "altitude";
+    private static final String KEY_SPEED = "speed";
+    private static final String KEY_ODOMETER = "odometer";
+
     private GaussPositionMapper() {}
 
     /**
@@ -55,10 +61,10 @@ public final class GaussPositionMapper {
                 telecom != null ? telecom.getString("gps_provider") : null,
                 defaults.eventProvider());
 
-        double lat = requireDouble(gps, "latitude");
-        double lon = requireDouble(gps, "longitude");
-        double altitude = gps.containsKey("altitude") ? gps.getDouble("altitude") : 0.0;
-        double speed = gps.containsKey("speed") ? gps.getDouble("speed") : 0.0;
+        double lat = requireDouble(gps, KEY_LATITUDE);
+        double lon = requireDouble(gps, KEY_LONGITUDE);
+        double altitude = gps.containsKey(KEY_ALTITUDE) ? gps.getDouble(KEY_ALTITUDE) : 0.0;
+        double speed = gps.containsKey(KEY_SPEED) ? gps.getDouble(KEY_SPEED) : 0.0;
         int heading = normalizeHeading(gps.getValue("heading"));
 
         boolean privacy = "privacy".equalsIgnoreCase(retransmitPayload.getString("mode"));
@@ -67,10 +73,10 @@ public final class GaussPositionMapper {
         JsonObject out = new JsonObject();
         out.put("start", formatStart(retransmitPayload.getValue("timestamp")));
         out.put("vehicleCode", vehicleCode);
-        out.put("latitude", lat);
-        out.put("longitude", lon);
-        out.put("altitude", altitude);
-        out.put("speed", speed);
+        out.put(KEY_LATITUDE, lat);
+        out.put(KEY_LONGITUDE, lon);
+        out.put(KEY_ALTITUDE, altitude);
+        out.put(KEY_SPEED, speed);
         out.put("tags", normalizeTags(defaults.tags()));
         out.putNull("driverCode");
         out.putNull("ibuttonCode");
@@ -88,8 +94,8 @@ public final class GaussPositionMapper {
         out.put("accelerometerY", 0.0);
         out.put("accelerometerZ", 9.81);
 
-        if (gps.containsKey("odometer") && gps.getValue("odometer") != null) {
-            out.put("odometer", gps.getDouble("odometer"));
+        if (gps.containsKey(KEY_ODOMETER) && gps.getValue(KEY_ODOMETER) != null) {
+            out.put(KEY_ODOMETER, gps.getDouble(KEY_ODOMETER));
         }
 
         return out;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapper.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapper.java
@@ -1,0 +1,213 @@
+package com.microboxlabs.miot.integrations.retransmit;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+
+/**
+ * Maps {@code miot.gps.retransmit@1} outbox payloads to Gauss Control
+ * <em>Inyección puntos GPS v2</em> position objects.
+ *
+ * <p>API body is a JSON array of these objects (even for a single point). See Gauss wiki
+ * {@code APG2 / Inyección puntos GPS v2}.
+ */
+public final class GaussPositionMapper {
+
+    private static final DateTimeFormatter GAUSS_START =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+
+    private GaussPositionMapper() {}
+
+    /**
+     * @param retransmitPayload outbox payload ({@code miot.gps.retransmit@1})
+     * @param defaults          tags, deviceType, eventProvider, deviceModel when source lacks them
+     */
+    public static JsonObject toGaussPosition(JsonObject retransmitPayload, Defaults defaults) {
+        if (retransmitPayload == null) {
+            throw new IllegalArgumentException("payload is required");
+        }
+        JsonObject gps = retransmitPayload.getJsonObject("gps");
+        if (gps == null) {
+            throw new IllegalArgumentException("payload.gps is required");
+        }
+
+        String vehicleCode = firstNonBlank(
+                retransmitPayload.getString("patent"),
+                retransmitPayload.getString("asset_id"),
+                "UNKNOWN");
+        String vehiclePlate = firstNonBlank(
+                retransmitPayload.getString("patent"),
+                retransmitPayload.getString("asset_id"));
+
+        JsonObject telecom = retransmitPayload.getJsonObject("telecom");
+        String deviceId = firstNonBlank(
+                telecom != null ? telecom.getString("iccid") : null,
+                retransmitPayload.getString("device_id"),
+                "streamhub-" + vehicleCode);
+
+        String eventProvider = firstNonBlank(
+                telecom != null ? telecom.getString("gps_provider") : null,
+                defaults.eventProvider());
+
+        double lat = requireDouble(gps, "latitude");
+        double lon = requireDouble(gps, "longitude");
+        double altitude = gps.containsKey("altitude") ? gps.getDouble("altitude") : 0.0;
+        double speed = gps.containsKey("speed") ? gps.getDouble("speed") : 0.0;
+        int heading = normalizeHeading(gps.getValue("heading"));
+
+        boolean privacy = "privacy".equalsIgnoreCase(retransmitPayload.getString("mode"));
+        int ignition = privacy ? 0 : 1;
+
+        JsonObject out = new JsonObject();
+        out.put("start", formatStart(retransmitPayload.getValue("timestamp")));
+        out.put("vehicleCode", vehicleCode);
+        out.put("latitude", lat);
+        out.put("longitude", lon);
+        out.put("altitude", altitude);
+        out.put("speed", speed);
+        out.put("tags", normalizeTags(defaults.tags()));
+        out.putNull("driverCode");
+        out.putNull("ibuttonCode");
+        if (vehiclePlate != null) {
+            out.put("vehiclePlate", vehiclePlate);
+        }
+        out.put("deviceType", defaults.deviceType());
+        out.put("deviceId", deviceId);
+        out.put("headingAngle", heading);
+        out.put("eventProvider", eventProvider != null ? eventProvider : defaults.eventProvider());
+        out.put("deviceModel", defaults.deviceModel());
+        out.put("ignition", ignition);
+        // Required by v2; enrichment does not always carry accelerometer — use gravity Z default.
+        out.put("accelerometerX", 0.0);
+        out.put("accelerometerY", 0.0);
+        out.put("accelerometerZ", 9.81);
+
+        if (gps.containsKey("odometer") && gps.getValue("odometer") != null) {
+            out.put("odometer", gps.getDouble("odometer"));
+        }
+
+        return out;
+    }
+
+    /** Gauss expects a JSON array body even for one point. */
+    public static JsonArray toGaussBody(JsonObject retransmitPayload, Defaults defaults) {
+        return new JsonArray().add(toGaussPosition(retransmitPayload, defaults));
+    }
+
+    static String formatStart(Object timestamp) {
+        if (timestamp == null) {
+            return GAUSS_START.format(Instant.now());
+        }
+        if (timestamp instanceof Number n) {
+            long epoch = n.longValue();
+            // Heuristic: ms vs s
+            Instant instant = epoch > 1_000_000_000_000L
+                    ? Instant.ofEpochMilli(epoch)
+                    : Instant.ofEpochSecond(epoch);
+            return GAUSS_START.format(instant);
+        }
+        String raw = String.valueOf(timestamp).trim();
+        if (raw.isEmpty()) {
+            return GAUSS_START.format(Instant.now());
+        }
+        // Already Gauss-ish
+        if (raw.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}")) {
+            return raw;
+        }
+        try {
+            return GAUSS_START.format(OffsetDateTime.parse(raw).toInstant());
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+        try {
+            return GAUSS_START.format(Instant.parse(raw));
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+        try {
+            LocalDateTime ldt = LocalDateTime.parse(raw, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            return GAUSS_START.format(ldt.toInstant(ZoneOffset.UTC));
+        } catch (DateTimeParseException e) {
+            return GAUSS_START.format(Instant.now());
+        }
+    }
+
+    /**
+     * Docs: each tag delimited with {@code ;} before and after, e.g. {@code ;MEL;ZALDIVAR;}.
+     */
+    static String normalizeTags(String tags) {
+        if (tags == null || tags.isBlank()) {
+            return ";MEL;";
+        }
+        String t = tags.trim();
+        if (!t.startsWith(";")) {
+            t = ";" + t;
+        }
+        if (!t.endsWith(";")) {
+            t = t + ";";
+        }
+        return t;
+    }
+
+    static int normalizeHeading(Object heading) {
+        if (heading == null) {
+            return 0;
+        }
+        double d = heading instanceof Number n ? n.doubleValue() : Double.parseDouble(String.valueOf(heading));
+        int h = (int) Math.round(d) % 360;
+        return h < 0 ? h + 360 : h;
+    }
+
+    private static double requireDouble(JsonObject obj, String key) {
+        Object v = obj.getValue(key);
+        if (v == null) {
+            throw new IllegalArgumentException("gps." + key + " is required");
+        }
+        if (v instanceof Number n) {
+            return n.doubleValue();
+        }
+        return Double.parseDouble(String.valueOf(v));
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String v : values) {
+            if (v != null && !v.isBlank()) {
+                return v.trim();
+            }
+        }
+        return null;
+    }
+
+    public record Defaults(
+            String tags,
+            String deviceType,
+            String eventProvider,
+            String deviceModel) {
+
+        public static Defaults fromConfig(
+                String tags, String deviceType, String eventProvider, String deviceModel) {
+            return new Defaults(
+                    tags == null || tags.isBlank() ? ";MEL;" : tags,
+                    deviceType == null || deviceType.isBlank() ? "gps" : deviceType,
+                    eventProvider == null || eventProvider.isBlank() ? "streamhub" : eventProvider,
+                    deviceModel == null || deviceModel.isBlank() ? "streamhub-miot" : deviceModel);
+        }
+
+        public static Defaults ofMap(Map<String, String> map) {
+            return fromConfig(
+                    map.get("tags"),
+                    map.get("deviceType"),
+                    map.get("eventProvider"),
+                    map.get("deviceModel"));
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
@@ -3,7 +3,9 @@ package com.microboxlabs.miot.integrations.retransmit;
 import com.microboxlabs.miot.integrations.domain.RetransmitDelivery;
 import com.microboxlabs.miot.integrations.domain.WebhookDeliveryState;
 import com.microboxlabs.miot.integrations.persistence.RetransmitDeliveryRepository;
+import com.microboxlabs.miot.integrations.retransmit.GaussPositionMapper.Defaults;
 import io.quarkus.scheduler.Scheduled;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.net.URI;
@@ -14,6 +16,8 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -21,6 +25,10 @@ import org.jboss.logging.Logger;
 /**
  * Claims PENDING retransmit outbox rows and POSTs payloads. Separate from the
  * Pulsar consume loop so slow destinations never nack the enriched topic.
+ *
+ * <p>When the destination is a Gauss Control position API (or
+ * {@code miot.integrations.retransmit.payload-format=gauss}), the body is mapped
+ * to <em>Inyección puntos GPS v2</em> (JSON array + Bearer auth).
  */
 @ApplicationScoped
 public class RetransmitDeliveryJob {
@@ -29,16 +37,20 @@ public class RetransmitDeliveryJob {
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(15);
 
     private final RetransmitDeliveryRepository repository;
+    private final GaussAuthClient gaussAuth;
     private final boolean workerEnabled;
     private final int claimLimit;
     private final int leaseSeconds;
     private final int retryBaseSeconds;
     private final int retryMaxSeconds;
+    private final String payloadFormat;
+    private final Defaults gaussDefaults;
     private final String workerId;
     private final HttpClient httpClient;
 
     RetransmitDeliveryJob(
             RetransmitDeliveryRepository repository,
+            GaussAuthClient gaussAuth,
             @ConfigProperty(name = "miot.integrations.retransmit.worker.enabled", defaultValue = "false")
                     boolean workerEnabled,
             @ConfigProperty(name = "miot.integrations.retransmit.claim-limit", defaultValue = "20")
@@ -48,17 +60,36 @@ public class RetransmitDeliveryJob {
             @ConfigProperty(name = "miot.integrations.retransmit.retry-base-seconds", defaultValue = "30")
                     int retryBaseSeconds,
             @ConfigProperty(name = "miot.integrations.retransmit.retry-max-seconds", defaultValue = "900")
-                    int retryMaxSeconds) {
+                    int retryMaxSeconds,
+            @ConfigProperty(
+                            name = "miot.integrations.retransmit.payload-format",
+                            defaultValue = "auto")
+                    String payloadFormat,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.tags", defaultValue = ";MEL;")
+                    String gaussTags,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.device-type", defaultValue = "gps")
+                    String gaussDeviceType,
+            @ConfigProperty(
+                            name = "miot.integrations.retransmit.gauss.event-provider",
+                            defaultValue = "streamhub")
+                    String gaussEventProvider,
+            @ConfigProperty(
+                            name = "miot.integrations.retransmit.gauss.device-model",
+                            defaultValue = "streamhub-miot")
+                    String gaussDeviceModel) {
         this.repository = repository;
+        this.gaussAuth = gaussAuth;
         this.workerEnabled = workerEnabled;
         this.claimLimit = claimLimit;
         this.leaseSeconds = leaseSeconds;
         this.retryBaseSeconds = retryBaseSeconds;
         this.retryMaxSeconds = retryMaxSeconds;
+        this.payloadFormat = payloadFormat == null ? "auto" : payloadFormat.trim().toLowerCase(Locale.ROOT);
+        this.gaussDefaults = Defaults.fromConfig(gaussTags, gaussDeviceType, gaussEventProvider, gaussDeviceModel);
         this.workerId = "retransmit-" + UUID.randomUUID().toString().substring(0, 8);
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build();
     }
 
@@ -82,33 +113,116 @@ public class RetransmitDeliveryJob {
     void deliverOne(RetransmitDelivery delivery) {
         UUID id = UUID.fromString(delivery.id());
         try {
-            String body = new JsonObject(delivery.payload()).encode();
-            HttpRequest request = HttpRequest.newBuilder()
+            boolean gauss = useGaussFormat(delivery);
+            String body;
+            HttpRequest.Builder req = HttpRequest.newBuilder()
                     .uri(URI.create(delivery.destinationUrl()))
                     .timeout(HTTP_TIMEOUT)
                     .header("Content-Type", "application/json")
                     .header("User-Agent", "ModularIoT-Retransmit/1.0")
-                    .header("X-Miot-Retransmit-Config", delivery.configId())
-                    .POST(HttpRequest.BodyPublishers.ofString(body))
-                    .build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            int code = response.statusCode();
-            if (code >= 200 && code < 300) {
-                repository.markSucceeded(id, workerId, code);
-                LOG.debugf("Retransmit delivered id=%s status=%d", delivery.id(), code);
-                return;
+                    .header("X-Miot-Retransmit-Config", delivery.configId());
+
+            if (gauss) {
+                JsonObject payload = new JsonObject(delivery.payload());
+                JsonArray gaussBody = GaussPositionMapper.toGaussBody(payload, gaussDefaults);
+                body = gaussBody.encode();
+                attachGaussAuth(req, false);
+            } else {
+                body = new JsonObject(delivery.payload()).encode();
             }
-            failOrRetry(delivery, id, code, "HTTP " + code);
+
+            HttpResponse<String> response = httpClient.send(
+                    req.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+                    HttpResponse.BodyHandlers.ofString());
+            int code = response.statusCode();
+
+            // One retry after re-auth on 401 for Gauss
+            if (gauss && code == 401) {
+                gaussAuth.invalidate();
+                HttpRequest.Builder retry = HttpRequest.newBuilder()
+                        .uri(URI.create(delivery.destinationUrl()))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Content-Type", "application/json")
+                        .header("User-Agent", "ModularIoT-Retransmit/1.0")
+                        .header("X-Miot-Retransmit-Config", delivery.configId());
+                attachGaussAuth(retry, true);
+                response = httpClient.send(
+                        retry.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+                        HttpResponse.BodyHandlers.ofString());
+                code = response.statusCode();
+            }
+
+            handleResponse(delivery, id, code, response.body(), gauss);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            failOrRetry(delivery, id, null, "interrupted: " + e.getMessage());
+            failOrRetry(delivery, id, null, "interrupted: " + e.getMessage(), true);
         } catch (Exception e) {
-            failOrRetry(delivery, id, null, e.getMessage());
+            failOrRetry(delivery, id, null, e.getMessage(), true);
         }
     }
 
-    private void failOrRetry(RetransmitDelivery delivery, UUID id, Integer statusCode, String error) {
-        boolean exhausted = delivery.attempts() >= delivery.maxAttempts();
+    private void attachGaussAuth(HttpRequest.Builder req, boolean force) {
+        if (force) {
+            gaussAuth.invalidate();
+        }
+        if (!gaussAuth.isConfigured()) {
+            LOG.warn("Gauss delivery without auth config — request will likely 401");
+            return;
+        }
+        String token = gaussAuth.getAccessToken();
+        req.header("Authorization", "bearer " + token);
+    }
+
+    private void handleResponse(
+            RetransmitDelivery delivery, UUID id, int code, String responseBody, boolean gauss) {
+        if (code >= 200 && code < 300) {
+            repository.markSucceeded(id, workerId, code);
+            LOG.infof(
+                    "Retransmit delivered id=%s config=%s asset=%s status=%d gauss=%s",
+                    delivery.id(),
+                    delivery.configId(),
+                    delivery.assetId(),
+                    code,
+                    gauss);
+            return;
+        }
+        // Gauss 409 = partial business rejection (unknown vehicle/driver or validation).
+        // Do not spin forever: mark DEAD with response snippet.
+        if (gauss && code == 409) {
+            String err = "Gauss 409: " + truncate(responseBody);
+            repository.markRetryOrDead(
+                    id, workerId, WebhookDeliveryState.DEAD, null, code, err);
+            LOG.warnf(
+                    "Retransmit DEAD (Gauss business reject) id=%s asset=%s %s",
+                    delivery.id(),
+                    delivery.assetId(),
+                    err);
+            return;
+        }
+        if (code == 401 || code == 403) {
+            failOrRetry(delivery, id, code, "HTTP " + code + ": " + truncate(responseBody), false);
+            return;
+        }
+        failOrRetry(delivery, id, code, "HTTP " + code + ": " + truncate(responseBody), true);
+    }
+
+    private boolean useGaussFormat(RetransmitDelivery delivery) {
+        if ("gauss".equals(payloadFormat)) {
+            return true;
+        }
+        if ("raw".equals(payloadFormat) || "miot".equals(payloadFormat)) {
+            return false;
+        }
+        // auto
+        String url = Optional.ofNullable(delivery.destinationUrl()).orElse("").toLowerCase(Locale.ROOT);
+        return url.contains("gausscontrol")
+                || url.contains("positionupdate")
+                || url.contains("/processor/events/");
+    }
+
+    private void failOrRetry(
+            RetransmitDelivery delivery, UUID id, Integer statusCode, String error, boolean retryable) {
+        boolean exhausted = !retryable || delivery.attempts() >= delivery.maxAttempts();
         WebhookDeliveryState next = exhausted ? WebhookDeliveryState.DEAD : WebhookDeliveryState.PENDING;
         OffsetDateTime retryAt = exhausted ? null : nextRetryAt(delivery.attempts());
         repository.markRetryOrDead(id, workerId, next, retryAt, statusCode, truncate(error));

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
@@ -87,7 +87,7 @@ public class RetransmitDeliveryJob {
                 JsonObject payload = new JsonObject(delivery.payload());
                 JsonArray gaussBody = GaussPositionMapper.toGaussBody(payload, settings.gaussDefaults());
                 body = gaussBody.encode();
-                attachGaussAuth(req, false);
+                gaussAuth.applyAuthHeaders(req);
             } else {
                 body = new JsonObject(delivery.payload()).encode();
             }
@@ -97,7 +97,7 @@ public class RetransmitDeliveryJob {
                     HttpResponse.BodyHandlers.ofString());
             int code = response.statusCode();
 
-            // One retry after re-auth on 401 for Gauss
+            // One retry after re-auth on 401 for Gauss (OAuth/bearer; API-key mode is static)
             if (gauss && code == 401) {
                 gaussAuth.invalidate();
                 HttpRequest.Builder retry = HttpRequest.newBuilder()
@@ -106,7 +106,7 @@ public class RetransmitDeliveryJob {
                         .header("Content-Type", "application/json")
                         .header("User-Agent", "ModularIoT-Retransmit/1.0")
                         .header("X-Miot-Retransmit-Config", delivery.configId());
-                attachGaussAuth(retry, true);
+                gaussAuth.applyAuthHeaders(retry);
                 response = httpClient.send(
                         retry.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -120,18 +120,6 @@ public class RetransmitDeliveryJob {
         } catch (Exception e) {
             failOrRetry(delivery, id, null, e.getMessage(), true);
         }
-    }
-
-    private void attachGaussAuth(HttpRequest.Builder req, boolean force) {
-        if (force) {
-            gaussAuth.invalidate();
-        }
-        if (!gaussAuth.isConfigured()) {
-            LOG.warn("Gauss delivery without auth config — request will likely 401");
-            return;
-        }
-        String token = gaussAuth.getAccessToken();
-        req.header("Authorization", "bearer " + token);
     }
 
     private void handleResponse(

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
@@ -3,7 +3,6 @@ package com.microboxlabs.miot.integrations.retransmit;
 import com.microboxlabs.miot.integrations.domain.RetransmitDelivery;
 import com.microboxlabs.miot.integrations.domain.WebhookDeliveryState;
 import com.microboxlabs.miot.integrations.persistence.RetransmitDeliveryRepository;
-import com.microboxlabs.miot.integrations.retransmit.GaussPositionMapper.Defaults;
 import io.quarkus.scheduler.Scheduled;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -19,7 +18,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 /**
@@ -38,54 +36,17 @@ public class RetransmitDeliveryJob {
 
     private final RetransmitDeliveryRepository repository;
     private final GaussAuthClient gaussAuth;
-    private final boolean workerEnabled;
-    private final int claimLimit;
-    private final int leaseSeconds;
-    private final int retryBaseSeconds;
-    private final int retryMaxSeconds;
-    private final String payloadFormat;
-    private final Defaults gaussDefaults;
+    private final RetransmitDeliverySettings settings;
     private final String workerId;
     private final HttpClient httpClient;
 
     RetransmitDeliveryJob(
             RetransmitDeliveryRepository repository,
             GaussAuthClient gaussAuth,
-            @ConfigProperty(name = "miot.integrations.retransmit.worker.enabled", defaultValue = "false")
-                    boolean workerEnabled,
-            @ConfigProperty(name = "miot.integrations.retransmit.claim-limit", defaultValue = "20")
-                    int claimLimit,
-            @ConfigProperty(name = "miot.integrations.retransmit.lease-seconds", defaultValue = "60")
-                    int leaseSeconds,
-            @ConfigProperty(name = "miot.integrations.retransmit.retry-base-seconds", defaultValue = "30")
-                    int retryBaseSeconds,
-            @ConfigProperty(name = "miot.integrations.retransmit.retry-max-seconds", defaultValue = "900")
-                    int retryMaxSeconds,
-            @ConfigProperty(
-                            name = "miot.integrations.retransmit.payload-format",
-                            defaultValue = "auto")
-                    String payloadFormat,
-            @ConfigProperty(name = "miot.integrations.retransmit.gauss.tags", defaultValue = ";MEL;")
-                    String gaussTags,
-            @ConfigProperty(name = "miot.integrations.retransmit.gauss.device-type", defaultValue = "gps")
-                    String gaussDeviceType,
-            @ConfigProperty(
-                            name = "miot.integrations.retransmit.gauss.event-provider",
-                            defaultValue = "streamhub")
-                    String gaussEventProvider,
-            @ConfigProperty(
-                            name = "miot.integrations.retransmit.gauss.device-model",
-                            defaultValue = "streamhub-miot")
-                    String gaussDeviceModel) {
+            RetransmitDeliverySettings settings) {
         this.repository = repository;
         this.gaussAuth = gaussAuth;
-        this.workerEnabled = workerEnabled;
-        this.claimLimit = claimLimit;
-        this.leaseSeconds = leaseSeconds;
-        this.retryBaseSeconds = retryBaseSeconds;
-        this.retryMaxSeconds = retryMaxSeconds;
-        this.payloadFormat = payloadFormat == null ? "auto" : payloadFormat.trim().toLowerCase(Locale.ROOT);
-        this.gaussDefaults = Defaults.fromConfig(gaussTags, gaussDeviceType, gaussEventProvider, gaussDeviceModel);
+        this.settings = settings;
         this.workerId = "retransmit-" + UUID.randomUUID().toString().substring(0, 8);
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
@@ -95,14 +56,14 @@ public class RetransmitDeliveryJob {
 
     @Scheduled(every = "${miot.integrations.retransmit.claim-every:5s}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void claimAndDeliver() {
-        if (!workerEnabled) {
+        if (!settings.workerEnabled()) {
             return;
         }
         // Claim one row at a time so a slow HTTP POST cannot expire later leases
         // from a multi-row claim while this worker is still serializing delivery.
-        int remaining = Math.max(claimLimit, 1);
+        int remaining = Math.max(settings.claimLimit(), 1);
         while (remaining-- > 0) {
-            List<RetransmitDelivery> batch = repository.claim(workerId, 1, leaseSeconds);
+            List<RetransmitDelivery> batch = repository.claim(workerId, 1, settings.leaseSeconds());
             if (batch.isEmpty()) {
                 return;
             }
@@ -124,7 +85,7 @@ public class RetransmitDeliveryJob {
 
             if (gauss) {
                 JsonObject payload = new JsonObject(delivery.payload());
-                JsonArray gaussBody = GaussPositionMapper.toGaussBody(payload, gaussDefaults);
+                JsonArray gaussBody = GaussPositionMapper.toGaussBody(payload, settings.gaussDefaults());
                 body = gaussBody.encode();
                 attachGaussAuth(req, false);
             } else {
@@ -207,10 +168,11 @@ public class RetransmitDeliveryJob {
     }
 
     private boolean useGaussFormat(RetransmitDelivery delivery) {
-        if ("gauss".equals(payloadFormat)) {
+        String format = settings.payloadFormat();
+        if ("gauss".equals(format)) {
             return true;
         }
-        if ("raw".equals(payloadFormat) || "miot".equals(payloadFormat)) {
+        if ("raw".equals(format) || "miot".equals(format)) {
             return false;
         }
         // auto
@@ -245,8 +207,8 @@ public class RetransmitDeliveryJob {
 
     private OffsetDateTime nextRetryAt(int attempts) {
         long delay = Math.min(
-                retryMaxSeconds,
-                (long) retryBaseSeconds * (1L << Math.min(Math.max(attempts - 1, 0), 8)));
+                settings.retryMaxSeconds(),
+                (long) settings.retryBaseSeconds() * (1L << Math.min(Math.max(attempts - 1, 0), 8)));
         return OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(delay);
     }
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
@@ -1,0 +1,92 @@
+package com.microboxlabs.miot.integrations.retransmit;
+
+import com.microboxlabs.miot.integrations.retransmit.GaussPositionMapper.Defaults;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import java.util.Locale;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Groups retransmit delivery config so {@link RetransmitDeliveryJob} stays within
+ * constructor-parameter limits (Sonar java:S107).
+ */
+@ApplicationScoped
+public class RetransmitDeliverySettings {
+
+    private final boolean workerEnabled;
+    private final int claimLimit;
+    private final int leaseSeconds;
+    private final int retryBaseSeconds;
+    private final int retryMaxSeconds;
+    private final String payloadFormat;
+    private final Defaults gaussDefaults;
+
+    RetransmitDeliverySettings(
+            @ConfigProperty(name = "miot.integrations.retransmit.worker.enabled", defaultValue = "false")
+                    boolean workerEnabled,
+            @ConfigProperty(name = "miot.integrations.retransmit.claim-limit", defaultValue = "20")
+                    int claimLimit,
+            @ConfigProperty(name = "miot.integrations.retransmit.lease-seconds", defaultValue = "60")
+                    int leaseSeconds,
+            @ConfigProperty(name = "miot.integrations.retransmit.retry-base-seconds", defaultValue = "30")
+                    int retryBaseSeconds,
+            @ConfigProperty(name = "miot.integrations.retransmit.retry-max-seconds", defaultValue = "900")
+                    int retryMaxSeconds,
+            @ConfigProperty(name = "miot.integrations.retransmit.payload-format", defaultValue = "auto")
+                    String payloadFormat,
+            Defaults gaussDefaults) {
+        this.workerEnabled = workerEnabled;
+        this.claimLimit = claimLimit;
+        this.leaseSeconds = leaseSeconds;
+        this.retryBaseSeconds = retryBaseSeconds;
+        this.retryMaxSeconds = retryMaxSeconds;
+        this.payloadFormat = payloadFormat == null ? "auto" : payloadFormat.trim().toLowerCase(Locale.ROOT);
+        this.gaussDefaults = gaussDefaults;
+    }
+
+    @Produces
+    @ApplicationScoped
+    static Defaults gaussDefaults(
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.tags", defaultValue = ";MEL;")
+                    String gaussTags,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.device-type", defaultValue = "gps")
+                    String gaussDeviceType,
+            @ConfigProperty(
+                            name = "miot.integrations.retransmit.gauss.event-provider",
+                            defaultValue = "streamhub")
+                    String gaussEventProvider,
+            @ConfigProperty(
+                            name = "miot.integrations.retransmit.gauss.device-model",
+                            defaultValue = "streamhub-miot")
+                    String gaussDeviceModel) {
+        return Defaults.fromConfig(gaussTags, gaussDeviceType, gaussEventProvider, gaussDeviceModel);
+    }
+
+    boolean workerEnabled() {
+        return workerEnabled;
+    }
+
+    int claimLimit() {
+        return claimLimit;
+    }
+
+    int leaseSeconds() {
+        return leaseSeconds;
+    }
+
+    int retryBaseSeconds() {
+        return retryBaseSeconds;
+    }
+
+    int retryMaxSeconds() {
+        return retryMaxSeconds;
+    }
+
+    String payloadFormat() {
+        return payloadFormat;
+    }
+
+    Defaults gaussDefaults() {
+        return gaussDefaults;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitMatchService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitMatchService.java
@@ -25,6 +25,10 @@ public class RetransmitMatchService {
     private final RetransmitDeliveryRepository deliveryRepository;
     private final Optional<String> defaultDestinationUrl;
     private final int maxAttempts;
+    /** Optional privacy pin from env/secret (preferred over SQL seed for non-public coords). */
+    private final Optional<Double> privacyPinLat;
+    private final Optional<Double> privacyPinLon;
+    private final Optional<String> privacyPinLabel;
 
     RetransmitMatchService(
             StreamhubGpsClient gpsClient,
@@ -32,11 +36,20 @@ public class RetransmitMatchService {
             @ConfigProperty(name = "miot.integrations.retransmit.default-url")
                     Optional<String> defaultDestinationUrl,
             @ConfigProperty(name = "miot.integrations.retransmit.max-attempts", defaultValue = "5")
-                    int maxAttempts) {
+                    int maxAttempts,
+            @ConfigProperty(name = "miot.integrations.retransmit.privacy-pin.lat")
+                    Optional<Double> privacyPinLat,
+            @ConfigProperty(name = "miot.integrations.retransmit.privacy-pin.lon")
+                    Optional<Double> privacyPinLon,
+            @ConfigProperty(name = "miot.integrations.retransmit.privacy-pin.label")
+                    Optional<String> privacyPinLabel) {
         this.gpsClient = gpsClient;
         this.deliveryRepository = deliveryRepository;
         this.defaultDestinationUrl = defaultDestinationUrl;
         this.maxAttempts = maxAttempts;
+        this.privacyPinLat = privacyPinLat;
+        this.privacyPinLon = privacyPinLon;
+        this.privacyPinLabel = privacyPinLabel.filter(s -> s != null && !s.isBlank());
     }
 
     /**
@@ -112,6 +125,8 @@ public class RetransmitMatchService {
             return false;
         }
 
+        applyPrivacyPinOverride(payload);
+
         String dedupeKey = buildDedupeKey(payload);
         Map<String, Object> body = new LinkedHashMap<>(payload.getMap());
         body.remove("destination_url");
@@ -132,6 +147,30 @@ public class RetransmitMatchService {
                     dedupeKey);
         }
         return inserted;
+    }
+
+    /**
+     * When mode is privacy and env pin lat/lon are set, overwrite GPS (and label).
+     * Keeps sensitive coordinates out of public SQL seeds / git.
+     */
+    void applyPrivacyPinOverride(JsonObject payload) {
+        if (payload == null || !"privacy".equalsIgnoreCase(payload.getString("mode"))) {
+            return;
+        }
+        if (privacyPinLat.isEmpty() || privacyPinLon.isEmpty()) {
+            return;
+        }
+        JsonObject gps = payload.getJsonObject("gps");
+        if (gps == null) {
+            gps = new JsonObject();
+            payload.put("gps", gps);
+        }
+        gps.put("latitude", privacyPinLat.get());
+        gps.put("longitude", privacyPinLon.get());
+        gps.put("fixed", true);
+        if (privacyPinLabel.isPresent()) {
+            gps.put("label", privacyPinLabel.get());
+        }
     }
 
     static List<JsonObject> extractPayloads(Object data) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapperTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/retransmit/GaussPositionMapperTest.java
@@ -1,0 +1,114 @@
+package com.microboxlabs.miot.integrations.retransmit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.retransmit.GaussPositionMapper.Defaults;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+class GaussPositionMapperTest {
+
+    private final Defaults defaults = Defaults.fromConfig(";MEL;", "gps", "streamhub", "streamhub-miot");
+
+    @Test
+    void mapsFullModeFromRetransmitPayload() {
+        JsonObject payload = new JsonObject()
+                .put("spec", "miot.gps.retransmit@1")
+                .put("mode", "full")
+                .put("config_id", "mel-gauss")
+                .put("asset_id", "VKFR64")
+                .put("patent", "VKFR64")
+                .put("timestamp", "2026-07-10T18:56:18+00:00")
+                .put(
+                        "gps",
+                        new JsonObject()
+                                .put("latitude", -24.339208)
+                                .put("longitude", -69.060755)
+                                .put("altitude", 3189)
+                                .put("speed", 12.5)
+                                .put("heading", 159))
+                .put(
+                        "telecom",
+                        new JsonObject()
+                                .put("gps_provider", "QuecLink")
+                                .put("iccid", "8956012345678901234"));
+
+        JsonObject gauss = GaussPositionMapper.toGaussPosition(payload, defaults);
+
+        assertEquals("2026-07-10 18:56:18", gauss.getString("start"));
+        assertEquals("VKFR64", gauss.getString("vehicleCode"));
+        assertEquals("VKFR64", gauss.getString("vehiclePlate"));
+        assertEquals(-24.339208, gauss.getDouble("latitude"), 1e-9);
+        assertEquals(-69.060755, gauss.getDouble("longitude"), 1e-9);
+        assertEquals(3189.0, gauss.getDouble("altitude"), 1e-9);
+        assertEquals(12.5, gauss.getDouble("speed"), 1e-9);
+        assertEquals(159, gauss.getInteger("headingAngle"));
+        assertEquals(";MEL;", gauss.getString("tags"));
+        assertEquals("gps", gauss.getString("deviceType"));
+        assertEquals("8956012345678901234", gauss.getString("deviceId"));
+        assertEquals("QuecLink", gauss.getString("eventProvider"));
+        assertEquals("streamhub-miot", gauss.getString("deviceModel"));
+        assertEquals(1, gauss.getInteger("ignition"));
+        assertNull(gauss.getValue("driverCode"));
+        assertNull(gauss.getValue("ibuttonCode"));
+        assertEquals(0.0, gauss.getDouble("accelerometerX"), 1e-9);
+        assertEquals(9.81, gauss.getDouble("accelerometerZ"), 1e-9);
+    }
+
+    @Test
+    void mapsPrivacyModeWithZerosAndOffIgnition() {
+        JsonObject payload = new JsonObject()
+                .put("mode", "privacy")
+                .put("asset_id", "VHTC24")
+                .put("timestamp", "2026-07-10T18:54:38+00:00")
+                .put(
+                        "gps",
+                        new JsonObject()
+                                .put("latitude", -33.45)
+                                .put("longitude", -70.66)
+                                .put("fixed", true)
+                                .put("label", "privacy-pin"));
+
+        JsonObject gauss = GaussPositionMapper.toGaussPosition(payload, defaults);
+        assertEquals(0.0, gauss.getDouble("speed"), 1e-9);
+        assertEquals(0, gauss.getInteger("headingAngle"));
+        assertEquals(0, gauss.getInteger("ignition"));
+        assertEquals("streamhub-VHTC24", gauss.getString("deviceId"));
+        assertEquals("streamhub", gauss.getString("eventProvider"));
+    }
+
+    @Test
+    void bodyIsJsonArray() {
+        JsonObject payload = new JsonObject()
+                .put("asset_id", "ABC12")
+                .put("timestamp", "2026-02-24T13:45:10Z")
+                .put("gps", new JsonObject().put("latitude", 1.0).put("longitude", 2.0));
+        JsonArray body = GaussPositionMapper.toGaussBody(payload, defaults);
+        assertEquals(1, body.size());
+        assertEquals("ABC12", body.getJsonObject(0).getString("vehicleCode"));
+    }
+
+    @Test
+    void normalizeTagsAddsSemicolons() {
+        assertEquals(";MEL;", GaussPositionMapper.normalizeTags("MEL"));
+        assertEquals(";MEL;ZALDIVAR;", GaussPositionMapper.normalizeTags(";MEL;ZALDIVAR"));
+        assertEquals(";MEL;", GaussPositionMapper.normalizeTags(null));
+    }
+
+    @Test
+    void formatStartAcceptsIso() {
+        assertEquals("2026-02-24 13:45:10", GaussPositionMapper.formatStart("2026-02-24T13:45:10Z"));
+        assertTrue(GaussPositionMapper.formatStart(null).matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"));
+    }
+
+    @Test
+    void headingWraps() {
+        assertEquals(0, GaussPositionMapper.normalizeHeading(360));
+        assertEquals(32, GaussPositionMapper.normalizeHeading(32.4));
+        assertFalse(GaussPositionMapper.normalizeHeading(-1) < 0);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/retransmit/RetransmitMatchServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/retransmit/RetransmitMatchServiceTest.java
@@ -1,13 +1,47 @@
 package com.microboxlabs.miot.integrations.retransmit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class RetransmitMatchServiceTest {
+
+    @Test
+    void applyPrivacyPinOverride_fromEnv() {
+        RetransmitMatchService svc = new RetransmitMatchService(
+                null,
+                null,
+                Optional.empty(),
+                5,
+                Optional.of(-33.55),
+                Optional.of(-70.69),
+                Optional.of("test-pin"));
+        JsonObject payload = new JsonObject()
+                .put("mode", "privacy")
+                .put("gps", new JsonObject().put("latitude", 0).put("longitude", 0));
+        svc.applyPrivacyPinOverride(payload);
+        assertEquals(-33.55, payload.getJsonObject("gps").getDouble("latitude"), 1e-9);
+        assertEquals(-70.69, payload.getJsonObject("gps").getDouble("longitude"), 1e-9);
+        assertTrue(payload.getJsonObject("gps").getBoolean("fixed"));
+        assertEquals("test-pin", payload.getJsonObject("gps").getString("label"));
+    }
+
+    @Test
+    void applyPrivacyPinOverride_skipsFullMode() {
+        RetransmitMatchService svc = new RetransmitMatchService(
+                null, null, Optional.empty(), 5, Optional.of(1.0), Optional.of(2.0), Optional.empty());
+        JsonObject payload = new JsonObject()
+                .put("mode", "full")
+                .put("gps", new JsonObject().put("latitude", -24.0).put("longitude", -69.0));
+        svc.applyPrivacyPinOverride(payload);
+        assertEquals(-24.0, payload.getJsonObject("gps").getDouble("latitude"), 1e-9);
+    }
+
 
     @Test
     void extractPayloads_singleObject() {


### PR DESCRIPTION
## Summary

Follow-up after #904 (retransmit worker on trunk).

1. **Gauss GPS v2 delivery** ([Inyección puntos GPS v2](https://gausscontrol.atlassian.net/wiki/spaces/APG2/pages/4933845095))
   - Map `miot.gps.retransmit@1` → Gauss position object
   - POST body as JSON **array**
   - Auth: static bearer or OAuth password grant + refresh
   - `payload-format`: `auto` | `gauss` | `raw`

2. **Privacy pin from env/secret** (not public git)
   - `MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LAT` / `_LON` / `_LABEL`
   - Applied on `mode=privacy` before enqueue
   - SQL seed keeps a non-sensitive placeholder

### Classes
- `GaussPositionMapper`, `GaussAuthClient`
- `RetransmitDeliveryJob` (format + auth)
- `RetransmitMatchService.applyPrivacyPinOverride`

## Test plan
- [x] Unit tests: mapper + privacy pin override
- [ ] Deploy with `payload-format=gauss` + echo URL (dry-run)
- [ ] Privacy pin secret wired; privacy posts use env coords
- [ ] Full mode still uses real MEL coords
- [ ] Real Gauss: OAuth secret + upload URL

Supersedes open #907 if still open (same work, clean branch off current trunk).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable GPS payload formatting for raw and GAUSS submissions.
  * Added GAUSS authentication options, including API keys, bearer tokens, and OAuth credentials.
  * Added automatic GAUSS GPS payload mapping with configurable device and provider details.
  * Added privacy-mode GPS pin overrides using configured coordinates and labels.
* **Bug Fixes**
  * Improved delivery response handling, authentication retries, and retryable failure behavior.
  * Added clearer handling for authorization failures and terminal GAUSS rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->