### PR TITLE
chore(release): prepare MIOT stack v0.5.24

### DIFF
--- a/releases/notes/v1.31.23.mdx
+++ b/releases/notes/v1.31.23.mdx
@@ -1,0 +1,36 @@
+# 🔔 Release Notes v1.31.23 — ModularIoT
+
+### Fecha: 14/07/2026
+
+**Objetivo**: Esta versión consolida una mejora integral de autenticación en la app para ofrecer un acceso más claro, escalable y consistente entre flujos de credenciales, proveedores y SSO. También alinea la configuración de visibilidad de búsqueda en páginas seguras con el stack `0.5.24`.
+
+## 🚀 Evolutivos
+
+- **📍 Rediseño de la experiencia de inicio de sesión**
+  - **Key point**: Se renovó la UI de sign-in con una estructura más clara, se extrajo el marco compartido en `AuthPageShell`, se ajustó el formulario de credenciales/proveedores y se incorporó un flujo dedicado de SSO con identificador de equipo y validación.
+  - **Technical detail**: Se ampliaron traducciones en inglés y español, se eliminó la implementación anterior de team slug, y se añadió soporte en layouts seguros para configurar disponibilidad de búsqueda con su correspondiente cableado de build/env. *(Integración OSS — MIOT-0.5.24)*
+
+## 📊 Beneficios
+
+- Mejor experiencia de acceso para usuarios con distintos métodos de autenticación.
+- Base reutilizable para futuras pantallas de autenticación mediante `AuthPageShell`.
+- Menor fricción en flujos SSO gracias a una entrada de identificador de equipo dedicada.
+- Mayor consistencia visual en navbar, botones, divisor, campos y modo oscuro.
+- Mejor cobertura multilenguaje (ES/EN) para la interfaz de autenticación.
+- Más control operativo en páginas seguras al poder habilitar/ocultar búsqueda por configuración.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.24`
+- **App**: `app@v0.5.24` *(actualizado en esta release)*
+- **Modulith**: `modulith@v0.5.17` *(sin cambios)*
+- **Harness**: `harness@v0.1.3` *(sin cambios)*
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.23` prioriza una modernización tangible del acceso a la plataforma, enfocada en claridad de uso y preparación para crecimiento de los flujos de autenticación.
+
+Con esta base, ModularIoT fortalece la mantenibilidad del frontend de auth y reduce acoplamientos en implementaciones futuras, especialmente en escenarios con SSO y configuración de páginas seguras.
+
+El resultado es una experiencia más coherente para usuarios finales y una superficie técnica más ordenada para evolución continua del producto.

--- a/releases/stacks/v0.5.24.plan.json
+++ b/releases/stacks/v0.5.24.plan.json
@@ -1,0 +1,62 @@
+{
+  "stack_version": "0.5.24",
+  "stack_tag": "miot-stack@v0.5.24",
+  "milestone": "MIOT-0.5.24",
+  "pull_requests": [
+    {
+      "number": 902,
+      "title": "Based/refactor on style of login",
+      "source_issues": [
+        {
+          "number": 916,
+          "title": "feat(app): redesigned login experience and auth page shell"
+        }
+      ]
+    }
+  ],
+  "changed_files": [
+    "turbo-repo/apps/app/src/app/[lang]/sign-in/page.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/auth-page-shell/auth-page-shell.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/form-sign-in/form-sign-in.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/form-sign-in/form-sign-in.types.ts",
+    "turbo-repo/apps/app/src/features/auth/components/form-sign-in/sign-in-saml.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/form-sign-in/sign-in.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/login-button/login-button.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/login-button/login-button.types.ts",
+    "turbo-repo/apps/app/src/features/auth/components/login-divider/login-divider.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/navbar-sign-in.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/register-link/index.ts",
+    "turbo-repo/apps/app/src/features/auth/components/register-link/register-link.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/team-slug-input/index.ts",
+    "turbo-repo/apps/app/src/features/auth/components/team-slug-input/team-slug-input.tsx",
+    "turbo-repo/apps/app/src/features/auth/components/team-slug-input/team-slug-input.types.ts",
+    "turbo-repo/apps/app/src/features/auth/utils/utils.ts",
+    "turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx",
+    "turbo-repo/apps/app/src/features/theme/components/CustomThemeToggle.tsx",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/turbo.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.24",
+      "tag": "app@v0.5.24"
+    },
+    "docs": {
+      "changed": false,
+      "version": "0.5.22",
+      "tag": "docs@v0.5.22"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.17",
+      "tag": "modulith@v0.5.17"
+    },
+    "harness": {
+      "changed": false,
+      "version": "0.1.3",
+      "tag": "harness@v0.1.3"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.23.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.23.mdx
@@ -1,0 +1,36 @@
+# 🔔 Release Notes v1.31.23 — ModularIoT
+
+### Fecha: 14/07/2026
+
+**Objetivo**: Esta versión consolida una mejora integral de autenticación en la app para ofrecer un acceso más claro, escalable y consistente entre flujos de credenciales, proveedores y SSO. También alinea la configuración de visibilidad de búsqueda en páginas seguras con el stack `0.5.24`.
+
+## 🚀 Evolutivos
+
+- **📍 Rediseño de la experiencia de inicio de sesión**
+  - **Key point**: Se renovó la UI de sign-in con una estructura más clara, se extrajo el marco compartido en `AuthPageShell`, se ajustó el formulario de credenciales/proveedores y se incorporó un flujo dedicado de SSO con identificador de equipo y validación.
+  - **Technical detail**: Se ampliaron traducciones en inglés y español, se eliminó la implementación anterior de team slug, y se añadió soporte en layouts seguros para configurar disponibilidad de búsqueda con su correspondiente cableado de build/env. *(Integración OSS — MIOT-0.5.24)*
+
+## 📊 Beneficios
+
+- Mejor experiencia de acceso para usuarios con distintos métodos de autenticación.
+- Base reutilizable para futuras pantallas de autenticación mediante `AuthPageShell`.
+- Menor fricción en flujos SSO gracias a una entrada de identificador de equipo dedicada.
+- Mayor consistencia visual en navbar, botones, divisor, campos y modo oscuro.
+- Mejor cobertura multilenguaje (ES/EN) para la interfaz de autenticación.
+- Más control operativo en páginas seguras al poder habilitar/ocultar búsqueda por configuración.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.24`
+- **App**: `app@v0.5.24` *(actualizado en esta release)*
+- **Modulith**: `modulith@v0.5.17` *(sin cambios)*
+- **Harness**: `harness@v0.1.3` *(sin cambios)*
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.23` prioriza una modernización tangible del acceso a la plataforma, enfocada en claridad de uso y preparación para crecimiento de los flujos de autenticación.
+
+Con esta base, ModularIoT fortalece la mantenibilidad del frontend de auth y reduce acoplamientos en implementaciones futuras, especialmente en escenarios con SSO y configuración de páginas seguras.
+
+El resultado es una experiencia más coherente para usuarios finales y una superficie técnica más ordenada para evolución continua del producto.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.23",
+      "version": "0.5.24",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.24 from milestone MIOT-0.5.24, with release notes v1.31.23.

Components:
- App: app@v0.5.24 (changed: true)
- Docs: docs@v0.5.22 (changed: false)
- Modulith: modulith@v0.5.17 (changed: false)
- Harness: harness@v0.1.3 (changed: false)

Milestones: Release 1.31.23, MIOT-0.5.24.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an SSO sign-in flow with team identifier entry and validation.
  - Improved consistency across credential, provider, and SSO authentication experiences.
  - Updated secure-page search visibility configuration.

- **Improvements**
  - Refined the sign-in interface and shared authentication layout for a clearer experience.
  - Enhanced authentication form and navigation flows.

- **Documentation**
  - Added release documentation for version 1.31.23 and aligned stack version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->