### PR TITLE
feat(calendar): live workflow stage on the planning grid (CALSYNC F1)

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// The workspace package ships source (no dist build in CI for app tests);
+// the chip only pulls one hook from it, so mock at the boundary.
+vi.mock("@microboxlabs/miot-calendar-ui", () => ({
+  useScrollIntoViewWhen: () => ({ current: null }),
+}));
+
+import { PlannedServiceChip } from "./planned-service-chip";
+import type { PlannedService } from "./planning-selection-context";
+
+function plannedService(workflowStage?: string): PlannedService {
+  return {
+    service: {
+      id: "1658427-V",
+      cliente: "ACME",
+      origen: "ANF",
+      lugarCarguio: "",
+      destino: "SPC",
+      tipoViaje: "Rampla",
+      ocupacion: 0,
+      permanencia: "",
+      leadTime: {
+        total_lineasoc_cumplen: 0,
+        total_lineasoc_incumplen: 0,
+        lineasoc_pctn_cumplimiento: 0,
+      },
+      eta: "",
+      incidencias: [],
+      observaciones: "",
+      prioridad: 0,
+      mintral_serviceCode: "1658427",
+    },
+    slot: { date: new Date("2026-07-13T00:00:00Z"), hour: 5, minutes: 0 },
+    ...(workflowStage ? { workflowStage } : {}),
+  };
+}
+
+function renderChip(workflowStage?: string) {
+  return render(
+    <PlannedServiceChip
+      plannedService={plannedService(workflowStage)}
+      onContextMenu={vi.fn()}
+      dict={{}}
+    />
+  );
+}
+
+describe("PlannedServiceChip — workflow stage rendering", () => {
+  it("renders the plain planned look when no stage is known", () => {
+    renderChip();
+    const button = screen.getByRole("button");
+    expect(button.className).not.toContain("opacity-60");
+    expect(screen.queryByLabelText(/^workflow-stage-/)).toBeNull();
+  });
+
+  it("marks a finished service muted with a check indicator", () => {
+    renderChip("finished");
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("opacity-60");
+    expect(screen.getByLabelText("workflow-stage-finished")).toBeTruthy();
+  });
+
+  it("marks a cancelled service muted with a cross indicator", () => {
+    renderChip("cancelled");
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("opacity-60");
+    expect(screen.getByLabelText("workflow-stage-cancelled")).toBeTruthy();
+  });
+
+  it("marks an in-course service with the en-route indicator, not muted", () => {
+    renderChip("monitorTrip");
+    const button = screen.getByRole("button");
+    expect(button.className).not.toContain("opacity-60");
+    expect(screen.getByLabelText("workflow-stage-monitorTrip")).toBeTruthy();
+  });
+
+  it("keeps planning-segment stages on the plain look", () => {
+    renderChip("assignDriver");
+    expect(screen.queryByLabelText(/^workflow-stage-/)).toBeNull();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -73,6 +73,37 @@ export function getDriverCount(service: PlannedService["service"]): 0 | 1 | 2 {
   return 0;
 }
 
+/** CALSYNC read-time stage → chip presentation flags + tooltip suffix. */
+interface StageIndicator {
+  /** Terminal/muted: the slot is history, not plannable work. */
+  readonly isTerminal: boolean;
+  readonly isFinished: boolean;
+  readonly isCancelled: boolean;
+  /** In-course stages get an "en route" marker. */
+  readonly isInCourse: boolean;
+  /** " · <label>" appended to the chip title, or "" when no stage. */
+  readonly titleSuffix: string;
+}
+
+function getStageIndicator(
+  workflowStage: string | undefined,
+  dict: I18nRecord
+): StageIndicator {
+  const isFinished = workflowStage === "finished";
+  const isCancelled = workflowStage === "cancelled";
+  const stageTitle = workflowStage
+    ? tr(`pages.planning.sidebar.taskStage.${workflowStage}`, dict)
+    : undefined;
+  return {
+    isTerminal: isFinished || isCancelled,
+    isFinished,
+    isCancelled,
+    isInCourse:
+      workflowStage !== undefined && IN_COURSE_STAGES.has(workflowStage),
+    titleSuffix: stageTitle ? ` · ${stageTitle}` : "",
+  };
+}
+
 interface PlannedServiceChipProps {
   readonly plannedService: PlannedService;
   readonly isBeingReassigned?: boolean;
@@ -121,13 +152,8 @@ export function PlannedServiceChip({
   // stages get a marker so a dispatched service stops looking merely
   // "planned".
   const workflowStage = plannedService.workflowStage;
-  const isFinished = workflowStage === "finished";
-  const isCancelled = workflowStage === "cancelled";
-  const isInCourse =
-    workflowStage !== undefined && IN_COURSE_STAGES.has(workflowStage);
-  const stageTitle = workflowStage
-    ? tr(`pages.planning.sidebar.taskStage.${workflowStage}`, dict)
-    : undefined;
+  const { isTerminal, isFinished, isCancelled, isInCourse, titleSuffix } =
+    getStageIndicator(workflowStage, dict);
   // Weakest accreditation level across the assigned resources — rendered with
   // the same labelled badge the service card and sidebar show (icon + text),
   // with the per-resource breakdown as tooltip. Unknown levels (legacy
@@ -193,13 +219,13 @@ export function PlannedServiceChip({
           "ring-2 ring-amber-500 ring-offset-1",
         // Terminal services recede (the search dim below is stronger and
         // still wins when both apply).
-        (isFinished || isCancelled) && "opacity-60 saturate-50",
+        isTerminal && "opacity-60 saturate-50",
         // Non-matches stay legible enough to keep the slot's context, but
         // clearly recede so the eye lands on the match.
         isDimmed && "opacity-30",
         className
       )}
-      title={`${plannedService.service.id}${stageTitle ? ` · ${stageTitle}` : ""} - ${tr("pages.planning.sidebar.contextMenu.chipTitle", dict)}`}
+      title={`${plannedService.service.id}${titleSuffix} - ${tr("pages.planning.sidebar.contextMenu.chipTitle", dict)}`}
     >
       {/* Left: Service ID + Route stacked */}
       <div className="flex flex-col flex-1 min-w-0">

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { twMerge } from "tailwind-merge";
-import { IoPerson, IoPeople } from "react-icons/io5";
+import {
+  IoPerson,
+  IoPeople,
+  IoNavigate,
+  IoCheckmarkCircle,
+  IoCloseCircle,
+} from "react-icons/io5";
 import { useScrollIntoViewWhen } from "@microboxlabs/miot-calendar-ui";
 import type { PlannedService } from "./planning-selection-context";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
@@ -44,6 +50,17 @@ export function hasUrgenciaIncidencia(
 
   return false;
 }
+
+/**
+ * Post-planning workflow stages the chip marks with an "en route" indicator.
+ * Planning-segment stages keep the plain chip look (the chip's existence
+ * already means "planned", driver icons mean "assigned").
+ */
+const IN_COURSE_STAGES = new Set<string>([
+  "monitorTrip",
+  "confirmArrival",
+  "closeMonitoring",
+]);
 
 /**
  * Get the number of assigned drivers for a service
@@ -99,6 +116,18 @@ export function PlannedServiceChip({
   const hasUrgencia = hasUrgenciaIncidencia(plannedService.service);
   const driverCount = getDriverCount(plannedService.service);
   const { origen, destino } = plannedService.service;
+  // Live/terminal workflow stage (CALSYNC read-time join). Terminal chips
+  // recede — the slot is history, not plannable work — while in-course
+  // stages get a marker so a dispatched service stops looking merely
+  // "planned".
+  const workflowStage = plannedService.workflowStage;
+  const isFinished = workflowStage === "finished";
+  const isCancelled = workflowStage === "cancelled";
+  const isInCourse =
+    workflowStage !== undefined && IN_COURSE_STAGES.has(workflowStage);
+  const stageTitle = workflowStage
+    ? tr(`pages.planning.sidebar.taskStage.${workflowStage}`, dict)
+    : undefined;
   // Weakest accreditation level across the assigned resources — rendered with
   // the same labelled badge the service card and sidebar show (icon + text),
   // with the per-resource breakdown as tooltip. Unknown levels (legacy
@@ -162,12 +191,15 @@ export function PlannedServiceChip({
           !isHighlighted &&
           isSelected &&
           "ring-2 ring-amber-500 ring-offset-1",
+        // Terminal services recede (the search dim below is stronger and
+        // still wins when both apply).
+        (isFinished || isCancelled) && "opacity-60 saturate-50",
         // Non-matches stay legible enough to keep the slot's context, but
         // clearly recede so the eye lands on the match.
         isDimmed && "opacity-30",
         className
       )}
-      title={`${plannedService.service.id} - ${tr("pages.planning.sidebar.contextMenu.chipTitle", dict)}`}
+      title={`${plannedService.service.id}${stageTitle ? ` · ${stageTitle}` : ""} - ${tr("pages.planning.sidebar.contextMenu.chipTitle", dict)}`}
     >
       {/* Left: Service ID + Route stacked */}
       <div className="flex flex-col flex-1 min-w-0">
@@ -214,6 +246,24 @@ export function PlannedServiceChip({
               ? "text-purple-700 dark:text-purple-300"
               : "text-blue-700 dark:text-blue-300"
           )}
+        />
+      )}
+      {isInCourse && (
+        <IoNavigate
+          aria-label={`workflow-stage-${workflowStage}`}
+          className="ml-1 shrink-0 w-3.5 h-3.5 text-sky-600 dark:text-sky-400"
+        />
+      )}
+      {isFinished && (
+        <IoCheckmarkCircle
+          aria-label="workflow-stage-finished"
+          className="ml-1 shrink-0 w-4 h-4 text-emerald-600 dark:text-emerald-400"
+        />
+      )}
+      {isCancelled && (
+        <IoCloseCircle
+          aria-label="workflow-stage-cancelled"
+          className="ml-1 shrink-0 w-4 h-4 text-red-500 dark:text-red-400"
         />
       )}
     </button>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-context.tsx
@@ -37,6 +37,7 @@ export type {
   SelectedService,
   TripType,
   TaskStage,
+  PlannedWorkflowStage,
   LeadTimeData,
 } from "./planning-selection-types";
 

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-types.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-types.ts
@@ -17,7 +17,18 @@ export type TaskStage =
   | "assignDriver"
   | "presentDriver"
   | "prepareService"
-  | "missionControl";
+  | "missionControl"
+  | "monitorTrip"
+  | "confirmArrival"
+  | "closeMonitoring";
+
+/**
+ * Stage shown on the planning grid for a booked service: a live kanban stage
+ * from the workflow index, or a terminal state read from the booking's
+ * lifecycle status (CALSYNC). Terminal values only appear once the booking
+ * backend carries a status column and ECM pushes transitions.
+ */
+export type PlannedWorkflowStage = TaskStage | "finished" | "cancelled";
 
 /**
  * Represents a service that can be selected in the planning calendar.

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -64,6 +64,7 @@ import { useCalendarViewMode } from "./use-calendar-view-mode";
 import type { SelectedService, TaskStage } from "./planning-selection-types";
 import { ServiceEvent } from "./service-event";
 import { mapBookingToPlannedService } from "@/features/calendar/services/booking-service-mapper";
+import { CALENDAR_LIVE_TASK_COLUMNS } from "@/features/calendar/services/workflow-stage";
 
 
 async function cancelBookingWithWarning(
@@ -276,13 +277,7 @@ export function PlanningSelectionProvider({
   // per workflow stage; this is the single source of truth for "which Alfresco
   // task represents service X right now".
   const { data: liveTasksData, refresh: refreshLiveTasks } = useMyTasks(
-    [
-      "planService",
-      "assignDriver",
-      "presentDriver",
-      "prepareService",
-      "missionControl",
-    ],
+    [...CALENDAR_LIVE_TASK_COLUMNS],
     false,
     1,
     500
@@ -413,6 +408,12 @@ export function PlanningSelectionProvider({
         listBookings,
       },
       getLiveTask,
+      // Read-time join: the provider overlays this onto each planned
+      // service's workflowStage, so chips re-label when the live index
+      // refreshes. Undefined keeps any terminal stage the booking mapper
+      // read from the row's lifecycle status.
+      resolveWorkflowStage: (service) =>
+        getLiveTask(service.mintral_serviceCode)?.stage,
       hooks: {
         shouldPersistBooking: (item, slot, ctx) => {
           const service = item.raw as SelectedService;

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -16,6 +16,7 @@ import { tr } from "@/features/i18n/tr.service";
 import {
   usePlanningSelection,
   type SelectedService,
+  type PlannedWorkflowStage,
 } from "./planning-selection-context";
 import { PlanningSidebarForm } from "./planning-sidebar-form";
 import { PlanningSearchAutocomplete } from "./planning-search-autocomplete";
@@ -200,6 +201,7 @@ export function PlanningSidebarClient({
     bookingVersion,
     isSidebarOpen,
     getLiveTask,
+    plannedServices,
   } = usePlanningSelection();
   const [filteredServiceId, setFilteredServiceId] = useState<string | null>(
     null
@@ -745,7 +747,13 @@ export function PlanningSidebarClient({
           backendSlots={backendSlots}
           isSlotsLoading={isSlotsLoading}
           liveTaskStage={
-            getLiveTask(displayState.selectedService?.mintral_serviceCode)?.stage
+            // Live task first; a finished/cancelled service has no live task,
+            // so fall back to the terminal stage the booking row carries.
+            getLiveTask(displayState.selectedService?.mintral_serviceCode)
+              ?.stage ??
+            (plannedServices.find(
+              (p) => p.service.id === displayState.selectedService?.id
+            )?.workflowStage as PlannedWorkflowStage | undefined)
           }
         />
       }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -16,7 +16,7 @@ import {
   usePlanningSelection,
   type SelectedService,
   type SelectedSlot,
-  type TaskStage,
+  type PlannedWorkflowStage,
 } from "./planning-selection-context";
 import { useServiceTypes } from "@/features/common/providers/client-api.provider";
 import { HiCalendar, HiExclamation, HiUserAdd } from "react-icons/hi";
@@ -125,11 +125,12 @@ interface PlanningSidebarFormProps {
   /** Whether backend slots are currently loading */
   readonly isSlotsLoading?: boolean;
   /**
-   * Live kanban stage of the selected task, derived by the parent from the
-   * freshly fetched myTasks payload. Never persisted on the booking — pass
-   * `undefined` when the task isn't in any active column.
+   * Workflow stage of the selected service: the live kanban stage when the
+   * task sits in an active column, or the terminal stage carried by the
+   * booking's lifecycle status ("finished"/"cancelled") once the workflow
+   * has ended. Pass `undefined` when neither source knows the service.
    */
-  readonly liveTaskStage?: TaskStage;
+  readonly liveTaskStage?: PlannedWorkflowStage;
 }
 
 export function PlanningSidebarForm({

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import type { BookingResponse } from "@microboxlabs/miot-calendar-client";
+import { mapBookingToPlannedService } from "./booking-service-mapper";
+
+function booking(overrides: Partial<BookingResponse> = {}): BookingResponse {
+  return {
+    id: "booking-1",
+    calendarId: "cal-A",
+    resource: {
+      id: "1658427-V",
+      type: "service",
+      data: {
+        mintral_serviceCode: "1658427",
+        origen: "ANF",
+        destino: "SPC",
+      },
+    },
+    slot: { date: "2026-07-13", hour: 5, minutes: 0 },
+    createdAt: "2026-07-12T15:16:30Z",
+    ...overrides,
+  } as BookingResponse;
+}
+
+describe("mapBookingToPlannedService — workflowStage from booking status", () => {
+  it("leaves workflowStage unset when the row carries no status (legacy servers)", () => {
+    const mapped = mapBookingToPlannedService(booking());
+    expect(mapped?.planned.workflowStage).toBeUndefined();
+  });
+
+  it("maps FINISHED to the terminal 'finished' stage", () => {
+    const mapped = mapBookingToPlannedService(booking({ status: "FINISHED" }));
+    expect(mapped?.planned.workflowStage).toBe("finished");
+  });
+
+  it("maps CANCELLED to the terminal 'cancelled' stage", () => {
+    const mapped = mapBookingToPlannedService(booking({ status: "CANCELLED" }));
+    expect(mapped?.planned.workflowStage).toBe("cancelled");
+  });
+
+  it("leaves planning-segment statuses unset (the live index owns them)", () => {
+    const mapped = mapBookingToPlannedService(booking({ status: "PLANNED" }));
+    expect(mapped?.planned.workflowStage).toBeUndefined();
+  });
+
+  it("still maps the service payload and slot as before", () => {
+    const mapped = mapBookingToPlannedService(booking({ status: "FINISHED" }));
+    expect(mapped?.bookingId).toBe("booking-1");
+    expect(mapped?.planned.service.mintral_serviceCode).toBe("1658427");
+    expect(mapped?.planned.service.origen).toBe("ANF");
+    expect(mapped?.planned.slot.hour).toBe(5);
+  });
+
+  it("returns null for slotless bookings regardless of status", () => {
+    const slotless = booking({ status: "FINISHED" });
+    // @ts-expect-error — exercising the runtime guard for a missing slot
+    slotless.slot = undefined;
+    expect(mapBookingToPlannedService(slotless)).toBeNull();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import type { BookingResponse } from "@microboxlabs/miot-calendar-client";
 import type { PlannedService } from "@microboxlabs/miot-calendar-ui";
 import type { SelectedService } from "@/features/calendar/components/planning/planning-selection-types";
+import { bookingStatusToWorkflowStage } from "@/features/calendar/services/workflow-stage";
 
 /**
  * Persisted accreditation level of an assigned resource — mirrors the
@@ -129,6 +130,12 @@ export function mapBookingToPlannedService(
       storedService.mintral_serviceCode ?? booking.resource.id.split("-")[0],
   };
 
+  // Terminal stages ride the booking row itself (ECM writes the status);
+  // load-time is fine for them because a FINISHED/CANCELLED booking never
+  // goes live again. Live stages overlay this at render time via the
+  // provider's workflow-stage merge, and win on conflict.
+  const workflowStage = bookingStatusToWorkflowStage(booking.status);
+
   return {
     bookingId: booking.id,
     calendarId: booking.calendarId,
@@ -140,6 +147,7 @@ export function mapBookingToPlannedService(
         minutes: booking.slot.minutes,
         ...(_anden === undefined ? {} : { anden: _anden }),
       },
+      ...(workflowStage === undefined ? {} : { workflowStage }),
     },
   };
 }

--- a/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-stage-transitions.ts
@@ -71,6 +71,9 @@ const KNOWN_TASK_STAGES = new Set<TaskStage>([
   "presentDriver",
   "prepareService",
   "missionControl",
+  "monitorTrip",
+  "confirmArrival",
+  "closeMonitoring",
 ]);
 
 /**

--- a/turbo-repo/apps/app/src/features/calendar/services/workflow-stage.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/workflow-stage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  CALENDAR_LIVE_TASK_COLUMNS,
+  bookingStatusToWorkflowStage,
+} from "./workflow-stage";
+import { asTaskStageFromColumn } from "./task-stage-transitions";
+
+describe("CALENDAR_LIVE_TASK_COLUMNS", () => {
+  it("covers the planning segment and the post-planning active stages", () => {
+    expect(CALENDAR_LIVE_TASK_COLUMNS).toEqual([
+      "planService",
+      "assignDriver",
+      "presentDriver",
+      "prepareService",
+      "missionControl",
+      "monitorTrip",
+      "confirmArrival",
+      "closeMonitoring",
+    ]);
+  });
+
+  it("every column round-trips through asTaskStageFromColumn", () => {
+    for (const column of CALENDAR_LIVE_TASK_COLUMNS) {
+      expect(asTaskStageFromColumn(column)).toBe(column);
+    }
+  });
+});
+
+describe("bookingStatusToWorkflowStage", () => {
+  it("maps terminal statuses to terminal stages", () => {
+    expect(bookingStatusToWorkflowStage("FINISHED")).toBe("finished");
+    expect(bookingStatusToWorkflowStage("CANCELLED")).toBe("cancelled");
+  });
+
+  it("maps in-course statuses onto their kanban-stage equivalents", () => {
+    expect(bookingStatusToWorkflowStage("IN_TRANSIT")).toBe("monitorTrip");
+    expect(bookingStatusToWorkflowStage("ARRIVED")).toBe("confirmArrival");
+  });
+
+  it("leaves planning-segment statuses and absent status unmapped", () => {
+    expect(bookingStatusToWorkflowStage("PLANNED")).toBeUndefined();
+    expect(bookingStatusToWorkflowStage("ASSIGNED")).toBeUndefined();
+    expect(bookingStatusToWorkflowStage(undefined)).toBeUndefined();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/workflow-stage.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/workflow-stage.ts
@@ -1,0 +1,47 @@
+import type { BookingStatus } from "@microboxlabs/miot-calendar-client";
+import type {
+  PlannedWorkflowStage,
+  TaskStage,
+} from "@/features/calendar/components/planning/planning-selection-types";
+
+/**
+ * Kanban columns the planning calendar's live workflow index tracks. Covers
+ * every ACTIVE v4 stage a booked service can be in, so a chip can show its
+ * real stage from planning through monitoring. Terminal states (finished /
+ * cancelled) are not queryable per-window from the live tasks API — they
+ * reach the grid via the booking's lifecycle status instead
+ * (see `bookingStatusToWorkflowStage`).
+ */
+export const CALENDAR_LIVE_TASK_COLUMNS: readonly TaskStage[] = [
+  "planService",
+  "assignDriver",
+  "presentDriver",
+  "prepareService",
+  "missionControl",
+  "monitorTrip",
+  "confirmArrival",
+  "closeMonitoring",
+];
+
+/**
+ * Map a booking's lifecycle status (written by ECM, CALSYNC phases 2-3) to
+ * the grid's stage vocabulary. PLANNED/ASSIGNED are deliberately absent: the
+ * planning-segment look (chip + driver icons) already conveys them, and the
+ * live index owns those stages anyway. IN_TRANSIT/ARRIVED map onto their
+ * kanban-stage equivalents so the chip has one stage vocabulary; when a live
+ * task is also present, the live answer wins upstream.
+ */
+const BOOKING_STATUS_TO_STAGE: Partial<
+  Record<BookingStatus, PlannedWorkflowStage>
+> = {
+  IN_TRANSIT: "monitorTrip",
+  ARRIVED: "confirmArrival",
+  FINISHED: "finished",
+  CANCELLED: "cancelled",
+};
+
+export function bookingStatusToWorkflowStage(
+  status: BookingStatus | undefined
+): PlannedWorkflowStage | undefined {
+  return status ? BOOKING_STATUS_TO_STAGE[status] : undefined;
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -376,7 +376,12 @@
           "assignDriver": "Assign driver",
           "presentDriver": "Present driver",
           "prepareService": "Prepare service",
-          "missionControl": "Mission control"
+          "missionControl": "Mission control",
+          "monitorTrip": "Trip in progress",
+          "confirmArrival": "Confirm arrival",
+          "closeMonitoring": "Close monitoring",
+          "finished": "Finished",
+          "cancelled": "Cancelled"
         },
         "contextMenu": {
           "service": "Service",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -376,7 +376,12 @@
           "assignDriver": "Asignar conductor",
           "presentDriver": "Presentar conductor",
           "prepareService": "Preparar servicio",
-          "missionControl": "Control de misión"
+          "missionControl": "Control de misión",
+          "monitorTrip": "Viaje en curso",
+          "confirmArrival": "Confirmar arribo",
+          "closeMonitoring": "Cierre de monitoreo",
+          "finished": "Finalizado",
+          "cancelled": "Cancelado"
         },
         "contextMenu": {
           "service": "Servicio",

--- a/turbo-repo/packages/miot-calendar-client/src/index.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/index.ts
@@ -6,6 +6,7 @@ export type {
   SlotData,
   BookingRequest,
   BookingUpdateRequest,
+  BookingStatus,
   BookingResponse,
   BookingListResponse,
   MoveBookingRequest,

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -63,13 +63,24 @@ export interface MoveBookingRequest {
   resource?: ResourceData;
 }
 
+/** Booking lifecycle status (CALSYNC). Servers without the status column omit it. */
+export type BookingStatus =
+  | "PLANNED"
+  | "ASSIGNED"
+  | "IN_TRANSIT"
+  | "ARRIVED"
+  | "FINISHED"
+  | "CANCELLED";
+
 export interface BookingResponse {
   id: string;
   calendarId: string;
   resource: ResourceData;
   slot: SlotData;
+  status?: BookingStatus;
   createdAt: string;
   createdBy?: string;
+  updatedAt?: string;
 }
 
 export interface BookingListResponse {

--- a/turbo-repo/packages/miot-calendar-ui/src/context/planning-selection-context.tsx
+++ b/turbo-repo/packages/miot-calendar-ui/src/context/planning-selection-context.tsx
@@ -45,6 +45,7 @@ import {
   buildResource,
   rollbackPlannedService,
 } from "../services/booking-persistence";
+import { mergeWorkflowStages } from "../services/workflow-stage-merge";
 
 dayjs.extend(isoWeek);
 dayjs.extend(isSameOrAfter);
@@ -288,7 +289,17 @@ export function PlanningSelectionProvider<
   // there is no data (downstream memos key off these references).
   const emptyPlannedRef = useRef<PlannedService<TItem>[]>([]);
   const emptyBookingIdsRef = useRef<Map<string, string>>(new Map());
-  const plannedServices = bookingsData?.planned ?? emptyPlannedRef.current;
+  const rawPlannedServices = bookingsData?.planned ?? emptyPlannedRef.current;
+  // Booking payloads are planning-time snapshots; the host's live workflow
+  // index is the source of truth for stage. Overlaying here — a derive over
+  // the SWR cache — instead of inside `loadBookings` keeps the stage
+  // reactive: a live-index refresh re-labels chips without refetching
+  // bookings (the fetcher is deliberately identity-stable, see above).
+  const resolveWorkflowStage = host.resolveWorkflowStage;
+  const plannedServices = useMemo(
+    () => mergeWorkflowStages(rawPlannedServices, resolveWorkflowStage),
+    [rawPlannedServices, resolveWorkflowStage]
+  );
   const bookingIds = bookingsData?.ids ?? emptyBookingIdsRef.current;
   const bookingsLoadError = bookingsError ? bookingsLoadErrorMessage : null;
 

--- a/turbo-repo/packages/miot-calendar-ui/src/contract/calendar-host.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/contract/calendar-host.ts
@@ -110,6 +110,14 @@ export interface CalendarHost<TRaw = unknown> {
   getLiveTask?: (
     serviceCode: string | undefined
   ) => { taskId: string; stage: string } | undefined;
+  /**
+   * Resolve the *live* workflow stage for a planned item (the host owns the
+   * item → business-code mapping, typically delegating to `getLiveTask`).
+   * When set, the provider overlays the result onto each planned service's
+   * `workflowStage` at render time — undefined preserves any load-time value
+   * (e.g. a terminal state read from the booking payload).
+   */
+  resolveWorkflowStage?: (item: TRaw) => string | undefined;
   /** Override the default sidebar card. */
   renderItemCard?: (item: CalendarItem) => ReactNode;
   /** Override the default grid chip. */

--- a/turbo-repo/packages/miot-calendar-ui/src/services/workflow-stage-merge.test.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/services/workflow-stage-merge.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { mergeWorkflowStages } from "./workflow-stage-merge";
+import type { PlannedService } from "../types/planning";
+
+type Item = { id: string; code?: string };
+
+const slot = { date: new Date("2026-07-13T00:00:00Z"), hour: 5, minutes: 0 };
+
+function planned(
+  id: string,
+  workflowStage?: string
+): PlannedService<Item> {
+  return { service: { id, code: id }, slot, ...(workflowStage ? { workflowStage } : {}) };
+}
+
+describe("mergeWorkflowStages", () => {
+  it("returns the input array untouched when no resolver is given", () => {
+    const input = [planned("1"), planned("2", "finished")];
+    expect(mergeWorkflowStages(input)).toBe(input);
+  });
+
+  it("overlays the resolver's stage onto matching items", () => {
+    const input = [planned("1"), planned("2")];
+    const out = mergeWorkflowStages(input, (item) =>
+      item.id === "1" ? "monitorTrip" : undefined
+    );
+    expect(out[0].workflowStage).toBe("monitorTrip");
+    expect(out[1].workflowStage).toBeUndefined();
+  });
+
+  it("preserves a load-time terminal stage when the resolver has no answer", () => {
+    const input = [planned("1", "finished")];
+    const out = mergeWorkflowStages(input, () => undefined);
+    expect(out[0].workflowStage).toBe("finished");
+    expect(out).toBe(input);
+  });
+
+  it("lets a live stage win over a load-time terminal stage", () => {
+    const input = [planned("1", "finished")];
+    const out = mergeWorkflowStages(input, () => "assignDriver");
+    expect(out[0].workflowStage).toBe("assignDriver");
+  });
+
+  it("keeps item identity for unchanged entries and array identity when nothing changed", () => {
+    const input = [planned("1", "monitorTrip"), planned("2")];
+    const same = mergeWorkflowStages(input, (item) =>
+      item.id === "1" ? "monitorTrip" : undefined
+    );
+    expect(same).toBe(input);
+
+    const out = mergeWorkflowStages(input, (item) =>
+      item.id === "2" ? "confirmArrival" : "monitorTrip"
+    );
+    expect(out[0]).toBe(input[0]);
+    expect(out[1]).not.toBe(input[1]);
+  });
+});

--- a/turbo-repo/packages/miot-calendar-ui/src/services/workflow-stage-merge.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/services/workflow-stage-merge.ts
@@ -1,0 +1,25 @@
+import type { PlannedService } from "../types/planning";
+
+/**
+ * Overlay the host's live workflow stage onto planned services (read-time
+ * join). The resolver's answer wins; undefined preserves any load-time
+ * `workflowStage` (e.g. a terminal state read from the booking payload).
+ *
+ * Identity-preserving: items whose effective stage is unchanged are returned
+ * as-is, and with no resolver the input array itself is returned, so
+ * downstream memos keyed on references stay stable.
+ */
+export function mergeWorkflowStages<TItem extends { id: string }>(
+  planned: PlannedService<TItem>[],
+  resolve?: (item: TItem) => string | undefined
+): PlannedService<TItem>[] {
+  if (!resolve) return planned;
+  let changed = false;
+  const merged = planned.map((ps) => {
+    const stage = resolve(ps.service) ?? ps.workflowStage;
+    if (stage === ps.workflowStage) return ps;
+    changed = true;
+    return { ...ps, workflowStage: stage };
+  });
+  return changed ? merged : planned;
+}

--- a/turbo-repo/packages/miot-calendar-ui/src/types/planning.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/types/planning.ts
@@ -9,6 +9,16 @@ import type { SelectedSlot } from "./calendar-slot";
 export interface PlannedService<TItem extends { id: string } = CalendarItem> {
   service: TItem;
   slot: SelectedSlot;
+  /**
+   * Live workflow stage of the planned item, host-defined (e.g. a kanban
+   * column key or a terminal state such as "finished"). Populated two ways:
+   * a terminal value may be written at load time from the booking payload,
+   * and the provider overlays {@link CalendarHost.resolveWorkflowStage} at
+   * render time so a live-index refresh re-labels chips without a booking
+   * refetch. Undefined = no known stage; renderers fall back to the plain
+   * planned look.
+   */
+  workflowStage?: string;
 }
 
 /** A planned item being reassigned, with its original slot for restoration. */


### PR DESCRIPTION
Closes #925.

## What

Read-time join of workflow state into the planning calendar, so chips stop looking merely "planned" once the workflow moves:

- **Package (`@microboxlabs/miot-calendar-ui`)**: `PlannedService` gains an optional `workflowStage`; the planning provider overlays a new `CalendarHost.resolveWorkflowStage` seam over the SWR-cached bookings at render time (`mergeWorkflowStages`, identity-preserving), so a live-index refresh re-labels chips without refetching bookings.
- **Live index coverage**: the wrapper's `useMyTasks` columns extend from the 5 planning stages to **all active v4 stages** (`+ monitorTrip, confirmArrival, closeMonitoring`).
- **Terminal states**: the booking mapper reads the new lifecycle `status` (`FINISHED→finished`, `CANCELLED→cancelled`, `IN_TRANSIT/ARRIVED→` their kanban equivalents) from `BookingResponse` — written by ECM in CALSYNC Phase 3, historic rows via backfill; live stages win on conflict. `@microboxlabs/miot-calendar-client` types gain optional `status`/`updatedAt`.
- **Chips**: en-route indicator for in-course stages; muted + check/cross for finished/cancelled; stage label in the tooltip. Plain look unchanged when no stage is known.
- **Sidebar**: stage row falls back to the booking's terminal stage when no live task exists (it went blank for finished services).
- i18n (es/en) for the new stage labels.

## Why terminal states don't come from `showFinished=true`

The ECM historic endpoint materializes all ~41K finished instances in memory per call, unordered, with no date filter — window-scoped or per-code queries are not viable, and inferring "finished" from absence in the live index is unsound for group-scoped viewers. Full analysis in ecm-coordinator `docs/plans/GOAL-STATE-CALSYNC.md` (F1 amendment).

## Tests

- 16 new tests: `workflow-stage-merge.test.ts` (package), `workflow-stage.test.ts`, `booking-service-mapper.test.ts`, `planned-service-chip.test.tsx`.
- Full `apps/app` vitest suite: 746 passed. `tsc --noEmit` clean in `apps/app`, `miot-calendar-ui`, `miot-calendar-client`.

Part of the CALSYNC ladder (design + rungs in ecm-coordinator `docs/plans/calendar-workflow-sync*.md`): Phase 2 (miot-calendar C1/C2) is implemented on `based/calsync-booking-status`; Phase 3 (ECM outbox pushes) is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Planning items now show workflow-stage context (including monitoring, arrival confirmation, close monitoring, finished, and cancelled) with corresponding status icons and clearer titles.
  - Live workflow updates are applied automatically when refreshed task columns are available.
  - Booking lifecycle statuses are mapped to the appropriate planning stages, with new English and Spanish labels.

- **Bug Fixes**
  - Terminal states (finished/cancelled) continue to render correctly when live task information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->