### PR TITLE
feat(retransmit): Gauss GPS v2 delivery + optional traffic logging

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -47,6 +47,10 @@ miot.integrations.retransmit.gauss.tags=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_TAG
 miot.integrations.retransmit.gauss.device-type=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_DEVICE_TYPE:gps}
 miot.integrations.retransmit.gauss.event-provider=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_EVENT_PROVIDER:streamhub}
 miot.integrations.retransmit.gauss.device-model=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_DEVICE_MODEL:streamhub-miot}
+# Traffic capture (INFO): log Gauss request payload + response body for each POST.
+# Auth headers (API key / Bearer) are never logged. Off by default — noisy in prod.
+#   MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_LOG_TRAFFIC=true
+miot.integrations.retransmit.gauss.log-traffic=${MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_LOG_TRAFFIC:false}
 # Privacy pin for outside-MEL mode (env/secret only — do not commit real coords):
 #   MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LAT
 #   MIOT_INTEGRATIONS_RETRANSMIT_PRIVACY_PIN_LON

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliveryJob.java
@@ -33,6 +33,8 @@ public class RetransmitDeliveryJob {
 
     private static final Logger LOG = Logger.getLogger(RetransmitDeliveryJob.class);
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(15);
+    /** Max chars of request/response body in traffic logs (full GPS points are small). */
+    private static final int TRAFFIC_BODY_MAX = 16_384;
 
     private final RetransmitDeliveryRepository repository;
     private final GaussAuthClient gaussAuth;
@@ -92,10 +94,18 @@ public class RetransmitDeliveryJob {
                 body = new JsonObject(delivery.payload()).encode();
             }
 
+            if (settings.logTraffic() && gauss) {
+                logTrafficRequest(delivery, body, false);
+            }
+
             HttpResponse<String> response = httpClient.send(
                     req.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
                     HttpResponse.BodyHandlers.ofString());
             int code = response.statusCode();
+
+            if (settings.logTraffic() && gauss) {
+                logTrafficResponse(delivery, code, response.body(), false);
+            }
 
             // One retry after re-auth on 401 for Gauss (OAuth/bearer; API-key mode is static)
             if (gauss && code == 401) {
@@ -107,10 +117,16 @@ public class RetransmitDeliveryJob {
                         .header("User-Agent", "ModularIoT-Retransmit/1.0")
                         .header("X-Miot-Retransmit-Config", delivery.configId());
                 gaussAuth.applyAuthHeaders(retry);
+                if (settings.logTraffic()) {
+                    logTrafficRequest(delivery, body, true);
+                }
                 response = httpClient.send(
                         retry.POST(HttpRequest.BodyPublishers.ofString(body)).build(),
                         HttpResponse.BodyHandlers.ofString());
                 code = response.statusCode();
+                if (settings.logTraffic()) {
+                    logTrafficResponse(delivery, code, response.body(), true);
+                }
             }
 
             handleResponse(delivery, id, code, response.body(), gauss);
@@ -205,5 +221,42 @@ public class RetransmitDeliveryJob {
             return null;
         }
         return error.length() > 1000 ? error.substring(0, 1000) : error;
+    }
+
+    /**
+     * Traffic capture for Gauss POSTs. Never logs Authorization / API-key values —
+     * only URL, delivery metadata, and JSON bodies.
+     */
+    private void logTrafficRequest(RetransmitDelivery delivery, String body, boolean retry) {
+        LOG.infof(
+                "Gauss traffic REQUEST%s id=%s config=%s asset=%s url=%s body=%s",
+                retry ? " (retry-after-401)" : "",
+                delivery.id(),
+                delivery.configId(),
+                delivery.assetId(),
+                delivery.destinationUrl(),
+                truncateTraffic(body));
+    }
+
+    private void logTrafficResponse(
+            RetransmitDelivery delivery, int statusCode, String responseBody, boolean retry) {
+        LOG.infof(
+                "Gauss traffic RESPONSE%s id=%s config=%s asset=%s status=%d body=%s",
+                retry ? " (retry-after-401)" : "",
+                delivery.id(),
+                delivery.configId(),
+                delivery.assetId(),
+                statusCode,
+                truncateTraffic(responseBody));
+    }
+
+    private static String truncateTraffic(String body) {
+        if (body == null) {
+            return "";
+        }
+        if (body.length() <= TRAFFIC_BODY_MAX) {
+            return body;
+        }
+        return body.substring(0, TRAFFIC_BODY_MAX) + "...[truncated " + body.length() + " chars]";
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
@@ -19,6 +19,7 @@ public class RetransmitDeliverySettings {
     private final int retryBaseSeconds;
     private final int retryMaxSeconds;
     private final String payloadFormat;
+    private final boolean logTraffic;
     private final Defaults gaussDefaults;
 
     RetransmitDeliverySettings(
@@ -34,6 +35,8 @@ public class RetransmitDeliverySettings {
                     int retryMaxSeconds,
             @ConfigProperty(name = "miot.integrations.retransmit.payload-format", defaultValue = "auto")
                     String payloadFormat,
+            @ConfigProperty(name = "miot.integrations.retransmit.gauss.log-traffic", defaultValue = "false")
+                    boolean logTraffic,
             Defaults gaussDefaults) {
         this.workerEnabled = workerEnabled;
         this.claimLimit = claimLimit;
@@ -41,6 +44,7 @@ public class RetransmitDeliverySettings {
         this.retryBaseSeconds = retryBaseSeconds;
         this.retryMaxSeconds = retryMaxSeconds;
         this.payloadFormat = payloadFormat == null ? "auto" : payloadFormat.trim().toLowerCase(Locale.ROOT);
+        this.logTraffic = logTraffic;
         this.gaussDefaults = gaussDefaults;
     }
 
@@ -84,6 +88,14 @@ public class RetransmitDeliverySettings {
 
     String payloadFormat() {
         return payloadFormat;
+    }
+
+    /**
+     * When true, log Gauss HTTP request payload and response body at INFO
+     * (auth headers redacted). Off by default — enable only for traffic capture.
+     */
+    boolean logTraffic() {
+        return logTraffic;
     }
 
     Defaults gaussDefaults() {


### PR DESCRIPTION
## Summary
- Map retransmit outbox rows to Gauss Control **Inyección puntos GPS v2** (JSON array body).
- Auth via provider gateway headers (`X-Provider-Api-Key` / `X-Target-Tenant`) with OAuth/bearer fallback.
- Privacy pin coordinates come from env/secret only (not committed).
- Optional traffic capture: when `MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_LOG_TRAFFIC=true`, log Gauss request payload and response body at INFO (auth headers never logged).

## Config
| Key | Env | Default |
|-----|-----|---------|
| `miot.integrations.retransmit.gauss.log-traffic` | `MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_LOG_TRAFFIC` | `false` |
| `miot.integrations.retransmit.gauss.provider-api-key` | `MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_PROVIDER_API_KEY` | unset |
| `miot.integrations.retransmit.gauss.target-tenant` | `MIOT_INTEGRATIONS_RETRANSMIT_GAUSS_TARGET_TENANT` | unset |

## Deploy pairing
StreamHub stack values: `miot-deployments` branch `feat/streamhub-gauss-retransmit-env` (enables `LOG_TRAFFIC=true` + retransmit package log level INFO).

## Test plan
- [ ] Unit tests: `GaussPositionMapperTest`, `RetransmitMatchServiceTest`
- [ ] With `LOG_TRAFFIC=true`, pod logs show `Gauss traffic REQUEST` / `RESPONSE` lines for a delivery
- [ ] Auth secrets never appear in those log lines
- [ ] With flag false (default), no traffic body logs