### PR TITLE
feat(integrations): job-failure park hooks — booking REJECTED stamp + WhatsApp notification rules

### DIFF
--- a/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandler.java
+++ b/quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandler.java
@@ -1,0 +1,176 @@
+package com.microboxlabs.miot.conversational.jobs;
+
+import com.microboxlabs.miot.conversational.domain.Message;
+import com.microboxlabs.miot.conversational.domain.MessageStatus;
+import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
+import com.microboxlabs.miot.conversational.service.WhatsAppMessagingService;
+import com.microboxlabs.miot.integrations.jobs.JobFailureNotificationFeature;
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import com.microboxlabs.miot.integrations.jobs.ModulithJobHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * {@link ModulithJobHandler} for {@code job_failure_notification}: messages a
+ * notification rule's recipients on WhatsApp that one of the tenant's async
+ * jobs parked as FAILED. Lives in miot-conversational because the module
+ * dependency direction (conversational → integrations) means integrations code
+ * cannot inject {@link WhatsAppMessagingService}; the worker discovers handler
+ * beans CDI-wide, so registration is automatic.
+ *
+ * <p>With a {@code templateName} in the payload the send uses that pre-approved
+ * Meta template (named params {@code job_type}/{@code correlation_key}/{@code
+ * error}); otherwise a free-form text, which Meta only delivers inside an open
+ * 24h session window — fine for ops numbers that talk to the bot.
+ *
+ * <p>Per-recipient outcomes: {@code send} never throws on a Meta failure (it
+ * persists a FAILED {@code wa_message} row), so each returned status is
+ * checked. Every recipient failed ⇒ throw (the ledger retries with backoff);
+ * partial ⇒ SUCCEEDED with the failures in the detail, because a retry would
+ * re-message the recipients that already got it.
+ *
+ * <p>Deliberately no {@code serviceCode} on the send: it would graft the ops
+ * recipient's message onto the service's driver conversation thread. These
+ * notifications ride plain per-phone threads.
+ */
+@ApplicationScoped
+public class JobFailureNotificationHandler implements ModulithJobHandler {
+
+    private static final Logger LOG = Logger.getLogger(JobFailureNotificationHandler.class);
+    private static final String ACTOR = "job-failure-notifier";
+    private static final String TYPE_TEXT = "TEXT";
+    private static final String TYPE_TEMPLATE = "TEMPLATE";
+    private static final String PARAM_FALLBACK = "-";
+
+    private final WhatsAppMessagingService messagingService;
+
+    @Inject
+    JobFailureNotificationHandler(WhatsAppMessagingService messagingService) {
+        this.messagingService = messagingService;
+    }
+
+    @Override
+    public String jobType() {
+        return JobFailureNotificationFeature.JOB_TYPE;
+    }
+
+    @Override
+    public JobOutcome handle(Map<String, Object> payload) {
+        String tenantCode = str(payload.get(JobFailureNotificationFeature.PAYLOAD_TENANT_CODE));
+        List<String> recipients = recipients(payload.get(JobFailureNotificationFeature.PAYLOAD_RECIPIENTS));
+        if (tenantCode == null) {
+            throw new IllegalArgumentException("job_failure_notification payload missing tenantCode");
+        }
+        if (recipients.isEmpty()) {
+            throw new IllegalArgumentException("job_failure_notification payload has no recipients");
+        }
+        String failedJobType = str(payload.get(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_TYPE));
+        String correlationKey = str(payload.get(JobFailureNotificationFeature.PAYLOAD_CORRELATION_KEY));
+        String error = str(payload.get(JobFailureNotificationFeature.PAYLOAD_ERROR));
+        String templateName = str(payload.get(JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME));
+        String language = str(payload.get(JobFailureNotificationFeature.PAYLOAD_LANGUAGE));
+
+        int sent = 0;
+        List<String> failures = new ArrayList<>();
+        for (String recipient : recipients) {
+            String failure = sendTo(tenantCode, recipient,
+                    templateName, language, failedJobType, correlationKey, error);
+            if (failure == null) {
+                sent++;
+            } else {
+                failures.add(failure);
+            }
+        }
+        if (sent == 0) {
+            throw new IllegalStateException("WhatsApp notification failed for all "
+                    + recipients.size() + " recipient(s): " + String.join("; ", failures));
+        }
+        String detail = "Notified " + sent + "/" + recipients.size() + " recipient(s) about "
+                + failedJobType + (correlationKey != null ? " " + correlationKey : "")
+                + (failures.isEmpty() ? "" : " — failed: " + String.join("; ", failures));
+        return JobOutcome.succeeded(detail);
+    }
+
+    /** @return null when delivered to Meta, else a masked-recipient failure description */
+    private String sendTo(String tenantCode, String recipient, String templateName, String language,
+            String failedJobType, String correlationKey, String error) {
+        try {
+            Message result = messagingService.send(tenantCode,
+                    request(recipient, templateName, language, failedJobType, correlationKey, error), ACTOR);
+            if (result.status() == MessageStatus.FAILED) {
+                return maskPhone(recipient) + ": " + result.errorMessage();
+            }
+            return null;
+        } catch (Exception e) {
+            LOG.warnf("Failure notification to %s (tenant %s) errored: %s",
+                    maskPhone(recipient), tenantCode, e.getMessage());
+            return maskPhone(recipient) + ": " + e.getMessage();
+        }
+    }
+
+    private static SendWhatsAppMessageRequest request(String recipient, String templateName, String language,
+            String failedJobType, String correlationKey, String error) {
+        if (templateName != null) {
+            Map<String, String> params = new LinkedHashMap<>();
+            params.put("job_type", orFallback(failedJobType));
+            params.put("correlation_key", orFallback(correlationKey));
+            params.put("error", orFallback(error));
+            return new SendWhatsAppMessageRequest(recipient, TYPE_TEMPLATE, null,
+                    templateName, language, params, null, null, null, null, null, null);
+        }
+        return new SendWhatsAppMessageRequest(recipient, TYPE_TEXT,
+                body(failedJobType, correlationKey, error),
+                null, null, null, null, null, null, null, null, null);
+    }
+
+    private static String body(String failedJobType, String correlationKey, String error) {
+        StringBuilder body = new StringBuilder("⚠️ MIOT: el trabajo de integración '")
+                .append(orFallback(failedJobType)).append("' quedó en error");
+        if (correlationKey != null) {
+            body.append(" (").append(correlationKey).append(")");
+        }
+        if (error != null) {
+            body.append(". Detalle: ").append(error);
+        }
+        return body.append(". Revisa la consola de trabajos para reintentarlo.").toString();
+    }
+
+    private static String orFallback(String value) {
+        return value == null || value.isBlank() ? PARAM_FALLBACK : value;
+    }
+
+    private static List<String> recipients(Object value) {
+        if (!(value instanceof Iterable<?> iterable)) {
+            return List.of();
+        }
+        List<String> recipients = new ArrayList<>();
+        for (Object item : iterable) {
+            String recipient = str(item);
+            if (recipient != null) {
+                recipients.add(recipient);
+            }
+        }
+        return recipients;
+    }
+
+    private static String str(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value);
+        return s.isBlank() ? null : s;
+    }
+
+    /** Masks a phone for logs/details, keeping only the last 4 digits (PII reduction). */
+    private static String maskPhone(String phone) {
+        if (phone == null || phone.length() <= 4) {
+            return "****";
+        }
+        return "****" + phone.substring(phone.length() - 4);
+    }
+}

--- a/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandlerTest.java
+++ b/quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandlerTest.java
@@ -1,0 +1,172 @@
+package com.microboxlabs.miot.conversational.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.conversational.domain.Message;
+import com.microboxlabs.miot.conversational.domain.MessageDirection;
+import com.microboxlabs.miot.conversational.domain.MessageRole;
+import com.microboxlabs.miot.conversational.domain.MessageStatus;
+import com.microboxlabs.miot.conversational.domain.MessageType;
+import com.microboxlabs.miot.conversational.dto.SendWhatsAppMessageRequest;
+import com.microboxlabs.miot.conversational.service.WhatsAppMessagingService;
+import com.microboxlabs.miot.integrations.jobs.JobFailureNotificationFeature;
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Send policy for job_failure_notification: one WhatsApp per recipient, text
+ * by default / template when configured, per-recipient failures collected —
+ * all failed throws (ledger retries), partial succeeds with detail (a retry
+ * would re-message the recipients that already got it). The send must never
+ * carry a serviceCode: that would graft the ops recipient's message onto the
+ * service's driver conversation thread.
+ */
+class JobFailureNotificationHandlerTest {
+
+    private final FakeMessaging messaging = new FakeMessaging();
+    private final JobFailureNotificationHandler handler = new JobFailureNotificationHandler(messaging);
+
+    private static Map<String, Object> payload(List<String> recipients) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(JobFailureNotificationFeature.PAYLOAD_TENANT_CODE, "tenant-1");
+        p.put(JobFailureNotificationFeature.PAYLOAD_RECIPIENTS, recipients);
+        p.put(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_ID, "job-1");
+        p.put(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_TYPE, "alerce_assignment");
+        p.put(JobFailureNotificationFeature.PAYLOAD_CORRELATION_KEY, "87920845");
+        p.put(JobFailureNotificationFeature.PAYLOAD_ERROR, "CONDUCTOR2 NO EXISTE");
+        return p;
+    }
+
+    @Test
+    void sendsOneTextPerRecipientWithTheFailureContext() {
+        var result = handler.handle(payload(List.of("+56911111111", "+56922222222")));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(2, messaging.sent.size());
+        assertEquals("tenant-1", messaging.tenants.get(0));
+        SendWhatsAppMessageRequest first = messaging.sent.get(0);
+        assertEquals("+56911111111", first.to());
+        assertEquals("+56922222222", messaging.sent.get(1).to());
+        assertTrue(first.body().contains("alerce_assignment"));
+        assertTrue(first.body().contains("87920845"));
+        assertTrue(first.body().contains("CONDUCTOR2 NO EXISTE"));
+        // Never thread-graft onto the service's driver conversation.
+        assertNull(first.serviceCode());
+        assertTrue(result.detail().contains("2/2"));
+    }
+
+    @Test
+    void templateNameSwitchesToATemplateSend() {
+        Map<String, Object> p = payload(List.of("+56911111111"));
+        p.put(JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME, "job_failed_alert");
+        p.put(JobFailureNotificationFeature.PAYLOAD_LANGUAGE, "es_CL");
+
+        handler.handle(p);
+
+        SendWhatsAppMessageRequest sent = messaging.sent.get(0);
+        assertTrue(sent.isTemplate());
+        assertEquals("job_failed_alert", sent.templateName());
+        assertEquals("es_CL", sent.language());
+        assertEquals("alerce_assignment", sent.templateParams().get("job_type"));
+        assertEquals("87920845", sent.templateParams().get("correlation_key"));
+        assertEquals("CONDUCTOR2 NO EXISTE", sent.templateParams().get("error"));
+    }
+
+    @Test
+    void blankTemplateParamsFallBackToPlaceholders() {
+        Map<String, Object> p = payload(List.of("+56911111111"));
+        p.remove(JobFailureNotificationFeature.PAYLOAD_CORRELATION_KEY);
+        p.remove(JobFailureNotificationFeature.PAYLOAD_ERROR);
+        p.put(JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME, "job_failed_alert");
+
+        handler.handle(p);
+
+        // The messaging service rejects blank param values — "-" keeps them valid.
+        assertEquals("-", messaging.sent.get(0).templateParams().get("correlation_key"));
+        assertEquals("-", messaging.sent.get(0).templateParams().get("error"));
+    }
+
+    @Test
+    void allRecipientsFailedThrowsForRetry() {
+        messaging.failAll = true;
+        Map<String, Object> p = payload(List.of("+56911111111", "+56922222222"));
+
+        assertThrows(IllegalStateException.class, () -> handler.handle(p));
+    }
+
+    @Test
+    void partialFailureSucceedsWithTheFailuresInTheDetail() {
+        messaging.failFirst = true;
+
+        var result = handler.handle(payload(List.of("+56911111111", "+56922222222")));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertTrue(result.detail().contains("1/2"));
+        assertTrue(result.detail().contains("****1111"));
+    }
+
+    @Test
+    void thrownSendErrorsCountAsRecipientFailures() {
+        messaging.throwFirst = new IllegalArgumentException("not on the test-recipient list");
+
+        var result = handler.handle(payload(List.of("+56911111111", "+56922222222")));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertTrue(result.detail().contains("not on the test-recipient list"));
+    }
+
+    @Test
+    void missingTenantOrRecipientsIsANonRetryableArgumentError() {
+        Map<String, Object> noTenant = payload(List.of("+56911111111"));
+        noTenant.remove(JobFailureNotificationFeature.PAYLOAD_TENANT_CODE);
+        assertThrows(IllegalArgumentException.class, () -> handler.handle(noTenant));
+
+        Map<String, Object> noRecipients = payload(List.of());
+        assertThrows(IllegalArgumentException.class, () -> handler.handle(noRecipients));
+    }
+
+    // -----------------------------------------------------------------------
+
+    /** Records send requests and fabricates SENT/FAILED results without Meta. */
+    private static class FakeMessaging extends WhatsAppMessagingService {
+        final List<SendWhatsAppMessageRequest> sent = new ArrayList<>();
+        final List<String> tenants = new ArrayList<>();
+        boolean failAll;
+        boolean failFirst;
+        RuntimeException throwFirst;
+
+        FakeMessaging() {
+            super(null, null, null, null);
+        }
+
+        @Override
+        public Message send(String tenantCode, SendWhatsAppMessageRequest request, String sentByUserId) {
+            if (throwFirst != null && sent.isEmpty() && tenants.isEmpty()) {
+                tenants.add(tenantCode);
+                throw throwFirst;
+            }
+            boolean fail = failAll || (failFirst && sent.isEmpty());
+            tenants.add(tenantCode);
+            sent.add(request);
+            return message(request, fail);
+        }
+
+        private static Message message(SendWhatsAppMessageRequest request, boolean failed) {
+            return new Message(UUID.randomUUID().toString(), "conv-1", MessageDirection.OUTBOUND,
+                    MessageRole.AGENT, request.isTemplate() ? MessageType.TEMPLATE : MessageType.TEXT,
+                    request.body(), request.templateName(), null, null, null,
+                    failed ? null : "wamid.test",
+                    failed ? MessageStatus.FAILED : MessageStatus.SENT,
+                    failed ? "Meta 400" : null,
+                    "job-failure-notifier", null, null, Map.of(), null, null, null, null);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/docs/job-failure-notifications.md
+++ b/quarkus-srv/miot-integrations/docs/job-failure-notifications.md
@@ -74,9 +74,11 @@ confirm means the calendar API is down, not that the data was rejected).
 | `template_name` / `language` | optional Meta template; absent ⇒ free-form TEXT (needs an open 24h session — fine for ops numbers that talk to the bot) |
 
 The throttle is claimed at *enqueue* time (observer side): a burst of parks
-within the window produces one notification job, not a queue of them. Rules for
-`job_failure_notification` itself are never matched (no notify-about-notify
-loops).
+within the window produces one notification job, not a queue of them. If the
+enqueue then fails, the claim is released again (CAS on the exact claimed
+stamp, so it can only undo itself) — a claim that produced no job must not
+suppress the window's next park. Rules for `job_failure_notification` itself
+are never matched (no notify-about-notify loops).
 
 ### The WhatsApp handler lives in miot-conversational
 

--- a/quarkus-srv/miot-integrations/docs/job-failure-notifications.md
+++ b/quarkus-srv/miot-integrations/docs/job-failure-notifications.md
@@ -1,0 +1,109 @@
+# Job-failure notifications: REJECTED stamp + WhatsApp rules
+
+Phase 2 of the calendar↔Alerce confirmation work (phase 1: the `calendar_confirm`
+chain leg + `sync_status` columns, ecm-coordinator#328). When an async job parks
+as FAILED (attempts exhausted or non-retryable), the ledger now *does something*
+about it instead of only waiting for the babysitter to notice:
+
+1. **Booking REJECTED stamp** — a parked external push (e.g. `alerce_assignment`)
+   stamps the linked calendar booking `syncStatus=REJECTED` with the failure
+   detail, so planners see "planned but the downstream system rejected it"
+   right on the calendar.
+2. **WhatsApp failure notifications** — per-tenant, per-job-type opt-in rules
+   ("when jobs of this type park, message these numbers"), configured from the
+   jobs console.
+
+Both hang off one seam: a CDI `JobParkedEvent` fired exactly where
+`AsyncJobService.report()` parks a job (the single funnel both executor lanes
+report through — ECM via REST, modulith via the in-process worker).
+
+## Design
+
+```
+report() parks job as FAILED
+        │  fire JobParkedEvent (sync, wrapped — can never break the report path)
+        ▼
+JobParkedObserver
+        ├─ reject stamp: parked jobType ∈ reject-stamp list AND has chain_key?
+        │     → find the chain's calendar_sync (seq 0) sibling for coordinates
+        │     → enqueue calendar_reject   (modulith lane, STANDALONE — no chain_key)
+        │
+        └─ notification: enabled rule for (tenant, jobType)?  [self-type excluded]
+              → atomically claim the rule's throttle slot (last_notified_at CAS)
+              → enqueue job_failure_notification (modulith lane, standalone)
+```
+
+Everything downstream of the event is itself an async job — retried with
+backoff, visible and babysittable in the console like any other work.
+
+### Why the reject stamp is a standalone job, not a chain leg
+
+A chained successor of the FAILED job would be *blocked by it* — the chain gate
+only passes SUCCEEDED/CANCELLED predecessors. The stamp must run precisely when
+the chain is stuck, so the observer enqueues it outside the chain.
+
+### Recovery loop stays intact
+
+Booking `syncStatus` has deliberately no forward-only rule. Parked push →
+`REJECTED`; the babysitter fixes the cause and hits retry; the push succeeds;
+the still-blocked `calendar_confirm` leg unblocks and overwrites to
+`CONFIRMED`. Dedupe keys carry the parked job's id *and* attempt count
+(`reject:{jobId}:{attempts}`, `notify:{ruleId}:{jobId}:{attempts}`) so a
+re-park after a failed manual retry stamps/notifies again, while a single park
+can never double-fire.
+
+### Which job types stamp REJECTED
+
+Config list `miot.integrations.jobs.reject-stamp.job-types` (default
+`alerce_assignment`): only the legs that represent the external push itself.
+Not seq 0 (`calendar_sync` parked ⇒ the booking was never patched — nothing to
+un-acknowledge) and not `calendar_confirm` (the push was *accepted*; a parked
+confirm means the calendar API is down, not that the data was rejected).
+
+### Notification rules
+
+`miot_integrations.job_notification_rules` — one row per
+(tenant, job_type, channel):
+
+| column | notes |
+|---|---|
+| `recipients` | JSONB array of E.164 strings (`+569…`) |
+| `enabled` | console toggle |
+| `throttle_seconds` | min gap between notifications for this rule (default 300) |
+| `last_notified_at` | throttle state; claimed via atomic UPDATE … WHERE, race-safe across pods |
+| `template_name` / `language` | optional Meta template; absent ⇒ free-form TEXT (needs an open 24h session — fine for ops numbers that talk to the bot) |
+
+The throttle is claimed at *enqueue* time (observer side): a burst of parks
+within the window produces one notification job, not a queue of them. Rules for
+`job_failure_notification` itself are never matched (no notify-about-notify
+loops).
+
+### The WhatsApp handler lives in miot-conversational
+
+Module dependency direction is `miot-conversational → miot-integrations`, so
+integrations code cannot inject `WhatsAppMessagingService`. Instead the handler
+bean (`JobFailureNotificationHandler implements ModulithJobHandler`) sits in
+miot-conversational — the worker discovers handlers CDI-wide, so registration
+is automatic. Payload is self-contained (`handle()` doesn't see the job row):
+tenantCode, recipients, failedJobType/Id, correlationKey, lastError, template.
+
+Per-recipient outcomes: `send()` never throws on Meta failure (it persists a
+FAILED `wa_message` row) — the handler checks each returned status. All
+recipients failed ⇒ throw (ledger retries with backoff); partial ⇒ SUCCEEDED
+with the failures in the detail, because a retry would re-message the
+recipients that already got it.
+
+## Config surface (console)
+
+`OrgJobNotificationRulesResource` under
+`/api/v1/orgs/{organizationId}/integrations/console/notification-rules`
+(RS256 org-member family, same idiom as the jobs console resource):
+`GET` list, `PUT /{jobType}` upsert, `DELETE /{jobType}`. The console gets a
+per-job-type "Notify on failure" settings panel (separate PR).
+
+## Rollout
+
+Ships dark: no rules ⇒ notification branch is a no-op; reject stamp only fires
+for chains that already carry `calendar_sync` coordinates, and only patches
+bookings on deployments that have the `sync_status` columns (miot-calendar
+≥ 0.6.2). No flags needed beyond the existing modulith-worker enablement.

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgJobNotificationRulesResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgJobNotificationRulesResource.java
@@ -1,0 +1,164 @@
+package com.microboxlabs.miot.integrations.api;
+
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.integrations.domain.JobNotificationRule;
+import com.microboxlabs.miot.integrations.dto.NotificationRuleRequest;
+import com.microboxlabs.miot.integrations.jobs.JobFailureNotificationFeature;
+import com.microboxlabs.miot.integrations.persistence.JobNotificationRuleRepository;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/**
+ * Console CRUD surface for {@link JobNotificationRule}s — "when jobs of this
+ * type park as FAILED, message these numbers". Same org-member RS256 family and
+ * reactive contract as {@link OrgAsyncJobsConsoleResource}: it lives under
+ * {@code /integrations/console/…} so the dual-JWT path matcher never routes it
+ * to HS256/M2M verification, tenant context is resolved eagerly on the event
+ * loop and the blocking repository runs on the worker pool.
+ */
+@Path("/api/v1/orgs/{organizationId}/integrations/console/notification-rules")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Job Notification Rules", description = "Per-job-type failure-notification configuration")
+@SecurityRequirement(name = "oidc")
+@Authenticated
+@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class OrgJobNotificationRulesResource {
+
+    private static final String ERROR_KEY = "error";
+    private static final Pattern E164 = Pattern.compile("^\\+[1-9]\\d{7,14}$");
+    private static final int MAX_RECIPIENTS = 20;
+    private static final int MAX_JOB_TYPE_LENGTH = 64;
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final JobNotificationRuleRepository repository;
+
+    @Inject
+    public OrgJobNotificationRulesResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            JobNotificationRuleRepository repository) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.repository = repository;
+    }
+
+    @GET
+    @Operation(summary = "List the org's failure-notification rules")
+    public Uni<Response> list(@PathParam("organizationId") String organizationId) {
+        String tenant = tenantCode(organizationId);
+        return onWorker(() -> Response.ok(repository.list(tenant)).build());
+    }
+
+    @PUT
+    @Path("/{jobType}")
+    @Operation(summary = "Create or replace the rule for a job type")
+    public Uni<Response> upsert(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobType") String jobType,
+            NotificationRuleRequest request) {
+        String tenant = tenantCode(organizationId);
+        String error = validate(jobType, request);
+        if (error != null) {
+            return Uni.createFrom().item(errorResponse(Response.Status.BAD_REQUEST, error));
+        }
+        JobNotificationRule rule = new JobNotificationRule(
+                null, tenant, jobType, request.channelOrDefault(),
+                List.copyOf(request.recipients()),
+                request.enabledOrDefault(), request.throttleSecondsOrDefault(),
+                blankToNull(request.templateName()), blankToNull(request.language()),
+                null, null, null);
+        return onWorker(() -> Response.ok(repository.upsert(rule)).build());
+    }
+
+    @DELETE
+    @Path("/{jobType}")
+    @Operation(summary = "Delete the rule for a job type")
+    public Uni<Response> delete(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("jobType") String jobType,
+            @QueryParam("channel") @DefaultValue(JobNotificationRule.CHANNEL_WHATSAPP) String channel) {
+        String tenant = tenantCode(organizationId);
+        return onWorker(() -> repository.delete(tenant, jobType, channel)
+                ? Response.noContent().build()
+                : errorResponse(Response.Status.NOT_FOUND, "No rule for job type: " + jobType));
+    }
+
+    private static String validate(String jobType, NotificationRuleRequest request) {
+        if (jobType == null || jobType.isBlank() || jobType.length() > MAX_JOB_TYPE_LENGTH) {
+            return "jobType must be 1-" + MAX_JOB_TYPE_LENGTH + " characters";
+        }
+        if (JobFailureNotificationFeature.JOB_TYPE.equals(jobType)) {
+            // The park hook never matches this type either — a rule here would
+            // silently do nothing, so reject it loudly instead.
+            return "Rules cannot target the notification job type itself";
+        }
+        if (request == null || request.recipients() == null || request.recipients().isEmpty()) {
+            return "recipients must contain at least one E.164 phone number";
+        }
+        if (request.recipients().size() > MAX_RECIPIENTS) {
+            return "recipients must contain at most " + MAX_RECIPIENTS + " numbers";
+        }
+        for (String recipient : request.recipients()) {
+            if (recipient == null || !E164.matcher(recipient).matches()) {
+                return "recipients must be full E.164 numbers (e.g. +56912345678), got: " + recipient;
+            }
+        }
+        if (request.throttleSeconds() != null && request.throttleSeconds() < 0) {
+            return "throttleSeconds must be >= 0";
+        }
+        if (!JobNotificationRule.CHANNEL_WHATSAPP.equals(request.channelOrDefault())) {
+            return "channel must be 'whatsapp'";
+        }
+        return null;
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /** Runs a blocking supplier on the worker pool (same contract as the jobs console resource). */
+    private static <T> Uni<T> onWorker(Supplier<T> work) {
+        return Uni.createFrom().item(work).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(
+                    errorResponse(Response.Status.FORBIDDEN, "Organization context does not match request path"));
+        }
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+
+    private static Response errorResponse(Response.Status status, String message) {
+        return Response.status(status)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Map.of(ERROR_KEY, message != null ? message : status.getReasonPhrase()))
+                .build();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutor.java
@@ -1,0 +1,87 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import com.microboxlabs.miot.integrations.jobs.ModulithJobHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+
+/**
+ * {@link ModulithJobHandler} for {@code calendar_reject}: stamps
+ * {@code syncStatus=REJECTED} plus the failure detail on the booking after its
+ * external push parked as FAILED — see {@link CalendarRejectFeature} for why
+ * this runs outside the chain.
+ *
+ * <p>Outcome policy mirrors {@link CalendarConfirmExecutor}: 404 (booking gone)
+ * is a benign SKIP; transport / 5xx / network errors are thrown so the ledger
+ * retries with backoff. The sync-status patch has no regression rules on the
+ * miot-calendar side, so there is no 409 case.
+ */
+@ApplicationScoped
+public class CalendarRejectExecutor implements ModulithJobHandler {
+
+    private static final Logger LOG = Logger.getLogger(CalendarRejectExecutor.class);
+    private static final String DEFAULT_DETAIL = "The external push failed";
+
+    private final CalendarBookingsClient client;
+
+    @Inject
+    CalendarRejectExecutor(CalendarBookingsClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String jobType() {
+        return CalendarRejectFeature.JOB_TYPE;
+    }
+
+    /** Not ready until the miot-calendar base URL is configured. */
+    @Override
+    public boolean isReady() {
+        return client.isConfigured();
+    }
+
+    @Override
+    public JobOutcome handle(Map<String, Object> payload) {
+        String resourceId = str(payload, CalendarRejectFeature.PAYLOAD_RESOURCE_ID);
+        String calendarIdRaw = str(payload, CalendarRejectFeature.PAYLOAD_CALENDAR_ID);
+        String serviceCode = str(payload, CalendarRejectFeature.PAYLOAD_SERVICE_CODE);
+        String detail = str(payload, CalendarRejectFeature.PAYLOAD_DETAIL);
+        if (resourceId == null) {
+            throw new IllegalArgumentException("calendar_reject payload missing resourceId");
+        }
+        UUID calendarId = calendarIdRaw == null ? null : UUID.fromString(calendarIdRaw);
+        String syncDetail = truncate(detail == null ? DEFAULT_DETAIL : detail);
+
+        try {
+            client.patchByResource(resourceId, calendarId, null, null,
+                    CalendarRejectFeature.SYNC_STATUS_REJECTED, syncDetail);
+            return JobOutcome.succeeded("Booking sync REJECTED for " + resourceId);
+        } catch (CalendarBookingsHttpException e) {
+            if (e.getStatus() == 404) {
+                // The booking was unplanned/cancelled meanwhile — nothing left
+                // to flag.
+                LOG.infof("calendar_reject: no booking for %s (service %s) — skipping", resourceId, serviceCode);
+                return JobOutcome.skipped("No booking to flag for " + resourceId);
+            }
+            throw e;
+        }
+    }
+
+    private static String truncate(String detail) {
+        return detail.length() <= CalendarRejectFeature.DETAIL_MAX_LENGTH
+                ? detail
+                : detail.substring(0, CalendarRejectFeature.DETAIL_MAX_LENGTH);
+    }
+
+    private static String str(Map<String, Object> payload, String key) {
+        Object v = payload.get(key);
+        if (v == null) {
+            return null;
+        }
+        String s = String.valueOf(v);
+        return s.isBlank() ? null : s;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectFeature.java
@@ -1,0 +1,41 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+/**
+ * Constants for the modulith-executed {@code calendar_reject} job: stamps
+ * {@code syncStatus=REJECTED} on a booking whose external push parked as
+ * FAILED, carrying the failure detail so planners see <i>why</i> right on the
+ * calendar.
+ *
+ * <p>Deliberately a <b>standalone</b> job, not a chain leg: a chained
+ * successor of the FAILED push would be blocked by the very predecessor whose
+ * failure it reports (the chain gate only passes SUCCEEDED/CANCELLED). The
+ * park hook ({@code CalendarRejectOnPark}) enqueues it outside the chain, with
+ * a dedupe key derived from the parked job's id and attempt count so a re-park
+ * after a failed manual retry stamps again while a single park never
+ * double-fires.
+ *
+ * <p>Recovery stays symmetric with {@link CalendarConfirmFeature}: a later
+ * successful manual retry of the push unblocks the still-pending
+ * {@code calendar_confirm} leg, which overwrites the booking to CONFIRMED —
+ * {@code syncStatus} has no forward-only rule by design.
+ */
+public final class CalendarRejectFeature {
+
+    private CalendarRejectFeature() {
+    }
+
+    public static final String JOB_TYPE = "calendar_reject";
+
+    /** Self-contained payload, resolved by the park hook from the chain's seq-0 sibling. */
+    public static final String PAYLOAD_SERVICE_CODE = "serviceCode";
+    public static final String PAYLOAD_CALENDAR_ID = "calendarId";
+    public static final String PAYLOAD_RESOURCE_ID = "resourceId";
+    /** The parked job's lastError, pre-truncated to the booking sync_detail budget. */
+    public static final String PAYLOAD_DETAIL = "detail";
+
+    /** Value written to the booking's {@code syncStatus}. */
+    public static final String SYNC_STATUS_REJECTED = "REJECTED";
+
+    /** miot-calendar's {@code sync_detail} column budget (VARCHAR(500)). */
+    public static final int DETAIL_MAX_LENGTH = 500;
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectOnPark.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectOnPark.java
@@ -1,0 +1,146 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
+import com.microboxlabs.miot.integrations.jobs.ModulithJobHandler;
+import com.microboxlabs.miot.integrations.jobs.ModulithJobWorker;
+import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Park hook for the booking REJECTED stamp: when an external-push job type
+ * (config list, default {@code alerce_assignment}) parks as FAILED inside a
+ * chain, enqueue a standalone {@code calendar_reject} job carrying the booking
+ * coordinates — resolved from the chain's {@code calendar_sync} (seq 0)
+ * sibling, whose payload is the only place that knows resourceId/calendarId.
+ *
+ * <p>Only push legs stamp: not seq 0 itself (a parked {@code calendar_sync}
+ * means the booking was never patched — nothing to un-acknowledge) and not
+ * {@code calendar_confirm} (the push was <i>accepted</i>; a parked confirm
+ * means the calendar API is down, not that the data was rejected).
+ *
+ * <p>Never throws — a stamping problem must not disturb the report path that
+ * fired the event.
+ */
+@ApplicationScoped
+public class CalendarRejectOnPark {
+
+    private static final Logger LOG = Logger.getLogger(CalendarRejectOnPark.class);
+    private static final int SIBLING_LOOKUP_LIMIT = 10;
+
+    private final List<String> rejectStampJobTypes;
+    private final AsyncJobRepository repository;
+    private final AsyncJobService jobService;
+    private final ModulithJobWorker worker;
+
+    @Inject
+    CalendarRejectOnPark(
+            @ConfigProperty(name = "miot.integrations.jobs.reject-stamp.job-types",
+                    defaultValue = "alerce_assignment") List<String> rejectStampJobTypes,
+            AsyncJobRepository repository,
+            AsyncJobService jobService,
+            ModulithJobWorker worker) {
+        this.rejectStampJobTypes = rejectStampJobTypes;
+        this.repository = repository;
+        this.jobService = jobService;
+        this.worker = worker;
+    }
+
+    void onParked(@Observes JobParkedEvent event) {
+        AsyncJob parked = event.job();
+        try {
+            if (!rejectStampJobTypes.contains(parked.jobType()) || parked.chainKey() == null) {
+                return;
+            }
+            Map<String, Object> coordinates = findSyncLegPayload(parked);
+            if (coordinates == null) {
+                LOG.warnf("Parked %s job %s has chain %s but no calendar_sync sibling — cannot stamp REJECTED",
+                        parked.jobType(), parked.id(), parked.chainKey());
+                return;
+            }
+            String resourceId = str(coordinates.get(CalendarSyncFeature.PAYLOAD_RESOURCE_ID));
+            if (resourceId == null) {
+                LOG.warnf("calendar_sync sibling of parked job %s carries no resourceId — cannot stamp REJECTED",
+                        parked.id());
+                return;
+            }
+            enqueueReject(parked, coordinates, resourceId);
+        } catch (Exception e) {
+            LOG.errorf(e, "REJECTED stamp hook failed for parked job %s (%s) — booking not flagged",
+                    parked.id(), parked.jobType());
+        }
+    }
+
+    /** The chain's earliest calendar_sync leg carries the booking coordinates. */
+    private Map<String, Object> findSyncLegPayload(AsyncJob parked) {
+        Optional<AsyncJob> syncLeg = repository
+                .list(parked.tenantCode(), null, null, CalendarSyncFeature.JOB_TYPE,
+                        parked.chainKey(), SIBLING_LOOKUP_LIMIT)
+                .stream()
+                .min(Comparator.comparingInt(AsyncJob::chainSequence));
+        return syncLeg.map(AsyncJob::payload).orElse(null);
+    }
+
+    private void enqueueReject(AsyncJob parked, Map<String, Object> coordinates, String resourceId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(CalendarRejectFeature.PAYLOAD_RESOURCE_ID, resourceId);
+        putIfPresent(payload, CalendarRejectFeature.PAYLOAD_CALENDAR_ID,
+                str(coordinates.get(CalendarSyncFeature.PAYLOAD_CALENDAR_ID)));
+        putIfPresent(payload, CalendarRejectFeature.PAYLOAD_SERVICE_CODE,
+                str(coordinates.get(CalendarSyncFeature.PAYLOAD_SERVICE_CODE)));
+        putIfPresent(payload, CalendarRejectFeature.PAYLOAD_DETAIL, truncatedError(parked));
+
+        // Standalone (no chainKey) on purpose: a chained successor would be
+        // blocked by the FAILED predecessor it is meant to report. The dedupe
+        // key includes the parked attempt count so a re-park after a failed
+        // manual retry stamps again.
+        AsyncJobSpec spec = new AsyncJobSpec(
+                CalendarRejectFeature.JOB_TYPE,
+                ModulithJobHandler.EXECUTOR,
+                parked.correlationKey(),
+                null, null,
+                "reject:" + parked.id() + ":" + parked.attempts(),
+                payload,
+                null);
+        worker.onEnqueued(jobService.enqueue(parked.tenantCode(),
+                new EnqueueJobsRequest(parked.sourceInstance(), "listener", List.of(spec))));
+        LOG.infof("Parked %s job %s → enqueued calendar_reject for booking resource %s",
+                parked.jobType(), parked.id(), resourceId);
+    }
+
+    private static String truncatedError(AsyncJob parked) {
+        String error = parked.lastError();
+        if (error == null || error.isBlank()) {
+            return null;
+        }
+        return error.length() <= CalendarRejectFeature.DETAIL_MAX_LENGTH
+                ? error
+                : error.substring(0, CalendarRejectFeature.DETAIL_MAX_LENGTH);
+    }
+
+    private static void putIfPresent(Map<String, Object> payload, String key, String value) {
+        if (value != null) {
+            payload.put(key, value);
+        }
+    }
+
+    private static String str(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value);
+        return s.isBlank() ? null : s;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/JobNotificationRule.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/JobNotificationRule.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * A per-tenant, per-job-type failure-notification rule: when an async job of
+ * {@code jobType} parks as FAILED, message {@code recipients} on
+ * {@code channel} — at most once per {@code throttleSeconds}
+ * ({@code lastNotifiedAt} is the throttle state, claimed atomically so a burst
+ * of parks produces one notification).
+ */
+public record JobNotificationRule(
+        String id,
+        String tenantCode,
+        String jobType,
+        String channel,
+        List<String> recipients,
+        boolean enabled,
+        int throttleSeconds,
+        String templateName,
+        String language,
+        OffsetDateTime lastNotifiedAt,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+
+    public static final String CHANNEL_WHATSAPP = "whatsapp";
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/NotificationRuleRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/NotificationRuleRequest.java
@@ -1,0 +1,34 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.util.List;
+
+/**
+ * Console upsert body for a job-failure notification rule. {@code jobType}
+ * comes from the path; tenant from the org context. Omitted {@code channel}
+ * defaults to whatsapp, omitted {@code enabled} to true, omitted
+ * {@code throttleSeconds} to 300.
+ */
+public record NotificationRuleRequest(
+        String channel,
+        List<String> recipients,
+        Boolean enabled,
+        Integer throttleSeconds,
+        String templateName,
+        String language) {
+
+    private static final int DEFAULT_THROTTLE_SECONDS = 300;
+
+    public String channelOrDefault() {
+        return channel == null || channel.isBlank()
+                ? com.microboxlabs.miot.integrations.domain.JobNotificationRule.CHANNEL_WHATSAPP
+                : channel;
+    }
+
+    public boolean enabledOrDefault() {
+        return enabled == null || enabled;
+    }
+
+    public int throttleSecondsOrDefault() {
+        return throttleSeconds == null ? DEFAULT_THROTTLE_SECONDS : throttleSeconds;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobParkedEvent.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobParkedEvent.java
@@ -1,0 +1,18 @@
+package com.microboxlabs.miot.integrations.events;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+
+/**
+ * Fired (synchronously, via CDI) the moment {@link
+ * com.microboxlabs.miot.integrations.service.AsyncJobService#report} parks a
+ * job as FAILED — attempts exhausted or a non-retryable failure. This is the
+ * single funnel both executor lanes report through (ECM via REST, the modulith
+ * worker in-process), so observers see every park exactly once, after the
+ * ledger write is durable.
+ *
+ * <p>{@code job} is the parked row (state FAILED, {@code lastError} set).
+ * Observers must never throw into the report path — the firer guards, but
+ * observers are expected to catch their own failures too.
+ */
+public record JobParkedEvent(AsyncJob job) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotificationFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotificationFeature.java
@@ -1,0 +1,39 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+/**
+ * Constants for the modulith-executed {@code job_failure_notification} job:
+ * message a rule's recipients that a job of theirs parked as FAILED.
+ *
+ * <p>The payload is fully self-contained (a {@link ModulithJobHandler} sees
+ * only the payload, not the job row) — including {@code tenantCode}, which the
+ * handler needs to resolve the tenant's messaging connection. The handler bean
+ * lives in miot-conversational (module dependency direction: conversational →
+ * integrations), discovered CDI-wide by {@link ModulithJobWorker} like any
+ * other handler.
+ *
+ * <p>The park hook ({@code JobFailureNotifyOnPark}) never matches notification
+ * rules against this job type itself, so a parked notification can't notify
+ * about its own failure in a loop.
+ */
+public final class JobFailureNotificationFeature {
+
+    private JobFailureNotificationFeature() {
+    }
+
+    public static final String JOB_TYPE = "job_failure_notification";
+
+    public static final String PAYLOAD_TENANT_CODE = "tenantCode";
+    /** JSON array of E.164 recipient phone numbers. */
+    public static final String PAYLOAD_RECIPIENTS = "recipients";
+    public static final String PAYLOAD_FAILED_JOB_ID = "failedJobId";
+    public static final String PAYLOAD_FAILED_JOB_TYPE = "failedJobType";
+    public static final String PAYLOAD_CORRELATION_KEY = "correlationKey";
+    /** The parked job's lastError, pre-truncated by the hook. */
+    public static final String PAYLOAD_ERROR = "error";
+    /** Optional pre-approved Meta template; absent = free-form text. */
+    public static final String PAYLOAD_TEMPLATE_NAME = "templateName";
+    public static final String PAYLOAD_LANGUAGE = "language";
+
+    /** Budget for {@link #PAYLOAD_ERROR} in the payload and the message body. */
+    public static final int ERROR_MAX_LENGTH = 300;
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnPark.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnPark.java
@@ -10,6 +10,7 @@ import com.microboxlabs.miot.integrations.service.AsyncJobService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,9 +23,11 @@ import org.jboss.logging.Logger;
  *
  * <p>The rule's throttle slot is claimed atomically <i>before</i> enqueueing,
  * so a burst of parks inside the window coalesces into the one notification
- * already sent (across pods — the claim is a DB CAS). Rules are never matched
- * for the notification job type itself: a parked notification can't notify
- * about its own failure.
+ * already sent (across pods — the claim is a DB CAS). When the enqueue then
+ * fails, the claim is released again (CAS on its own stamp) — a claim that
+ * produced no notification job must not suppress the window's next park.
+ * Rules are never matched for the notification job type itself: a parked
+ * notification can't notify about its own failure.
  *
  * <p>Never throws — a notification problem must not disturb the report path
  * that fired the event.
@@ -63,27 +66,47 @@ public class JobFailureNotifyOnPark {
         }
     }
 
+    /** Never throws — one rule's failure must not skip the tenant's other rules. */
     private void notifyRule(AsyncJob parked, JobNotificationRule rule) {
         if (rule.recipients() == null || rule.recipients().isEmpty()) {
             return;
         }
-        if (!ruleRepository.claimThrottleSlot(rule.id())) {
+        OffsetDateTime claimedAt = ruleRepository.claimThrottleSlot(rule.id());
+        if (claimedAt == null) {
             LOG.debugf("Notification for parked job %s (%s) throttled by rule %s",
                     parked.id(), parked.jobType(), rule.id());
             return;
         }
-        AsyncJobSpec spec = new AsyncJobSpec(
-                JobFailureNotificationFeature.JOB_TYPE,
-                ModulithJobHandler.EXECUTOR,
-                parked.correlationKey(),
-                null, null,
-                "notify:" + rule.id() + ":" + parked.id() + ":" + parked.attempts(),
-                notificationPayload(parked, rule),
-                null);
-        worker.onEnqueued(jobService.enqueue(parked.tenantCode(),
-                new EnqueueJobsRequest(parked.sourceInstance(), "listener", List.of(spec))));
-        LOG.infof("Parked %s job %s → enqueued %s notification to %d recipient(s)",
-                parked.jobType(), parked.id(), rule.channel(), rule.recipients().size());
+        try {
+            AsyncJobSpec spec = new AsyncJobSpec(
+                    JobFailureNotificationFeature.JOB_TYPE,
+                    ModulithJobHandler.EXECUTOR,
+                    parked.correlationKey(),
+                    null, null,
+                    "notify:" + rule.id() + ":" + parked.id() + ":" + parked.attempts(),
+                    notificationPayload(parked, rule),
+                    null);
+            worker.onEnqueued(jobService.enqueue(parked.tenantCode(),
+                    new EnqueueJobsRequest(parked.sourceInstance(), "listener", List.of(spec))));
+            LOG.infof("Parked %s job %s → enqueued %s notification to %d recipient(s)",
+                    parked.jobType(), parked.id(), rule.channel(), rule.recipients().size());
+        } catch (Exception e) {
+            // The claim consumed the throttle window but no notification job
+            // exists — release it so the window's next park notifies instead of
+            // being silently suppressed.
+            LOG.errorf(e, "Failed to enqueue %s notification for parked job %s — releasing rule %s's throttle slot",
+                    rule.channel(), parked.id(), rule.id());
+            releaseQuietly(rule, claimedAt);
+        }
+    }
+
+    private void releaseQuietly(JobNotificationRule rule, OffsetDateTime claimedAt) {
+        try {
+            ruleRepository.releaseThrottleSlot(rule.id(), claimedAt);
+        } catch (Exception e) {
+            LOG.errorf(e, "Could not release rule %s's throttle slot — notifications suppressed until %s + throttle",
+                    rule.id(), claimedAt);
+        }
     }
 
     /** Self-contained — the handler (in miot-conversational) sees only the payload. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnPark.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnPark.java
@@ -1,0 +1,118 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobNotificationRule;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
+import com.microboxlabs.miot.integrations.persistence.JobNotificationRuleRepository;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+/**
+ * Park hook for failure notifications: when a job parks as FAILED and the
+ * tenant has an enabled {@link JobNotificationRule} for its type, enqueue a
+ * {@code job_failure_notification} job for the rule's recipients.
+ *
+ * <p>The rule's throttle slot is claimed atomically <i>before</i> enqueueing,
+ * so a burst of parks inside the window coalesces into the one notification
+ * already sent (across pods — the claim is a DB CAS). Rules are never matched
+ * for the notification job type itself: a parked notification can't notify
+ * about its own failure.
+ *
+ * <p>Never throws — a notification problem must not disturb the report path
+ * that fired the event.
+ */
+@ApplicationScoped
+public class JobFailureNotifyOnPark {
+
+    private static final Logger LOG = Logger.getLogger(JobFailureNotifyOnPark.class);
+
+    private final JobNotificationRuleRepository ruleRepository;
+    private final AsyncJobService jobService;
+    private final ModulithJobWorker worker;
+
+    @Inject
+    JobFailureNotifyOnPark(
+            JobNotificationRuleRepository ruleRepository,
+            AsyncJobService jobService,
+            ModulithJobWorker worker) {
+        this.ruleRepository = ruleRepository;
+        this.jobService = jobService;
+        this.worker = worker;
+    }
+
+    void onParked(@Observes JobParkedEvent event) {
+        AsyncJob parked = event.job();
+        try {
+            if (JobFailureNotificationFeature.JOB_TYPE.equals(parked.jobType())) {
+                return;
+            }
+            for (JobNotificationRule rule : ruleRepository.findEnabled(parked.tenantCode(), parked.jobType())) {
+                notifyRule(parked, rule);
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "Failure-notification hook failed for parked job %s (%s)",
+                    parked.id(), parked.jobType());
+        }
+    }
+
+    private void notifyRule(AsyncJob parked, JobNotificationRule rule) {
+        if (rule.recipients() == null || rule.recipients().isEmpty()) {
+            return;
+        }
+        if (!ruleRepository.claimThrottleSlot(rule.id())) {
+            LOG.debugf("Notification for parked job %s (%s) throttled by rule %s",
+                    parked.id(), parked.jobType(), rule.id());
+            return;
+        }
+        AsyncJobSpec spec = new AsyncJobSpec(
+                JobFailureNotificationFeature.JOB_TYPE,
+                ModulithJobHandler.EXECUTOR,
+                parked.correlationKey(),
+                null, null,
+                "notify:" + rule.id() + ":" + parked.id() + ":" + parked.attempts(),
+                notificationPayload(parked, rule),
+                null);
+        worker.onEnqueued(jobService.enqueue(parked.tenantCode(),
+                new EnqueueJobsRequest(parked.sourceInstance(), "listener", List.of(spec))));
+        LOG.infof("Parked %s job %s → enqueued %s notification to %d recipient(s)",
+                parked.jobType(), parked.id(), rule.channel(), rule.recipients().size());
+    }
+
+    /** Self-contained — the handler (in miot-conversational) sees only the payload. */
+    private static Map<String, Object> notificationPayload(AsyncJob parked, JobNotificationRule rule) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(JobFailureNotificationFeature.PAYLOAD_TENANT_CODE, parked.tenantCode());
+        payload.put(JobFailureNotificationFeature.PAYLOAD_RECIPIENTS, rule.recipients());
+        payload.put(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_ID, parked.id());
+        payload.put(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_TYPE, parked.jobType());
+        putIfPresent(payload, JobFailureNotificationFeature.PAYLOAD_CORRELATION_KEY, parked.correlationKey());
+        putIfPresent(payload, JobFailureNotificationFeature.PAYLOAD_ERROR, truncatedError(parked));
+        putIfPresent(payload, JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME, rule.templateName());
+        putIfPresent(payload, JobFailureNotificationFeature.PAYLOAD_LANGUAGE, rule.language());
+        return payload;
+    }
+
+    private static String truncatedError(AsyncJob parked) {
+        String error = parked.lastError();
+        if (error == null || error.isBlank()) {
+            return null;
+        }
+        return error.length() <= JobFailureNotificationFeature.ERROR_MAX_LENGTH
+                ? error
+                : error.substring(0, JobFailureNotificationFeature.ERROR_MAX_LENGTH);
+    }
+
+    private static void putIfPresent(Map<String, Object> payload, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/JobNotificationRuleRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/JobNotificationRuleRepository.java
@@ -8,6 +8,7 @@ import io.vertx.mutiny.sqlclient.RowSet;
 import io.vertx.mutiny.sqlclient.Tuple;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,7 +53,8 @@ public class JobNotificationRuleRepository {
      * Atomic throttle claim: stamps {@code last_notified_at} only when the rule
      * is enabled and its window has elapsed, so concurrent parks across pods
      * race for one slot and exactly one wins ({@code throttle_seconds = 0}
-     * always passes).
+     * always passes). Returns the stamp so a caller whose follow-up work fails
+     * can hand it back to {@link #releaseThrottleSlot}.
      */
     private static final String CLAIM_SLOT = """
             UPDATE miot_integrations.job_notification_rules
@@ -61,7 +63,18 @@ public class JobNotificationRuleRepository {
               AND enabled
               AND (last_notified_at IS NULL
                    OR last_notified_at <= now() - make_interval(secs => throttle_seconds))
-            RETURNING id""";
+            RETURNING last_notified_at""";
+
+    /**
+     * Compensation for a claim whose follow-up enqueue failed: reopen the
+     * window so the claim doesn't suppress notifications it never produced.
+     * CAS on the exact claimed stamp — a newer claim's stamp never matches, so
+     * this can only undo its own claim.
+     */
+    private static final String RELEASE_SLOT = """
+            UPDATE miot_integrations.job_notification_rules
+            SET last_notified_at = NULL, updated_at = now()
+            WHERE id = $1::uuid AND last_notified_at = $2""";
 
     private final Instance<Pool> clientInstance;
 
@@ -111,12 +124,28 @@ public class JobNotificationRuleRepository {
                 .rowCount() > 0;
     }
 
-    /** @return true when this call won the rule's throttle slot. See {@link #CLAIM_SLOT}. */
-    public boolean claimThrottleSlot(String ruleId) {
-        return client().preparedQuery(CLAIM_SLOT)
+    /**
+     * @return the claimed {@code last_notified_at} stamp when this call won the
+     *         rule's throttle slot, null when throttled. See {@link #CLAIM_SLOT}.
+     */
+    public OffsetDateTime claimThrottleSlot(String ruleId) {
+        RowSet<Row> rows = client().preparedQuery(CLAIM_SLOT)
                 .execute(Tuple.of(ruleId))
+                .await().indefinitely();
+        return rows.iterator().hasNext()
+                ? rows.iterator().next().getOffsetDateTime("last_notified_at")
+                : null;
+    }
+
+    /**
+     * Reverts a {@link #claimThrottleSlot} whose follow-up enqueue failed.
+     * @return true when the claim was still in place and got released
+     */
+    public boolean releaseThrottleSlot(String ruleId, OffsetDateTime claimedAt) {
+        return client().preparedQuery(RELEASE_SLOT)
+                .execute(Tuple.of(ruleId, claimedAt))
                 .await().indefinitely()
-                .iterator().hasNext();
+                .rowCount() > 0;
     }
 
     private Pool client() {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/JobNotificationRuleRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/JobNotificationRuleRepository.java
@@ -1,0 +1,152 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.JobNotificationRule;
+import io.vertx.core.json.JsonArray;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.RowSet;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class JobNotificationRuleRepository {
+
+    private static final String COLUMNS = """
+            id, tenant_code, job_type, channel, recipients, enabled,
+            throttle_seconds, template_name, language, last_notified_at,
+            created_at, updated_at""";
+
+    private static final String LIST = """
+            SELECT %s
+            FROM miot_integrations.job_notification_rules
+            WHERE tenant_code = $1
+            ORDER BY job_type, channel""".formatted(COLUMNS);
+
+    private static final String FIND_ENABLED = """
+            SELECT %s
+            FROM miot_integrations.job_notification_rules
+            WHERE tenant_code = $1 AND job_type = $2 AND enabled""".formatted(COLUMNS);
+
+    private static final String UPSERT = """
+            INSERT INTO miot_integrations.job_notification_rules (
+                tenant_code, job_type, channel, recipients, enabled,
+                throttle_seconds, template_name, language
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (tenant_code, job_type, channel) DO UPDATE
+            SET recipients = EXCLUDED.recipients,
+                enabled = EXCLUDED.enabled,
+                throttle_seconds = EXCLUDED.throttle_seconds,
+                template_name = EXCLUDED.template_name,
+                language = EXCLUDED.language,
+                updated_at = now()
+            RETURNING %s""".formatted(COLUMNS);
+
+    private static final String DELETE = """
+            DELETE FROM miot_integrations.job_notification_rules
+            WHERE tenant_code = $1 AND job_type = $2 AND channel = $3""";
+
+    /**
+     * Atomic throttle claim: stamps {@code last_notified_at} only when the rule
+     * is enabled and its window has elapsed, so concurrent parks across pods
+     * race for one slot and exactly one wins ({@code throttle_seconds = 0}
+     * always passes).
+     */
+    private static final String CLAIM_SLOT = """
+            UPDATE miot_integrations.job_notification_rules
+            SET last_notified_at = now(), updated_at = now()
+            WHERE id = $1::uuid
+              AND enabled
+              AND (last_notified_at IS NULL
+                   OR last_notified_at <= now() - make_interval(secs => throttle_seconds))
+            RETURNING id""";
+
+    private final Instance<Pool> clientInstance;
+
+    protected JobNotificationRuleRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public List<JobNotificationRule> list(String tenantCode) {
+        return client().preparedQuery(LIST)
+                .execute(Tuple.of(tenantCode))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public List<JobNotificationRule> findEnabled(String tenantCode, String jobType) {
+        return client().preparedQuery(FIND_ENABLED)
+                .execute(Tuple.of(tenantCode, jobType))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    public JobNotificationRule upsert(JobNotificationRule rule) {
+        Tuple params = Tuple.tuple()
+                .addString(rule.tenantCode())
+                .addString(rule.jobType())
+                .addString(rule.channel())
+                .addJsonArray(new JsonArray(rule.recipients() == null ? List.of() : rule.recipients()))
+                .addBoolean(rule.enabled())
+                .addInteger(rule.throttleSeconds())
+                .addString(rule.templateName())
+                .addString(rule.language());
+        RowSet<Row> rows = client().preparedQuery(UPSERT)
+                .execute(params)
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    /** @return true when a rule existed and was deleted */
+    public boolean delete(String tenantCode, String jobType, String channel) {
+        return client().preparedQuery(DELETE)
+                .execute(Tuple.of(tenantCode, jobType, channel))
+                .await().indefinitely()
+                .rowCount() > 0;
+    }
+
+    /** @return true when this call won the rule's throttle slot. See {@link #CLAIM_SLOT}. */
+    public boolean claimThrottleSlot(String ruleId) {
+        return client().preparedQuery(CLAIM_SLOT)
+                .execute(Tuple.of(ruleId))
+                .await().indefinitely()
+                .iterator().hasNext();
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private JobNotificationRule mapRow(Row row) {
+        return new JobNotificationRule(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("job_type"),
+                row.getString("channel"),
+                toRecipients(row.getJsonArray("recipients")),
+                Boolean.TRUE.equals(row.getBoolean("enabled")),
+                row.getInteger("throttle_seconds"),
+                row.getString("template_name"),
+                row.getString("language"),
+                row.getOffsetDateTime("last_notified_at"),
+                row.getOffsetDateTime("created_at"),
+                row.getOffsetDateTime("updated_at"));
+    }
+
+    private List<String> toRecipients(JsonArray value) {
+        if (value == null) {
+            return List.of();
+        }
+        List<String> recipients = new ArrayList<>(value.size());
+        for (int i = 0; i < value.size(); i++) {
+            recipients.add(String.valueOf(value.getValue(i)));
+        }
+        return recipients;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -8,8 +8,10 @@ import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
 import com.microboxlabs.miot.integrations.events.JobEventEmitter;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -37,6 +39,7 @@ public class AsyncJobService {
 
     private final AsyncJobRepository repository;
     private final JobEventEmitter eventEmitter;
+    private final Event<JobParkedEvent> parkedEvent;
     private final int retryBaseSeconds;
     private final int retryMaxSeconds;
 
@@ -44,10 +47,12 @@ public class AsyncJobService {
     public AsyncJobService(
             AsyncJobRepository repository,
             JobEventEmitter eventEmitter,
+            Event<JobParkedEvent> parkedEvent,
             @ConfigProperty(name = "miot.integrations.jobs.retry-base-seconds", defaultValue = "60") int retryBaseSeconds,
             @ConfigProperty(name = "miot.integrations.jobs.retry-max-seconds", defaultValue = "3600") int retryMaxSeconds) {
         this.repository = repository;
         this.eventEmitter = eventEmitter;
+        this.parkedEvent = parkedEvent;
         this.retryBaseSeconds = retryBaseSeconds;
         this.retryMaxSeconds = retryMaxSeconds;
     }
@@ -188,6 +193,7 @@ public class AsyncJobService {
         if (newState == JobState.FAILED) {
             LOG.errorf("Job %s (%s, correlation=%s) parked as FAILED after %d attempt(s): %s",
                     jobId, job.jobType(), job.correlationKey(), job.attempts(), request.detail());
+            fireParked(updated);
         }
         eventEmitter.emit(updated, switch (newState) {
             case SUCCEEDED -> "succeeded";
@@ -241,6 +247,20 @@ public class AsyncJobService {
         }
         counts.putAll(repository.countByState(tenantCode));
         return counts;
+    }
+
+    /**
+     * Notifies park observers (REJECTED stamp, failure notifications). Fired
+     * after the ledger write is durable; a misbehaving observer must never fail
+     * the worker's report, so everything thrown is swallowed here.
+     */
+    private void fireParked(AsyncJob job) {
+        try {
+            parkedEvent.fire(new JobParkedEvent(job));
+        } catch (Exception e) {
+            LOG.errorf(e, "JobParkedEvent observer failed for job %s (%s) — park already recorded",
+                    job.id(), job.jobType());
+        }
     }
 
     private static void requireBody(Object request) {

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.8__create_job_notification_rules.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.8__create_job_notification_rules.sql
@@ -1,0 +1,30 @@
+-- Per-tenant, per-job-type opt-in failure notifications: when an async job parks
+-- as FAILED, matching enabled rules fire a notification job on the configured
+-- channel. Configured from the jobs console; matched by the park hook in
+-- AsyncJobService. See docs/job-failure-notifications.md.
+CREATE TABLE miot_integrations.job_notification_rules (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_code      VARCHAR(128) NOT NULL,
+    job_type         VARCHAR(64)  NOT NULL,
+    channel          VARCHAR(32)  NOT NULL DEFAULT 'whatsapp',
+    -- JSON array of E.164 recipient phone numbers ("+569...").
+    recipients       JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    enabled          BOOLEAN      NOT NULL DEFAULT TRUE,
+    -- Minimum gap between notifications for this rule; a burst of parks inside
+    -- the window coalesces into the one already sent. 0 = no throttle.
+    throttle_seconds INTEGER      NOT NULL DEFAULT 300,
+    -- Optional pre-approved Meta template; absent = free-form text (only
+    -- delivered inside an open 24h session window).
+    template_name    VARCHAR(128),
+    language         VARCHAR(16),
+    -- Throttle state, claimed atomically (UPDATE ... WHERE window elapsed).
+    last_notified_at TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT chk_job_notification_rules_channel CHECK (channel IN ('whatsapp')),
+    CONSTRAINT chk_job_notification_rules_throttle CHECK (throttle_seconds >= 0)
+);
+
+-- One rule per (tenant, job type, channel) — also serves the park-hook lookup.
+CREATE UNIQUE INDEX idx_job_notification_rules_key
+    ON miot_integrations.job_notification_rules(tenant_code, job_type, channel);

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutorTest.java
@@ -1,0 +1,128 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Outcome policy for the calendar_reject stamp: REJECTED plus the failure
+ * detail on success, benign-skip a vanished booking (404), propagate everything
+ * else for retry. The decision of WHEN to stamp lives in
+ * {@link CalendarRejectOnPark}, not here.
+ */
+class CalendarRejectExecutorTest {
+
+    private static final UUID CAL = UUID.fromString("3b4808f2-68ae-4b45-b921-f5a012a8962a");
+    private static final String RESOURCE = "1658427-V";
+    private static final String ERROR = "Alerce rejected the push: CONDUCTOR2 NO EXISTE";
+
+    private static Map<String, Object> payload() {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(CalendarRejectFeature.PAYLOAD_SERVICE_CODE, "1658427");
+        p.put(CalendarRejectFeature.PAYLOAD_CALENDAR_ID, CAL.toString());
+        p.put(CalendarRejectFeature.PAYLOAD_RESOURCE_ID, RESOURCE);
+        p.put(CalendarRejectFeature.PAYLOAD_DETAIL, ERROR);
+        return p;
+    }
+
+    @Test
+    void rejectStampsSyncStatusWithDetailOnly() {
+        FakeClient client = new FakeClient();
+        var result = new CalendarRejectExecutor(client).handle(payload());
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.patchCalls);
+        assertEquals("REJECTED", client.lastSyncStatus);
+        assertEquals(ERROR, client.lastSyncDetail);
+        // The lifecycle status must NOT be touched — rejection is the
+        // orthogonal acknowledgement dimension.
+        assertNull(client.lastStatus);
+        assertEquals(RESOURCE, client.lastResourceId);
+        assertEquals(CAL, client.lastCalendarId);
+    }
+
+    @Test
+    void oversizedDetailIsTruncatedToTheColumnBudget() {
+        FakeClient client = new FakeClient();
+        Map<String, Object> p = payload();
+        p.put(CalendarRejectFeature.PAYLOAD_DETAIL, "x".repeat(700));
+
+        new CalendarRejectExecutor(client).handle(p);
+
+        assertEquals(CalendarRejectFeature.DETAIL_MAX_LENGTH, client.lastSyncDetail.length());
+    }
+
+    @Test
+    void missingDetailFallsBackToAGenericOne() {
+        FakeClient client = new FakeClient();
+        Map<String, Object> p = payload();
+        p.remove(CalendarRejectFeature.PAYLOAD_DETAIL);
+
+        new CalendarRejectExecutor(client).handle(p);
+
+        assertEquals("The external push failed", client.lastSyncDetail);
+    }
+
+    @Test
+    void vanishedBookingIsBenignSkip() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(404, "no booking");
+
+        var result = new CalendarRejectExecutor(client).handle(payload());
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+    }
+
+    @Test
+    void transportErrorPropagatesForRetry() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(-1, "io error");
+        var executor = new CalendarRejectExecutor(client);
+        var p = payload();
+        assertThrows(CalendarBookingsHttpException.class, () -> executor.handle(p));
+    }
+
+    @Test
+    void missingResourceIdThrows() {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put(CalendarRejectFeature.PAYLOAD_SERVICE_CODE, "1658427");
+        var executor = new CalendarRejectExecutor(new FakeClient());
+        assertThrows(IllegalArgumentException.class, () -> executor.handle(p));
+    }
+
+    private static final class FakeClient extends CalendarBookingsClient {
+        RuntimeException patchThrows;
+        int patchCalls;
+        String lastResourceId;
+        UUID lastCalendarId;
+        String lastStatus;
+        String lastSyncStatus;
+        String lastSyncDetail;
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void patchByResource(String resourceId, UUID calendarId, String targetStatus,
+                                    Map<String, Object> resourceDataPatch,
+                                    String syncStatus, String syncDetail) {
+            patchCalls++;
+            lastResourceId = resourceId;
+            lastCalendarId = calendarId;
+            lastStatus = targetStatus;
+            lastSyncStatus = syncStatus;
+            lastSyncDetail = syncDetail;
+            if (patchThrows != null) {
+                throw patchThrows;
+            }
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectOnParkTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectOnParkTest.java
@@ -1,0 +1,170 @@
+package com.microboxlabs.miot.integrations.calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
+import com.microboxlabs.miot.integrations.jobs.TestWorkers;
+import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Park-hook policy for the REJECTED stamp: only configured push job types with
+ * a chain stamp, coordinates come from the chain's calendar_sync sibling, the
+ * reject job is standalone (no chain key — it must run while the chain is
+ * stuck), and nothing thrown here may escape into the report path.
+ */
+class CalendarRejectOnParkTest {
+
+    private static final UUID CAL = UUID.fromString("3b4808f2-68ae-4b45-b921-f5a012a8962a");
+    private static final String CHAIN = "calsync:chain:proc-9:task-3";
+
+    private final FakeRepository repository = new FakeRepository();
+    private final RecordingJobService jobService = new RecordingJobService();
+    private final TestWorkers.RecordingWorker worker = new TestWorkers.RecordingWorker(jobService);
+    private final CalendarRejectOnPark hook =
+            new CalendarRejectOnPark(List.of("alerce_assignment"), repository, jobService, worker);
+
+    @Test
+    void parkedPushEnqueuesStandaloneRejectWithSiblingCoordinates() {
+        repository.chainJobs = List.of(syncLeg());
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment", CHAIN)));
+
+        assertEquals("tenant-1", jobService.enqueuedTenant);
+        assertEquals("ecm-1", jobService.lastRequest.sourceInstance());
+        AsyncJobSpec spec = jobService.lastRequest.jobs().get(0);
+        assertEquals(CalendarRejectFeature.JOB_TYPE, spec.jobType());
+        assertEquals("modulith", spec.executor());
+        assertEquals("87920845", spec.correlationKey());
+        assertNull(spec.chainKey());
+        assertEquals("reject:job-1:5", spec.dedupeKey());
+        assertEquals("1658427-V", spec.payload().get(CalendarRejectFeature.PAYLOAD_RESOURCE_ID));
+        assertEquals(CAL.toString(), spec.payload().get(CalendarRejectFeature.PAYLOAD_CALENDAR_ID));
+        assertEquals("87920845", spec.payload().get(CalendarRejectFeature.PAYLOAD_SERVICE_CODE));
+        assertEquals("Alerce rejected: CONDUCTOR2 NO EXISTE",
+                spec.payload().get(CalendarRejectFeature.PAYLOAD_DETAIL));
+        assertEquals(1, worker.kicks.size());
+    }
+
+    @Test
+    void oversizedLastErrorIsTruncatedIntoThePayload() {
+        repository.chainJobs = List.of(syncLeg());
+        AsyncJob job = parkedWithError("alerce_assignment", CHAIN, "x".repeat(700));
+
+        hook.onParked(new JobParkedEvent(job));
+
+        String detail = (String) jobService.lastRequest.jobs().get(0)
+                .payload().get(CalendarRejectFeature.PAYLOAD_DETAIL);
+        assertEquals(CalendarRejectFeature.DETAIL_MAX_LENGTH, detail.length());
+    }
+
+    @Test
+    void unlistedJobTypesAreIgnored() {
+        repository.chainJobs = List.of(syncLeg());
+
+        hook.onParked(new JobParkedEvent(parked("calendar_sync", CHAIN)));
+        hook.onParked(new JobParkedEvent(parked("calendar_confirm", CHAIN)));
+
+        assertNull(jobService.lastRequest);
+        assertTrue(worker.kicks.isEmpty());
+    }
+
+    @Test
+    void chainlessParkIsIgnored() {
+        repository.chainJobs = List.of(syncLeg());
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment", null)));
+
+        assertNull(jobService.lastRequest);
+    }
+
+    @Test
+    void missingSyncSiblingSkipsTheStamp() {
+        repository.chainJobs = List.of();
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment", CHAIN)));
+
+        assertNull(jobService.lastRequest);
+    }
+
+    @Test
+    void hookSwallowsItsOwnFailures() {
+        repository.listThrows = new IllegalStateException("db down");
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment", CHAIN)));
+
+        assertNull(jobService.lastRequest);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static AsyncJob syncLeg() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_ID, "1658427-V");
+        payload.put(CalendarSyncFeature.PAYLOAD_CALENDAR_ID, CAL.toString());
+        payload.put(CalendarSyncFeature.PAYLOAD_SERVICE_CODE, "87920845");
+        return new AsyncJob("job-0", "tenant-1", "ecm-1", "modulith", CalendarSyncFeature.JOB_TYPE,
+                "87920845", CHAIN, 0, "dk-0", payload, JobState.SUCCEEDED, 1, 5,
+                null, null, null, null, List.of(), "listener", null, null);
+    }
+
+    private static AsyncJob parked(String jobType, String chainKey) {
+        return parkedWithError(jobType, chainKey, "Alerce rejected: CONDUCTOR2 NO EXISTE");
+    }
+
+    private static AsyncJob parkedWithError(String jobType, String chainKey, String lastError) {
+        return new AsyncJob("job-1", "tenant-1", "ecm-1", "ecm", jobType,
+                "87920845", chainKey, 1, "dk-1", Map.of(), JobState.FAILED, 5, 5,
+                null, null, null, lastError, List.of(), "listener", null, null);
+    }
+
+    /** Returns canned chain jobs for the sibling lookup. */
+    private static class FakeRepository extends AsyncJobRepository {
+        List<AsyncJob> chainJobs = List.of();
+        RuntimeException listThrows;
+
+        FakeRepository() {
+            super(null);
+        }
+
+        @Override
+        public List<AsyncJob> list(String tenantCode, String state, String correlationKey,
+                String jobType, String chainKey, int limit) {
+            if (listThrows != null) {
+                throw listThrows;
+            }
+            return chainJobs;
+        }
+    }
+
+    /** Captures the enqueue instead of hitting the ledger. */
+    private static class RecordingJobService extends AsyncJobService {
+        String enqueuedTenant;
+        EnqueueJobsRequest lastRequest;
+
+        RecordingJobService() {
+            super(null, new JobEventEmitter(Optional.empty()), null, 60, 3600);
+        }
+
+        @Override
+        public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
+            this.enqueuedTenant = tenantCode;
+            this.lastRequest = request;
+            return new EnqueueJobsResponse(List.of(), 0);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnParkTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnParkTest.java
@@ -1,0 +1,170 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.AsyncJob;
+import com.microboxlabs.miot.integrations.domain.JobNotificationRule;
+import com.microboxlabs.miot.integrations.domain.JobState;
+import com.microboxlabs.miot.integrations.dto.AsyncJobSpec;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
+import com.microboxlabs.miot.integrations.events.JobEventEmitter;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
+import com.microboxlabs.miot.integrations.persistence.JobNotificationRuleRepository;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Park-hook policy for failure notifications: enabled rules for the parked
+ * type fire one notification job each, the throttle slot is claimed before
+ * enqueueing (a burst coalesces), the notification type never matches itself,
+ * and nothing thrown here may escape into the report path.
+ */
+class JobFailureNotifyOnParkTest {
+
+    private final FakeRules rules = new FakeRules();
+    private final RecordingJobService jobService = new RecordingJobService();
+    private final TestWorkers.RecordingWorker worker = new TestWorkers.RecordingWorker(jobService);
+    private final JobFailureNotifyOnPark hook = new JobFailureNotifyOnPark(rules, jobService, worker);
+
+    @Test
+    void matchingRuleEnqueuesSelfContainedNotification() {
+        rules.enabled = List.of(rule(List.of("+56911111111", "+56922222222"), null, null));
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        assertEquals("tenant-1", jobService.enqueuedTenant);
+        AsyncJobSpec spec = jobService.lastRequest.jobs().get(0);
+        assertEquals(JobFailureNotificationFeature.JOB_TYPE, spec.jobType());
+        assertEquals(ModulithJobHandler.EXECUTOR, spec.executor());
+        assertNull(spec.chainKey());
+        assertEquals("notify:rule-1:job-1:5", spec.dedupeKey());
+        assertEquals("tenant-1", spec.payload().get(JobFailureNotificationFeature.PAYLOAD_TENANT_CODE));
+        assertEquals(List.of("+56911111111", "+56922222222"),
+                spec.payload().get(JobFailureNotificationFeature.PAYLOAD_RECIPIENTS));
+        assertEquals("job-1", spec.payload().get(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_ID));
+        assertEquals("alerce_assignment",
+                spec.payload().get(JobFailureNotificationFeature.PAYLOAD_FAILED_JOB_TYPE));
+        assertEquals("87920845", spec.payload().get(JobFailureNotificationFeature.PAYLOAD_CORRELATION_KEY));
+        assertEquals("Alerce rejected: CONDUCTOR2 NO EXISTE",
+                spec.payload().get(JobFailureNotificationFeature.PAYLOAD_ERROR));
+        assertFalse(spec.payload().containsKey(JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME));
+        assertEquals(1, worker.kicks.size());
+    }
+
+    @Test
+    void templateFieldsRideThePayloadWhenConfigured() {
+        rules.enabled = List.of(rule(List.of("+56911111111"), "job_failed_alert", "es_CL"));
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        Map<String, Object> payload = jobService.lastRequest.jobs().get(0).payload();
+        assertEquals("job_failed_alert", payload.get(JobFailureNotificationFeature.PAYLOAD_TEMPLATE_NAME));
+        assertEquals("es_CL", payload.get(JobFailureNotificationFeature.PAYLOAD_LANGUAGE));
+    }
+
+    @Test
+    void throttledRuleIsSkipped() {
+        rules.enabled = List.of(rule(List.of("+56911111111"), null, null));
+        rules.claimWins = false;
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        assertNull(jobService.lastRequest);
+        assertEquals(List.of("rule-1"), rules.claimedRuleIds);
+    }
+
+    @Test
+    void notificationJobTypeNeverMatchesItself() {
+        rules.enabled = List.of(rule(List.of("+56911111111"), null, null));
+
+        hook.onParked(new JobParkedEvent(parked(JobFailureNotificationFeature.JOB_TYPE)));
+
+        assertNull(rules.lookedUpJobType);
+        assertNull(jobService.lastRequest);
+    }
+
+    @Test
+    void ruleWithoutRecipientsNeverClaimsTheSlot() {
+        rules.enabled = List.of(rule(List.of(), null, null));
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        assertTrue(rules.claimedRuleIds.isEmpty());
+        assertNull(jobService.lastRequest);
+    }
+
+    @Test
+    void hookSwallowsItsOwnFailures() {
+        rules.findThrows = new IllegalStateException("db down");
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        assertNull(jobService.lastRequest);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static JobNotificationRule rule(List<String> recipients, String templateName, String language) {
+        return new JobNotificationRule("rule-1", "tenant-1", "alerce_assignment",
+                JobNotificationRule.CHANNEL_WHATSAPP, recipients, true, 300,
+                templateName, language, null, null, null);
+    }
+
+    private static AsyncJob parked(String jobType) {
+        return new AsyncJob("job-1", "tenant-1", "ecm-1", "ecm", jobType,
+                "87920845", null, 0, "dk-1", Map.of(), JobState.FAILED, 5, 5,
+                null, null, null, "Alerce rejected: CONDUCTOR2 NO EXISTE",
+                List.of(), "listener", null, null);
+    }
+
+    private static class FakeRules extends JobNotificationRuleRepository {
+        List<JobNotificationRule> enabled = List.of();
+        boolean claimWins = true;
+        RuntimeException findThrows;
+        String lookedUpJobType;
+        final List<String> claimedRuleIds = new java.util.ArrayList<>();
+
+        FakeRules() {
+            super(null);
+        }
+
+        @Override
+        public List<JobNotificationRule> findEnabled(String tenantCode, String jobType) {
+            if (findThrows != null) {
+                throw findThrows;
+            }
+            this.lookedUpJobType = jobType;
+            return enabled;
+        }
+
+        @Override
+        public boolean claimThrottleSlot(String ruleId) {
+            claimedRuleIds.add(ruleId);
+            return claimWins;
+        }
+    }
+
+    /** Captures the enqueue instead of hitting the ledger. */
+    private static class RecordingJobService extends AsyncJobService {
+        String enqueuedTenant;
+        EnqueueJobsRequest lastRequest;
+
+        RecordingJobService() {
+            super(null, new JobEventEmitter(Optional.empty()), null, 60, 3600);
+        }
+
+        @Override
+        public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
+            this.enqueuedTenant = tenantCode;
+            this.lastRequest = request;
+            return new EnqueueJobsResponse(List.of(), 0);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnParkTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnParkTest.java
@@ -15,6 +15,8 @@ import com.microboxlabs.miot.integrations.events.JobEventEmitter;
 import com.microboxlabs.miot.integrations.events.JobParkedEvent;
 import com.microboxlabs.miot.integrations.persistence.JobNotificationRuleRepository;
 import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -109,12 +111,43 @@ class JobFailureNotifyOnParkTest {
         assertNull(jobService.lastRequest);
     }
 
+    @Test
+    void failedEnqueueReleasesTheClaimedThrottleSlot() {
+        rules.enabled = List.of(rule(List.of("+56911111111"), null, null));
+        jobService.enqueueThrows = new IllegalStateException("db down");
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        // The claim produced no job — it must not suppress the window.
+        assertEquals(List.of("rule-1"), rules.releasedRuleIds);
+        assertEquals(FakeRules.CLAIMED_AT, rules.releasedAt);
+    }
+
+    @Test
+    void oneRuleFailingDoesNotSkipTheOthers() {
+        rules.enabled = List.of(
+                ruleWithId("rule-1", List.of("+56911111111")),
+                ruleWithId("rule-2", List.of("+56922222222")));
+        jobService.enqueueThrowsOnce = new IllegalStateException("transient");
+
+        hook.onParked(new JobParkedEvent(parked("alerce_assignment")));
+
+        assertEquals(List.of("rule-1"), rules.releasedRuleIds);
+        assertEquals("notify:rule-2:job-1:5", jobService.lastRequest.jobs().get(0).dedupeKey());
+    }
+
     // -----------------------------------------------------------------------
 
     private static JobNotificationRule rule(List<String> recipients, String templateName, String language) {
         return new JobNotificationRule("rule-1", "tenant-1", "alerce_assignment",
                 JobNotificationRule.CHANNEL_WHATSAPP, recipients, true, 300,
                 templateName, language, null, null, null);
+    }
+
+    private static JobNotificationRule ruleWithId(String id, List<String> recipients) {
+        return new JobNotificationRule(id, "tenant-1", "alerce_assignment",
+                JobNotificationRule.CHANNEL_WHATSAPP, recipients, true, 300,
+                null, null, null, null, null);
     }
 
     private static AsyncJob parked(String jobType) {
@@ -125,11 +158,16 @@ class JobFailureNotifyOnParkTest {
     }
 
     private static class FakeRules extends JobNotificationRuleRepository {
+        static final OffsetDateTime CLAIMED_AT =
+                OffsetDateTime.of(2026, 7, 21, 12, 0, 0, 0, ZoneOffset.UTC);
+
         List<JobNotificationRule> enabled = List.of();
         boolean claimWins = true;
         RuntimeException findThrows;
         String lookedUpJobType;
         final List<String> claimedRuleIds = new java.util.ArrayList<>();
+        final List<String> releasedRuleIds = new java.util.ArrayList<>();
+        OffsetDateTime releasedAt;
 
         FakeRules() {
             super(null);
@@ -145,9 +183,16 @@ class JobFailureNotifyOnParkTest {
         }
 
         @Override
-        public boolean claimThrottleSlot(String ruleId) {
+        public OffsetDateTime claimThrottleSlot(String ruleId) {
             claimedRuleIds.add(ruleId);
-            return claimWins;
+            return claimWins ? CLAIMED_AT : null;
+        }
+
+        @Override
+        public boolean releaseThrottleSlot(String ruleId, OffsetDateTime claimedAt) {
+            releasedRuleIds.add(ruleId);
+            releasedAt = claimedAt;
+            return true;
         }
     }
 
@@ -155,6 +200,8 @@ class JobFailureNotifyOnParkTest {
     private static class RecordingJobService extends AsyncJobService {
         String enqueuedTenant;
         EnqueueJobsRequest lastRequest;
+        RuntimeException enqueueThrows;
+        RuntimeException enqueueThrowsOnce;
 
         RecordingJobService() {
             super(null, new JobEventEmitter(Optional.empty()), null, 60, 3600);
@@ -162,6 +209,14 @@ class JobFailureNotifyOnParkTest {
 
         @Override
         public EnqueueJobsResponse enqueue(String tenantCode, EnqueueJobsRequest request) {
+            if (enqueueThrows != null) {
+                throw enqueueThrows;
+            }
+            if (enqueueThrowsOnce != null) {
+                RuntimeException once = enqueueThrowsOnce;
+                enqueueThrowsOnce = null;
+                throw once;
+            }
             this.enqueuedTenant = tenantCode;
             this.lastRequest = request;
             return new EnqueueJobsResponse(List.of(), 0);

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
@@ -161,7 +161,7 @@ class ModulithJobWorkerTest {
         int claimCalls;
 
         RecordingService() {
-            super(new NoopRepository(), new JobEventEmitter(Optional.empty()), 60, 3600);
+            super(new NoopRepository(), new JobEventEmitter(Optional.empty()), null, 60, 3600);
         }
 
         @Override

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/TestWorkers.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/TestWorkers.java
@@ -1,0 +1,33 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
+import com.microboxlabs.miot.integrations.service.AsyncJobService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test doubles for {@link ModulithJobWorker}, exported here because its
+ * constructors are package-private and the park hooks that inject it live in
+ * other packages.
+ */
+public final class TestWorkers {
+
+    private TestWorkers() {
+    }
+
+    /** Records {@link #onEnqueued} kicks without claiming or running anything. */
+    public static class RecordingWorker extends ModulithJobWorker {
+
+        public final List<EnqueueJobsResponse> kicks = new ArrayList<>();
+
+        public RecordingWorker(AsyncJobService service) {
+            super(service, Map.of(), false, 1, 60);
+        }
+
+        @Override
+        public void onEnqueued(EnqueueJobsResponse response) {
+            kicks.add(response);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -12,13 +12,19 @@ import com.microboxlabs.miot.integrations.dto.ClaimJobsRequest;
 import com.microboxlabs.miot.integrations.dto.EnqueueJobsRequest;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
 import com.microboxlabs.miot.integrations.events.JobEventEmitter;
+import com.microboxlabs.miot.integrations.events.JobParkedEvent;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.NotificationOptions;
+import jakarta.enterprise.util.TypeLiteral;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.Test;
 
 class AsyncJobServiceTest {
@@ -29,7 +35,7 @@ class AsyncJobServiceTest {
     @Test
     void reportFailureSchedulesBackoffRetryWhileAttemptsRemain() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("tenant-less-id", "job-1", failed());
 
@@ -39,7 +45,7 @@ class AsyncJobServiceTest {
 
     @Test
     void backoffDoublesPerAttemptAndIsCapped() throws Exception {
-        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
         Method backoff = AsyncJobService.class.getDeclaredMethod("backoffSeconds", int.class);
         backoff.setAccessible(true);
 
@@ -51,7 +57,7 @@ class AsyncJobServiceTest {
     @Test
     void reportFailureParksJobWhenAttemptsExhausted() {
         var repo = new FakeRepository(runningJob(5, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", failed());
 
@@ -62,7 +68,7 @@ class AsyncJobServiceTest {
     @Test
     void reportNonRetryableFailureParksImmediately() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("w", "FAILED", "bad config", false, null));
 
@@ -72,7 +78,7 @@ class AsyncJobServiceTest {
     @Test
     void reportSkippedClosesJobAsSucceeded() {
         var repo = new FakeRepository(runningJob(1, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("w", "SKIPPED", "already delivered", null, null));
 
@@ -83,7 +89,7 @@ class AsyncJobServiceTest {
     @Test
     void reportRejectsJobsThatAreNotRunning() {
         var repo = new FakeRepository(jobInState(JobState.PENDING, 0, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
         var request = failed();
 
         assertThrows(IllegalStateException.class,
@@ -93,14 +99,14 @@ class AsyncJobServiceTest {
     @Test
     void retryRejectsSucceededJobs() {
         var repo = new FakeRepository(jobInState(JobState.SUCCEEDED, 1, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         assertThrows(IllegalStateException.class, () -> service.retry("t", "job-1", "actor"));
     }
 
     @Test
     void enqueueValidatesRequiredFields() {
-        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
         var missingSource = new EnqueueJobsRequest(null, "listener", List.of(spec()));
         var emptyJobs = new EnqueueJobsRequest("ecm-1", "listener", List.of());
         var bogusActor = new EnqueueJobsRequest("ecm-1", "bogus", List.of(spec()));
@@ -121,7 +127,7 @@ class AsyncJobServiceTest {
                 return ++calls == 1 ? job : null;
             }
         };
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         var response = service.enqueue("t",
                 new EnqueueJobsRequest("ecm-1", "reconciler", List.of(spec(), spec())));
@@ -132,7 +138,7 @@ class AsyncJobServiceTest {
 
     @Test
     void nullRequestBodiesAreRejected() {
-        var service = new AsyncJobService(new FakeRepository(null), noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(null), noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         assertThrows(IllegalArgumentException.class, () -> service.enqueue("t", null));
         assertThrows(IllegalArgumentException.class, () -> service.claim("t", null));
@@ -142,7 +148,7 @@ class AsyncJobServiceTest {
     @Test
     void claimScopesByTenantAndValidatesBounds() {
         var repo = new FakeRepository(null);
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
         var badLimit = new ClaimJobsRequest("ecm", "w1", 0, null, null);
         var badLease = new ClaimJobsRequest("ecm", "w1", null, 0, null);
 
@@ -157,7 +163,7 @@ class AsyncJobServiceTest {
     void staleReportIsRejectedWhenLeaseCasFails() {
         var repo = new FakeRepository(runningJob(1, 5));
         repo.reportStale = true;
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
         var request = failed();
 
         assertThrows(IllegalStateException.class, () -> service.report("t", "job-1", request));
@@ -166,7 +172,7 @@ class AsyncJobServiceTest {
     @Test
     void reportEchoesWorkerAndAttemptIntoLeaseCas() {
         var repo = new FakeRepository(runningJob(2, 5));
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", new ReportJobRequest("worker-1", "SUCCEEDED", "ok", null, 2));
 
@@ -177,7 +183,7 @@ class AsyncJobServiceTest {
     @Test
     void reportEmitsTransitionEvents() {
         var emitter = new RecordingEmitter();
-        var service = new AsyncJobService(new FakeRepository(runningJob(1, 5)), emitter, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(new FakeRepository(runningJob(1, 5)), emitter, noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.report("t", "job-1", failed());
 
@@ -188,7 +194,7 @@ class AsyncJobServiceTest {
     void retryEmitsRetriedEvent() {
         var emitter = new RecordingEmitter();
         var service = new AsyncJobService(new FakeRepository(jobInState(JobState.FAILED, 5, 5)),
-                emitter, BASE_SECONDS, MAX_SECONDS);
+                emitter, noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.retry("t", "job-1", "operator@test.example");
 
@@ -206,7 +212,7 @@ class AsyncJobServiceTest {
             }
         };
         var emitter = new RecordingEmitter();
-        var service = new AsyncJobService(repo, emitter, BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, emitter, noParked(), BASE_SECONDS, MAX_SECONDS);
 
         service.enqueue("t", new EnqueueJobsRequest("ecm-1", "listener", List.of(spec(), spec())));
 
@@ -221,7 +227,7 @@ class AsyncJobServiceTest {
                 return Map.of("FAILED", 2);
             }
         };
-        var service = new AsyncJobService(repo, noEvents(), BASE_SECONDS, MAX_SECONDS);
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
 
         Map<String, Integer> counts = service.counts("t");
 
@@ -230,10 +236,87 @@ class AsyncJobServiceTest {
         assertEquals(JobState.values().length, counts.size());
     }
 
+    @Test
+    void reportParkFiresParkedEvent() {
+        var parked = new RecordingParkedEvent();
+        var service = new AsyncJobService(new FakeRepository(runningJob(5, 5)), noEvents(), parked,
+                BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", failed());
+
+        assertEquals(1, parked.fired.size());
+        assertEquals("job-1", parked.fired.get(0).job().id());
+    }
+
+    @Test
+    void reportRetrySchedulingDoesNotFireParkedEvent() {
+        var parked = new RecordingParkedEvent();
+        var service = new AsyncJobService(new FakeRepository(runningJob(1, 5)), noEvents(), parked,
+                BASE_SECONDS, MAX_SECONDS);
+
+        service.report("t", "job-1", failed());
+
+        assertEquals(List.of(), parked.fired);
+    }
+
+    @Test
+    void parkedObserverFailureDoesNotBreakTheReport() {
+        var repo = new FakeRepository(runningJob(5, 5));
+        var parked = new RecordingParkedEvent();
+        parked.throwOnFire = new IllegalStateException("observer blew up");
+        var service = new AsyncJobService(repo, noEvents(), parked, BASE_SECONDS, MAX_SECONDS);
+
+        assertNotNull(service.report("t", "job-1", failed()));
+        assertEquals(JobState.FAILED, repo.reportedState);
+    }
+
     // -----------------------------------------------------------------------
 
     private static JobEventEmitter noEvents() {
         return new JobEventEmitter(Optional.empty());
+    }
+
+    private static Event<JobParkedEvent> noParked() {
+        return new RecordingParkedEvent();
+    }
+
+    /** Captures fired park events instead of dispatching to CDI observers. */
+    private static class RecordingParkedEvent implements Event<JobParkedEvent> {
+        final List<JobParkedEvent> fired = new ArrayList<>();
+        RuntimeException throwOnFire;
+
+        @Override
+        public void fire(JobParkedEvent event) {
+            if (throwOnFire != null) {
+                throw throwOnFire;
+            }
+            fired.add(event);
+        }
+
+        @Override
+        public <U extends JobParkedEvent> CompletionStage<U> fireAsync(U event) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U extends JobParkedEvent> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Event<JobParkedEvent> select(Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U extends JobParkedEvent> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U extends JobParkedEvent> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /** Captures transitions instead of POSTing to quarkus-sse. */


### PR DESCRIPTION
Backend scope of #941 (phase 2 of microboxlabs/ecm-coordinator#328). Design doc: `quarkus-srv/miot-integrations/docs/job-failure-notifications.md`.

## What

One seam powers everything: `AsyncJobService.report()` now fires a CDI **`JobParkedEvent`** exactly where a job parks as FAILED (single funnel for both executor lanes — ECM via REST, modulith in-process). The fire is guarded: an observer can never break a worker's report.

**1. Booking REJECTED stamp** (`CalendarRejectOnPark` → `calendar_reject` job)
- A parked push-leg type (config `miot.integrations.jobs.reject-stamp.job-types`, default `alerce_assignment`) with a chain key looks up the chain's `calendar_sync` seq-0 sibling for booking coordinates and enqueues a **standalone** modulith `calendar_reject` job → `PATCH syncStatus=REJECTED` + failure detail (truncated to the 500-char column budget).
- Standalone on purpose: a chained successor would be gate-blocked by the FAILED predecessor it reports.
- Dedupe `reject:{jobId}:{attempts}` — a re-park after a failed manual retry stamps again; one park never double-fires.
- Not seq 0 (`calendar_sync` parked ⇒ booking never patched) and not `calendar_confirm` (push was accepted; a parked confirm means the calendar API is down). Recovery loop intact: successful manual retry → the still-blocked confirm leg overwrites to CONFIRMED.

**2. WhatsApp failure notifications** (`JobFailureNotifyOnPark` → `job_failure_notification` job)
- New table `miot_integrations.job_notification_rules` (V0.6.8): (tenant, job_type, channel) → recipients (E.164 JSONB), enabled, throttle_seconds + last_notified_at, optional Meta template_name/language.
- The throttle slot is claimed **atomically at enqueue time** (`UPDATE … WHERE window elapsed RETURNING`) — a burst of parks coalesces into one notification, race-safe across pods. Rules never match the notification job type itself (no loops).
- Handler `JobFailureNotificationHandler` lives in **miot-conversational** (dependency direction: conversational → integrations, so integrations can't inject `WhatsAppMessagingService`; the worker discovers handlers CDI-wide). Per-recipient outcomes: all failed ⇒ throw (ledger retries with backoff); partial ⇒ SUCCEEDED with failures in the detail (a retry would re-message recipients that already got it). Deliberately no `serviceCode` on the send — it would graft the ops message onto the service's driver conversation thread.

**3. Rules CRUD** — `OrgJobNotificationRulesResource` under `/api/v1/orgs/{org}/integrations/console/notification-rules` (RS256 org-member console family): GET list, PUT /{jobType} upsert (E.164 validation, ≤20 recipients), DELETE /{jobType}.

## Rollout

Ships dark: no rules ⇒ notification branch is a no-op; the reject stamp only fires for chains carrying `calendar_sync` coordinates and needs miot-calendar ≥ 0.6.2 (`sync_status` columns — already on dev). No new flags beyond the existing modulith-worker enablement.

## Tests

- miot-integrations: 160 tests green (new: `CalendarRejectExecutorTest`, `CalendarRejectOnParkTest`, `JobFailureNotifyOnParkTest`, +3 park-event tests in `AsyncJobServiceTest`).
- miot-conversational: 65 tests green (new: `JobFailureNotificationHandlerTest`).
- Full `quarkus-srv` reactor `package` passes → ArC validates the whole new CDI graph. NOTE: that build only passes together with the one-line producer-scope fix PR for trunk's `RetransmitDeliverySettings` (filed separately) — trunk currently fails miot-cli augmentation on its own.

Console settings UI ("Notify on failure" per job type) follows in a separate PR on #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)