### PR TITLE
feat(calendar): slot-only task-driven booking moves, no inline Alerce

### DIFF
--- a/turbo-repo/apps/app/.env.example
+++ b/turbo-repo/apps/app/.env.example
@@ -91,6 +91,16 @@ MAPBOX_API_KEY=your_mapbox_api_key
 
 # ─── Feature flags ──────────────────────────────────────────────
 NEXT_PUBLIC_SKIP_DRIVER_VERIFICATION=true
+# Per-origin rollout of the task-driven planner. Listed origins skip the
+# legacy synchronous /mintral/calendar/binding call: the planner advances the
+# workflow task and ECM projects the booking + notifies Alerce via the async
+# job outbox. Booking moves for listed origins are forwarded slot-only — the
+# planner's frozen resource blob is never merged onto the booking and no
+# binding/Alerce call fires on a re-slot. EXACT string match against the
+# service's origen / mintral_originDelegateCode — delegation codes
+# (SCL, ANF, …), not names.
+# Empty/unset = every origin takes the legacy in-request Alerce push.
+TASK_DRIVEN_ORIGINS=
 
 # ─── OpenAPI ─────────────────────────────────────────────────────
 OPENAPI_URL=https://your-openapi-host.com

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Move-path flag gating tests for the bookings move BFF.
+ *
+ * When the per-origin task-driven flag is ON for the booking's origin, the
+ * move is forwarded slot-only (the planner's frozen resource blob is never
+ * merged onto the booking) and the ECM `/mintral/calendar/binding` call —
+ * with its reverse-move compensation — is skipped entirely: ECM owns both
+ * the binding and the booking payload via the async-job ledger. When the
+ * flag is OFF, the route's behavior is byte-for-byte unchanged: full-body
+ * move, binding call derived from the moved booking, reverse-move
+ * compensation on binding failure.
+ *
+ * Heavy collaborators (auth, miot-calendar client, the binding helper) are
+ * mocked at the module level so the test stays focused on the gating
+ * decision; the helpers themselves are exercised by their own unit tests.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const ENV_KEY = "TASK_DRIVEN_ORIGINS";
+const ORIGINAL_ENV = process.env[ENV_KEY];
+
+const requireAnyGroupMock = vi.fn();
+const runCalendarBindingMock = vi.fn();
+const createMiotCalendarClientMock = vi.fn();
+const bookingsGetMock = vi.fn();
+const bookingsMoveMock = vi.fn();
+
+vi.mock("../../../../utils/alfresco-crud-client", () => ({
+  requireAnyGroup: (...args: unknown[]) => requireAnyGroupMock(...args),
+}));
+
+vi.mock("../../binding-helpers", () => ({
+  runCalendarBinding: (...args: unknown[]) => runCalendarBindingMock(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+class MiotCalendarApiErrorStub extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+vi.mock("@microboxlabs/miot-calendar-client", () => ({
+  createMiotCalendarClient: (...args: unknown[]) =>
+    createMiotCalendarClientMock(...args),
+  MiotCalendarApiError: MiotCalendarApiErrorStub,
+}));
+
+async function loadRoute() {
+  vi.resetModules();
+  return import("./route");
+}
+
+const TASK_DRIVEN_ORIGIN = "ANF";
+const LEGACY_ORIGIN = "SCL";
+const BOOKING_ID = "bk-001";
+
+const ASSIGNMENT_TUPLE = {
+  assignedCarrier: "carrier-uuid",
+  assignedDriver: "driver-uuid",
+  assignedTruck: "truck-uuid",
+  assignedCarrierExternalId: "21",
+};
+
+function makeBooking(
+  origen: string | undefined,
+  data: Record<string, unknown> = {}
+) {
+  return {
+    id: BOOKING_ID,
+    calendarId: "cal-001",
+    resource: {
+      id: "1586586-V",
+      type: "service",
+      label: "1586586-V",
+      data: {
+        mintral_serviceCode: "1586586",
+        ...(origen ? { origen } : {}),
+        ...data,
+      },
+    },
+    slot: { date: "2026-06-01", hour: 9, minutes: 0 },
+    createdAt: "2026-06-01T00:00:00Z",
+  };
+}
+
+function makeMoveRequest(body: Record<string, unknown>) {
+  return new Request(
+    `http://localhost/api/calendar/bookings/${BOOKING_ID}/move`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeMoveBody(origen: string, data: Record<string, unknown> = {}) {
+  return {
+    slot: { date: "2026-06-02", hour: 5, minutes: 0 },
+    resource: {
+      id: "1586586-V",
+      type: "service",
+      label: "1586586-V",
+      data: {
+        mintral_serviceCode: "1586586",
+        origen,
+        ...data,
+      },
+    },
+  };
+}
+
+const routeParams = { params: Promise.resolve({ bookingId: BOOKING_ID }) };
+
+describe("bookings move POST — task-driven flag gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAnyGroupMock.mockResolvedValue({
+      authorized: true,
+      session: { user: { rawJWT: "jwt" } },
+    });
+    createMiotCalendarClientMock.mockReturnValue({
+      bookings: {
+        get: bookingsGetMock,
+        move: bookingsMoveMock,
+      },
+    });
+    runCalendarBindingMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = ORIGINAL_ENV;
+    }
+  });
+
+  it("flag OFF: forwards the full body and fires the assigned-stage binding", async () => {
+    delete process.env[ENV_KEY];
+    const snapshot = makeBooking(LEGACY_ORIGIN);
+    const body = makeMoveBody(LEGACY_ORIGIN, ASSIGNMENT_TUPLE);
+    const moved = makeBooking(LEGACY_ORIGIN, ASSIGNMENT_TUPLE);
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(moved);
+
+    const { POST } = await loadRoute();
+    const response = await POST(makeMoveRequest(body), routeParams);
+
+    expect(response.status).toBe(200);
+    expect(bookingsMoveMock).toHaveBeenCalledWith(BOOKING_ID, body);
+    expect(runCalendarBindingMock).toHaveBeenCalledTimes(1);
+    const [, payload] = runCalendarBindingMock.mock.calls[0];
+    expect(payload).toMatchObject({
+      numero_servicio: "1586586",
+      stage: "assigned",
+      carrier_id: "carrier-uuid",
+    });
+  });
+
+  it("flag OFF: reverses the move when the binding call fails", async () => {
+    delete process.env[ENV_KEY];
+    const snapshot = makeBooking(LEGACY_ORIGIN);
+    const body = makeMoveBody(LEGACY_ORIGIN, ASSIGNMENT_TUPLE);
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(LEGACY_ORIGIN, ASSIGNMENT_TUPLE));
+    runCalendarBindingMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      message: "Alerce push failed",
+    });
+
+    const { POST } = await loadRoute();
+    const response = await POST(makeMoveRequest(body), routeParams);
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      calendarBindingFailed: true,
+      bookingCompensated: true,
+    });
+    // Second move call is the compensation, restoring the snapshot state.
+    expect(bookingsMoveMock).toHaveBeenCalledTimes(2);
+    expect(bookingsMoveMock).toHaveBeenLastCalledWith(BOOKING_ID, {
+      slot: snapshot.slot,
+      resource: snapshot.resource,
+    });
+  });
+
+  it("flag ON: forwards a slot-only move and never calls the binding", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(TASK_DRIVEN_ORIGIN);
+    // The drag payload still carries a (possibly stale) assignment tuple —
+    // it must not reach the calendar service nor trigger an Alerce push.
+    const body = makeMoveBody(TASK_DRIVEN_ORIGIN, ASSIGNMENT_TUPLE);
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(TASK_DRIVEN_ORIGIN));
+
+    const { POST } = await loadRoute();
+    const response = await POST(makeMoveRequest(body), routeParams);
+
+    expect(response.status).toBe(200);
+    expect(bookingsMoveMock).toHaveBeenCalledTimes(1);
+    expect(bookingsMoveMock).toHaveBeenCalledWith(BOOKING_ID, {
+      slot: body.slot,
+    });
+    expect(runCalendarBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("flag ON: reads the origin from the persisted booking when the body has none", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(TASK_DRIVEN_ORIGIN);
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(TASK_DRIVEN_ORIGIN));
+
+    const { POST } = await loadRoute();
+    const response = await POST(
+      makeMoveRequest({ slot: { date: "2026-06-02", hour: 5, minutes: 0 } }),
+      routeParams
+    );
+
+    expect(response.status).toBe(200);
+    expect(bookingsMoveMock).toHaveBeenCalledWith(BOOKING_ID, {
+      slot: { date: "2026-06-02", hour: 5, minutes: 0 },
+    });
+    expect(runCalendarBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("flag ON for a different origin: the legacy path still runs", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(LEGACY_ORIGIN);
+    const body = makeMoveBody(LEGACY_ORIGIN, ASSIGNMENT_TUPLE);
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(LEGACY_ORIGIN, ASSIGNMENT_TUPLE));
+
+    const { POST } = await loadRoute();
+    const response = await POST(makeMoveRequest(body), routeParams);
+
+    expect(response.status).toBe(200);
+    expect(bookingsMoveMock).toHaveBeenCalledWith(BOOKING_ID, body);
+    expect(runCalendarBindingMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -9,6 +9,11 @@ import { logger } from "@/lib/logger";
 import { z } from "zod";
 import { extractCalendarBindingPayload } from "../../binding-extractor";
 import { runCalendarBinding } from "../../binding-helpers";
+import {
+  isOriginTaskDriven,
+  parseTaskDrivenOrigins,
+  readBookingOrigin,
+} from "@/features/calendar/services/task-driven-origin";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
 
@@ -168,9 +173,32 @@ export async function POST(
   const snapshot = await snapshotBooking(client, bookingId);
   if (!snapshot.ok) return snapshot.error;
 
-  const move = await executeMove(client, bookingId, body.value);
+  // Task-driven origins: ECM owns the calendar binding AND the booking's
+  // resource payload (the assign chain patches the tuple onto the booking via
+  // the async-job ledger), so a move is slot-only. The request body's
+  // resource blob is the planner's frozen drag payload — after a workflow
+  // revert it can still carry an assignment tuple nobody holds, and merging
+  // it would both corrupt the booking and (below) fire a stage=assigned
+  // Alerce push for a stale assignment. Dropping it also makes the binding
+  // call and its reverse-move compensation dead for this path. Flag-off
+  // origins keep today's behavior byte-for-byte. The origin is read from the
+  // persisted booking first, falling back to the request body.
+  const enabledOrigins = parseTaskDrivenOrigins(
+    process.env.TASK_DRIVEN_ORIGINS
+  );
+  const originCode =
+    readBookingOrigin(snapshot.value.resource.data) ??
+    readBookingOrigin(body.value.resource?.data);
+  const taskDriven = isOriginTaskDriven(originCode, enabledOrigins);
+
+  const move = await executeMove(
+    client,
+    bookingId,
+    taskDriven ? { slot: body.value.slot } : body.value
+  );
   if (!move.ok) return move.error;
   const moved = move.value;
+  if (taskDriven) return NextResponse.json(moved);
 
   // Notify the coordinator about the (possibly refreshed) calendar binding.
   // Stage is derived from `resource.data` exactly like the create path — the

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -30,6 +30,7 @@ import { runCalendarBinding } from "./binding-helpers";
 import {
   isOriginTaskDriven,
   parseTaskDrivenOrigins,
+  readBookingOrigin,
 } from "@/features/calendar/services/task-driven-origin";
 
 const MIOT_CALENDAR_URL = process.env.MIOT_CALENDAR_URL ?? "";
@@ -190,23 +191,6 @@ async function compensateBooking(
   }
 }
 
-/**
- * Resolve the service's origin delegate code from the booking's
- * `resource.data` blob. `origen` is the canonical key the planner persists
- * (`SelectedService.origen`, populated from `mintral_originDelegateCode`);
- * the longer key is checked as a defensive fallback for bookings written
- * through paths that store the raw Alfresco field name. Returns undefined
- * when the field is missing or not a non-empty string.
- */
-function readOrigin(data: Record<string, unknown> | undefined): string | undefined {
-  if (!data) return undefined;
-  const candidates = [data.origen, data.mintral_originDelegateCode];
-  for (const value of candidates) {
-    if (typeof value === "string" && value.length > 0) return value;
-  }
-  return undefined;
-}
-
 async function runTaskAdvance(
   session: Session,
   advance: TaskAdvance
@@ -257,7 +241,7 @@ export async function POST(request: Request) {
   const enabledOrigins = parseTaskDrivenOrigins(
     process.env.TASK_DRIVEN_ORIGINS
   );
-  const originCode = readOrigin(body.resource?.data);
+  const originCode = readBookingOrigin(body.resource?.data);
   if (!isOriginTaskDriven(originCode, enabledOrigins)) {
     // Tell the coordinator about this calendar binding *before* the workflow
     // advance. The coordinator dispatches based on stage:

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-origin.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-origin.ts
@@ -34,3 +34,22 @@ export function isOriginTaskDriven(
   if (!origin) return false;
   return enabledOrigins.has(origin);
 }
+
+/**
+ * Resolve the service's origin delegate code from a booking's
+ * `resource.data` blob. `origen` is the canonical key the planner persists
+ * (`SelectedService.origen`, populated from `mintral_originDelegateCode`);
+ * the longer key is checked as a defensive fallback for bookings written
+ * through paths that store the raw Alfresco field name. Returns undefined
+ * when the field is missing or not a non-empty string.
+ */
+export function readBookingOrigin(
+  data: Record<string, unknown> | undefined
+): string | undefined {
+  if (!data) return undefined;
+  const candidates = [data.origen, data.mintral_originDelegateCode];
+  for (const value of candidates) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Why

Moving an assigned service in the planner reproduced a stale-write on dev (service 1586586, 2026-07-20 02:56): the move BFF unconditionally fired the deprecated synchronous `/mintral/calendar/binding` webscript with the drag payload's frozen resource blob. After a workflow revert that blob still carried the full assignment tuple, so the move (1) merged a stale `assigned*` tuple back onto the booking and (2) triggered a `stage=assigned` inline Alerce `ModificacionRecursoServicios` push for an assignment nobody holds (soft-failed with `SERVICIO NO EXISTE`, invisible to the user).

Unlike the create route, the move route never consulted `TASK_DRIVEN_ORIGINS`.

## What

- **Move BFF** (`bookings/[bookingId]/move/route.ts`): for origins in `TASK_DRIVEN_ORIGINS` the move is forwarded **slot-only** — the FE resource blob is never merged (ECM owns the booking payload via the async-job ledger: `calendar_sync` patch/ensure/unassign ops) — and the binding call plus its reverse-move compensation are skipped entirely. The origin is read from the persisted booking first, falling back to the request body. Flag-off origins keep today's behavior byte-for-byte.
- **Shared helper**: `readOrigin` moves from the create route into `task-driven-origin.ts` as `readBookingOrigin`, so both bookings routes gate identically.
- **`.env.example`**: documents the flag's move semantics.
- **Tests**: new `move/route.test.ts` covering flag-off full-body + binding + compensation, flag-on slot-only + no binding, snapshot-origin fallback, and per-origin selectivity.

The modulith contract already supports this: `MoveBookingRequest.resource` is optional and `BookingService.moveBooking` leaves the payload untouched when absent.

## Verification

- `vitest run src/features/calendar src/app/api/calendar` — 146 tests, 15 files, all green
- `turbo run check-types --filter=@modulariot/app` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for task-driven booking origins through the `TASK_DRIVEN_ORIGINS` configuration.
  - Bookings from enabled origins now use streamlined slot-only moves and avoid unnecessary calendar binding updates.
  - Origin detection works from either the request or the booking’s saved data.
- **Bug Fixes**
  - Preserved existing move, binding, and recovery behavior for origins not enabled for the task-driven workflow.
  - Added safeguards for missing or invalid origin values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->