### PR TITLE
feat(integrations): calendar_confirm job handler + syncStatus passthrough

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
@@ -80,12 +80,31 @@ public class CalendarBookingsClient {
      */
     public void patchByResource(String resourceId, UUID calendarId,
                                 String targetStatus, Map<String, Object> resourceDataPatch) {
+        patchByResource(resourceId, calendarId, targetStatus, resourceDataPatch, null, null);
+    }
+
+    /**
+     * Full patch variant, additionally carrying the TMS-confirmation
+     * {@code syncStatus} (PENDING/CONFIRMED/REJECTED — orthogonal to the
+     * monotonic lifecycle {@code status}; null leaves it untouched) and its
+     * optional detail. Overridden by test fakes — keep this the single method
+     * that actually sends.
+     */
+    public void patchByResource(String resourceId, UUID calendarId,
+                                String targetStatus, Map<String, Object> resourceDataPatch,
+                                String syncStatus, String syncDetail) {
         JsonObject body = new JsonObject();
         if (targetStatus != null) {
             body.put("status", targetStatus);
         }
         if (resourceDataPatch != null && !resourceDataPatch.isEmpty()) {
             body.put("resourceData", new JsonObject(resourceDataPatch));
+        }
+        if (syncStatus != null) {
+            body.put("syncStatus", syncStatus);
+            if (syncDetail != null) {
+                body.put("syncDetail", syncDetail);
+            }
         }
         String url = base() + BASE_PATH + "/resource/" + enc(resourceId)
                 + (calendarId != null ? "?calendarId=" + calendarId : "");

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java
@@ -1,0 +1,79 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import com.microboxlabs.miot.integrations.jobs.ModulithJobHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * {@link ModulithJobHandler} for {@code calendar_confirm}: stamps
+ * {@code syncStatus=CONFIRMED} on the booking once its chain predecessor (the
+ * {@code alerce_assignment} push) has SUCCEEDED — see
+ * {@link CalendarConfirmFeature} for the chain semantics.
+ *
+ * <p>Outcome policy mirrors {@link CalendarSyncExecutor}: 404 (booking gone —
+ * unplanned or cancelled while the push was in flight) is a benign SKIP;
+ * transport / 5xx / network ({@code -1}) errors are thrown so the worker
+ * reports FAILED and the ledger retries with backoff. The sync-status patch
+ * has no regression rules on the miot-calendar side, so there is no 409 case.
+ */
+@ApplicationScoped
+public class CalendarConfirmExecutor implements ModulithJobHandler {
+
+    private static final Logger LOG = Logger.getLogger(CalendarConfirmExecutor.class);
+
+    private final CalendarBookingsClient client;
+
+    @Inject
+    CalendarConfirmExecutor(CalendarBookingsClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String jobType() {
+        return CalendarConfirmFeature.JOB_TYPE;
+    }
+
+    /** Not ready until the miot-calendar base URL is configured. */
+    @Override
+    public boolean isReady() {
+        return client.isConfigured();
+    }
+
+    @Override
+    public JobOutcome handle(Map<String, Object> payload) {
+        String resourceId = str(payload, CalendarConfirmFeature.PAYLOAD_RESOURCE_ID);
+        String calendarIdRaw = str(payload, CalendarConfirmFeature.PAYLOAD_CALENDAR_ID);
+        String serviceCode = str(payload, CalendarConfirmFeature.PAYLOAD_SERVICE_CODE);
+        if (resourceId == null) {
+            throw new IllegalArgumentException("calendar_confirm payload missing resourceId");
+        }
+        java.util.UUID calendarId = calendarIdRaw == null ? null : java.util.UUID.fromString(calendarIdRaw);
+
+        try {
+            client.patchByResource(resourceId, calendarId, null, null,
+                    CalendarConfirmFeature.SYNC_STATUS_CONFIRMED,
+                    "Alerce accepted the assignment (code=OK)");
+            return JobOutcome.succeeded("Booking sync CONFIRMED for " + resourceId);
+        } catch (CalendarBookingsHttpException e) {
+            if (e.getStatus() == 404) {
+                // The booking was unplanned/cancelled while the push was in
+                // flight — nothing left to confirm.
+                LOG.infof("calendar_confirm: no booking for %s (service %s) — skipping", resourceId, serviceCode);
+                return JobOutcome.skipped("No booking to confirm for " + resourceId);
+            }
+            throw e;
+        }
+    }
+
+    private static String str(Map<String, Object> payload, String key) {
+        Object v = payload.get(key);
+        if (v == null) {
+            return null;
+        }
+        String s = String.valueOf(v);
+        return s.isBlank() ? null : s;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmFeature.java
@@ -1,0 +1,31 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+/**
+ * Constants for the modulith-executed {@code calendar_confirm} job — the third
+ * leg of ECM's assign chain ({@code calendar_sync} seq 0 → {@code
+ * alerce_assignment} seq 1 → this, seq 2). Payload field names MUST stay in
+ * lockstep with ECM's {@code CalendarConfirmFeature} (the payload is the wire
+ * contract).
+ *
+ * <p>The ledger's chain gate is the whole design: this job becomes claimable
+ * only once the {@code alerce_assignment} leg reports SUCCEEDED — which, since
+ * the executor fails jobs on a non-OK Alerce body, means Alerce genuinely
+ * accepted the tuple. A rejected/parked push keeps this leg blocked and the
+ * booking stays {@code syncStatus=PENDING} ("planned but unconfirmed"); a
+ * later successful manual retry unblocks it with no extra machinery.
+ */
+public final class CalendarConfirmFeature {
+
+    private CalendarConfirmFeature() {
+    }
+
+    public static final String JOB_TYPE = "calendar_confirm";
+
+    /** Self-contained payload (mirrors ECM's enqueuer). */
+    public static final String PAYLOAD_SERVICE_CODE = "serviceCode";
+    public static final String PAYLOAD_CALENDAR_ID = "calendarId";
+    public static final String PAYLOAD_RESOURCE_ID = "resourceId";
+
+    /** Value written to the booking's {@code syncStatus} on confirmation. */
+    public static final String SYNC_STATUS_CONFIRMED = "CONFIRMED";
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -131,9 +131,10 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
 
     private JobOutcome executePatch(Map<String, Object> payload, String resourceId, UUID calendarId) {
         String targetStatus = str(payload, CalendarSyncFeature.PAYLOAD_TARGET_STATUS);
+        String syncStatus = str(payload, CalendarSyncFeature.PAYLOAD_SYNC_STATUS);
         Map<String, Object> resourceData = asMap(payload.get(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA));
         try {
-            client.patchByResource(resourceId, calendarId, targetStatus, resourceData);
+            client.patchByResource(resourceId, calendarId, targetStatus, resourceData, syncStatus, null);
             return JobOutcome.succeeded("Booking patched to " + targetStatus + " for " + resourceId);
         } catch (CalendarBookingsHttpException e) {
             JobOutcome benign = benignSkip(e, resourceId, targetStatus);

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
@@ -33,6 +33,14 @@ public final class CalendarSyncFeature {
      * driver" is called in it.
      */
     public static final String PAYLOAD_CLEAR_DATA_KEYS = "clearDataKeys";
+    /**
+     * Optional TMS-confirmation status on an {@link #OP_PATCH}
+     * (miot-calendar {@code syncStatus} — orthogonal to the monotonic
+     * lifecycle {@code status}). The ECM assign chain stamps {@code PENDING}
+     * here to open the confirmation window that the {@code calendar_confirm}
+     * leg later closes.
+     */
+    public static final String PAYLOAD_SYNC_STATUS = "syncStatus";
 
     /**
      * Slot source for {@link #OP_ENSURE} (Phase 2). Either an explicit slot

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
@@ -1,0 +1,101 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Outcome policy for the calendar_confirm leg: stamp CONFIRMED on success,
+ * benign-skip a vanished booking (404), propagate everything else for retry.
+ * The chain-ordering guarantees (runs only after alerce_assignment SUCCEEDED)
+ * live in the ledger's claim SQL, not here.
+ */
+class CalendarConfirmExecutorTest {
+
+    private static final UUID CAL = UUID.fromString("3b4808f2-68ae-4b45-b921-f5a012a8962a");
+    private static final String RESOURCE = "1658427-V";
+
+    private static Map<String, Object> payload() {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(CalendarConfirmFeature.PAYLOAD_SERVICE_CODE, "1658427");
+        p.put(CalendarConfirmFeature.PAYLOAD_CALENDAR_ID, CAL.toString());
+        p.put(CalendarConfirmFeature.PAYLOAD_RESOURCE_ID, RESOURCE);
+        return p;
+    }
+
+    @Test
+    void confirmStampsSyncStatusOnly() {
+        FakeClient client = new FakeClient();
+        var result = new CalendarConfirmExecutor(client).handle(payload());
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.patchCalls);
+        assertEquals("CONFIRMED", client.lastSyncStatus);
+        // The lifecycle status must NOT be touched — confirmation is the
+        // orthogonal dimension; sending a status here could 409 or regress.
+        assertNull(client.lastStatus);
+        assertEquals(RESOURCE, client.lastResourceId);
+        assertEquals(CAL, client.lastCalendarId);
+    }
+
+    @Test
+    void vanishedBookingIsBenignSkip() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(404, "no booking");
+
+        var result = new CalendarConfirmExecutor(client).handle(payload());
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+    }
+
+    @Test
+    void transportErrorPropagatesForRetry() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(-1, "io error");
+        var executor = new CalendarConfirmExecutor(client);
+        var p = payload();
+        assertThrows(CalendarBookingsHttpException.class, () -> executor.handle(p));
+    }
+
+    @Test
+    void missingResourceIdThrows() {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(CalendarConfirmFeature.PAYLOAD_SERVICE_CODE, "1658427");
+        var executor = new CalendarConfirmExecutor(new FakeClient());
+        assertThrows(IllegalArgumentException.class, () -> executor.handle(p));
+    }
+
+    private static final class FakeClient extends CalendarBookingsClient {
+        RuntimeException patchThrows;
+        int patchCalls;
+        String lastResourceId;
+        UUID lastCalendarId;
+        String lastStatus;
+        String lastSyncStatus;
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void patchByResource(String resourceId, UUID calendarId, String targetStatus,
+                                    Map<String, Object> resourceDataPatch,
+                                    String syncStatus, String syncDetail) {
+            patchCalls++;
+            lastResourceId = resourceId;
+            lastCalendarId = calendarId;
+            lastStatus = targetStatus;
+            lastSyncStatus = syncStatus;
+            if (patchThrows != null) {
+                throw patchThrows;
+            }
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -95,6 +95,26 @@ class CalendarSyncExecutorTest {
         assertEquals("ASSIGNED", client.lastPatchStatus);
     }
 
+    /** The assign chain's PENDING stamp rides the patch payload untouched. */
+    @Test
+    void patchPassesSyncStatusThrough() {
+        FakeClient client = new FakeClient();
+        Map<String, Object> payload = patchPayload("ASSIGNED");
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+
+        var result = new CalendarSyncExecutor(client, CLOCK).handle(payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals("PENDING", client.lastPatchSyncStatus);
+    }
+
+    @Test
+    void patchWithoutSyncStatusSendsNone() {
+        FakeClient client = new FakeClient();
+        new CalendarSyncExecutor(client, CLOCK).handle(patchPayload("ASSIGNED"));
+        org.junit.jupiter.api.Assertions.assertNull(client.lastPatchSyncStatus);
+    }
+
     @Test
     void patch404IsBenignSkip() {
         FakeClient client = new FakeClient();
@@ -425,6 +445,7 @@ class CalendarSyncExecutorTest {
         RuntimeException patchThrows;
         int patchCalls;
         String lastPatchStatus;
+        String lastPatchSyncStatus;
         final List<UUID> cancelled = new ArrayList<>();
 
         final UUID createdId = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
@@ -451,9 +472,11 @@ class CalendarSyncExecutorTest {
 
         @Override
         public void patchByResource(String resourceId, UUID calendarId, String targetStatus,
-                                    Map<String, Object> resourceDataPatch) {
+                                    Map<String, Object> resourceDataPatch,
+                                    String syncStatus, String syncDetail) {
             patchCalls++;
             lastPatchStatus = targetStatus;
+            lastPatchSyncStatus = syncStatus;
             if (patchThrows != null) {
                 throw patchThrows;
             }


### PR DESCRIPTION
Part of microboxlabs/ecm-coordinator#328 (calendar_confirm chain leg).

## What

The modulith half of the Alerce-confirmation chain: after ECM's assign chain pushes the tuple to Alerce, a third chained job — running on the modulith lane, where the miot-calendar client lives — marks the booking as confirmed.

```
calendar_sync (seq 0, modulith) → alerce_assignment (seq 1, ecm) → calendar_confirm (seq 2, modulith)
```

- **`CalendarConfirmExecutor`** (new `ModulithJobHandler`, job type `calendar_confirm`): stamps `syncStatus=CONFIRMED` on the booking via the resource patch. It never touches the lifecycle `status` (confirmation is the orthogonal dimension — sending a status could 409). 404 (booking unplanned/cancelled while the push was in flight) is a benign SKIP; transport errors throw → ledger retry.
- **`CalendarSyncExecutor`**: passes the new optional `syncStatus` payload field through `OP_PATCH` — the ECM chain stamps `PENDING` on the calendar leg to open the confirmation window this leg later closes.
- **`CalendarBookingsClient`**: `patchByResource` grows `syncStatus`/`syncDetail` body fields (server side: miot-calendar#40).

The chain gate on the async-jobs ledger provides the ordering guarantees: this job is claimable only once `alerce_assignment` SUCCEEDED — which, with ecm-coordinator#329, genuinely means Alerce accepted (`code=OK`). A rejected/parked push keeps the leg blocked and the booking reads "planned but unconfirmed in Alerce"; a successful manual retry later unblocks it with no extra machinery.

## Rollout

Deploy after miot-calendar#40 (nullable columns, additive API) and with the modulith job worker enabled (`miot.integrations.modulith-worker.enabled`), **before** ECM enables `mintral.features.integrationOutbox.calendarConfirm.enabled` — otherwise confirm jobs strand PENDING.

## Tests

miot-integrations module: 131/131 — `CalendarConfirmExecutorTest` (confirm stamps sync-only, 404 skip, transport retry, missing resourceId) + `CalendarSyncExecutorTest` passthrough cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

