### PR TITLE
fix(integrations): Gauss defaults producer breaks quarkus build (record + normal scope)

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/retransmit/RetransmitDeliverySettings.java
@@ -3,6 +3,7 @@ package com.microboxlabs.miot.integrations.retransmit;
 import com.microboxlabs.miot.integrations.retransmit.GaussPositionMapper.Defaults;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import java.util.Locale;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -44,8 +45,10 @@ public class RetransmitDeliverySettings {
         this.gaussDefaults = gaussDefaults;
     }
 
+    // Singleton, not @ApplicationScoped: Defaults is a record (final), and a
+    // normal scope would need a client proxy ArC cannot subclass it into.
     @Produces
-    @ApplicationScoped
+    @Singleton
     static Defaults gaussDefaults(
             @ConfigProperty(name = "miot.integrations.retransmit.gauss.tags", defaultValue = ";MEL;")
                     String gaussTags,


### PR DESCRIPTION
Since #909, `./mvnw package` fails at miot-cli's Quarkus augmentation:

```
DeploymentException: Producer method for a normal scoped bean must not have a type
that is a record, because records are always final: PRODUCER METHOD
RetransmitDeliverySettings.gaussDefaults(...)
```

`GaussPositionMapper.Defaults` is a record — final — so ArC cannot generate the client proxy an `@ApplicationScoped` producer requires. This would also fail tonight's modulith image build.

One-line fix: the producer becomes `@Singleton` (proxy-free pseudo-scope) — identical one-instance semantics for an immutable config holder. Verified: full `quarkus-srv` reactor `package` goes back to BUILD SUCCESS with this change.

Unrelated to but unblocks #942 (which needs a buildable trunk to deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)