### PR TITLE
chore(release): prepare MIOT stack v0.5.23

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miot-harness"
-version = "0.1.2"
+version = "0.1.3"
 description = "ASK MIOT multi-agent backend harness pilot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1415,7 +1415,7 @@ wheels = [
 
 [[package]]
 name = "miot-harness"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/releases/notes/v1.31.22.mdx
+++ b/releases/notes/v1.31.22.mdx
@@ -1,0 +1,42 @@
+# 🔔 Release Notes v1.31.22 — ModularIoT
+
+### Fecha: 13/07/2026
+
+**Objetivo**: Esta versión refuerza la estabilidad operativa de la app en dashboards y avanza capacidades del stack para asistentes con contexto más eficiente. El foco combina corrección de experiencia de usuario y preparación de mejoras evolutivas en `harness`.
+
+## 🚀 Evolutivos
+
+- **📍 Carga diferida de skills en el loop del agente** *(Integración OSS — MIOT-0.5.23)*
+  - **Key point**: Se prepara un mecanismo de *progressive disclosure* para que el agente cargue skills bajo demanda mediante `load_skill`, manteniendo el índice en el prefijo estable.
+  - **Technical detail**: El alcance contempla integración entre `runtime/agent_prompt.py`, `runtime/agent_loop.py` y `api/server.py`, con reglas de *scoping* por tenant/conexiones y eventos de herramienta en SSE; al estar el issue abierto, queda como trabajo preparado en el alcance del release.
+
+## 🐛 Correcciones
+
+- **🐛 Posicionamiento y visibilidad de la barra de filtros en dashboards** *(Integración OSS — MIOT-0.5.23)*
+  - **Impacto**: Los paneles de filtros podían mostrarse mal posicionados, con baja visibilidad o cerrarse al interactuar con controles internos.
+  - **Solución**: Se corrigió el comportamiento de renderizado/posicionamiento inicial y la lógica de foco/click (incluyendo manejo de clic externo y badges de filtros) para mantener los paneles visibles y utilizables en distintos layouts.
+
+## 📊 Beneficios
+
+- Mejor experiencia de filtrado en dashboards con menor fricción en interacción.
+- Reducción de cierres involuntarios en paneles de filtros y mayor consistencia visual.
+- Base técnica más sólida para el loop de agentes con contexto único y skills bajo demanda.
+- Mejor preservación del contrato de caché del prompt al separar índice y cuerpo de skills.
+- Mayor mantenibilidad del flujo de herramientas del agente con eventos SSE explícitos.
+- Mejor alineación entre evolución OSS (`MIOT-0.5.23`) y release de plataforma.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.23`
+- **App**: `app@v0.5.23` (con cambios)
+- **Modulith**: `modulith@v0.5.17` (sin cambios en este release)
+- **Harness**: `harness@v0.1.3` (con cambios)
+- Los *digests* exactos de imágenes desplegadas se pueden consultar en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` del release.
+
+## 📌 Conclusión
+
+La `v1.31.22` aporta una mejora directa y tangible en la usabilidad de dashboards, corrigiendo un punto crítico de interacción en filtros que impactaba el trabajo diario de operación.
+
+En paralelo, el release incorpora trabajo evolutivo de OSS para robustecer la arquitectura del agente en `harness`, dejando preparado un patrón de carga de skills más eficiente y escalable.
+
+En conjunto, la entrega equilibra estabilización funcional inmediata y avance técnico estratégico del stack `0.5.23`.

--- a/releases/stacks/v0.5.23.plan.json
+++ b/releases/stacks/v0.5.23.plan.json
@@ -1,0 +1,63 @@
+{
+  "stack_version": "0.5.23",
+  "stack_tag": "miot-stack@v0.5.23",
+  "milestone": "MIOT-0.5.23",
+  "pull_requests": [
+    {
+      "number": 911,
+      "title": "feat(harness): lazy-loaded skills for the agent loop (progressive disclosure)",
+      "source_issues": [
+        {
+          "number": 910,
+          "title": "feat(harness): lazy-loaded skills for the agent loop (progressive disclosure)"
+        }
+      ]
+    },
+    {
+      "number": 913,
+      "title": "Fixing filter bar positioning issues",
+      "source_issues": [
+        {
+          "number": 914,
+          "title": "fix(app): dashboard filter bar positioning and visibility"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    "miot-harness/src/miot_harness/api/server.py",
+    "miot-harness/src/miot_harness/context_skills/registry.py",
+    "miot-harness/src/miot_harness/runtime/agent_loop.py",
+    "miot-harness/src/miot_harness/runtime/agent_prompt.py",
+    "miot-harness/tests/context_skills/test_bundle_layering.py",
+    "miot-harness/tests/runtime/test_agent_loop.py",
+    "miot-harness/tests/runtime/test_agent_prompt.py",
+    "turbo-repo/apps/app/src/features/common/components/absolute-modal/absolute-modal.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/filter-badge-shell.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/select-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/text-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/use-outside-click.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.23",
+      "tag": "app@v0.5.23"
+    },
+    "docs": {
+      "changed": false,
+      "version": "0.5.22",
+      "tag": "docs@v0.5.22"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.17",
+      "tag": "modulith@v0.5.17"
+    },
+    "harness": {
+      "changed": true,
+      "version": "0.1.3",
+      "tag": "harness@v0.1.3"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.22.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.22.mdx
@@ -1,0 +1,42 @@
+# 🔔 Release Notes v1.31.22 — ModularIoT
+
+### Fecha: 13/07/2026
+
+**Objetivo**: Esta versión refuerza la estabilidad operativa de la app en dashboards y avanza capacidades del stack para asistentes con contexto más eficiente. El foco combina corrección de experiencia de usuario y preparación de mejoras evolutivas en `harness`.
+
+## 🚀 Evolutivos
+
+- **📍 Carga diferida de skills en el loop del agente** *(Integración OSS — MIOT-0.5.23)*
+  - **Key point**: Se prepara un mecanismo de *progressive disclosure* para que el agente cargue skills bajo demanda mediante `load_skill`, manteniendo el índice en el prefijo estable.
+  - **Technical detail**: El alcance contempla integración entre `runtime/agent_prompt.py`, `runtime/agent_loop.py` y `api/server.py`, con reglas de *scoping* por tenant/conexiones y eventos de herramienta en SSE; al estar el issue abierto, queda como trabajo preparado en el alcance del release.
+
+## 🐛 Correcciones
+
+- **🐛 Posicionamiento y visibilidad de la barra de filtros en dashboards** *(Integración OSS — MIOT-0.5.23)*
+  - **Impacto**: Los paneles de filtros podían mostrarse mal posicionados, con baja visibilidad o cerrarse al interactuar con controles internos.
+  - **Solución**: Se corrigió el comportamiento de renderizado/posicionamiento inicial y la lógica de foco/click (incluyendo manejo de clic externo y badges de filtros) para mantener los paneles visibles y utilizables en distintos layouts.
+
+## 📊 Beneficios
+
+- Mejor experiencia de filtrado en dashboards con menor fricción en interacción.
+- Reducción de cierres involuntarios en paneles de filtros y mayor consistencia visual.
+- Base técnica más sólida para el loop de agentes con contexto único y skills bajo demanda.
+- Mejor preservación del contrato de caché del prompt al separar índice y cuerpo de skills.
+- Mayor mantenibilidad del flujo de herramientas del agente con eventos SSE explícitos.
+- Mejor alineación entre evolución OSS (`MIOT-0.5.23`) y release de plataforma.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.23`
+- **App**: `app@v0.5.23` (con cambios)
+- **Modulith**: `modulith@v0.5.17` (sin cambios en este release)
+- **Harness**: `harness@v0.1.3` (con cambios)
+- Los *digests* exactos de imágenes desplegadas se pueden consultar en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` del release.
+
+## 📌 Conclusión
+
+La `v1.31.22` aporta una mejora directa y tangible en la usabilidad de dashboards, corrigiendo un punto crítico de interacción en filtros que impactaba el trabajo diario de operación.
+
+En paralelo, el release incorpora trabajo evolutivo de OSS para robustecer la arquitectura del agente en `harness`, dejando preparado un patrón de carga de skills más eficiente y escalable.
+
+En conjunto, la entrega equilibra estabilización funcional inmediata y avance técnico estratégico del stack `0.5.23`.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.22",
+      "version": "0.5.23",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.23 from milestone MIOT-0.5.23, with release notes v1.31.22.

Components:
- App: app@v0.5.23 (changed: true)
- Docs: docs@v0.5.22 (changed: false)
- Modulith: modulith@v0.5.17 (changed: false)
- Harness: harness@v0.1.3 (changed: true)

Milestones: Release 1.31.22, MIOT-0.5.23.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive, on-demand loading for agent skills to improve agent interactions and resource usage.
* **Bug Fixes**
  * Improved dashboard filter bar positioning, visibility, focus, and click behavior across layouts.
  * Ensured filter panels remain usable when interacting with external areas and badges.
* **Documentation**
  * Added release notes for ModularIoT v1.31.22, including feature updates, corrections, and component versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->