### PR TITLE
feat: async-jobs console (Temporal-inspired) + live quarkus-sse job events + bell inbox

### DIFF
--- a/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
+++ b/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
@@ -116,6 +116,7 @@ value you have confirmed; never emit a literal placeholder.
 | `/fleet-management` | fleet, flota, trucks, camiones, trailers, remolques | Fleet vehicles (detail at `/fleet-management/{plate}`) | `licensePlate`, `client`, `state=active\|maintenance\|alert\|inactive` |
 | `/where-is-my-load` | where is my load, dónde está mi carga, expedición, expedition | Load/expedition tracking | `expeditionCode` or `expeditionNumber` (one at a time) |
 | `/notifications` | notifications, notificaciones | User notifications | — |
+| `/integrations/jobs` | integration jobs, trabajos de integración, job console, consola de trabajos | Asynchronous integration job activity and status | — |
 | `/users/settings` | settings, configuración, ajustes | User settings; organizations at `/users/settings/organizations`, data sources at `/users/settings/data-sources` | — |
 | `/admin/console/logs` | admin logs, logs, registros (admins only) | Operational logs | — |
 | `/admin/console/message-templates` | message templates, plantillas de mensaje (admins only) | Message templates | — |

--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -52,6 +52,12 @@ miot.integrations.modulith-worker.lease-seconds=${MIOT_INTEGRATIONS_MODULITH_WOR
 miot.integrations.calendar-sync.miot-calendar.base-url=${MIOT_INTEGRATIONS_CALENDAR_SYNC_MIOT_CALENDAR_BASE_URL:}
 # Optional bearer (env only): MIOT_INTEGRATIONS_CALENDAR_SYNC_MIOT_CALENDAR_TOKEN
 
+# Live job-console events: base URL of the quarkus-sse service; each async-job
+# state transition is POSTed to {url}/api/v1/events/emit as an EventData frame
+# (eventType integrations.job, tenantId = tenant code). Emission is OFF until
+# this is set (empty default — fire-and-forget, never blocks the job path).
+miot.integrations.job-events.sse-base-url=${MIOT_INTEGRATIONS_JOB_EVENTS_SSE_BASE_URL:}
+
 
 # --- HTTP ---
 quarkus.http.port=8180

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsConsoleResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsConsoleResource.java
@@ -1,0 +1,169 @@
+package com.microboxlabs.miot.integrations.api;
+
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * Read/babysit surface of the integration outbox for the web job console.
+ *
+ * <p>Unlike {@link OrgAsyncJobsResource} (the {@code @M2MAuth} control plane
+ * ECM drives), this resource is called by org members with an RS256 web token:
+ * membership and role come from {@code OrganizationRequestFilter} via Alfresco.
+ * It deliberately lives under {@code /integrations/console/jobs} — a path NOT
+ * prefixed by {@code /integrations/jobs} — so the dual-JWT path matcher never
+ * routes it to HS256/M2M verification.
+ *
+ * <p>Same reactive contract as the other org-scoped resources: endpoints
+ * return {@link Uni}, tenant context is resolved eagerly on the event loop and
+ * the blocking {@link AsyncJobService} runs on the worker pool.
+ */
+@Path("/api/v1/orgs/{organizationId}/integrations/console/jobs")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Async Jobs Console", description = "Org-member read and babysit surface for integration jobs")
+@SecurityRequirement(name = "oidc")
+@Authenticated
+@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class OrgAsyncJobsConsoleResource {
+
+    private static final String ERROR_KEY = "error";
+    private static final String CONFLICT = "Conflict";
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final AsyncJobService service;
+    private final JobEventEmitter eventEmitter;
+
+    @Inject
+    public OrgAsyncJobsConsoleResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            AsyncJobService service,
+            JobEventEmitter eventEmitter) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.service = service;
+        this.eventEmitter = eventEmitter;
+    }
+
+    @GET
+    @Operation(summary = "List the org's jobs with optional filters")
+    public Uni<Response> list(
+            @PathParam("organizationId") String organizationId,
+            @QueryParam("state") String state,
+            @QueryParam("correlationKey") String correlationKey,
+            @QueryParam("jobType") String jobType,
+            @QueryParam("chainKey") String chainKey,
+            @QueryParam("limit") @DefaultValue("100") int limit) {
+        String tenant = tenantCode(organizationId);
+        return onWorker(() -> Response.ok(
+                service.list(tenant, state, correlationKey, jobType, chainKey, Math.min(limit, 500))).build())
+                .onFailure(IllegalArgumentException.class)
+                .recoverWithItem(errorResponse(Response.Status.BAD_REQUEST, "Invalid state filter: " + state, null));
+    }
+
+    /**
+     * One round-trip bootstrap for the console: whole-ledger per-state counts
+     * plus what the browser needs to subscribe to the live quarkus-sse stream
+     * ({@code tenantId} is the SSE stream key — the org's tenant code — which
+     * the {@code /me/scopes} payload deliberately does not expose).
+     */
+    @GET
+    @Path("/overview")
+    @Operation(summary = "Per-state counts plus the live-stream subscription context")
+    public Uni<Response> overview(@PathParam("organizationId") String organizationId) {
+        String tenant = tenantCode(organizationId);
+        return onWorker(() -> Response.ok(Map.of(
+                "counts", service.counts(tenant),
+                "tenantId", tenant,
+                "eventType", JobEventEmitter.EVENT_TYPE,
+                "liveEventsConfigured", eventEmitter.isConfigured())).build());
+    }
+
+    @GET
+    @Path("/{jobId}")
+    @Operation(summary = "Get a job with its full attempt history")
+    public Uni<Response> get(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobId") String jobId) {
+        String tenant = tenantCode(organizationId);
+        return onWorker(() -> {
+            AsyncJob job = service.get(tenant, jobId);
+            return job == null ? notFound(jobId) : Response.ok(job).build();
+        });
+    }
+
+    @POST
+    @Path("/{jobId}/retry")
+    @Operation(summary = "Manually reset a parked job so workers pick it up again")
+    public Uni<Response> retry(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobId") String jobId) {
+        String tenant = tenantCode(organizationId);
+        String actor = organizationContext.getUserEmail() != null
+                ? organizationContext.getUserEmail()
+                : tenantContext.getClientId();
+        return onWorker(() -> {
+            AsyncJob job = service.retry(tenant, jobId, actor);
+            return job == null ? notFound(jobId) : Response.ok(job).build();
+        })
+                .onFailure(IllegalStateException.class)
+                .recoverWithItem(e -> errorResponse(Response.Status.CONFLICT, e.getMessage(), CONFLICT));
+    }
+
+    /**
+     * Runs a blocking supplier on the worker pool so this non-blocking endpoint
+     * keeps the request on the event loop (required by the reactive org filter).
+     */
+    private static <T> Uni<T> onWorker(Supplier<T> work) {
+        return Uni.createFrom().item(work).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(
+                    errorResponse(Response.Status.FORBIDDEN, "Organization context does not match request path", null));
+        }
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+
+    private Response notFound(String jobId) {
+        return errorResponse(Response.Status.NOT_FOUND, "Job not found: " + jobId, null);
+    }
+
+    private static Response errorResponse(Response.Status status, String message, String fallback) {
+        String body = message != null ? message : fallback;
+        if (body == null) {
+            body = status.getReasonPhrase();
+        }
+        return Response.status(status)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Map.of(ERROR_KEY, body))
+                .build();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAsyncJobsResource.java
@@ -147,10 +147,11 @@ public class OrgAsyncJobsResource {
             @QueryParam("state") String state,
             @QueryParam("correlationKey") String correlationKey,
             @QueryParam("jobType") String jobType,
+            @QueryParam("chainKey") String chainKey,
             @QueryParam("limit") @DefaultValue("100") int limit) {
         String tenant = tenantCode(organizationId);
         return onWorker(() -> Response.ok(
-                service.list(tenant, state, correlationKey, jobType, Math.min(limit, 500))).build())
+                service.list(tenant, state, correlationKey, jobType, chainKey, Math.min(limit, 500))).build())
                 .onFailure(IllegalArgumentException.class)
                 .recoverWithItem(errorResponse(Response.Status.BAD_REQUEST, "Invalid state filter: " + state, null));
     }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
@@ -1,0 +1,115 @@
+package com.microboxlabs.miot.integrations.events;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Publishes async-job state transitions to the quarkus-sse event bus so the
+ * frontend job console and notification inbox update live.
+ *
+ * <p>Each transition becomes one {@code EventData} frame POSTed to
+ * {@code {base-url}/api/v1/events/emit} with {@code eventType} {@value #EVENT_TYPE}
+ * and {@code tenantId} = the job's tenant code, matching the tenant-scoped
+ * stream the browser subscribes to
+ * ({@code GET /api/v1/events/tenant/{tenantId}/stream/{eventType}}).
+ *
+ * <p>quarkus-sse is a live fan-out with no persistence: frames sent with no
+ * subscriber are dropped, which is fine — the console's source of truth is the
+ * {@code async_jobs} ledger; SSE only triggers refreshes. Delivery is therefore
+ * strictly fire-and-forget: failures are logged at DEBUG and never propagate
+ * into the enqueue/claim/report path.
+ *
+ * <p>Disabled until {@code miot.integrations.job-events.sse-base-url} is set
+ * (empty default — no baked endpoint), mirroring {@code CalendarBookingsClient}.
+ */
+@ApplicationScoped
+public class JobEventEmitter {
+
+    public static final String EVENT_TYPE = "integrations.job";
+
+    private static final Logger LOG = Logger.getLogger(JobEventEmitter.class);
+    private static final String EMIT_PATH = "/api/v1/events/emit";
+
+    private final Optional<String> baseUrl;
+    private final HttpClient http;
+
+    @Inject
+    public JobEventEmitter(
+            @ConfigProperty(name = "miot.integrations.job-events.sse-base-url") Optional<String> baseUrl) {
+        this.baseUrl = baseUrl
+                .filter(url -> !url.isBlank())
+                .map(url -> url.endsWith("/") ? url.substring(0, url.length() - 1) : url);
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(3))
+                .build();
+    }
+
+    public boolean isConfigured() {
+        return baseUrl.isPresent();
+    }
+
+    /**
+     * Emits one transition frame for the job's current row state. Never throws;
+     * a no-op when unconfigured.
+     *
+     * @param transition what just happened to the job: {@code enqueued},
+     *        {@code claimed}, {@code succeeded}, {@code retry_scheduled},
+     *        {@code failed} or {@code retried}
+     */
+    public void emit(AsyncJob job, String transition) {
+        if (job == null || baseUrl.isEmpty()) {
+            return;
+        }
+        String body = eventData(job, transition).encode();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl.get() + EMIT_PATH))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        http.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+                .whenComplete((response, error) -> {
+                    if (error != null) {
+                        LOG.debugf("Job event emit failed for job %s (%s): %s",
+                                job.id(), transition, error.getMessage());
+                    } else if (response.statusCode() >= 400) {
+                        LOG.debugf("Job event emit rejected for job %s (%s): HTTP %d",
+                                job.id(), transition, response.statusCode());
+                    }
+                });
+    }
+
+    /** quarkus-sse {@code EventData} frame for a job transition. */
+    JsonObject eventData(AsyncJob job, String transition) {
+        JsonObject payload = new JsonObject()
+                .put("jobId", job.id())
+                .put("jobType", job.jobType())
+                .put("executor", job.executor())
+                .put("state", job.state() != null ? job.state().name() : null)
+                .put("transition", transition)
+                .put("attempts", job.attempts())
+                .put("maxAttempts", job.maxAttempts())
+                .put("correlationKey", job.correlationKey())
+                .put("chainKey", job.chainKey())
+                .put("chainSequence", job.chainSequence())
+                .put("enqueuedBy", job.enqueuedBy())
+                .put("lastError", job.lastError())
+                .put("nextRetryAt", job.nextRetryAt() != null ? job.nextRetryAt().toString() : null)
+                .put("updatedAt", job.updatedAt() != null ? job.updatedAt().toString() : null);
+        return new JsonObject()
+                .put("eventType", EVENT_TYPE)
+                .put("tenantId", job.tenantCode())
+                .put("timestamp", Instant.now().toString())
+                .put("payload", payload);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
@@ -71,22 +71,29 @@ public class JobEventEmitter {
         if (job == null || baseUrl.isEmpty()) {
             return;
         }
-        String body = eventData(job, transition).encode();
-        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl.get() + EMIT_PATH))
-                .timeout(Duration.ofSeconds(5))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .build();
-        http.sendAsync(request, HttpResponse.BodyHandlers.discarding())
-                .whenComplete((response, error) -> {
-                    if (error != null) {
-                        LOG.debugf("Job event emit failed for job %s (%s): %s",
-                                job.id(), transition, error.getMessage());
-                    } else if (response.statusCode() >= 400) {
-                        LOG.debugf("Job event emit rejected for job %s (%s): HTTP %d",
-                                job.id(), transition, response.statusCode());
-                    }
-                });
+        try {
+            String body = eventData(job, transition).encode();
+            HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl.get() + EMIT_PATH))
+                    .timeout(Duration.ofSeconds(5))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+            http.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+                    .whenComplete((response, error) -> {
+                        if (error != null) {
+                            LOG.debugf("Job event emit failed for job %s (%s): %s",
+                                    job.id(), transition, error.getMessage());
+                        } else if (response.statusCode() >= 400) {
+                            LOG.debugf("Job event emit rejected for job %s (%s): HTTP %d",
+                                    job.id(), transition, response.statusCode());
+                        }
+                    });
+        } catch (Exception e) {
+            // e.g. a malformed configured base URL (URI.create) — never let the
+            // emitter abort the enqueue/claim/report path it piggybacks on.
+            LOG.debugf("Job event emit failed for job %s (%s): %s",
+                    job.id(), transition, e.getMessage());
+        }
     }
 
     /** quarkus-sse {@code EventData} frame for a job transition. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java
@@ -163,8 +163,15 @@ public class AsyncJobRepository {
               AND ($2::varchar IS NULL OR state = $2)
               AND ($3::varchar IS NULL OR correlation_key = $3)
               AND ($4::varchar IS NULL OR job_type = $4)
+              AND ($5::varchar IS NULL OR chain_key = $5)
             ORDER BY created_at DESC
-            LIMIT $5""".formatted(COLUMNS);
+            LIMIT $6""".formatted(COLUMNS);
+
+    private static final String COUNT_BY_STATE = """
+            SELECT state, count(*)::int AS n
+            FROM miot_integrations.async_jobs
+            WHERE tenant_code = $1
+            GROUP BY state""";
 
     private final Instance<Pool> clientInstance;
 
@@ -264,12 +271,14 @@ public class AsyncJobRepository {
         return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
     }
 
-    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType, int limit) {
+    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType,
+            String chainKey, int limit) {
         Tuple params = Tuple.tuple()
                 .addString(tenantCode)
                 .addString(state)
                 .addString(correlationKey)
                 .addString(jobType)
+                .addString(chainKey)
                 .addInteger(limit);
         return client().preparedQuery(LIST)
                 .execute(params)
@@ -277,6 +286,16 @@ public class AsyncJobRepository {
                 .stream()
                 .map(this::mapRow)
                 .toList();
+    }
+
+    /** Per-state row counts for the whole tenant ledger (not window-limited like {@link #list}). */
+    public Map<String, Integer> countByState(String tenantCode) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        client().preparedQuery(COUNT_BY_STATE)
+                .execute(Tuple.of(tenantCode))
+                .await().indefinitely()
+                .forEach(row -> counts.put(row.getString("state"), row.getInteger("n")));
+        return counts;
     }
 
     private Pool client() {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -7,6 +7,7 @@ import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -35,15 +36,18 @@ public class AsyncJobService {
     private static final int MAX_CLAIM_LIMIT = 50;
 
     private final AsyncJobRepository repository;
+    private final JobEventEmitter eventEmitter;
     private final int retryBaseSeconds;
     private final int retryMaxSeconds;
 
     @Inject
     public AsyncJobService(
             AsyncJobRepository repository,
+            JobEventEmitter eventEmitter,
             @ConfigProperty(name = "miot.integrations.jobs.retry-base-seconds", defaultValue = "60") int retryBaseSeconds,
             @ConfigProperty(name = "miot.integrations.jobs.retry-max-seconds", defaultValue = "3600") int retryMaxSeconds) {
         this.repository = repository;
+        this.eventEmitter = eventEmitter;
         this.retryBaseSeconds = retryBaseSeconds;
         this.retryMaxSeconds = retryMaxSeconds;
     }
@@ -68,6 +72,7 @@ public class AsyncJobService {
                 duplicates++;
             } else {
                 created.add(row);
+                eventEmitter.emit(row, "enqueued");
             }
         }
         logEnqueueOutcome(tenantCode, enqueuedBy, created, duplicates);
@@ -118,8 +123,10 @@ public class AsyncJobService {
         }
         int limit = request.limit() == null ? DEFAULT_CLAIM_LIMIT : Math.min(request.limit(), MAX_CLAIM_LIMIT);
         int lease = request.leaseSeconds() == null ? DEFAULT_LEASE_SECONDS : request.leaseSeconds();
-        return repository.claim(tenantCode, request.executor(), request.workerId(), limit, lease,
+        List<AsyncJob> claimed = repository.claim(tenantCode, request.executor(), request.workerId(), limit, lease,
                 request.chainKey());
+        claimed.forEach(job -> eventEmitter.emit(job, "claimed"));
+        return claimed;
     }
 
     /**
@@ -137,7 +144,9 @@ public class AsyncJobService {
         }
         int lim = Math.min(Math.max(limit, 1), MAX_CLAIM_LIMIT);
         int lease = leaseSeconds < 1 ? DEFAULT_LEASE_SECONDS : leaseSeconds;
-        return repository.claimForExecutor(executor, workerId, lim, lease);
+        List<AsyncJob> claimed = repository.claimForExecutor(executor, workerId, lim, lease);
+        claimed.forEach(job -> eventEmitter.emit(job, "claimed"));
+        return claimed;
     }
 
     /**
@@ -180,6 +189,11 @@ public class AsyncJobService {
             LOG.errorf("Job %s (%s, correlation=%s) parked as FAILED after %d attempt(s): %s",
                     jobId, job.jobType(), job.correlationKey(), job.attempts(), request.detail());
         }
+        eventEmitter.emit(updated, switch (newState) {
+            case SUCCEEDED -> "succeeded";
+            case PENDING -> "retry_scheduled";
+            default -> "failed";
+        });
         return updated;
     }
 
@@ -199,21 +213,34 @@ public class AsyncJobService {
             throw new IllegalStateException(
                     "Job " + jobId + " is " + job.state() + " and cannot be manually retried");
         }
-        return repository.retry(jobId, attemptEntry("RETRY_REQUESTED", "Manual retry", actor));
+        AsyncJob updated = repository.retry(jobId, attemptEntry("RETRY_REQUESTED", "Manual retry", actor));
+        eventEmitter.emit(updated, "retried");
+        return updated;
     }
 
     public AsyncJob get(String tenantCode, String jobId) {
         return repository.findByTenantAndId(tenantCode, jobId);
     }
 
-    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType, int limit) {
+    public List<AsyncJob> list(String tenantCode, String state, String correlationKey, String jobType,
+            String chainKey, int limit) {
         if (limit < 1) {
             throw new IllegalArgumentException("limit must be >= 1");
         }
         if (state != null) {
             JobState.valueOf(state); // validate
         }
-        return repository.list(tenantCode, state, correlationKey, jobType, limit);
+        return repository.list(tenantCode, state, correlationKey, jobType, chainKey, limit);
+    }
+
+    /** Whole-ledger per-state counts for the console's summary tiles (zero-filled). */
+    public Map<String, Integer> counts(String tenantCode) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (JobState state : JobState.values()) {
+            counts.put(state.name(), 0);
+        }
+        counts.putAll(repository.countByState(tenantCode));
+        return counts;
     }
 
     private static void requireBody(Object request) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/events/JobEventEmitterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/events/JobEventEmitterTest.java
@@ -1,0 +1,64 @@
+package com.microboxlabs.miot.integrations.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import io.vertx.core.json.JsonObject;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class JobEventEmitterTest {
+
+    @Test
+    void unconfiguredEmitterIsDisabledAndEmitIsANoOp() {
+        var emitter = new JobEventEmitter(Optional.empty());
+        assertFalse(emitter.isConfigured());
+        emitter.emit(job(), "enqueued"); // must not throw or attempt I/O
+        emitter.emit(null, "enqueued");
+    }
+
+    @Test
+    void blankUrlCountsAsUnconfigured() {
+        assertFalse(new JobEventEmitter(Optional.of("   ")).isConfigured());
+        assertTrue(new JobEventEmitter(Optional.of("http://quarkus-sse:8080/")).isConfigured());
+    }
+
+    @Test
+    void eventDataMatchesTheQuarkusSseContract() {
+        var emitter = new JobEventEmitter(Optional.of("http://quarkus-sse:8080"));
+
+        JsonObject frame = emitter.eventData(job(), "retry_scheduled");
+
+        assertEquals("integrations.job", frame.getString("eventType"));
+        assertEquals("tenant-code-1", frame.getString("tenantId"));
+        assertNotNull(frame.getString("timestamp"));
+
+        JsonObject payload = frame.getJsonObject("payload");
+        assertEquals("job-1", payload.getString("jobId"));
+        assertEquals("calendar_sync", payload.getString("jobType"));
+        assertEquals("PENDING", payload.getString("state"));
+        assertEquals("retry_scheduled", payload.getString("transition"));
+        assertEquals(2, payload.getInteger("attempts"));
+        assertEquals(5, payload.getInteger("maxAttempts"));
+        assertEquals("VJ-26-0001", payload.getString("correlationKey"));
+        assertEquals("chain-1", payload.getString("chainKey"));
+        assertEquals("409 conflict", payload.getString("lastError"));
+        assertNull(payload.getString("updatedAt"));
+    }
+
+    private static AsyncJob job() {
+        return new AsyncJob("job-1", "tenant-code-1", "ecm-1", "modulith", "calendar_sync", "VJ-26-0001",
+                "chain-1", 0, "dk-1", Map.of(), JobState.PENDING, 2, 5,
+                OffsetDateTime.now(ZoneOffset.UTC), null, null, "409 conflict", List.of(), "listener",
+                null, null);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
@@ -8,6 +8,7 @@ import com.microboxlabs.miot.integrations.domain.AsyncJob;
 import com.microboxlabs.miot.integrations.domain.JobState;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import com.microboxlabs.miot.integrations.service.AsyncJobService;
 import java.util.ArrayDeque;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -159,7 +161,7 @@ class ModulithJobWorkerTest {
         int claimCalls;
 
         RecordingService() {
-            super(new NoopRepository(), 60, 3600);
+            super(new NoopRepository(), new JobEventEmitter(Optional.empty()), 60, 3600);
         }
 
         @Override

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -11,11 +11,14 @@ import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
 import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class AsyncJobServiceTest {
@@ -26,7 +29,7 @@ class AsyncJobServiceTest {
     @Test
     void reportFailureSchedulesBackoffRetryWhileAttemptsRemain() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("tenant-less-id", "job-1", failed());
 
@@ -36,7 +39,7 @@ class AsyncJobServiceTest {
 
     @Test
     void backoffDoublesPerAttemptAndIsCapped() throws Exception {
-        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
         Method backoff = AsyncJobService.class.getDeclaredMethod("backoffSeconds", int.class);
         backoff.setAccessible(true);
 
@@ -48,7 +51,7 @@ class AsyncJobServiceTest {
     @Test
     void reportFailureParksJobWhenAttemptsExhausted() {
         var repo = new FakeRepository(runningJob(5, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", failed());
 
@@ -59,7 +62,7 @@ class AsyncJobServiceTest {
     @Test
     void reportNonRetryableFailureParksImmediately() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("w", "FAILED", "bad config", false, null));
 
@@ -69,7 +72,7 @@ class AsyncJobServiceTest {
     @Test
     void reportSkippedClosesJobAsSucceeded() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("w", "SKIPPED", "already delivered", null, null));
 
@@ -80,7 +83,7 @@ class AsyncJobServiceTest {
     @Test
     void reportRejectsJobsThatAreNotRunning() {
         var repo = new FakeRepository(jobInState(JobState.PENDING, 0, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
         var request = failed();
 
         assertThrows(IllegalStateException.class,
@@ -90,14 +93,14 @@ class AsyncJobServiceTest {
     @Test
     void retryRejectsSucceededJobs() {
         var repo = new FakeRepository(jobInState(JobState.SUCCEEDED, 1, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         assertThrows(IllegalStateException.class, () -> service.retry("t", "job-1", "actor"));
     }
 
     @Test
     void enqueueValidatesRequiredFields() {
-        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
         var missingSource = new EnqueueJobsRequest(null, "listener", List.of(spec()));
         var emptyJobs = new EnqueueJobsRequest("ecm-1", "listener", List.of());
         var bogusActor = new EnqueueJobsRequest("ecm-1", "bogus", List.of(spec()));
@@ -118,7 +121,7 @@ class AsyncJobServiceTest {
                 return ++calls == 1 ? job : null;
             }
         };
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         var response = service.enqueue("t",
                 new EnqueueJobsRequest("ecm-1", "reconciler", List.of(spec(), spec())));
@@ -129,7 +132,7 @@ class AsyncJobServiceTest {
 
     @Test
     void nullRequestBodiesAreRejected() {
-        var service = new AsyncJobService(new FakeRepository(null), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", null));
         assertThrows(IllegalArgumentException.class, () -> service.claim("t", null));
@@ -139,7 +142,7 @@ class AsyncJobServiceTest {
     @Test
     void claimScopesByTenantAndValidatesBounds() {
         var repo = new FakeRepository(null);
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
         var badLimit = new ClaimJobsRequest("ecm", "w1", 0, null, null);
         var badLease = new ClaimJobsRequest("ecm", "w1", null, 0, null);
 
@@ -154,7 +157,7 @@ class AsyncJobServiceTest {
     void staleReportIsRejectedWhenLeaseCasFails() {
         var repo = new FakeRepository(runningJob(1, 5));
         repo.reportStale = true;
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
         var request = failed();
 
         assertThrows(IllegalStateException.class, () -> service.report("t", "job-1", request));
@@ -163,7 +166,7 @@ class AsyncJobServiceTest {
     @Test
     void reportEchoesWorkerAndAttemptIntoLeaseCas() {
         var repo = new FakeRepository(runningJob(2, 5));
-        var service = new AsyncJobService(repo, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("worker-1", "SUCCEEDED", "ok", null, 2));
 
@@ -171,7 +174,83 @@ class AsyncJobServiceTest {
         assertEquals(2, repo.reportedExpectedAttempts);
     }
 
+    @Test
+    void reportEmitsTransitionEvents() {
+        var emitter = new RecordingEmitter();
+        var service = new AsyncJobService(new FakeRepository(runningJob(1, 5)), emitter, BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", failed());
+
+        assertEquals(List.of("retry_scheduled"), emitter.transitions);
+    }
+
+    @Test
+    void retryEmitsRetriedEvent() {
+        var emitter = new RecordingEmitter();
+        var service = new AsyncJobService(new FakeRepository(jobInState(JobState.FAILED, 5, 5)),
+                emitter, BASE_SECONDS, MAX_SECONDS);
+
+        service.retry("t", "job-1", "operator@test.example");
+
+        assertEquals(List.of("retried"), emitter.transitions);
+    }
+
+    @Test
+    void enqueueEmitsEnqueuedPerCreatedJobOnly() {
+        var repo = new FakeRepository(null) {
+            private int calls = 0;
+
+            @Override
+            public AsyncJob insert(AsyncJob job) {
+                return ++calls == 1 ? job : null; // second insert is a dedupe hit
+            }
+        };
+        var emitter = new RecordingEmitter();
+        var service = new AsyncJobService(repo, emitter, BASE_SECONDS, MAX_SECONDS);
+
+        service.enqueue("t", new EnqueueJobsRequest("ecm-1", "listener", List.of(spec(), spec())));
+
+        assertEquals(List.of("enqueued"), emitter.transitions);
+    }
+
+    @Test
+    void countsZeroFillsEveryState() {
+        var repo = new FakeRepository(null) {
+            @Override
+            public Map<String, Integer> countByState(String tenantCode) {
+                return Map.of("FAILED", 2);
+            }
+        };
+        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+
+        Map<String, Integer> counts = service.counts("t");
+
+        assertEquals(2, counts.get("FAILED"));
+        assertEquals(0, counts.get("PENDING"));
+        assertEquals(JobState.values().length, counts.size());
+    }
+
     // -----------------------------------------------------------------------
+
+    private static JobEventEmitter noEvents() {
+        return new JobEventEmitter(Optional.empty());
+    }
+
+    /** Captures transitions instead of POSTing to quarkus-sse. */
+    private static class RecordingEmitter extends JobEventEmitter {
+        final List<String> transitions = new ArrayList<>();
+
+        RecordingEmitter() {
+            super(Optional.empty());
+        }
+
+        @Override
+        public void emit(AsyncJob job, String transition) {
+            if (job != null) {
+                transitions.add(transition);
+            }
+        }
+    }
 
     private static ReportJobRequest failed() {
         return new ReportJobRequest("worker-1", "FAILED", "Alerce 500", null, null);

--- a/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
+++ b/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
@@ -1,0 +1,16 @@
+import { getDictionary } from "@/features/i18n/i18n.service";
+import { I18nRecord, ParamsWithLang } from "@/features/i18n/i18n.service.types";
+import { RouteGuard } from "@/features/auth/components/route-guard";
+import JobConsolePageContent from "@/features/integration-jobs/components/job-console-page-content";
+
+export default async function IntegrationJobsPage({ params }: ParamsWithLang) {
+  const { lang } = await params;
+  const [, dictionary] = await getDictionary(lang);
+  const dict = (dictionary.pages as I18nRecord)?.integrationJobs as I18nRecord;
+
+  return (
+    <RouteGuard path="/integrations/jobs" fallbackPath={`/${lang}/shipping`}>
+      <JobConsolePageContent dict={dict ?? {}} />
+    </RouteGuard>
+  );
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/[jobId]/retry/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/[jobId]/retry/route.ts
@@ -1,0 +1,15 @@
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/** Manually reset a parked job so workers pick it up again. */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string; jobId: string }> },
+) {
+  const { orgId, jobId } = await params;
+  const safeOrg = encodeURIComponent(orgId);
+  const safeJob = encodeURIComponent(jobId);
+  return forwardToQuarkus(
+    `/api/v1/orgs/${safeOrg}/integrations/console/jobs/${safeJob}/retry`,
+    { method: "POST" },
+  );
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/[jobId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/[jobId]/route.ts
@@ -1,0 +1,12 @@
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/** One integration job with its full attempt history. */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string; jobId: string }> },
+) {
+  const { orgId, jobId } = await params;
+  const safeOrg = encodeURIComponent(orgId);
+  const safeJob = encodeURIComponent(jobId);
+  return forwardToQuarkus(`/api/v1/orgs/${safeOrg}/integrations/console/jobs/${safeJob}`);
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/overview/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/overview/route.ts
@@ -1,0 +1,11 @@
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/** Per-state counts + live-stream subscription context for the job console. */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { orgId } = await params;
+  const safe = encodeURIComponent(orgId);
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/console/jobs/overview`);
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/route.ts
@@ -1,0 +1,14 @@
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+/** List the org's integration jobs (state/jobType/chainKey/limit filters). */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const { orgId } = await params;
+  const safe = encodeURIComponent(orgId);
+  const query = new URL(request.url).searchParams.toString();
+  return forwardToQuarkus(
+    `/api/v1/orgs/${safe}/integrations/console/jobs${query ? `?${query}` : ""}`,
+  );
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/jobs/route.ts
@@ -8,7 +8,6 @@ export async function GET(
   const { orgId } = await params;
   const safe = encodeURIComponent(orgId);
   const query = new URL(request.url).searchParams.toString();
-  return forwardToQuarkus(
-    `/api/v1/orgs/${safe}/integrations/console/jobs${query ? `?${query}` : ""}`,
-  );
+  const suffix = query ? `?${query}` : "";
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/console/jobs${suffix}`);
 }

--- a/turbo-repo/apps/app/src/features/auth/config/route-permissions.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/route-permissions.ts
@@ -60,6 +60,10 @@ export const ROUTE_PERMISSIONS = {
   // Fleet management
   "/fleet-management": FLEET_MANAGEMENT_ROLES,
 
+  // Integrations job console — any authenticated org member; the backend
+  // enforces org membership per request.
+  "/integrations/jobs": [],
+
   // Admin console routes
   "/admin/console/message-templates": ADMIN_ROLES,
 } as const;

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { HiOutlineChevronRight, HiOutlineSearch, HiOutlineRefresh } from "react-icons/hi";
+import { tr } from "@/features/i18n/tr.service";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { useOrgScopes } from "@/features/layout/components/secured-navbar/org-switcher/use-org-scopes";
+import {
+  JOB_STATES,
+  JOB_STATE_DOT,
+  jobContextLine,
+  jobTypeLabel,
+  relativeAge,
+  shortJobId,
+  type AsyncJob,
+  type JobState,
+} from "../integration-job.types";
+import { useIntegrationJobs, useIntegrationJobsOverview } from "../use-integration-jobs";
+import { useJobEvents } from "../use-job-events";
+import JobDetailPanel from "./job-detail-panel";
+import JobStateBadge from "./job-state-badge";
+
+interface JobConsolePageContentProps {
+  readonly dict: I18nRecord;
+}
+
+const CONTEXT_TONE: Record<JobState, string> = {
+  PENDING: "text-amber-600 dark:text-amber-400",
+  RUNNING: "text-blue-600 dark:text-blue-400",
+  SUCCEEDED: "text-green-700 dark:text-green-400",
+  FAILED: "text-rose-600 dark:text-rose-400",
+  CANCELLED: "text-gray-500 dark:text-gray-400",
+};
+
+export default function JobConsolePageContent({ dict }: JobConsolePageContentProps) {
+  const { activeOrg } = useOrgScopes();
+  const orgSlug = activeOrg?.slug ?? null;
+
+  const [stateFilter, setStateFilter] = useState<JobState | null>(null);
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const [laneFilter, setLaneFilter] = useState<string>("");
+  const [search, setSearch] = useState("");
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  // Countdown/age labels tick every 5s without refetching.
+  useEffect(() => {
+    const timer = window.setInterval(() => setNowMs(Date.now()), 5_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const { overview, isLoading: overviewLoading } = useIntegrationJobsOverview(orgSlug);
+  const { jobs, isLoading, error, refresh } = useIntegrationJobs(orgSlug, {
+    state: stateFilter ?? undefined,
+    jobType: typeFilter || undefined,
+    limit: 100,
+  });
+  const { connected, liveConfigured } = useJobEvents(orgSlug);
+
+  const jobTypes = useMemo(() => {
+    const types = new Set<string>(jobs.map((job) => job.jobType));
+    if (typeFilter) types.add(typeFilter);
+    return [...types].sort((a, b) => a.localeCompare(b));
+  }, [jobs, typeFilter]);
+
+  const lanes = useMemo(() => [...new Set(jobs.map((job) => job.executor))].sort((a, b) => a.localeCompare(b)), [jobs]);
+
+  const visibleJobs = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return jobs.filter(
+      (job) =>
+        (!laneFilter || job.executor === laneFilter) &&
+        (!query ||
+          job.id.startsWith(query) ||
+          (job.correlationKey ?? "").toLowerCase().includes(query) ||
+          (job.chainKey ?? "").toLowerCase().includes(query)),
+    );
+  }, [jobs, laneFilter, search]);
+
+  const counts = overview?.counts;
+
+  return (
+    <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-4 p-4">
+      {/* header */}
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-white">{tr("title", dict)}</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{tr("subtitle", dict)}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+            title={liveConfigured ? undefined : tr("live.notConfigured", dict)}
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${
+                connected ? "animate-pulse bg-green-500" : liveConfigured ? "bg-amber-500" : "bg-gray-400"
+              }`}
+            />
+            {connected ? tr("live.connected", dict) : tr("live.disconnected", dict)}
+          </span>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            <HiOutlineRefresh className="h-3.5 w-3.5" />
+            {tr("refresh", dict)}
+          </button>
+        </div>
+      </div>
+
+      {/* state summary tiles */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {JOB_STATES.map((state) => {
+          const active = stateFilter === state;
+          const count = counts?.[state];
+          return (
+            <button
+              key={state}
+              type="button"
+              onClick={() => setStateFilter(active ? null : state)}
+              className={`rounded-lg border bg-white p-3 text-left transition-colors dark:bg-gray-800 ${
+                active
+                  ? "border-gray-900 ring-2 ring-gray-900/10 dark:border-white dark:ring-white/10"
+                  : "border-gray-200 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-500"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+                  {count ?? (overviewLoading ? "…" : 0)}
+                </span>
+                <span className={`h-2 w-2 rounded-full ${JOB_STATE_DOT[state]}`} />
+              </div>
+              <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{tr(`states.${state}`, dict)}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => setStateFilter(null)}
+            className={`rounded-full border px-3 py-1 text-xs ${
+              stateFilter === null
+                ? "border-gray-900 bg-gray-900 text-white dark:border-white dark:bg-white dark:text-gray-900"
+                : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            }`}
+          >
+            {tr("filters.all", dict)}
+          </button>
+          {JOB_STATES.map((state) => (
+            <button
+              key={state}
+              type="button"
+              onClick={() => setStateFilter(stateFilter === state ? null : state)}
+              className={`rounded-full border px-3 py-1 text-xs ${
+                stateFilter === state
+                  ? "border-gray-900 bg-gray-900 text-white dark:border-white dark:bg-white dark:text-gray-900"
+                  : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              }`}
+            >
+              {tr(`states.${state}`, dict)}
+            </button>
+          ))}
+        </div>
+        <span className="flex-1" />
+        <select
+          value={laneFilter}
+          onChange={(event) => setLaneFilter(event.target.value)}
+          className="h-8 rounded-lg border border-gray-300 bg-white px-2 text-xs text-gray-700 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+        >
+          <option value="">{tr("filters.allLanes", dict)}</option>
+          {lanes.map((lane) => (
+            <option key={lane} value={lane}>
+              {lane}
+            </option>
+          ))}
+        </select>
+        <select
+          value={typeFilter}
+          onChange={(event) => setTypeFilter(event.target.value)}
+          className="h-8 rounded-lg border border-gray-300 bg-white px-2 text-xs text-gray-700 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+        >
+          <option value="">{tr("filters.allTypes", dict)}</option>
+          {jobTypes.map((type) => (
+            <option key={type} value={type}>
+              {jobTypeLabel(type)}
+            </option>
+          ))}
+        </select>
+        <label className="relative">
+          <HiOutlineSearch className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={tr("filters.searchPlaceholder", dict)}
+            className="h-8 w-56 rounded-lg border border-gray-300 bg-white pl-8 pr-2 text-xs text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          />
+        </label>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300">
+          {tr("loadError", dict)}
+        </div>
+      )}
+
+      {/* table + detail */}
+      <div
+        className={`grid grid-cols-1 items-start gap-4 ${selectedJobId ? "xl:grid-cols-[minmax(0,1fr)_400px]" : ""}`}
+      >
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-center border-b border-gray-100 px-4 py-3 dark:border-gray-700">
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">
+              {tr("table.title", dict)} · {visibleJobs.length}
+            </span>
+            <span className="flex-1" />
+            <span className="font-mono text-[11px] text-gray-400 dark:text-gray-500">
+              async_jobs · miot_integrations
+            </span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-gray-100 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:border-gray-700 dark:text-gray-500">
+                  <th className="px-4 py-2 font-semibold">{tr("table.job", dict)}</th>
+                  <th className="px-2 py-2 font-semibold">{tr("table.correlation", dict)}</th>
+                  <th className="px-2 py-2 font-semibold">{tr("table.lane", dict)}</th>
+                  <th className="px-2 py-2 font-semibold">{tr("table.state", dict)}</th>
+                  <th className="px-2 py-2 font-semibold">{tr("table.attempts", dict)}</th>
+                  <th className="px-2 py-2 font-semibold">{tr("table.detail", dict)}</th>
+                  <th className="px-2 py-2 text-right font-semibold">{tr("table.age", dict)}</th>
+                  <th className="w-8 px-2 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading && jobs.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
+                      {tr("table.loading", dict)}
+                    </td>
+                  </tr>
+                )}
+                {!isLoading && visibleJobs.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
+                      {tr("table.empty", dict)}
+                    </td>
+                  </tr>
+                )}
+                {visibleJobs.map((job: AsyncJob) => (
+                  <tr
+                    key={job.id}
+                    onClick={() => setSelectedJobId(job.id)}
+                    className={`cursor-pointer border-b border-gray-50 last:border-0 dark:border-gray-700/50 ${
+                      selectedJobId === job.id
+                        ? "bg-gray-100 dark:bg-gray-700/60"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                    }`}
+                  >
+                    <td className="px-4 py-2.5">
+                      <span className="block text-[13px] font-semibold text-gray-900 dark:text-white">
+                        {jobTypeLabel(job.jobType)}
+                      </span>
+                      <span className="block font-mono text-[10px] text-gray-400 dark:text-gray-500">
+                        {shortJobId(job.id)}
+                        {job.chainKey ? ` · ${tr("table.chainStep", dict)} ${job.chainSequence}` : ""}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 font-mono text-xs text-gray-700 dark:text-gray-300">
+                      {job.correlationKey ?? "—"}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                        {job.executor}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <JobStateBadge state={job.state} label={tr(`states.${job.state}`, dict)} />
+                    </td>
+                    <td
+                      className={`px-2 py-2.5 font-mono text-xs ${
+                        job.attempts > 1 ? "text-amber-600 dark:text-amber-400" : "text-gray-500 dark:text-gray-400"
+                      }`}
+                    >
+                      {job.attempts}/{job.maxAttempts}
+                    </td>
+                    <td className={`max-w-[220px] truncate px-2 py-2.5 text-xs ${CONTEXT_TONE[job.state]}`}>
+                      {jobContextLine(job, nowMs)}
+                    </td>
+                    <td className="px-2 py-2.5 text-right text-[11px] text-gray-400 dark:text-gray-500">
+                      {relativeAge(job.createdAt, nowMs)}
+                    </td>
+                    <td className="px-2 py-2.5 text-gray-300 dark:text-gray-600">
+                      <HiOutlineChevronRight className="h-3.5 w-3.5" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {selectedJobId && orgSlug && (
+          <JobDetailPanel
+            orgSlug={orgSlug}
+            jobId={selectedJobId}
+            dict={dict}
+            nowMs={nowMs}
+            onClose={() => setSelectedJobId(null)}
+            onSelectJob={setSelectedJobId}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
@@ -256,14 +256,6 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
                   <tr
                     key={job.id}
                     onClick={() => setSelectedJobId(job.id)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        setSelectedJobId(job.id);
-                      }
-                    }}
-                    role="button"
-                    tabIndex={0}
                     className={`cursor-pointer border-b border-gray-50 last:border-0 dark:border-gray-700/50 ${
                       selectedJobId === job.id
                         ? "bg-gray-100 dark:bg-gray-700/60"
@@ -271,13 +263,21 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
                     }`}
                   >
                     <td className="px-4 py-2.5">
-                      <span className="block text-[13px] font-semibold text-gray-900 dark:text-white">
-                        {jobTypeLabel(job.jobType)}
-                      </span>
-                      <span className="block font-mono text-[10px] text-gray-400 dark:text-gray-500">
-                        {shortJobId(job.id)}
-                        {job.chainKey ? ` · ${tr("table.chainStep", dict)} ${job.chainSequence}` : ""}
-                      </span>
+                      {/* Native button = the keyboard/AT path for opening the
+                          detail panel; the row onClick is mouse convenience. */}
+                      <button
+                        type="button"
+                        onClick={() => setSelectedJobId(job.id)}
+                        className="block text-left"
+                      >
+                        <span className="block text-[13px] font-semibold text-gray-900 dark:text-white">
+                          {jobTypeLabel(job.jobType)}
+                        </span>
+                        <span className="block font-mono text-[10px] text-gray-400 dark:text-gray-500">
+                          {shortJobId(job.id)}
+                          {job.chainKey ? ` · ${tr("table.chainStep", dict)} ${job.chainSequence}` : ""}
+                        </span>
+                      </button>
                     </td>
                     <td className="px-2 py-2.5 font-mono text-xs text-gray-700 dark:text-gray-300">
                       {job.correlationKey ?? "—"}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
@@ -79,6 +79,10 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
 
   const counts = overview?.counts;
 
+  let liveDotClass = "bg-gray-400";
+  if (connected) liveDotClass = "animate-pulse bg-green-500";
+  else if (liveConfigured) liveDotClass = "bg-amber-500";
+
   return (
     <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-4 p-4">
       {/* header */}
@@ -92,11 +96,7 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
             className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300"
             title={liveConfigured ? undefined : tr("live.notConfigured", dict)}
           >
-            <span
-              className={`h-1.5 w-1.5 rounded-full ${
-                connected ? "animate-pulse bg-green-500" : liveConfigured ? "bg-amber-500" : "bg-gray-400"
-              }`}
-            />
+            <span className={`h-1.5 w-1.5 rounded-full ${liveDotClass}`} />
             {connected ? tr("live.connected", dict) : tr("live.disconnected", dict)}
           </span>
           <button
@@ -256,6 +256,14 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
                   <tr
                     key={job.id}
                     onClick={() => setSelectedJobId(job.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        setSelectedJobId(job.id);
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
                     className={`cursor-pointer border-b border-gray-50 last:border-0 dark:border-gray-700/50 ${
                       selectedJobId === job.id
                         ? "bg-gray-100 dark:bg-gray-700/60"

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "flowbite-react";
+import { twMerge } from "tailwind-merge";
 import { HiOutlineX, HiLightningBolt, HiCheck } from "react-icons/hi";
 import { tr } from "@/features/i18n/tr.service";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
@@ -30,7 +31,15 @@ interface JobDetailPanelProps {
   readonly onSelectJob: (jobId: string) => void;
 }
 
-function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+function Stat({
+  label,
+  value,
+  mono,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly mono?: boolean;
+}) {
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 min-w-0">
       <div className="text-[11px] text-gray-500 dark:text-gray-400">{label}</div>
@@ -55,6 +64,18 @@ interface TimelineNode {
   readonly error?: string | null;
 }
 
+function historyDotClass(outcome: string): string {
+  if (outcome === "RETRY_REQUESTED") return "bg-amber-500";
+  if (outcome === "FAILED") return "bg-rose-500";
+  return "bg-green-500";
+}
+
+function chainBadgeClass(memberState: string, isCurrent: boolean): string {
+  if (memberState === "SUCCEEDED") return "bg-green-500 text-white";
+  if (isCurrent) return "bg-gray-900 text-white dark:bg-white dark:text-gray-900";
+  return "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300";
+}
+
 function timelineNodes(job: AsyncJob, dict: I18nRecord, nowMs: number): TimelineNode[] {
   const nodes: TimelineNode[] = [
     {
@@ -70,7 +91,7 @@ function timelineNodes(job: AsyncJob, dict: I18nRecord, nowMs: number): Timeline
     const isManual = outcome === "RETRY_REQUESTED";
     nodes.push({
       key: `h-${index}`,
-      dotClass: isManual ? "bg-amber-500" : isFailure ? "bg-rose-500" : "bg-green-500",
+      dotClass: historyDotClass(outcome),
       title: isManual ? tr("timeline.manualRetry", dict) : `${tr("timeline.report", dict)} — ${outcome.toLowerCase()}`,
       meta: [entry.by, entry.at ? relativeAge(entry.at, nowMs) : null].filter(Boolean).join(" · "),
       error: isFailure && typeof entry.detail === "string" ? entry.detail : null,
@@ -118,6 +139,10 @@ export default function JobDetailPanel({
       </aside>
     );
   }
+
+  const handleTabChange = (key: DetailTab) => () => setTab(key);
+  const handleSelectChainJob = (id: string) => () => onSelectJob(id);
+  const handleRetry = () => void retry(job.id);
 
   const chainMembers = sortChain(chain);
   const tabs: Array<[DetailTab, string]> = [
@@ -169,12 +194,13 @@ export default function JobDetailPanel({
             <button
               key={key}
               type="button"
-              onClick={() => setTab(key)}
-              className={`-mb-px border-b-2 px-2.5 py-2 text-xs font-medium ${
+              onClick={handleTabChange(key)}
+              className={twMerge(
+                "-mb-px border-b-2 px-2.5 py-2 text-xs font-medium",
                 tab === key
                   ? "border-gray-900 text-gray-900 dark:border-white dark:text-white"
-                  : "border-transparent text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-              }`}
+                  : "border-transparent text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300",
+              )}
             >
               {label}
             </button>
@@ -276,24 +302,22 @@ export default function JobDetailPanel({
                   <span className="absolute left-[10px] top-6 bottom-0 w-px bg-gray-200 dark:bg-gray-700" />
                 )}
                 <span
-                  className={`mt-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
-                    member.state === "SUCCEEDED"
-                      ? "bg-green-500 text-white"
-                      : member.id === job.id
-                        ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
-                        : "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-                  }`}
+                  className={twMerge(
+                    "mt-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold",
+                    chainBadgeClass(member.state, member.id === job.id),
+                  )}
                 >
                   {member.state === "SUCCEEDED" ? <HiCheck className="h-3 w-3" /> : member.chainSequence}
                 </span>
                 <button
                   type="button"
-                  onClick={() => onSelectJob(member.id)}
-                  className={`flex min-w-0 flex-1 items-center gap-2 rounded-lg border px-3 py-2 text-left ${
+                  onClick={handleSelectChainJob(member.id)}
+                  className={twMerge(
+                    "flex min-w-0 flex-1 items-center gap-2 rounded-lg border px-3 py-2 text-left",
                     member.id === job.id
                       ? "border-gray-900 dark:border-white"
-                      : "border-gray-200 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-500"
-                  }`}
+                      : "border-gray-200 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-500",
+                  )}
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-semibold text-gray-900 dark:text-white">
@@ -327,7 +351,7 @@ export default function JobDetailPanel({
             size="xs"
             color="blue"
             disabled={retrying === job.id}
-            onClick={() => void retry(job.id)}
+            onClick={handleRetry}
           >
             <HiLightningBolt className="mr-1 h-3.5 w-3.5" />
             {job.state === "PENDING" ? tr("detail.runNow", dict) : tr("detail.retry", dict)}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "flowbite-react";
+import { HiOutlineX, HiLightningBolt, HiCheck } from "react-icons/hi";
+import { tr } from "@/features/i18n/tr.service";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import {
+  canRetry,
+  countdownTo,
+  jobTypeLabel,
+  relativeAge,
+  shortJobId,
+  sortChain,
+  JOB_STATE_DOT,
+  type AsyncJob,
+  type AsyncJobAttempt,
+} from "../integration-job.types";
+import { useIntegrationJob, useIntegrationJobChain, useRetryJob } from "../use-integration-jobs";
+import JobStateBadge from "./job-state-badge";
+
+type DetailTab = "overview" | "attempts" | "payload" | "chain";
+
+interface JobDetailPanelProps {
+  readonly orgSlug: string;
+  readonly jobId: string;
+  readonly dict: I18nRecord;
+  readonly nowMs: number;
+  readonly onClose: () => void;
+  readonly onSelectJob: (jobId: string) => void;
+}
+
+function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2 min-w-0">
+      <div className="text-[11px] text-gray-500 dark:text-gray-400">{label}</div>
+      <div
+        className={`mt-0.5 truncate text-gray-900 dark:text-white ${
+          mono ? "font-mono text-xs" : "text-sm font-semibold"
+        }`}
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+interface TimelineNode {
+  readonly key: string;
+  readonly dotClass: string;
+  readonly hollow?: boolean;
+  readonly title: string;
+  readonly meta: string;
+  readonly error?: string | null;
+}
+
+function timelineNodes(job: AsyncJob, dict: I18nRecord, nowMs: number): TimelineNode[] {
+  const nodes: TimelineNode[] = [
+    {
+      key: "enqueued",
+      dotClass: "bg-gray-400",
+      title: `${tr("timeline.enqueuedBy", dict)} ${job.enqueuedBy}`,
+      meta: `${job.sourceInstance} · ${relativeAge(job.createdAt, nowMs)}`,
+    },
+  ];
+  job.attemptHistory.forEach((entry: AsyncJobAttempt, index) => {
+    const outcome = typeof entry.outcome === "string" ? entry.outcome : "";
+    const isFailure = outcome === "FAILED";
+    const isManual = outcome === "RETRY_REQUESTED";
+    nodes.push({
+      key: `h-${index}`,
+      dotClass: isManual ? "bg-amber-500" : isFailure ? "bg-rose-500" : "bg-green-500",
+      title: isManual ? tr("timeline.manualRetry", dict) : `${tr("timeline.report", dict)} — ${outcome.toLowerCase()}`,
+      meta: [entry.by, entry.at ? relativeAge(entry.at, nowMs) : null].filter(Boolean).join(" · "),
+      error: isFailure && typeof entry.detail === "string" ? entry.detail : null,
+    });
+  });
+  if (job.state === "RUNNING") {
+    nodes.push({
+      key: "running",
+      dotClass: "bg-blue-500 animate-pulse",
+      title: `${tr("timeline.running", dict)} · ${tr("detail.attempt", dict)} ${job.attempts}`,
+      meta: job.lockedBy ?? "",
+    });
+  }
+  if (job.state === "PENDING" && job.nextRetryAt) {
+    nodes.push({
+      key: "scheduled",
+      dotClass: "border-2 border-dashed border-amber-500 bg-transparent",
+      hollow: true,
+      title: `${tr("timeline.retryScheduled", dict)} ${Math.min(job.attempts + 1, job.maxAttempts)}`,
+      meta: `${tr("timeline.backoff", dict)} · ${countdownTo(job.nextRetryAt, nowMs)}`,
+    });
+  }
+  return nodes;
+}
+
+export default function JobDetailPanel({
+  orgSlug,
+  jobId,
+  dict,
+  nowMs,
+  onClose,
+  onSelectJob,
+}: JobDetailPanelProps) {
+  const [tab, setTab] = useState<DetailTab>("overview");
+  const { job, isLoading, error } = useIntegrationJob(orgSlug, jobId);
+  const { chain } = useIntegrationJobChain(orgSlug, job?.chainKey ?? null);
+  const { retry, retrying, retryError } = useRetryJob(orgSlug);
+
+  if (isLoading || !job) {
+    return (
+      <aside className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800 h-fit">
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          {error ? tr("detail.loadError", dict) : tr("detail.loading", dict)}
+        </div>
+      </aside>
+    );
+  }
+
+  const chainMembers = sortChain(chain);
+  const tabs: Array<[DetailTab, string]> = [
+    ["overview", tr("detail.overview", dict)],
+    ["attempts", `${tr("detail.attempts", dict)} · ${job.attempts}`],
+    ["payload", tr("detail.payload", dict)],
+  ];
+  if (chainMembers.length > 1) {
+    tabs.push(["chain", `${tr("detail.chain", dict)} · ${chainMembers.length}`]);
+  }
+  const stateLabel = tr(`states.${job.state}`, dict);
+  const nodes = timelineNodes(job, dict, nowMs);
+
+  return (
+    <aside className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 flex flex-col max-h-[calc(100vh-10rem)] sticky top-4">
+      {/* header */}
+      <div className="px-4 pt-4">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-base font-semibold text-gray-900 dark:text-white">
+                {jobTypeLabel(job.jobType)}
+              </span>
+              <JobStateBadge state={job.state} label={stateLabel} />
+            </div>
+            <div className="mt-1 truncate font-mono text-[11px] text-gray-400 dark:text-gray-500" title={job.id}>
+              {job.id}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+              {job.correlationKey && <span className="font-mono">{job.correlationKey}</span>}
+              <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                {job.executor}
+              </span>
+              <span>{job.enqueuedBy}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={tr("detail.close", dict)}
+            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+          >
+            <HiOutlineX className="h-4 w-4" />
+          </button>
+        </div>
+        {/* tabs */}
+        <div className="mt-2 flex gap-1 border-b border-gray-100 dark:border-gray-700">
+          {tabs.map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setTab(key)}
+              className={`-mb-px border-b-2 px-2.5 py-2 text-xs font-medium ${
+                tab === key
+                  ? "border-gray-900 text-gray-900 dark:border-white dark:text-white"
+                  : "border-transparent text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        {tab === "overview" && (
+          <div className="flex flex-col gap-2">
+            {job.lastError && (
+              <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-900/20">
+                <div className="text-[10px] font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
+                  {tr("detail.lastError", dict)}
+                </div>
+                <div className="mt-0.5 text-xs text-red-700 dark:text-red-300">{job.lastError}</div>
+              </div>
+            )}
+            <div className="grid grid-cols-2 gap-2">
+              <Stat label={tr("detail.attemptsLabel", dict)} value={`${job.attempts} / ${job.maxAttempts}`} />
+              <Stat label={tr("detail.lane", dict)} value={job.executor} mono />
+              <Stat label={tr("detail.created", dict)} value={relativeAge(job.createdAt, nowMs)} />
+              <Stat label={tr("detail.updated", dict)} value={relativeAge(job.updatedAt, nowMs)} />
+              {job.nextRetryAt && (
+                <Stat label={tr("detail.nextRetry", dict)} value={countdownTo(job.nextRetryAt, nowMs)} />
+              )}
+              {job.state === "RUNNING" && job.lockedBy && (
+                <Stat label={tr("detail.lease", dict)} value={job.lockedBy} mono />
+              )}
+              <Stat label={tr("detail.source", dict)} value={job.sourceInstance} mono />
+              <Stat label={tr("detail.tenant", dict)} value={job.tenantCode} mono />
+            </div>
+            {job.dedupeKey && <Stat label={tr("detail.dedupe", dict)} value={job.dedupeKey} mono />}
+            {job.chainKey && (
+              <Stat
+                label={`${tr("detail.chain", dict)} · ${tr("detail.step", dict)} ${job.chainSequence}`}
+                value={job.chainKey}
+                mono
+              />
+            )}
+          </div>
+        )}
+
+        {tab === "attempts" && (
+          <ol className="relative flex flex-col">
+            {nodes.map((node, index) => (
+              <li key={node.key} className="relative flex gap-3 pb-4 last:pb-0">
+                {index < nodes.length - 1 && (
+                  <span className="absolute left-[5px] top-4 bottom-0 w-px bg-gray-200 dark:bg-gray-700" />
+                )}
+                <span className={`mt-1 h-3 w-3 flex-shrink-0 rounded-full ${node.dotClass}`} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs font-semibold text-gray-900 dark:text-white">{node.title}</div>
+                  {node.meta && (
+                    <div className="font-mono text-[11px] text-gray-400 dark:text-gray-500">{node.meta}</div>
+                  )}
+                  {node.error && (
+                    <div className="mt-1 rounded bg-red-50 px-2 py-1 text-[11px] text-red-700 dark:bg-red-900/20 dark:text-red-300">
+                      {node.error}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        {tab === "payload" && (
+          <div className="flex flex-col gap-3">
+            <div>
+              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                payload · jsonb
+              </div>
+              <pre className="overflow-auto rounded-lg bg-gray-900 p-3 font-mono text-[11px] leading-relaxed text-gray-200">
+                {JSON.stringify(job.payload, null, 2)}
+              </pre>
+            </div>
+            {job.attemptHistory.length > 0 && (
+              <div>
+                <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  attempt_history · jsonb
+                </div>
+                <pre className="overflow-auto rounded-lg bg-gray-900 p-3 font-mono text-[11px] leading-relaxed text-gray-400">
+                  {JSON.stringify(job.attemptHistory, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
+
+        {tab === "chain" && (
+          <div className="flex flex-col">
+            <div className="mb-3 break-all font-mono text-[11px] text-gray-500 dark:text-gray-400">
+              {job.chainKey}
+            </div>
+            {chainMembers.map((member, index) => (
+              <div key={member.id} className="relative flex gap-3 pb-3 last:pb-0">
+                {index < chainMembers.length - 1 && (
+                  <span className="absolute left-[10px] top-6 bottom-0 w-px bg-gray-200 dark:bg-gray-700" />
+                )}
+                <span
+                  className={`mt-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
+                    member.state === "SUCCEEDED"
+                      ? "bg-green-500 text-white"
+                      : member.id === job.id
+                        ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                        : "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                  }`}
+                >
+                  {member.state === "SUCCEEDED" ? <HiCheck className="h-3 w-3" /> : member.chainSequence}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onSelectJob(member.id)}
+                  className={`flex min-w-0 flex-1 items-center gap-2 rounded-lg border px-3 py-2 text-left ${
+                    member.id === job.id
+                      ? "border-gray-900 dark:border-white"
+                      : "border-gray-200 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-500"
+                  }`}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-semibold text-gray-900 dark:text-white">
+                      {jobTypeLabel(member.jobType)}
+                    </span>
+                    <span className="block truncate font-mono text-[10px] text-gray-400 dark:text-gray-500">
+                      {shortJobId(member.id)}
+                      {member.correlationKey ? ` · ${member.correlationKey}` : ""}
+                    </span>
+                  </span>
+                  <span className={`h-2 w-2 flex-shrink-0 rounded-full ${JOB_STATE_DOT[member.state]}`} />
+                </button>
+              </div>
+            ))}
+            <p className="mt-3 text-[11px] leading-relaxed text-gray-400 dark:text-gray-500">
+              {tr("detail.chainHint", dict)}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {canRetry(job) && (
+        <div className="flex items-center gap-2 border-t border-gray-100 p-3 dark:border-gray-700">
+          {retryError && (
+            <span className="min-w-0 flex-1 truncate text-xs text-red-600 dark:text-red-400" title={retryError.message}>
+              {retryError.message}
+            </span>
+          )}
+          <span className="flex-1" />
+          <Button
+            size="xs"
+            color="blue"
+            disabled={retrying === job.id}
+            onClick={() => void retry(job.id)}
+          >
+            <HiLightningBolt className="mr-1 h-3.5 w-3.5" />
+            {job.state === "PENDING" ? tr("detail.runNow", dict) : tr("detail.retry", dict)}
+          </Button>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-state-badge.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-state-badge.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Badge, Spinner } from "flowbite-react";
+import { JOB_STATE_BADGE, type JobState } from "../integration-job.types";
+
+interface JobStateBadgeProps {
+  readonly state: JobState;
+  readonly label: string;
+}
+
+export default function JobStateBadge({ state, label }: JobStateBadgeProps) {
+  return (
+    <Badge color={JOB_STATE_BADGE[state]} className="w-fit whitespace-nowrap">
+      <span className="inline-flex items-center gap-1.5">
+        {state === "RUNNING" && <Spinner size="xs" aria-hidden />}
+        {label}
+      </span>
+    </Badge>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/notification-bell.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/notification-bell.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import {
+  HiBell,
+  HiCheck,
+  HiLightningBolt,
+  HiOutlineArrowRight,
+  HiOutlineClock,
+  HiOutlinePlus,
+  HiOutlineX,
+} from "react-icons/hi";
+import { tr } from "@/features/i18n/tr.service";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { useLoadNotifications } from "@/features/notifications/hooks/use-load-notifications";
+import { useOrgScopes } from "@/features/layout/components/secured-navbar/org-switcher/use-org-scopes";
+import { jobTypeLabel, relativeAge, shortJobId, type JobEventPayload } from "../integration-job.types";
+import { useJobEvents } from "../use-job-events";
+
+/**
+ * Topbar notification bell.
+ *
+ * Keeps the historical behavior (unread Alfresco notification count, link to
+ * the /notifications inbox) and adds a live "integration activity" dropdown
+ * fed by the quarkus-sse `integrations.job` stream, with a deep link into the
+ * job console.
+ */
+
+const TRANSITION_ICON: Record<
+  JobEventPayload["transition"],
+  { icon: typeof HiCheck; className: string }
+> = {
+  enqueued: { icon: HiOutlinePlus, className: "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300" },
+  claimed: { icon: HiLightningBolt, className: "bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300" },
+  succeeded: { icon: HiCheck, className: "bg-green-100 text-green-600 dark:bg-green-900/40 dark:text-green-300" },
+  retry_scheduled: {
+    icon: HiOutlineClock,
+    className: "bg-amber-100 text-amber-600 dark:bg-amber-900/40 dark:text-amber-300",
+  },
+  failed: { icon: HiOutlineX, className: "bg-rose-100 text-rose-600 dark:bg-rose-900/40 dark:text-rose-300" },
+  retried: { icon: HiLightningBolt, className: "bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300" },
+};
+
+interface NotificationBellProps {
+  readonly dict: I18nRecord;
+}
+
+export default function NotificationBell({ dict }: NotificationBellProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  const { data: notifications } = useLoadNotifications();
+  const { activeOrg } = useOrgScopes();
+  const { events, unseen, connected, markAllSeen } = useJobEvents(activeOrg?.slug ?? null);
+
+  let unreadNotifications = 0;
+  if (notifications?.notifications && Array.isArray(notifications.notifications)) {
+    unreadNotifications = notifications.notifications.filter(
+      (notification: { is_read?: boolean }) => !notification.is_read,
+    ).length;
+  }
+  const badgeCount = unreadNotifications + unseen;
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [open]);
+
+  const bellDict = dict;
+  const shown = events.slice(0, 12);
+
+  function toggleOpen() {
+    setOpen((wasOpen) => {
+      if (!wasOpen) markAllSeen();
+      return !wasOpen;
+    });
+  }
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={toggleOpen}
+        className="h-10 w-10 select-none cursor-pointer relative flex items-center justify-center p-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-transparent transition-all duration-300 hover:border-gray-300 dark:hover:border-gray-600 active:ring-2 active:ring-gray-300 dark:active:ring-gray-600"
+      >
+        {badgeCount > 0 && (
+          <div
+            className={`absolute flex items-center justify-center ${
+              badgeCount.toString().length > 1 ? "w-7 -left-3" : "w-5 -left-1"
+            } h-5 bg-red-400 dark:bg-red-600 text-xs font-medium text-white rounded-full -top-2 min-w-[1.25rem]`}
+          >
+            {badgeCount > 99 ? "99+" : badgeCount}
+          </div>
+        )}
+        <span className="sr-only">{tr("pages.integrationJobs.bell.title", bellDict)}</span>
+        <HiBell className="h-6 w-6 text-gray-500 dark:text-gray-400" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-12 z-50 w-96 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          {/* header */}
+          <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 dark:border-gray-700">
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">
+              {tr("pages.integrationJobs.bell.title", bellDict)}
+            </span>
+            <span className="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+              <span className={`h-1.5 w-1.5 rounded-full ${connected ? "animate-pulse bg-green-500" : "bg-gray-400"}`} />
+              {connected
+                ? tr("pages.integrationJobs.live.connected", bellDict)
+                : tr("pages.integrationJobs.live.disconnected", bellDict)}
+            </span>
+            <span className="flex-1" />
+            <Link
+              href="/notifications"
+              onClick={() => setOpen(false)}
+              className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {tr("pages.integrationJobs.bell.viewAll", bellDict)}
+              {unreadNotifications > 0 ? ` (${unreadNotifications})` : ""}
+            </Link>
+          </div>
+
+          {/* integration activity feed */}
+          <div className="max-h-96 overflow-auto">
+            <div className="px-4 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+              {tr("pages.integrationJobs.bell.integrations", bellDict)}
+            </div>
+            {shown.length === 0 && (
+              <div className="px-4 pb-6 pt-4 text-center text-xs text-gray-400 dark:text-gray-500">
+                {tr("pages.integrationJobs.bell.empty", bellDict)}
+              </div>
+            )}
+            {shown.map((entry) => {
+              const { icon: Icon, className } = TRANSITION_ICON[entry.payload.transition];
+              const title = `${jobTypeLabel(entry.payload.jobType)} — ${tr(
+                `pages.integrationJobs.transitions.${entry.payload.transition}`,
+                bellDict,
+              )}`;
+              const detailParts = [
+                entry.payload.correlationKey ?? shortJobId(entry.payload.jobId),
+                `${entry.payload.attempts}/${entry.payload.maxAttempts}`,
+              ];
+              if (entry.payload.lastError) detailParts.push(entry.payload.lastError);
+              return (
+                <Link
+                  key={entry.id}
+                  href="/integrations/jobs"
+                  onClick={() => setOpen(false)}
+                  className="flex gap-3 border-b border-gray-50 px-4 py-2.5 last:border-0 hover:bg-gray-50 dark:border-gray-700/50 dark:hover:bg-gray-700/40"
+                >
+                  <span
+                    className={`mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg ${className}`}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-medium text-gray-900 dark:text-white">{title}</span>
+                    <span className="block truncate text-[11px] text-gray-500 dark:text-gray-400">
+                      {detailParts.join(" · ")}
+                    </span>
+                  </span>
+                  <span className="flex-shrink-0 text-[10px] text-gray-400 dark:text-gray-500">
+                    {relativeAge(new Date(entry.receivedAt).toISOString())}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+
+          {/* footer */}
+          <div className="flex items-center border-t border-gray-100 px-4 py-2.5 dark:border-gray-700">
+            <span className="text-[10px] text-gray-400 dark:text-gray-500">
+              {tr("pages.integrationJobs.bell.hint", bellDict)}
+            </span>
+            <span className="flex-1" />
+            <Link
+              href="/integrations/jobs"
+              onClick={() => setOpen(false)}
+              className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {tr("pages.integrationJobs.bell.openConsole", bellDict)}
+              <HiOutlineArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  canRetry,
+  countdownTo,
+  jobContextLine,
+  jobTypeLabel,
+  relativeAge,
+  shortJobId,
+  sortChain,
+  type AsyncJob,
+} from "./integration-job.types";
+
+const NOW = Date.parse("2026-07-19T12:00:00Z");
+
+function job(overrides: Partial<AsyncJob> = {}): AsyncJob {
+  return {
+    id: "6f9c1c2a-0000-4000-9000-000000000000",
+    tenantCode: "tenant-1",
+    sourceInstance: "ecm-prod",
+    executor: "modulith",
+    jobType: "calendar_sync",
+    correlationKey: "VJ-26-8710",
+    chainKey: null,
+    chainSequence: 0,
+    dedupeKey: null,
+    payload: {},
+    state: "PENDING",
+    attempts: 0,
+    maxAttempts: 5,
+    nextRetryAt: null,
+    lockedBy: null,
+    lockedUntil: null,
+    lastError: null,
+    attemptHistory: [],
+    enqueuedBy: "listener",
+    createdAt: new Date(NOW - 60_000).toISOString(),
+    updatedAt: new Date(NOW - 30_000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("integration-job.types", () => {
+  it("labels known job types and prettifies unknown ones", () => {
+    expect(jobTypeLabel("calendar_sync")).toBe("Calendar sync");
+    expect(jobTypeLabel("alerce_arrival")).toBe("Alerce arrival");
+    expect(jobTypeLabel("my_custom-type")).toBe("My custom type");
+  });
+
+  it("shortJobId keeps the first uuid segment", () => {
+    expect(shortJobId("6f9c1c2a-0000-4000-9000-000000000000")).toBe("6f9c1c2a");
+  });
+
+  it("relativeAge is compact and countdownTo handles past instants", () => {
+    expect(relativeAge(new Date(NOW - 2_000).toISOString(), NOW)).toBe("now");
+    expect(relativeAge(new Date(NOW - 42_000).toISOString(), NOW)).toBe("42s");
+    expect(relativeAge(new Date(NOW - 7 * 60_000).toISOString(), NOW)).toBe("7m");
+    expect(countdownTo(new Date(NOW + 12_000).toISOString(), NOW)).toBe("in 12s");
+    expect(countdownTo(new Date(NOW - 1_000).toISOString(), NOW)).toBe("due now");
+  });
+
+  it("jobContextLine covers running, backoff, chain-blocked and failed", () => {
+    expect(jobContextLine(job({ state: "RUNNING", lockedBy: "modulith-01" }), NOW)).toBe(
+      "running · modulith-01",
+    );
+    expect(
+      jobContextLine(job({ attempts: 2, nextRetryAt: new Date(NOW + 18_000).toISOString() }), NOW),
+    ).toBe("retry 3 of 5 · in 18s");
+    expect(jobContextLine(job({ chainKey: "svc:x", chainSequence: 1 }), NOW)).toBe(
+      "chain step 1 · waiting",
+    );
+    expect(jobContextLine(job({ state: "FAILED", lastError: "409 Conflict" }), NOW)).toBe("409 Conflict");
+    expect(jobContextLine(job(), NOW)).toBe("queued · listener");
+  });
+
+  it("canRetry mirrors the backend babysitter rule", () => {
+    expect(canRetry(job({ state: "FAILED" }))).toBe(true);
+    expect(canRetry(job({ state: "CANCELLED" }))).toBe(true);
+    expect(canRetry(job({ state: "PENDING", nextRetryAt: new Date(NOW + 5_000).toISOString() }))).toBe(true);
+    expect(canRetry(job({ state: "PENDING" }))).toBe(false);
+    expect(canRetry(job({ state: "RUNNING" }))).toBe(false);
+    expect(canRetry(job({ state: "SUCCEEDED" }))).toBe(false);
+  });
+
+  it("sortChain orders by chainSequence without mutating input", () => {
+    const first = job({ id: "a", chainSequence: 1 });
+    const second = job({ id: "b", chainSequence: 0 });
+    const input = [first, second];
+    expect(sortChain(input).map((entry) => entry.id)).toEqual(["b", "a"]);
+    expect(input[0].id).toBe("a");
+  });
+});

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
@@ -1,0 +1,197 @@
+/**
+ * Types + pure helpers for the integrations job console.
+ *
+ * Mirrors the quarkus-srv integrations component: the `AsyncJob` record served
+ * by `/api/v1/orgs/{org}/integrations/console/jobs` and the `integrations.job`
+ * EventData frames the backend emits to quarkus-sse on every state transition.
+ */
+
+export const JOB_STATES = [
+  "PENDING",
+  "RUNNING",
+  "SUCCEEDED",
+  "FAILED",
+  "CANCELLED",
+] as const;
+
+export type JobState = (typeof JOB_STATES)[number];
+
+export interface AsyncJobAttempt {
+  readonly at?: string;
+  readonly outcome?: string;
+  readonly detail?: string;
+  readonly by?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface AsyncJob {
+  readonly id: string;
+  readonly tenantCode: string;
+  readonly sourceInstance: string;
+  readonly executor: string;
+  readonly jobType: string;
+  readonly correlationKey: string | null;
+  readonly chainKey: string | null;
+  readonly chainSequence: number;
+  readonly dedupeKey: string | null;
+  readonly payload: Record<string, unknown>;
+  readonly state: JobState;
+  readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly nextRetryAt: string | null;
+  readonly lockedBy: string | null;
+  readonly lockedUntil: string | null;
+  readonly lastError: string | null;
+  readonly attemptHistory: AsyncJobAttempt[];
+  readonly enqueuedBy: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface JobsOverview {
+  readonly counts: Record<JobState, number>;
+  readonly tenantId: string;
+  readonly eventType: string;
+  readonly liveEventsConfigured: boolean;
+}
+
+/** Payload of one `integrations.job` EventData frame from quarkus-sse. */
+export interface JobEventPayload {
+  readonly jobId: string;
+  readonly jobType: string;
+  readonly executor: string;
+  readonly state: JobState;
+  readonly transition:
+    | "enqueued"
+    | "claimed"
+    | "succeeded"
+    | "retry_scheduled"
+    | "failed"
+    | "retried";
+  readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly correlationKey: string | null;
+  readonly chainKey: string | null;
+  readonly chainSequence: number;
+  readonly enqueuedBy: string;
+  readonly lastError: string | null;
+  readonly nextRetryAt: string | null;
+  readonly updatedAt: string | null;
+}
+
+export interface JobListFilters {
+  readonly state?: JobState;
+  readonly jobType?: string;
+  readonly chainKey?: string;
+  readonly limit?: number;
+}
+
+/** flowbite-react Badge color per job state. */
+export const JOB_STATE_BADGE: Record<JobState, string> = {
+  PENDING: "warning",
+  RUNNING: "info",
+  SUCCEEDED: "success",
+  FAILED: "failure",
+  CANCELLED: "gray",
+};
+
+/** Tailwind text/dot color pairs for the summary tiles + timeline dots. */
+export const JOB_STATE_DOT: Record<JobState, string> = {
+  PENDING: "bg-amber-500",
+  RUNNING: "bg-blue-500",
+  SUCCEEDED: "bg-green-500",
+  FAILED: "bg-rose-500",
+  CANCELLED: "bg-gray-400",
+};
+
+/** Human label for a job_type (free-form strings; known ones get a nice label). */
+export function jobTypeLabel(jobType: string): string {
+  const known: Record<string, string> = {
+    calendar_sync: "Calendar sync",
+    alerce_arrival: "Alerce arrival",
+    whatsapp_send: "WhatsApp message",
+  };
+  if (known[jobType]) return known[jobType];
+  const words = jobType.replaceAll(/[_-]+/g, " ").trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export function shortJobId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/** "now", "42s", "7m", "3h", "2d" — compact relative age. */
+export function relativeAge(iso: string | null, nowMs: number = Date.now()): string {
+  if (!iso) return "—";
+  const seconds = Math.round((nowMs - new Date(iso).getTime()) / 1000);
+  if (Number.isNaN(seconds)) return "—";
+  if (seconds < 5) return "now";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+/** "in 12s" / "in 3m" / "due now" — countdown to a future instant. */
+export function countdownTo(iso: string | null, nowMs: number = Date.now()): string {
+  if (!iso) return "—";
+  const seconds = Math.round((new Date(iso).getTime() - nowMs) / 1000);
+  if (Number.isNaN(seconds)) return "—";
+  if (seconds <= 0) return "due now";
+  if (seconds < 60) return `in ${seconds}s`;
+  return `in ${Math.round(seconds / 60)}m`;
+}
+
+/** Duration of the last finished attempt, in ms, when derivable from history. */
+export function lastAttemptDurationMs(job: AsyncJob): number | null {
+  // History entries are appended per report; a claim stamps no entry, so we
+  // approximate with createdAt→updatedAt when the job closed on attempt one.
+  const finished = [...job.attemptHistory]
+    .reverse()
+    .find((entry) => entry.outcome === "SUCCEEDED" || entry.outcome === "FAILED" || entry.outcome === "SKIPPED");
+  if (!finished?.at || !job.updatedAt) return null;
+  const startedAt = new Date(job.createdAt).getTime();
+  const finishedAt = new Date(finished.at).getTime();
+  if (Number.isNaN(startedAt) || Number.isNaN(finishedAt) || finishedAt < startedAt) return null;
+  return finishedAt - startedAt;
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+/** One line of context for the table's detail column. */
+export function jobContextLine(job: AsyncJob, nowMs: number = Date.now()): string {
+  switch (job.state) {
+    case "RUNNING":
+      return job.lockedBy ? `running · ${job.lockedBy}` : "running";
+    case "PENDING":
+      if (job.nextRetryAt) {
+        return `retry ${Math.min(job.attempts + 1, job.maxAttempts)} of ${job.maxAttempts} · ${countdownTo(job.nextRetryAt, nowMs)}`;
+      }
+      if (job.chainKey && job.chainSequence > 0) {
+        return `chain step ${job.chainSequence} · waiting`;
+      }
+      return `queued · ${job.enqueuedBy}`;
+    case "SUCCEEDED":
+      return "completed";
+    case "FAILED":
+      return job.lastError ?? "failed";
+    case "CANCELLED":
+      return "cancelled";
+  }
+}
+
+/** Whether the console can offer a manual retry (mirrors the backend rule). */
+export function canRetry(job: AsyncJob): boolean {
+  return job.state === "FAILED" || job.state === "CANCELLED" || (job.state === "PENDING" && job.nextRetryAt != null);
+}
+
+/** Sort chain members for the drawer's chain tab. */
+export function sortChain(jobs: AsyncJob[]): AsyncJob[] {
+  return [...jobs].sort((a, b) => a.chainSequence - b.chainSequence);
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-jobs-data-service.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-jobs-data-service.ts
@@ -58,7 +58,8 @@ export function fetchJobs(orgSlug: string, filters: JobListFilters = {}): Promis
   if (filters.chainKey) params.set("chainKey", filters.chainKey);
   if (filters.limit) params.set("limit", String(filters.limit));
   const qs = params.toString();
-  return getJson<AsyncJob[]>(`${base(orgSlug)}${qs ? `?${qs}` : ""}`);
+  const suffix = qs ? `?${qs}` : "";
+  return getJson<AsyncJob[]>(`${base(orgSlug)}${suffix}`);
 }
 
 export function fetchJobsOverview(orgSlug: string): Promise<JobsOverview> {

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-jobs-data-service.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-jobs-data-service.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import type { AsyncJob, JobListFilters, JobsOverview } from "./integration-job.types";
+
+/**
+ * Thin client-side fetch wrappers around the Next.js proxy routes for the
+ * integrations job console. Throw on non-2xx so SWR can surface the error.
+ */
+
+interface ApiErrorOptions {
+  readonly status: number;
+  readonly url: string;
+  readonly message?: string;
+}
+
+export class JobsApiError extends Error {
+  readonly status: number;
+  readonly url: string;
+
+  constructor({ status, url, message }: ApiErrorOptions) {
+    super(message ?? `Request failed with status ${status}`);
+    this.name = "JobsApiError";
+    this.status = status;
+    this.url = url;
+  }
+}
+
+const base = (orgSlug: string) =>
+  `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/integrations/jobs`;
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new JobsApiError({ status: res.status, url });
+  }
+  return (await res.json()) as T;
+}
+
+async function postJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { method: "POST" });
+  if (!res.ok) {
+    let message: string | undefined;
+    try {
+      const body = (await res.json()) as { error?: string; message?: string };
+      message = body.error ?? body.message;
+    } catch {
+      // non-JSON error body — fall back to the status message
+    }
+    throw new JobsApiError({ status: res.status, url, message });
+  }
+  return (await res.json()) as T;
+}
+
+export function fetchJobs(orgSlug: string, filters: JobListFilters = {}): Promise<AsyncJob[]> {
+  const params = new URLSearchParams();
+  if (filters.state) params.set("state", filters.state);
+  if (filters.jobType) params.set("jobType", filters.jobType);
+  if (filters.chainKey) params.set("chainKey", filters.chainKey);
+  if (filters.limit) params.set("limit", String(filters.limit));
+  const qs = params.toString();
+  return getJson<AsyncJob[]>(`${base(orgSlug)}${qs ? `?${qs}` : ""}`);
+}
+
+export function fetchJobsOverview(orgSlug: string): Promise<JobsOverview> {
+  return getJson<JobsOverview>(`${base(orgSlug)}/overview`);
+}
+
+export function fetchJob(orgSlug: string, jobId: string): Promise<AsyncJob> {
+  return getJson<AsyncJob>(`${base(orgSlug)}/${encodeURIComponent(jobId)}`);
+}
+
+export function retryJob(orgSlug: string, jobId: string): Promise<AsyncJob> {
+  return postJson<AsyncJob>(`${base(orgSlug)}/${encodeURIComponent(jobId)}/retry`);
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.test.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { JobEventPayload } from "./integration-job.types";
+import {
+  getJobEventsSnapshot,
+  markJobEventsSeen,
+  pushJobEventForTests,
+  resetJobEventsStoreForTests,
+  subscribeJobEvents,
+} from "./job-events-store";
+
+function payload(overrides: Partial<JobEventPayload> = {}): JobEventPayload {
+  return {
+    jobId: "6f9c1c2a-0000-4000-9000-000000000000",
+    jobType: "calendar_sync",
+    executor: "modulith",
+    state: "SUCCEEDED",
+    transition: "succeeded",
+    attempts: 1,
+    maxAttempts: 5,
+    correlationKey: "VJ-26-8710",
+    chainKey: null,
+    chainSequence: 0,
+    enqueuedBy: "listener",
+    lastError: null,
+    nextRetryAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  resetJobEventsStoreForTests();
+});
+
+describe("job-events-store", () => {
+  it("prepends events, counts notify-worthy transitions as unseen", () => {
+    pushJobEventForTests(payload({ transition: "succeeded" }));
+    pushJobEventForTests(payload({ transition: "claimed" })); // too chatty — not unseen
+    pushJobEventForTests(payload({ transition: "failed" }));
+
+    const snapshot = getJobEventsSnapshot();
+    expect(snapshot.events).toHaveLength(3);
+    expect(snapshot.events[0].payload.transition).toBe("failed");
+    expect(snapshot.unseen).toBe(2);
+  });
+
+  it("markJobEventsSeen resets the unseen counter but keeps the feed", () => {
+    pushJobEventForTests(payload({ transition: "failed" }));
+    markJobEventsSeen();
+
+    const snapshot = getJobEventsSnapshot();
+    expect(snapshot.unseen).toBe(0);
+    expect(snapshot.events).toHaveLength(1);
+  });
+
+  it("caps the feed at 50 entries", () => {
+    for (let index = 0; index < 60; index += 1) {
+      pushJobEventForTests(payload({ transition: "enqueued" }));
+    }
+    expect(getJobEventsSnapshot().events).toHaveLength(50);
+  });
+
+  it("notifies subscribers on every push and stops after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeJobEvents(listener);
+
+    pushJobEventForTests(payload());
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    pushJobEventForTests(payload());
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import type { JobEventPayload } from "./integration-job.types";
+
+/**
+ * Module-level store for live `integrations.job` events.
+ *
+ * One shared EventSource per tenant stream (same singleton pattern as
+ * `sse-listener.tsx`), subscribed to the type-filtered endpoint
+ * `{ECM_PUBLIC_URL}/api/v1/events/tenant/{tenantId}/stream/integrations.job`
+ * served by quarkus-sse. Consumers (job console page, notification bell)
+ * read a bounded in-memory feed via useSyncExternalStore-compatible
+ * subscribe/getSnapshot functions.
+ */
+
+export interface JobActivityEntry {
+  readonly id: string;
+  readonly receivedAt: number;
+  readonly payload: JobEventPayload;
+}
+
+export interface JobEventsSnapshot {
+  readonly connected: boolean;
+  readonly events: readonly JobActivityEntry[];
+  readonly unseen: number;
+}
+
+const MAX_EVENTS = 50;
+/** Transitions worth surfacing in the bell (claims are too chatty). */
+const NOTIFY_TRANSITIONS = new Set(["enqueued", "succeeded", "retry_scheduled", "failed", "retried"]);
+
+let eventSource: EventSource | null = null;
+let connectedTenant: string | null = null;
+let sequence = 0;
+
+let snapshot: JobEventsSnapshot = { connected: false, events: [], unseen: 0 };
+const listeners = new Set<() => void>();
+
+function publish(next: Partial<JobEventsSnapshot>): void {
+  snapshot = { ...snapshot, ...next };
+  listeners.forEach((listener) => listener());
+}
+
+export function subscribeJobEvents(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getJobEventsSnapshot(): JobEventsSnapshot {
+  return snapshot;
+}
+
+/** Server snapshot (SSR): nothing connected, empty feed. */
+const SERVER_SNAPSHOT: JobEventsSnapshot = { connected: false, events: [], unseen: 0 };
+export function getJobEventsServerSnapshot(): JobEventsSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function markJobEventsSeen(): void {
+  if (snapshot.unseen > 0) {
+    publish({ unseen: 0 });
+  }
+}
+
+/**
+ * Ensures the shared stream is connected for the tenant. Safe to call from
+ * every consumer render; reconnects only when the tenant changes.
+ */
+export function connectJobEvents(ecmPublicUrl: string, tenantId: string, eventType: string): void {
+  if (typeof window === "undefined") return;
+  if (eventSource && connectedTenant === tenantId) return;
+
+  eventSource?.close();
+  connectedTenant = tenantId;
+  eventSource = new EventSource(
+    `${ecmPublicUrl}/api/v1/events/tenant/${encodeURIComponent(tenantId)}/stream/${encodeURIComponent(eventType)}`,
+  );
+
+  eventSource.onopen = () => publish({ connected: true });
+  eventSource.onerror = () => publish({ connected: false }); // EventSource auto-reconnects
+
+  eventSource.onmessage = (message) => {
+    let payload: JobEventPayload | null = null;
+    try {
+      const frame = JSON.parse(message.data) as { eventType?: string; payload?: JobEventPayload };
+      payload = frame.payload ?? null;
+    } catch {
+      return; // ignore malformed frames
+    }
+    if (!payload?.jobId || !payload.transition) return;
+
+    const entry: JobActivityEntry = {
+      id: `jev-${++sequence}`,
+      receivedAt: Date.now(),
+      payload,
+    };
+    const events = [entry, ...snapshot.events].slice(0, MAX_EVENTS);
+    const unseen = NOTIFY_TRANSITIONS.has(payload.transition) ? snapshot.unseen + 1 : snapshot.unseen;
+    publish({ connected: true, events, unseen });
+  };
+}
+
+/** Test-only: reset module state between tests. */
+export function resetJobEventsStoreForTests(): void {
+  eventSource?.close();
+  eventSource = null;
+  connectedTenant = null;
+  sequence = 0;
+  snapshot = { connected: false, events: [], unseen: 0 };
+  listeners.clear();
+}
+
+/** Test-only: inject an event as if it arrived on the stream. */
+export function pushJobEventForTests(payload: JobEventPayload): void {
+  const entry: JobActivityEntry = { id: `jev-${++sequence}`, receivedAt: Date.now(), payload };
+  const events = [entry, ...snapshot.events].slice(0, MAX_EVENTS);
+  const unseen = NOTIFY_TRANSITIONS.has(payload.transition) ? snapshot.unseen + 1 : snapshot.unseen;
+  publish({ connected: true, events, unseen });
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/job-events-store.ts
@@ -67,7 +67,7 @@ export function markJobEventsSeen(): void {
  * every consumer render; reconnects only when the tenant changes.
  */
 export function connectJobEvents(ecmPublicUrl: string, tenantId: string, eventType: string): void {
-  if (typeof window === "undefined") return;
+  if (globalThis.window === undefined) return;
   if (eventSource && connectedTenant === tenantId) return;
 
   eventSource?.close();

--- a/turbo-repo/apps/app/src/features/integration-jobs/use-integration-jobs.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/use-integration-jobs.ts
@@ -16,7 +16,9 @@ const JOB_KEY = "org-integration-job";
 
 export function useIntegrationJobs(orgSlug: string | null, filters: JobListFilters = {}) {
   const { data, error, isLoading, mutate } = useSWR<AsyncJob[], Error>(
-    orgSlug ? [JOBS_KEY, orgSlug, filters.state ?? "", filters.jobType ?? "", filters.limit ?? 100] : null,
+    orgSlug
+      ? [JOBS_KEY, orgSlug, filters.state ?? "", filters.jobType ?? "", filters.chainKey ?? "", filters.limit ?? 100]
+      : null,
     () => fetchJobs(orgSlug as string, filters),
     { revalidateOnFocus: false, dedupingInterval: 5_000 },
   );

--- a/turbo-repo/apps/app/src/features/integration-jobs/use-integration-jobs.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/use-integration-jobs.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import useSWR, { useSWRConfig } from "swr";
+import type { AsyncJob, JobListFilters, JobsOverview } from "./integration-job.types";
+import {
+  fetchJob,
+  fetchJobs,
+  fetchJobsOverview,
+  retryJob,
+} from "./integration-jobs-data-service";
+
+const JOBS_KEY = "org-integration-jobs";
+const OVERVIEW_KEY = "org-integration-jobs-overview";
+const JOB_KEY = "org-integration-job";
+
+export function useIntegrationJobs(orgSlug: string | null, filters: JobListFilters = {}) {
+  const { data, error, isLoading, mutate } = useSWR<AsyncJob[], Error>(
+    orgSlug ? [JOBS_KEY, orgSlug, filters.state ?? "", filters.jobType ?? "", filters.limit ?? 100] : null,
+    () => fetchJobs(orgSlug as string, filters),
+    { revalidateOnFocus: false, dedupingInterval: 5_000 },
+  );
+  return { jobs: data ?? [], isLoading, error, refresh: mutate };
+}
+
+export function useIntegrationJobsOverview(orgSlug: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<JobsOverview, Error>(
+    orgSlug ? [OVERVIEW_KEY, orgSlug] : null,
+    () => fetchJobsOverview(orgSlug as string),
+    { revalidateOnFocus: false, dedupingInterval: 10_000 },
+  );
+  return { overview: data ?? null, isLoading, error, refresh: mutate };
+}
+
+export function useIntegrationJob(orgSlug: string | null, jobId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<AsyncJob, Error>(
+    orgSlug && jobId ? [JOB_KEY, orgSlug, jobId] : null,
+    () => fetchJob(orgSlug as string, jobId as string),
+    { revalidateOnFocus: false },
+  );
+  return { job: data ?? null, isLoading, error, refresh: mutate };
+}
+
+/** Chain members for the detail panel (only fetches when the job has a chain). */
+export function useIntegrationJobChain(orgSlug: string | null, chainKey: string | null) {
+  const { data } = useSWR<AsyncJob[], Error>(
+    orgSlug && chainKey ? [JOBS_KEY, orgSlug, "chain", chainKey] : null,
+    () => fetchJobs(orgSlug as string, { chainKey: chainKey as string, limit: 50 }),
+    { revalidateOnFocus: false, dedupingInterval: 5_000 },
+  );
+  return { chain: data ?? [] };
+}
+
+export function useRetryJob(orgSlug: string | null) {
+  const { mutate } = useSWRConfig();
+  const [retrying, setRetrying] = useState<string | null>(null);
+  const [retryError, setRetryError] = useState<Error | null>(null);
+
+  const retry = useCallback(
+    async (jobId: string) => {
+      if (!orgSlug) return null;
+      setRetrying(jobId);
+      setRetryError(null);
+      try {
+        const updated = await retryJob(orgSlug, jobId);
+        await Promise.all([
+          mutate((key) => Array.isArray(key) && key[0] === JOBS_KEY && key[1] === orgSlug),
+          mutate([OVERVIEW_KEY, orgSlug]),
+          mutate([JOB_KEY, orgSlug, jobId]),
+        ]);
+        return updated;
+      } catch (error) {
+        setRetryError(error as Error);
+        return null;
+      } finally {
+        setRetrying(null);
+      }
+    },
+    [orgSlug, mutate],
+  );
+
+  return { retry, retrying, retryError };
+}
+
+/** Revalidates every jobs-related SWR key for the org (used on live events). */
+export function useRevalidateJobs(orgSlug: string | null) {
+  const { mutate } = useSWRConfig();
+  return useCallback(() => {
+    if (!orgSlug) return;
+    void mutate(
+      (key) =>
+        Array.isArray(key) &&
+        (key[0] === JOBS_KEY || key[0] === OVERVIEW_KEY || key[0] === JOB_KEY) &&
+        key[1] === orgSlug,
+    );
+  }, [orgSlug, mutate]);
+}

--- a/turbo-repo/apps/app/src/features/integration-jobs/use-job-events.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/use-job-events.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useRuntimeConfig } from "@/features/runtime-config/runtime-config-context";
+import { useIntegrationJobsOverview, useRevalidateJobs } from "./use-integration-jobs";
+import {
+  connectJobEvents,
+  getJobEventsServerSnapshot,
+  getJobEventsSnapshot,
+  markJobEventsSeen,
+  subscribeJobEvents,
+  type JobEventsSnapshot,
+} from "./job-events-store";
+
+/**
+ * Live `integrations.job` feed for an org.
+ *
+ * Fetches the console overview (which carries the SSE subscription context —
+ * tenantId + eventType), keeps the shared tenant stream connected, and
+ * debounce-revalidates the jobs SWR keys whenever a frame arrives so the
+ * console table, tiles and bell stay current without polling.
+ */
+export function useJobEvents(orgSlug: string | null): JobEventsSnapshot & {
+  liveConfigured: boolean;
+  markAllSeen: () => void;
+} {
+  const runtimeConfig = useRuntimeConfig();
+  const { overview } = useIntegrationJobsOverview(orgSlug);
+  const revalidate = useRevalidateJobs(orgSlug);
+  const debounceRef = useRef<number | null>(null);
+
+  const snapshot = useSyncExternalStore(
+    subscribeJobEvents,
+    getJobEventsSnapshot,
+    getJobEventsServerSnapshot,
+  );
+
+  useEffect(() => {
+    if (!runtimeConfig?.ECM_PUBLIC_URL || !overview?.liveEventsConfigured || !overview.tenantId) {
+      return;
+    }
+    connectJobEvents(runtimeConfig.ECM_PUBLIC_URL, overview.tenantId, overview.eventType);
+  }, [runtimeConfig, overview]);
+
+  const eventCount = snapshot.events.length;
+  const latestId = snapshot.events[0]?.id;
+  useEffect(() => {
+    if (!eventCount || !latestId) return;
+    if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      debounceRef.current = null;
+      revalidate();
+    }, 400);
+    return () => {
+      if (debounceRef.current != null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [eventCount, latestId, revalidate]);
+
+  return {
+    ...snapshot,
+    liveConfigured: overview?.liveEventsConfigured ?? false,
+    markAllSeen: markJobEventsSeen,
+  };
+}

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx
@@ -4,7 +4,7 @@ import { useSidebarContext } from "@/features/sidebar/context/sidebar-context";
 import { Navbar, NavbarBrand } from "flowbite-react";
 import Image from "next/image";
 import Link from "next/link";
-import { HiBell, HiMenuAlt1, HiX } from "react-icons/hi";
+import { HiMenuAlt1, HiX } from "react-icons/hi";
 import { useMediaQuery } from "../../hooks/use-media-query";
 import UserDropdown from "../user-dropdown/user-dropdown";
 import { SecuredNavBarProps } from "./secured-navbar.types";
@@ -13,7 +13,7 @@ import { twMerge } from "tailwind-merge";
 /* import { useSearch } from "@/features/search/context/search-context"; */
 import { usePathname } from "next/navigation";
 import CustomThemeToggle from "@/features/theme/components/CustomThemeToggle";
-import { useLoadNotifications } from "@/features/notifications/hooks/use-load-notifications";
+import NotificationBell from "@/features/integration-jobs/components/notification-bell";
 import SpotlightSearch from "./spotlight-search/spotlight-search";
 import OrgSwitcher from "./org-switcher/org-switcher";
 // import { Filter } from "flowbite-react-icons/outline";
@@ -139,19 +139,7 @@ export function SecuredNavbar({
   const pathname = usePathname();
   /* const { searchTerm, setSearchTerm } = useSearch(); */
 
-  const { data: notifications } = useLoadNotifications();
   const { logoUrlLight, logoUrlDark, isLoading: isLoadingLogo } = useUserSite();
-
-  let unreadNotifications = 0;
-  if (
-    notifications &&
-    notifications.notifications &&
-    Array.isArray(notifications.notifications)
-  ) {
-    unreadNotifications = notifications.notifications.filter(
-      (notification: any) => !notification.is_read
-    ).length;
-  }
 
   function handleToggleSidebar() {
     if (!isDesktop) {
@@ -203,24 +191,7 @@ export function SecuredNavbar({
           <div className="flex items-center justify-end gap-2 w-full">
             <OrgSwitcher dict={dict} />
             {!pathname.includes("/notifications") && (
-              <Link
-                href="/notifications"
-                className="h-10 w-10 select-none cursor-pointer relative flex items-center justify-center p-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-transparent transition-all duration-300 hover:border-gray-300 dark:hover:border-gray-600 active:ring-2 active:ring-gray-300 dark:active:ring-gray-600"
-              >
-                {unreadNotifications > 0 && (
-                  <div
-                    className={`absolute flex items-center justify-center ${
-                      unreadNotifications.toString().length > 1
-                        ? "w-7 -left-3"
-                        : "w-5 -left-1"
-                    } h-5 bg-red-400 dark:bg-red-600 text-xs font-medium text-white rounded-full -top-2  min-w-[1.25rem]`}
-                  >
-                    {unreadNotifications > 99 ? "99+" : unreadNotifications}
-                  </div>
-                )}
-                <span className="sr-only">Notifications</span>
-                <HiBell className="h-6 w-6 text-gray-500 dark:text-gray-400" />
-              </Link>
+              <NotificationBell dict={dict} />
             )}
             <div className="hidden md:block">
               <CustomThemeToggle />

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx
@@ -157,6 +157,7 @@ export function SecuredNavbar({
           <div className="flex items-center w-fit">
             {isSidebarToggleEnabled && (
               <button
+                type="button"
                 onClick={handleToggleSidebar}
                 className={twMerge(
                   "cursor-pointer rounded p-2 text-gray-600 lg:hidden",

--- a/turbo-repo/apps/app/src/features/layout/models/pages-config.json
+++ b/turbo-repo/apps/app/src/features/layout/models/pages-config.json
@@ -79,6 +79,12 @@
     "blockedGroups": []
   },
   {
+    "label": "integrations",
+    "href": "/integrations/jobs",
+    "requiredGroups": [],
+    "blockedGroups": []
+  },
+  {
     "label": "settings",
     "items": [
       { "href": "/users/settings/organizations", "label": "organizations", "requiredGroups": [], "blockedGroups": [] },

--- a/turbo-repo/apps/app/src/features/layout/models/pages.ts
+++ b/turbo-repo/apps/app/src/features/layout/models/pages.ts
@@ -7,7 +7,7 @@ import { SidebarItem } from "../types/common.types";
 import FaBookIcon from "@/features/icons/FaBook";
 import VideoCameraIcon from "@/features/icons/video-camera";
 import { FaTruckLoading } from "react-icons/fa";
-import { HiCog } from "react-icons/hi";
+import { HiCog, HiLightningBolt } from "react-icons/hi";
 import { LuTowerControl } from "react-icons/lu";
 import type { FC, ComponentProps } from "react";
 import pagesConfig from "./pages-config.json";
@@ -22,6 +22,7 @@ const PAGE_ICONS: Record<string, FC<ComponentProps<"svg">>> = {
   collaboratorsManagement: PeopleIcon,
   fleetManagement: TruckIcon,
   whereIsMyLoad: FaTruckLoading as FC<ComponentProps<"svg">>,
+  integrations: HiLightningBolt as FC<ComponentProps<"svg">>,
   settings: HiCog as FC<ComponentProps<"svg">>,
 };
 

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1497,6 +1497,91 @@
         "dataSources": "Data Sources"
       }
     },
+    "integrationJobs": {
+      "title": "Job console",
+      "subtitle": "Asynchronous integration jobs, live from the outbox ledger",
+      "refresh": "Refresh",
+      "loadError": "Couldn't load integration jobs.",
+      "live": {
+        "connected": "Live",
+        "disconnected": "Offline",
+        "notConfigured": "Live updates are not configured for this environment"
+      },
+      "states": {
+        "PENDING": "Pending",
+        "RUNNING": "Running",
+        "SUCCEEDED": "Succeeded",
+        "FAILED": "Failed",
+        "CANCELLED": "Cancelled"
+      },
+      "filters": {
+        "all": "All",
+        "allLanes": "All lanes",
+        "allTypes": "All job types",
+        "searchPlaceholder": "Job id, correlation, chain…"
+      },
+      "table": {
+        "title": "Jobs",
+        "job": "Job",
+        "correlation": "Correlation",
+        "lane": "Lane",
+        "state": "State",
+        "attempts": "Att.",
+        "detail": "Detail",
+        "age": "Age",
+        "chainStep": "chain",
+        "loading": "Loading jobs…",
+        "empty": "No jobs match the current filters."
+      },
+      "detail": {
+        "overview": "Overview",
+        "attempts": "Attempts",
+        "payload": "Payload",
+        "chain": "Chain",
+        "loading": "Loading job…",
+        "loadError": "Couldn't load the job.",
+        "close": "Close",
+        "lastError": "Last error",
+        "attemptsLabel": "Attempts",
+        "attempt": "attempt",
+        "lane": "Executor lane",
+        "created": "Created",
+        "updated": "Updated",
+        "nextRetry": "Next retry",
+        "lease": "Lease",
+        "source": "Source instance",
+        "tenant": "Tenant",
+        "dedupe": "Dedupe key",
+        "step": "step",
+        "chainHint": "Steps run in order — a step is claimed only after the previous one finishes.",
+        "retry": "Retry job",
+        "runNow": "Run now"
+      },
+      "timeline": {
+        "enqueuedBy": "Enqueued by",
+        "manualRetry": "Manual retry — attempts reset",
+        "report": "Report",
+        "running": "Running",
+        "retryScheduled": "Retry scheduled, attempt",
+        "backoff": "exponential backoff"
+      },
+      "bell": {
+        "title": "Notifications",
+        "viewAll": "View all",
+        "integrations": "Integration activity",
+        "empty": "No integration activity yet. Job executions show up here in real time.",
+        "hint": "Streamed from the integrations outbox",
+        "openConsole": "Open job console"
+      },
+      "transitions": {
+        "enqueued": "enqueued",
+        "claimed": "started",
+        "succeeded": "completed",
+        "retry_scheduled": "retry scheduled",
+        "failed": "failed permanently",
+        "retried": "retry queued"
+      }
+    },
     "admin": {
       "breadcrumb": {
         "admin": "Admin",
@@ -1637,6 +1722,7 @@
         "others": "Others",
         "reports": "Reports",
         "details": "Service details nº {serviceCode}",
+        "integrations": "Integrations",
         "settings": "Settings",
         "organizations": "Organizations",
         "dataSources": "Data Sources",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1497,6 +1497,91 @@
         "dataSources": "Fuentes de Datos"
       }
     },
+    "integrationJobs": {
+      "title": "Consola de trabajos",
+      "subtitle": "Trabajos de integración asíncronos, en vivo desde el ledger del outbox",
+      "refresh": "Actualizar",
+      "loadError": "No se pudieron cargar los trabajos de integración.",
+      "live": {
+        "connected": "En vivo",
+        "disconnected": "Sin conexión",
+        "notConfigured": "Las actualizaciones en vivo no están configuradas en este ambiente"
+      },
+      "states": {
+        "PENDING": "Pendiente",
+        "RUNNING": "En curso",
+        "SUCCEEDED": "Completado",
+        "FAILED": "Fallido",
+        "CANCELLED": "Cancelado"
+      },
+      "filters": {
+        "all": "Todos",
+        "allLanes": "Todos los ejecutores",
+        "allTypes": "Todos los tipos",
+        "searchPlaceholder": "Id, correlación, cadena…"
+      },
+      "table": {
+        "title": "Trabajos",
+        "job": "Trabajo",
+        "correlation": "Correlación",
+        "lane": "Ejecutor",
+        "state": "Estado",
+        "attempts": "Int.",
+        "detail": "Detalle",
+        "age": "Edad",
+        "chainStep": "cadena",
+        "loading": "Cargando trabajos…",
+        "empty": "Ningún trabajo coincide con los filtros actuales."
+      },
+      "detail": {
+        "overview": "Resumen",
+        "attempts": "Intentos",
+        "payload": "Payload",
+        "chain": "Cadena",
+        "loading": "Cargando trabajo…",
+        "loadError": "No se pudo cargar el trabajo.",
+        "close": "Cerrar",
+        "lastError": "Último error",
+        "attemptsLabel": "Intentos",
+        "attempt": "intento",
+        "lane": "Ejecutor",
+        "created": "Creado",
+        "updated": "Actualizado",
+        "nextRetry": "Próximo reintento",
+        "lease": "Lease",
+        "source": "Instancia origen",
+        "tenant": "Tenant",
+        "dedupe": "Clave de deduplicación",
+        "step": "paso",
+        "chainHint": "Los pasos corren en orden — un paso se reclama solo cuando el anterior termina.",
+        "retry": "Reintentar trabajo",
+        "runNow": "Ejecutar ahora"
+      },
+      "timeline": {
+        "enqueuedBy": "Encolado por",
+        "manualRetry": "Reintento manual — intentos reiniciados",
+        "report": "Reporte",
+        "running": "En curso",
+        "retryScheduled": "Reintento agendado, intento",
+        "backoff": "backoff exponencial"
+      },
+      "bell": {
+        "title": "Notificaciones",
+        "viewAll": "Ver todas",
+        "integrations": "Actividad de integraciones",
+        "empty": "Sin actividad de integraciones aún. Las ejecuciones aparecen aquí en tiempo real.",
+        "hint": "Transmitido desde el outbox de integraciones",
+        "openConsole": "Abrir consola de trabajos"
+      },
+      "transitions": {
+        "enqueued": "encolado",
+        "claimed": "iniciado",
+        "succeeded": "completado",
+        "retry_scheduled": "reintento agendado",
+        "failed": "falló definitivamente",
+        "retried": "reintento en cola"
+      }
+    },
     "admin": {
       "breadcrumb": {
         "admin": "Admin",
@@ -1641,6 +1726,7 @@
         "subtitle3": "Validación Sistema Cliente",
         "subtitle4": "Validación GPS",
         "details": "Detalles servicio nº {serviceCode}",
+        "integrations": "Integraciones",
         "settings": "Ajustes",
         "organizations": "Organizaciones",
         "dataSources": "Fuentes de Datos",


### PR DESCRIPTION
## What

End-to-end **async jobs console** for the integrations component, following the design prototype in the ModularIoT Design System project (`ui_kits/modulariot-shell/jobs.html`).

### Backend — quarkus-srv/miot-integrations
- **`OrgAsyncJobsConsoleResource`** (`/api/v1/orgs/{org}/integrations/console/jobs`): org-member (RS256 web token) read/babysit surface — list with `state`/`jobType`/`correlationKey`/`chainKey` filters, `overview` (whole-ledger per-state counts + SSE subscription context), job detail with full `attempt_history`, and manual `retry`. Deliberately outside the `/integrations/jobs` prefix so the dual-JWT path matcher keeps that path HS256/M2M-only.
- **`JobEventEmitter`**: fire-and-forget `EventData` frames (`eventType: integrations.job`, `tenantId` = tenant code) POSTed to quarkus-sse `/api/v1/events/emit` on `enqueued` / `claimed` / `succeeded` / `retry_scheduled` / `failed` / `retried` — covers both lanes because every transition flows through `AsyncJobService`. **Off by default**: enable with `MIOT_INTEGRATIONS_JOB_EVENTS_SSE_BASE_URL` (empty default, no baked endpoint).
- `AsyncJobRepository`: `chainKey` filter on list + per-state counts query.

### Frontend — apps/app
- **`/integrations/jobs` page** (sidebar: *Integrations*): clickable per-state summary tiles, state pills + lane/type selects + search, jobs table (mono ids, retry countdowns, chain steps), detail panel with Overview / Attempts timeline / Payload (`jsonb` + `attempt_history`) / Chain tabs, and Retry / Run now (mirrors the backend babysitter rule). Light + dark.
- **Live updates**: shared `EventSource` on the type-filtered quarkus-sse tenant stream (`.../stream/integrations.job`); the console overview API supplies the tenant stream key, so nothing sensitive is guessed client-side. Debounced SWR revalidation; graceful fallback to plain SWR when emission isn't configured.
- **Bell inbox activated**: the topbar bell is now a dropdown — keeps the Alfresco unread count + "View all" link, adds the live integration-activity feed (bounded, session-scoped) deep-linking into the console.
- Proxy routes `/app/api/admin/orgs/[orgId]/integrations/jobs/**` via `forwardToQuarkus`; en/es dictionaries kept in parity.

## Verification
- `miot-integrations`: 29 unit tests green (new: emitter contract frame, transition emissions, counts zero-fill); full `miot-cli` assembly compiles.
- `apps/app`: `check-types`, eslint (0 errors), vitest (types helpers + events store) and `next build` all green; i18n parity test passes.
- UX was validated interactively against the hi-fi prototype in the design system project (same states, chain gating, retry flows).

## Notes for reviewers
- Rollout: the console works read-only with zero config; live events need `MIOT_INTEGRATIONS_JOB_EVENTS_SSE_BASE_URL` pointing at the quarkus-sse service, and browsers reach the stream through the existing `ECM_PUBLIC_URL`.
- quarkus-sse is fan-out only (no replay) — the ledger stays the source of truth; SSE just triggers refreshes.
- WhatsApp does not flow through `async_jobs` yet (miot-conversational sends directly); today the console will mostly show `calendar_sync` (+ `alerce_arrival` when ECM starts enqueuing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Integrations jobs console for asynchronous job activity, including job details (overview/attempts/payload, optional chain) and manual retry where eligible.
  * Enabled live job updates via SSE-backed job events (shown with connection status and automatic refresh) and an activity notification bell with unseen counts.
  * Added new backend console endpoints and matching admin proxy routes, plus Integrations navigation and EN/ES translations.
* **Bug Fixes**
  * Improved job querying and overview counts, including filtering by chain key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #934
