### PR TITLE
chore(release): prepare MIOT stack v0.5.25

### DIFF
--- a/releases/notes/v1.31.24.mdx
+++ b/releases/notes/v1.31.24.mdx
@@ -1,0 +1,34 @@
+# 🔔 Release Notes v1.31.24 — ModularIoT
+
+### Fecha: 15/07/2026
+
+**Objetivo**: Esta versión prioriza la estabilidad operativa del flujo de planificación y asignación en ECM/Alfresco, corrigiendo errores de permisos que bloqueaban la operación diaria. Además, alinea el despliegue de la plataforma con el stack `0.5.25` para mantener consistencia entre componentes.
+
+## 🐛 Correcciones
+
+- **🐛 Error de permisos en planificación desde calendario y asignación de conductor**
+  - **Impacto**: Usuarios de planificación recibían errores `500` (`AccessDenied`) al planificar servicios o avanzar tareas cuando no figuraban en los grupos candidatos configurados para `planService` y `assignDriver`.
+  - **Solución**: Se ampliaron los grupos candidatos para incluir los perfiles de planificación/asignación en ambos pasos, y se ejecutó una migración idempotente para corregir tareas e instancias en curso. La corrección quedó verificada en entornos dev y prod; para nuevas instancias, requiere desplegar la imagen ECM actualizada en producción.
+
+## 📊 Beneficios
+
+- Se elimina un bloqueo crítico en la planificación operativa desde calendario.
+- Se reduce el riesgo de fallas recurrentes entre pasos consecutivos del workflow (`planService` y `assignDriver`).
+- Se mejora la continuidad de operación en instancias ya activas mediante backfill controlado.
+- La migración idempotente permite reejecución segura para cubrir ventanas entre despliegues.
+- Se refuerza la trazabilidad y gobernanza de permisos en tareas BPM vinculadas a Alfresco.
+- Se mantiene la estabilidad del release con un cambio focalizado y de alto impacto funcional.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.25`
+- **App**: `app@v0.5.25` (con cambios)
+- **Modulith**: `modulith@v0.5.17` (sin cambios)
+- **Harness**: `harness@v0.1.3` (sin cambios)
+- Los *digests* exactos de imágenes desplegadas están disponibles en el diálogo de información de compilación de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.24` se enfoca en confiabilidad del flujo de trabajo donde el impacto era más directo para operación: planificación y asignación en ECM. Con esta corrección, el proceso recupera capacidad de ejecución para los equipos correctos y disminuye la fricción en tareas críticas.
+
+También deja preparada una transición segura a nivel de despliegue: la migración cubre instancias en curso y el ajuste de imagen ECM asegura que las nuevas instancias nazcan con la configuración correcta. En conjunto, es un release de estabilización con efecto operativo inmediato.

--- a/releases/stacks/v0.5.25.plan.json
+++ b/releases/stacks/v0.5.25.plan.json
@@ -1,0 +1,29 @@
+{
+  "stack_version": "0.5.25",
+  "stack_tag": "miot-stack@v0.5.25",
+  "milestone": "MIOT-0.5.25",
+  "pull_requests": [],
+  "changed_files": [],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.25",
+      "tag": "app@v0.5.25"
+    },
+    "docs": {
+      "changed": false,
+      "version": "0.5.22",
+      "tag": "docs@v0.5.22"
+    },
+    "modulith": {
+      "changed": false,
+      "version": "0.5.17",
+      "tag": "modulith@v0.5.17"
+    },
+    "harness": {
+      "changed": false,
+      "version": "0.1.3",
+      "tag": "harness@v0.1.3"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.24.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.24.mdx
@@ -1,0 +1,34 @@
+# 🔔 Release Notes v1.31.24 — ModularIoT
+
+### Fecha: 15/07/2026
+
+**Objetivo**: Esta versión prioriza la estabilidad operativa del flujo de planificación y asignación en ECM/Alfresco, corrigiendo errores de permisos que bloqueaban la operación diaria. Además, alinea el despliegue de la plataforma con el stack `0.5.25` para mantener consistencia entre componentes.
+
+## 🐛 Correcciones
+
+- **🐛 Error de permisos en planificación desde calendario y asignación de conductor**
+  - **Impacto**: Usuarios de planificación recibían errores `500` (`AccessDenied`) al planificar servicios o avanzar tareas cuando no figuraban en los grupos candidatos configurados para `planService` y `assignDriver`.
+  - **Solución**: Se ampliaron los grupos candidatos para incluir los perfiles de planificación/asignación en ambos pasos, y se ejecutó una migración idempotente para corregir tareas e instancias en curso. La corrección quedó verificada en entornos dev y prod; para nuevas instancias, requiere desplegar la imagen ECM actualizada en producción.
+
+## 📊 Beneficios
+
+- Se elimina un bloqueo crítico en la planificación operativa desde calendario.
+- Se reduce el riesgo de fallas recurrentes entre pasos consecutivos del workflow (`planService` y `assignDriver`).
+- Se mejora la continuidad de operación en instancias ya activas mediante backfill controlado.
+- La migración idempotente permite reejecución segura para cubrir ventanas entre despliegues.
+- Se refuerza la trazabilidad y gobernanza de permisos en tareas BPM vinculadas a Alfresco.
+- Se mantiene la estabilidad del release con un cambio focalizado y de alto impacto funcional.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.25`
+- **App**: `app@v0.5.25` (con cambios)
+- **Modulith**: `modulith@v0.5.17` (sin cambios)
+- **Harness**: `harness@v0.1.3` (sin cambios)
+- Los *digests* exactos de imágenes desplegadas están disponibles en el diálogo de información de compilación de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.24` se enfoca en confiabilidad del flujo de trabajo donde el impacto era más directo para operación: planificación y asignación en ECM. Con esta corrección, el proceso recupera capacidad de ejecución para los equipos correctos y disminuye la fricción en tareas críticas.
+
+También deja preparada una transición segura a nivel de despliegue: la migración cubre instancias en curso y el ajuste de imagen ECM asegura que las nuevas instancias nazcan con la configuración correcta. En conjunto, es un release de estabilización con efecto operativo inmediato.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.24",
+      "version": "0.5.25",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "^0.34.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.25 from milestone MIOT-0.5.25, with release notes v1.31.24.

Components:
- App: app@v0.5.25 (changed: true)
- Docs: docs@v0.5.22 (changed: false)
- Modulith: modulith@v0.5.17 (changed: false)
- Harness: harness@v0.1.3 (changed: false)

Milestones: Release 1.31.24, MIOT-0.5.25.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
