### PR TITLE
added hiding searchbar capabilities through .env

### DIFF
--- a/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx
@@ -30,6 +30,11 @@ export default async function SecuredLayout({
     redirect(`/${lang}/sign-in`);
   }
   const initialOrgLogo = await getPublicOrgLogo();
+  // Server-only flag: kept off NEXT_PUBLIC_ so it never ships to the client
+  // bundle. When false/unset, SpotlightSearch isn't rendered at all below,
+  // which also removes its Cmd+K listener — there's no client-side toggle
+  // to bypass.
+  const isSeachEnabled = process.env.ENABLE_SEARCHBAR === "true";
   return (
     <RuntimeConfigProvider>
       <SidebarProvider>
@@ -42,7 +47,7 @@ export default async function SecuredLayout({
             messages={navBarMessages}
             dict={dictionary as I18nRecord}
             initialOrgLogo={initialOrgLogo}
-            isSeachEnabled={true}
+            isSeachEnabled={isSeachEnabled}
           />
           <div
             data-testid="content-with-sidebar"


### PR DESCRIPTION
Allowing dishability of the searchbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality in the secured area can now be enabled or disabled through deployment configuration.
  * The search interface and its keyboard shortcut are only available when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->