### PR TITLE
feat(calendar-sync): add the unassign op for the assignDriver revert

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
@@ -96,6 +96,29 @@ public class CalendarBookingsClient {
     }
 
     /**
+     * Unassign every booking of a resource: reset to {@code PLANNED} and drop
+     * {@code clearDataKeys} from {@code resource.data}, keeping the slot.
+     *
+     * <p>The sanctioned ASSIGNED → PLANNED regression, which a plain
+     * {@link #patchByResource} cannot express — miot-calendar keeps status
+     * patches strictly forward-only and carries each legal regression on its
+     * own operation. 200 = ok; 404 = no booking, 409 = the booking is past
+     * ASSIGNED; the caller decides what those mean.
+     */
+    public void unassignByResource(String resourceId, UUID calendarId, List<String> clearDataKeys) {
+        JsonObject body = new JsonObject();
+        if (clearDataKeys != null && !clearDataKeys.isEmpty()) {
+            body.put("clearDataKeys", new JsonArray(clearDataKeys));
+        }
+        String url = base() + BASE_PATH + "/resource/" + enc(resourceId) + "/unassign"
+                + (calendarId != null ? "?calendarId=" + calendarId : "");
+        HttpResponse<String> response = send("POST", url, body.encode());
+        if (response.statusCode() != 200) {
+            throw httpError("unassignByResource", url, response);
+        }
+    }
+
+    /**
      * Lists a resource's bookings with the fields the cancel decision needs (id,
      * calendar, slot date/time, status). 404 = no bookings (empty list). Scoped
      * to one calendar when {@code calendarId} is non-null (filtered client-side).

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -26,6 +26,13 @@ import org.jboss.logging.Logger;
  * / 5xx / network ({@code -1}) errors are thrown so the worker reports FAILED and
  * the ledger retries with backoff. miot-calendar only moves statuses forward, so
  * unordered jobs converge on the max status.
+ *
+ * <p><b>Except when a regression is the point.</b> The workflow is not
+ * monotonic — a service can go back from {@code presentDriver} to
+ * {@code assignDriver} — so {@link CalendarSyncFeature#OP_UNASSIGN} exists to
+ * carry that revert, and it reads 409 the opposite way: not "this job is late"
+ * but "the booking has run ahead of the workflow". See
+ * {@code executeUnassign}.
  */
 @ApplicationScoped
 public class CalendarSyncExecutor implements ModulithJobHandler {
@@ -79,10 +86,47 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         if (CalendarSyncFeature.OP_ENSURE.equals(op)) {
             return executeEnsure(payload, resourceId, calendarId);
         }
+        if (CalendarSyncFeature.OP_UNASSIGN.equals(op)) {
+            return executeUnassign(payload, resourceId, calendarId);
+        }
         if (CalendarSyncFeature.OP_CANCEL.equals(op)) {
             return executeCancel(resourceId, calendarId);
         }
         throw new IllegalArgumentException("calendar_sync unknown op: " + op);
+    }
+
+    /**
+     * Reset the booking to PLANNED and clear the assignment keys, keeping the
+     * slot — the {@code presentDriver → assignDriver} revert.
+     *
+     * <p>Outcome policy differs from {@link #executePatch} on purpose, because
+     * the two 409s mean opposite things. There, a 409 says the job lost a race
+     * and a newer status already won, so skipping is right. Here the job is on
+     * time and the regression <b>is</b> the intent, so a 409 says the booking
+     * has run ahead of the workflow — past ASSIGNED, truck already moving. No
+     * retry makes that converge, so it is a terminal skip, logged loudly rather
+     * than reported as a clean success.
+     *
+     * <p>404 stays quietly benign: the forward {@code planService →
+     * assignDriver} path enqueues the same op with no booking yet to unassign.
+     */
+    private JobOutcome executeUnassign(Map<String, Object> payload, String resourceId, UUID calendarId) {
+        List<String> clearDataKeys = asStringList(payload.get(CalendarSyncFeature.PAYLOAD_CLEAR_DATA_KEYS));
+        try {
+            client.unassignByResource(resourceId, calendarId, clearDataKeys);
+            return JobOutcome.succeeded("Booking unassigned for " + resourceId
+                    + " (cleared " + clearDataKeys.size() + " data key(s))");
+        } catch (CalendarBookingsHttpException e) {
+            if (e.getStatus() == 404) {
+                return JobOutcome.skipped("No booking to unassign for " + resourceId);
+            }
+            if (e.getStatus() == 409) {
+                LOG.warnf("calendar_sync unassign rejected for %s: the booking is past ASSIGNED while the "
+                        + "workflow went back to assignDriver — calendar and workflow have diverged", resourceId);
+                return JobOutcome.skipped("Unassign rejected for " + resourceId + " (booking past ASSIGNED)");
+            }
+            throw e;
+        }
     }
 
     private JobOutcome executePatch(Map<String, Object> payload, String resourceId, UUID calendarId) {
@@ -383,6 +427,23 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
     @SuppressWarnings("unchecked")
     private static Map<String, Object> asMap(Object value) {
         return value instanceof Map<?, ?> map ? (Map<String, Object>) map : null;
+    }
+
+    /**
+     * Payload list of resource-data keys, normalized: never null, no null or
+     * blank entries. Unlike {@link #asMap} this returns an empty list rather
+     * than null, because an unassign with nothing to clear is a valid job (it
+     * resets the lifecycle and leaves the payload alone).
+     */
+    private static List<String> asStringList(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(Object::toString)
+                .filter(s -> !s.isBlank())
+                .toList();
     }
 
     /** Resolved slot for an ensure create/move. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
@@ -26,6 +26,13 @@ public final class CalendarSyncFeature {
     public static final String PAYLOAD_RESOURCE_TYPE = "resourceType";
     public static final String PAYLOAD_TARGET_STATUS = "targetStatus";
     public static final String PAYLOAD_RESOURCE_DATA = "resourceData";
+    /**
+     * Top-level {@code resource.data} keys an {@link #OP_UNASSIGN} clears. ECM
+     * names them because the payload vocabulary is its own — miot-calendar and
+     * this worker only know a booking <i>has</i> data, not what "assigned
+     * driver" is called in it.
+     */
+    public static final String PAYLOAD_CLEAR_DATA_KEYS = "clearDataKeys";
 
     /**
      * Slot source for {@link #OP_ENSURE} (Phase 2). Either an explicit slot
@@ -48,6 +55,14 @@ public final class CalendarSyncFeature {
      */
     public static final String OP_ENSURE = "ensure";
     public static final String OP_CANCEL = "cancel";
+    /**
+     * Unassign: reset the booking to {@code PLANNED} and clear the assignment
+     * keys, keeping the slot. The coordinator's workflow is not monotonic — a
+     * service can go back from {@code presentDriver} to {@code assignDriver} —
+     * and miot-calendar rejects that as a status regression on a plain
+     * {@link #OP_PATCH}, so the revert needs its own operation.
+     */
+    public static final String OP_UNASSIGN = "unassign";
 
     /** Resource type sent when {@link #OP_ENSURE} creates a booking. */
     public static final String DEFAULT_RESOURCE_TYPE = "service";

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -37,6 +37,19 @@ class CalendarSyncExecutorTest {
         return p;
     }
 
+    private static final List<String> CLEAR_KEYS = List.of("assignedDriver", "assignedTruck");
+
+    private static Map<String, Object> unassignPayload(List<String> clearDataKeys) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(CalendarSyncFeature.PAYLOAD_OP, CalendarSyncFeature.OP_UNASSIGN);
+        p.put(CalendarSyncFeature.PAYLOAD_RESOURCE_ID, RESOURCE);
+        p.put(CalendarSyncFeature.PAYLOAD_CALENDAR_ID, CAL.toString());
+        if (clearDataKeys != null) {
+            p.put(CalendarSyncFeature.PAYLOAD_CLEAR_DATA_KEYS, clearDataKeys);
+        }
+        return p;
+    }
+
     private static Map<String, Object> cancelPayload() {
         Map<String, Object> p = new LinkedHashMap<>();
         p.put(CalendarSyncFeature.PAYLOAD_OP, CalendarSyncFeature.OP_CANCEL);
@@ -105,6 +118,79 @@ class CalendarSyncExecutorTest {
         var executor = new CalendarSyncExecutor(client, CLOCK);
         var payload = patchPayload("FINISHED");
         assertThrows(CalendarBookingsHttpException.class, () -> executor.handle(payload));
+    }
+
+    // --- unassign ------------------------------------------------------------
+
+    @Test
+    void unassignSuccessIsSucceededAndForwardsTheKeys() {
+        FakeClient client = new FakeClient();
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(unassignPayload(CLEAR_KEYS));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.unassignCalls);
+        assertEquals(CLEAR_KEYS, client.lastClearDataKeys);
+    }
+
+    /**
+     * The forward {@code planService → assignDriver} path enqueues this op with
+     * no booking yet to unassign.
+     */
+    @Test
+    void unassign404IsBenignSkip() {
+        FakeClient client = new FakeClient();
+        client.unassignThrows = new CalendarBookingsHttpException(404, "no booking");
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(unassignPayload(CLEAR_KEYS));
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+    }
+
+    /**
+     * Unlike a patch 409 — which means this job lost a race and a newer status
+     * already won — an unassign 409 means the booking ran ahead of the
+     * workflow. No retry converges, so it is terminal rather than a failure.
+     */
+    @Test
+    void unassign409IsTerminalSkipNotRetried() {
+        FakeClient client = new FakeClient();
+        client.unassignThrows = new CalendarBookingsHttpException(409, "past ASSIGNED");
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(unassignPayload(CLEAR_KEYS));
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+        assertTrue(result.detail().contains("past ASSIGNED"), result.detail());
+    }
+
+    @Test
+    void unassign500PropagatesForRetry() {
+        FakeClient client = new FakeClient();
+        client.unassignThrows = new CalendarBookingsHttpException(500, "boom");
+        var executor = new CalendarSyncExecutor(client, CLOCK);
+        var payload = unassignPayload(CLEAR_KEYS);
+        assertThrows(CalendarBookingsHttpException.class, () -> executor.handle(payload));
+    }
+
+    /** No keys is a valid job: reset the lifecycle, leave the payload alone. */
+    @Test
+    void unassignWithoutClearKeysStillRuns() {
+        FakeClient client = new FakeClient();
+        var payload = unassignPayload(null);
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(List.of(), client.lastClearDataKeys);
+    }
+
+    /** Null and blank entries would silently target nothing — drop them. */
+    @Test
+    void unassignSkipsNullAndBlankKeys() {
+        FakeClient client = new FakeClient();
+        var keys = new ArrayList<String>();
+        keys.add("assignedDriver");
+        keys.add(null);
+        keys.add("   ");
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(unassignPayload(keys));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(List.of("assignedDriver"), client.lastClearDataKeys);
     }
 
     // --- cancel --------------------------------------------------------------
@@ -348,6 +434,10 @@ class CalendarSyncExecutorTest {
         int lastCreateMinutes;
         int listAvailableCalls;
 
+        RuntimeException unassignThrows;
+        int unassignCalls;
+        List<String> lastClearDataKeys;
+
         int moveCalls;
         UUID lastMoveBookingId;
         LocalDate lastMoveDate;
@@ -403,6 +493,15 @@ class CalendarSyncExecutorTest {
                 UUID calendarId, LocalDate startDate, LocalDate endDate) {
             listAvailableCalls++;
             return availableSlots;
+        }
+
+        @Override
+        public void unassignByResource(String resourceId, UUID calendarId, List<String> clearDataKeys) {
+            unassignCalls++;
+            lastClearDataKeys = clearDataKeys;
+            if (unassignThrows != null) {
+                throw unassignThrows;
+            }
         }
     }
 }


### PR DESCRIPTION
Second of three PRs for microboxlabs/ecm-coordinator#321. Depends on the contract in microboxlabs/miot-calendar#37.

## Problem

Reverting a service from `presentDriver` back to `assignDriver` left its booking showing **ASSIGNED**, old driver still on the card, while the job reported SUCCEEDED.

ECM enqueued `ensure(PLANNED)`. miot-calendar rejected the backward status as a regression (409). `benignSkip` at `CalendarSyncExecutor:163` swallowed it as success.

## Change

miot-calendar now carries that reset on its own operation (miot-calendar#37), so this wires it up: `OP_UNASSIGN`, `executeUnassign`, and `CalendarBookingsClient.unassignByResource`.

## The 409 asymmetry

This is the part worth reviewing. `executeUnassign` reads 409 the *opposite* way from `executePatch`, deliberately:

| | what 409 means | outcome |
|---|---|---|
| `patch` | this job lost a race; a newer status already won | benign skip |
| `unassign` | the booking ran ahead of the workflow — past ASSIGNED, truck moving | **terminal skip, logged as divergence** |

On a patch the job is late. On an unassign the job is on time and the regression *is* the intent. No retry converges on the second case, so it stays a skip rather than a failure — but it is logged as a divergence instead of passing as a clean success, which is what hid the original defect.

404 stays quietly benign in both: the forward `planService → assignDriver` path enqueues the same op with no booking yet to unassign.

## Why ECM names the keys

`resource.data` is an opaque coordinator-owned payload — this worker knows a booking *has* data, not what "assigned driver" is called in it. `PAYLOAD_CLEAR_DATA_KEYS` keeps that vocabulary caller-side, so a new assignment field never needs a change here or in miot-calendar.

## Tests

6 new cases in `CalendarSyncExecutorTest`: success forwards the keys, 404 benign, 409 terminal-skip, 500 propagates for retry, the empty-keys job, and null/blank key filtering.

- `CalendarSyncExecutorTest`: **27 tests, 0 failures**
- `miot-integrations` module: **125 tests, 0 failures**

Note: `miot-core`'s `AuthTestInfrastructureTest` fails discovery without Docker and aborts an `-am` reactor run — pre-existing and unrelated, worked around by installing deps with `-DskipTests` and testing the module alone.

## Follow-up

ecm-coordinator: `OnCreateAssignDriverBinding` co-enqueues `ensure` + `unassign` as one chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)