### PR TITLE
fix(app): make the jobs console page scrollable

### DIFF
--- a/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
+++ b/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
@@ -12,7 +12,7 @@ export default async function IntegrationJobsPage({ params }: ParamsWithLang) {
     <RouteGuard path="/integrations/jobs" fallbackPath={`/${lang}/shipping`}>
       {/* LayoutContent is overflow-hidden — pages own their scroll (same
           wrapper as fleet-management). */}
-      <div className="h-full w-full flex flex-col bg-white dark:bg-gray-900 overflow-y-auto">
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-white dark:bg-gray-900">
         <JobConsolePageContent dict={dict ?? {}} />
       </div>
     </RouteGuard>

--- a/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
+++ b/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/jobs/page.tsx
@@ -10,7 +10,11 @@ export default async function IntegrationJobsPage({ params }: ParamsWithLang) {
 
   return (
     <RouteGuard path="/integrations/jobs" fallbackPath={`/${lang}/shipping`}>
-      <JobConsolePageContent dict={dict ?? {}} />
+      {/* LayoutContent is overflow-hidden — pages own their scroll (same
+          wrapper as fleet-management). */}
+      <div className="h-full w-full flex flex-col bg-white dark:bg-gray-900 overflow-y-auto">
+        <JobConsolePageContent dict={dict ?? {}} />
+      </div>
     </RouteGuard>
   );
 }


### PR DESCRIPTION
Follow-up to #933. `LayoutContent` is `overflow-hidden` — every `(secured)` page owns its own scroll. The jobs console was missing the `h-full`/`overflow-y-auto` page wrapper the fleet-management pages use, so content taller than the viewport could not scroll. Wraps the console in the same wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the integrations jobs page layout with full-height scrolling.
  * Added consistent light and dark theme background styling.
  * Ensured page content scrolls within its own layout for a smoother viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->