### PR TITLE
feat: configure organization multimedia auto-approval permissions

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -197,6 +197,11 @@ miot.alfresco.url=${ALFRESCO_URL:http://localhost:8080/alfresco}
 miot.alfresco.auth=${MIOT_ALFRESCO_AUTH:stub}
 miot.alfresco.basic.username=${ALFRESCO_USER:}
 miot.alfresco.basic.password=${ALFRESCO_PASSWORD:}
+
+# Destination projection for the Modulith-owned CONTENT_REVIEW_AUTO_APPROVER role.
+# The normalized organization tax id is appended to this prefix. Keep aligned
+# with mintral.features.review.autoApprove.groupPrefix in ecm-coordinator.
+miot.permissions.content-review.alfresco-group-prefix=${MIOT_CONTENT_REVIEW_AUTO_APPROVERS_GROUP_PREFIX:GROUP_MINTRAL_AUTO_APPROVERS_}
 # REST client base — points the typed client at the public v1 core API.
 quarkus.rest-client.alfresco-core.url=${miot.alfresco.url}/api/-default-/public/alfresco/versions/1
 quarkus.rest-client.alfresco-core.connect-timeout=10000

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoGroupAdminClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoGroupAdminClient.java
@@ -38,7 +38,14 @@ public class RealAlfrescoGroupAdminClient implements IAlfrescoGroupAdminClient {
     @Override
     public Uni<String> createGroup(String groupId, String displayName) {
         return coreApi.createGroup(new CreateGroupRequest(groupId, displayName))
-                .map(resp -> resp.entry() != null ? resp.entry().id() : groupId);
+                .map(resp -> resp.entry() != null ? resp.entry().id() : groupId)
+                .onFailure(AlfrescoClientException.class).recoverWithUni(ex -> {
+                    if (ex.isConflict()) {
+                        LOG.debugf("createGroup(%s): already exists — ignoring 409", groupId);
+                        return Uni.createFrom().item(groupId);
+                    }
+                    return Uni.createFrom().failure(ex);
+                });
     }
 
     @Override

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/OrgContentReviewPermissionResource.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/OrgContentReviewPermissionResource.java
@@ -1,0 +1,48 @@
+package com.microboxlabs.miot.core.api;
+
+import com.microboxlabs.miot.core.api.dto.ContentReviewPermissionDto;
+import com.microboxlabs.miot.core.api.dto.SetContentReviewPermissionRequest;
+import com.microboxlabs.miot.core.permission.ContentReviewPermissionService;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/** Organization settings endpoint for multimedia review auto-approval. */
+@Path("/api/v1/orgs/{organizationId}/permissions/content-review-auto-approval")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Organization Permissions")
+@SecurityRequirement(name = "oidc")
+public class OrgContentReviewPermissionResource {
+
+    private final ContentReviewPermissionService service;
+
+    @Inject
+    public OrgContentReviewPermissionResource(ContentReviewPermissionService service) {
+        this.service = service;
+    }
+
+    @GET
+    @Operation(summary = "Get multimedia review auto-approval settings")
+    public Uni<ContentReviewPermissionDto> get(
+            @PathParam("organizationId") String organizationId) {
+        return service.get(organizationId);
+    }
+
+    @PUT
+    @Operation(summary = "Replace multimedia review auto-approval settings")
+    public Uni<ContentReviewPermissionDto> replace(
+            @PathParam("organizationId") String organizationId,
+            SetContentReviewPermissionRequest request) {
+        return service.replace(organizationId, request);
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/dto/ContentReviewPermissionDto.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/dto/ContentReviewPermissionDto.java
@@ -1,0 +1,16 @@
+package com.microboxlabs.miot.core.api.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Organization configuration for automatic multimedia review approval. */
+public record ContentReviewPermissionDto(
+        boolean enabled,
+        String permissionCode,
+        String roleCode,
+        String alfrescoGroupId,
+        List<String> assigneeIds,
+        String projectionStatus,
+        String projectionError,
+        Instant projectedAt) {
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/dto/SetContentReviewPermissionRequest.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/api/dto/SetContentReviewPermissionRequest.java
@@ -1,0 +1,7 @@
+package com.microboxlabs.miot.core.api.dto;
+
+import java.util.List;
+
+/** Full replacement request for the content-review auto-approval policy. */
+public record SetContentReviewPermissionRequest(boolean enabled, List<String> assigneeIds) {
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/OrganizationPermissionSetting.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/OrganizationPermissionSetting.java
@@ -1,0 +1,80 @@
+package com.microboxlabs.miot.core.model;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+import io.smallrye.mutiny.Uni;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/** Authoritative per-organization switch for a Modulith permission. */
+@Entity
+@Table(name = "organization_permission_settings", schema = "miot_core")
+public class OrganizationPermissionSetting extends PanacheEntityBase {
+
+    @EmbeddedId
+    public OrganizationPermissionSettingId id;
+
+    @Column(nullable = false)
+    public boolean enabled;
+
+    @Column(name = "projection_status", nullable = false)
+    public String projectionStatus = "PENDING";
+
+    @Column(name = "projection_error")
+    public String projectionError;
+
+    @Column(name = "projected_at")
+    public Instant projectedAt;
+
+    @Column(name = "updated_at", nullable = false)
+    public Instant updatedAt = Instant.now();
+
+    public OrganizationPermissionSetting() {
+    }
+
+    public OrganizationPermissionSetting(Long organizationId, String permissionCode) {
+        this.id = new OrganizationPermissionSettingId(organizationId, permissionCode);
+    }
+
+    public static Uni<OrganizationPermissionSetting> findSetting(
+            Long organizationId, String permissionCode) {
+        return find("id.organizationId = ?1 and id.permissionCode = ?2",
+                organizationId, permissionCode).firstResult();
+    }
+
+    @Embeddable
+    public static class OrganizationPermissionSettingId implements Serializable {
+
+        @Column(name = "organization_id")
+        public Long organizationId;
+
+        @Column(name = "permission_code")
+        public String permissionCode;
+
+        public OrganizationPermissionSettingId() {
+        }
+
+        public OrganizationPermissionSettingId(Long organizationId, String permissionCode) {
+            this.organizationId = organizationId;
+            this.permissionCode = permissionCode;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof OrganizationPermissionSettingId that)) return false;
+            return Objects.equals(organizationId, that.organizationId)
+                    && Objects.equals(permissionCode, that.permissionCode);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(organizationId, permissionCode);
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/OrganizationRoleAssignment.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/model/OrganizationRoleAssignment.java
@@ -1,0 +1,69 @@
+package com.microboxlabs.miot.core.model;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+import io.smallrye.mutiny.Uni;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/** A role granted to an Alfresco person within an organization. */
+@Entity
+@Table(name = "organization_role_assignments", schema = "miot_core")
+public class OrganizationRoleAssignment extends PanacheEntityBase {
+
+    @EmbeddedId
+    public OrganizationRoleAssignmentId id;
+
+    public OrganizationRoleAssignment() {
+    }
+
+    public OrganizationRoleAssignment(Long organizationId, String roleCode, String personId) {
+        this.id = new OrganizationRoleAssignmentId(organizationId, roleCode, personId);
+    }
+
+    public static Uni<List<OrganizationRoleAssignment>> findAssignments(
+            Long organizationId, String roleCode) {
+        return find("id.organizationId = ?1 and id.roleCode = ?2", organizationId, roleCode).list();
+    }
+
+    @Embeddable
+    public static class OrganizationRoleAssignmentId implements Serializable {
+
+        @Column(name = "organization_id")
+        public Long organizationId;
+
+        @Column(name = "role_code")
+        public String roleCode;
+
+        @Column(name = "person_id")
+        public String personId;
+
+        public OrganizationRoleAssignmentId() {
+        }
+
+        public OrganizationRoleAssignmentId(Long organizationId, String roleCode, String personId) {
+            this.organizationId = organizationId;
+            this.roleCode = roleCode;
+            this.personId = personId;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof OrganizationRoleAssignmentId that)) return false;
+            return Objects.equals(organizationId, that.organizationId)
+                    && Objects.equals(roleCode, that.roleCode)
+                    && Objects.equals(personId, that.personId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(organizationId, roleCode, personId);
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
@@ -1,0 +1,74 @@
+package com.microboxlabs.miot.core.permission;
+
+import com.microboxlabs.miot.core.alfresco.AlfrescoPerson;
+import com.microboxlabs.miot.core.alfresco.IAlfrescoDirectoryClient;
+import com.microboxlabs.miot.core.alfresco.IAlfrescoGroupAdminClient;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** Reconciles a desired set of people into an Alfresco authority group. */
+@ApplicationScoped
+public class AlfrescoGroupProjector {
+
+    private static final int PAGE_SIZE = 50;
+
+    private final IAlfrescoDirectoryClient directoryClient;
+    private final IAlfrescoGroupAdminClient groupAdmin;
+
+    @Inject
+    public AlfrescoGroupProjector(
+            IAlfrescoDirectoryClient directoryClient,
+            IAlfrescoGroupAdminClient groupAdmin) {
+        this.directoryClient = directoryClient;
+        this.groupAdmin = groupAdmin;
+    }
+
+    public Uni<Void> reconcile(String groupId, String displayName, Set<String> desired) {
+        return groupAdmin.createGroup(groupId, displayName)
+                .flatMap(ignored -> listAllMembers(groupId))
+                .flatMap(currentMembers -> {
+                    Set<String> current = currentMembers.stream()
+                            .map(AlfrescoPerson::id)
+                            .collect(java.util.stream.Collectors.toSet());
+                    return applyMembershipDelta(groupId, current, desired);
+                });
+    }
+
+    private Uni<Void> applyMembershipDelta(
+            String groupId, Set<String> current, Set<String> desired) {
+        Set<String> additions = new TreeSet<>(desired);
+        additions.removeAll(current);
+        Set<String> removals = new TreeSet<>(current);
+        removals.removeAll(desired);
+
+        Uni<Void> chain = Uni.createFrom().voidItem();
+        for (String personId : additions) {
+            chain = chain.flatMap(ignored -> groupAdmin.addGroupMember(groupId, personId));
+        }
+        for (String personId : removals) {
+            chain = chain.flatMap(ignored -> groupAdmin.removeGroupMember(groupId, personId));
+        }
+        return chain;
+    }
+
+    private Uni<List<AlfrescoPerson>> listAllMembers(String groupId) {
+        return listAllMembers(groupId, 0, new ArrayList<>());
+    }
+
+    private Uni<List<AlfrescoPerson>> listAllMembers(
+            String groupId, int skipCount, List<AlfrescoPerson> collected) {
+        return directoryClient.listGroupMembers(groupId, PAGE_SIZE, skipCount)
+                .flatMap(page -> {
+                    collected.addAll(page);
+                    if (page.size() < PAGE_SIZE) {
+                        return Uni.createFrom().item(List.copyOf(collected));
+                    }
+                    return listAllMembers(groupId, skipCount + PAGE_SIZE, collected);
+                });
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
@@ -1,0 +1,259 @@
+package com.microboxlabs.miot.core.permission;
+
+import com.microboxlabs.miot.core.alfresco.AlfrescoPerson;
+import com.microboxlabs.miot.core.alfresco.IAlfrescoDirectoryClient;
+import com.microboxlabs.miot.core.api.dto.ContentReviewPermissionDto;
+import com.microboxlabs.miot.core.api.dto.SetContentReviewPermissionRequest;
+import com.microboxlabs.miot.core.auth.WriteAuthorizer;
+import com.microboxlabs.miot.core.model.Organization;
+import com.microboxlabs.miot.core.model.OrganizationPermissionSetting;
+import com.microboxlabs.miot.core.model.OrganizationRoleAssignment;
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * Owns automatic content-review permission state and projects effective role
+ * assignments into the Alfresco group consumed by ecm-coordinator.
+ */
+@ApplicationScoped
+public class ContentReviewPermissionService {
+
+    public static final String PERMISSION_CODE = "CONTENT_MULTIMEDIA_REVIEW_AUTO_APPROVE";
+    public static final String ROLE_CODE = "CONTENT_REVIEW_AUTO_APPROVER";
+
+    private static final int PAGE_SIZE = 50;
+    private static final Logger LOG = Logger.getLogger(ContentReviewPermissionService.class);
+
+    private final IAlfrescoDirectoryClient directoryClient;
+    private final AlfrescoGroupProjector groupProjector;
+    private final WriteAuthorizer writeAuthorizer;
+    private final String targetGroupPrefix;
+
+    @Inject
+    public ContentReviewPermissionService(
+            IAlfrescoDirectoryClient directoryClient,
+            AlfrescoGroupProjector groupProjector,
+            WriteAuthorizer writeAuthorizer,
+            @ConfigProperty(
+                    name = "miot.permissions.content-review.alfresco-group-prefix",
+                    defaultValue = "GROUP_MINTRAL_AUTO_APPROVERS_") String targetGroupPrefix) {
+        this.directoryClient = directoryClient;
+        this.groupProjector = groupProjector;
+        this.writeAuthorizer = writeAuthorizer;
+        this.targetGroupPrefix = targetGroupPrefix;
+    }
+
+    public Uni<ContentReviewPermissionDto> get(String organizationSlug) {
+        return Panache.withSession(() -> Organization.findBySlug(organizationSlug)
+                .flatMap(org -> {
+                    if (org == null) {
+                        return Uni.createFrom().failure(new NotFoundException(
+                                "Organization not found: " + organizationSlug));
+                    }
+                    return loadDto(org.id, targetGroupFor(org));
+                }));
+    }
+
+    public Uni<ContentReviewPermissionDto> replace(
+            String organizationSlug, SetContentReviewPermissionRequest request) {
+        Set<String> assigneeIds = normalize(request);
+
+        return authorizeAndResolve(organizationSlug)
+                .flatMap(target -> validateOrganizationMembers(target, assigneeIds))
+                .flatMap(target -> persistDesiredState(target, request.enabled(), assigneeIds))
+                .flatMap(target -> reconcileProjection(target, request.enabled(), assigneeIds)
+                        .flatMap(v -> markProjection(
+                                target.organizationId(), "SYNCED", null, Instant.now()))
+                        .onFailure().recoverWithUni(error -> {
+                            LOG.errorf(error, "Content-review role projection to %s failed",
+                                    target.targetGroupId());
+                            return markProjection(target.organizationId(), "FAILED",
+                                    abbreviate(error.getMessage()), null);
+                        }))
+                .flatMap(organizationId -> Panache.withSession(() -> Organization.<Organization>findById(organizationId)
+                        .flatMap(org -> loadDto(organizationId, targetGroupFor(org)))));
+    }
+
+    private Uni<OrganizationTarget> authorizeAndResolve(String organizationSlug) {
+        return Panache.withSession(() -> Organization.findBySlug(organizationSlug)
+                .flatMap(org -> {
+                    if (org == null) {
+                        return Uni.createFrom().failure(new NotFoundException(
+                                "Organization not found: " + organizationSlug));
+                    }
+                    if (org.alfrescoGroupId == null || org.alfrescoGroupId.isBlank()) {
+                        return Uni.createFrom().failure(new BadRequestException(
+                                "Organization has no Alfresco group binding"));
+                    }
+                    OrganizationTarget target = new OrganizationTarget(
+                            org.id, org.alfrescoGroupId, targetGroupFor(org));
+                    return writeAuthorizer.requireParentSiteManager(org).replaceWith(target);
+                }));
+    }
+
+    private Uni<OrganizationTarget> validateOrganizationMembers(
+            OrganizationTarget target, Set<String> requested) {
+        if (requested.isEmpty()) {
+            return Uni.createFrom().item(target);
+        }
+        return listAllMembers(target.alfrescoGroupId())
+                .map(members -> members.stream().map(AlfrescoPerson::id).collect(java.util.stream.Collectors.toSet()))
+                .map(validIds -> {
+                    Set<String> invalid = new TreeSet<>(requested);
+                    invalid.removeAll(validIds);
+                    if (!invalid.isEmpty()) {
+                        throw new BadRequestException(
+                                "Auto-approvers must be organization members: " + String.join(", ", invalid));
+                    }
+                    return target;
+                });
+    }
+
+    private Uni<OrganizationTarget> persistDesiredState(
+            OrganizationTarget target, boolean enabled, Set<String> assigneeIds) {
+        return Panache.withTransaction(() -> OrganizationPermissionSetting
+                .findSetting(target.organizationId(), PERMISSION_CODE)
+                .flatMap(setting -> {
+                    OrganizationPermissionSetting row = setting != null
+                            ? setting
+                            : new OrganizationPermissionSetting(target.organizationId(), PERMISSION_CODE);
+                    row.enabled = enabled;
+                    row.projectionStatus = "PENDING";
+                    row.projectionError = null;
+                    row.updatedAt = Instant.now();
+                    return row.<OrganizationPermissionSetting>persist();
+                })
+                .flatMap(setting -> replaceAssignments(target.organizationId(), assigneeIds))
+                .replaceWith(target));
+    }
+
+    @SuppressWarnings("java:S3252")
+    private Uni<Void> replaceAssignments(Long organizationId, Set<String> assigneeIds) {
+        return OrganizationRoleAssignment
+                .delete("id.organizationId = ?1 and id.roleCode = ?2", organizationId, ROLE_CODE)
+                .flatMap(ignored -> persistAssignments(organizationId, assigneeIds));
+    }
+
+    private Uni<Void> persistAssignments(Long organizationId, Set<String> assigneeIds) {
+        Uni<Void> chain = Uni.createFrom().voidItem();
+        for (String personId : assigneeIds) {
+            chain = chain.flatMap(ignored -> new OrganizationRoleAssignment(
+                    organizationId, ROLE_CODE, personId).persist().replaceWithVoid());
+        }
+        return chain;
+    }
+
+    private Uni<Void> reconcileProjection(
+            OrganizationTarget target, boolean enabled, Set<String> assigneeIds) {
+        Set<String> desired = enabled ? assigneeIds : Set.of();
+        return groupProjector.reconcile(
+                target.targetGroupId(), "Multimedia content auto approvers", desired);
+    }
+
+    private Uni<List<AlfrescoPerson>> listAllMembers(String groupId) {
+        return listAllMembers(groupId, 0, new ArrayList<>());
+    }
+
+    private Uni<List<AlfrescoPerson>> listAllMembers(
+            String groupId, int skipCount, List<AlfrescoPerson> collected) {
+        return directoryClient.listGroupMembers(groupId, PAGE_SIZE, skipCount)
+                .flatMap(page -> {
+                    collected.addAll(page);
+                    if (page.size() < PAGE_SIZE) {
+                        return Uni.createFrom().item(List.copyOf(collected));
+                    }
+                    return listAllMembers(groupId, skipCount + PAGE_SIZE, collected);
+                });
+    }
+
+    private Uni<Long> markProjection(
+            Long organizationId, String status, String error, Instant projectedAt) {
+        return Panache.withTransaction(() -> OrganizationPermissionSetting
+                .findSetting(organizationId, PERMISSION_CODE)
+                .flatMap(setting -> {
+                    setting.projectionStatus = status;
+                    setting.projectionError = error;
+                    setting.projectedAt = projectedAt;
+                    setting.updatedAt = Instant.now();
+                    return setting.<OrganizationPermissionSetting>persist();
+                })
+                .replaceWith(organizationId));
+    }
+
+    private Uni<ContentReviewPermissionDto> loadDto(Long organizationId, String targetGroupId) {
+        return OrganizationPermissionSetting.findSetting(organizationId, PERMISSION_CODE)
+                .flatMap(setting -> OrganizationRoleAssignment
+                        .findAssignments(organizationId, ROLE_CODE)
+                        .map(assignments -> toDto(setting, assignments, targetGroupId)));
+    }
+
+    private ContentReviewPermissionDto toDto(
+            OrganizationPermissionSetting setting,
+            List<OrganizationRoleAssignment> assignments,
+            String targetGroupId) {
+        List<String> assigneeIds = assignments.stream()
+                .map(assignment -> assignment.id.personId)
+                .sorted()
+                .toList();
+        return new ContentReviewPermissionDto(
+                setting != null && setting.enabled,
+                PERMISSION_CODE,
+                ROLE_CODE,
+                targetGroupId,
+                assigneeIds,
+                setting == null ? "SYNCED" : setting.projectionStatus,
+                setting == null ? null : setting.projectionError,
+                setting == null ? null : setting.projectedAt);
+    }
+
+    private static Set<String> normalize(SetContentReviewPermissionRequest request) {
+        if (request == null || request.assigneeIds() == null) {
+            throw new BadRequestException("assigneeIds list is required (can be empty)");
+        }
+        Set<String> normalized = new HashSet<>();
+        for (String personId : request.assigneeIds()) {
+            if (personId != null && !personId.isBlank()) {
+                normalized.add(personId.trim());
+            }
+        }
+        return normalized;
+    }
+
+    private static String abbreviate(String message) {
+        if (message == null || message.isBlank()) {
+            return "Alfresco projection failed";
+        }
+        return message.length() <= 500 ? message : message.substring(0, 500);
+    }
+
+    private String targetGroupFor(Organization organization) {
+        return targetGroupForTaxId(targetGroupPrefix, organization.taxId);
+    }
+
+    static String targetGroupForTaxId(String groupPrefix, String taxId) {
+        if (taxId == null || taxId.isBlank()) {
+            throw new BadRequestException(
+                    "Content-review permissions require an organization tax id");
+        }
+        String normalizedTaxId = taxId.toUpperCase(Locale.ROOT)
+                .replaceAll("[^A-Z0-9]", "");
+        return groupPrefix + normalizedTaxId;
+    }
+
+    private record OrganizationTarget(
+            Long organizationId, String alfrescoGroupId, String targetGroupId) {
+    }
+}

--- a/quarkus-srv/miot-core/src/main/resources/db/migration/core/V0.1.4__add_organization_permissions.sql
+++ b/quarkus-srv/miot-core/src/main/resources/db/migration/core/V0.1.4__add_organization_permissions.sql
@@ -1,0 +1,26 @@
+-- Modulith-owned organization permission settings and role assignments.
+-- Alfresco is a projection target only; these tables are authoritative.
+CREATE TABLE miot_core.organization_permission_settings (
+    organization_id   BIGINT       NOT NULL REFERENCES miot_core.organizations(id) ON DELETE CASCADE,
+    permission_code   VARCHAR(96)  NOT NULL,
+    enabled           BOOLEAN      NOT NULL DEFAULT false,
+    projection_status VARCHAR(16)  NOT NULL DEFAULT 'PENDING',
+    projection_error  VARCHAR(500),
+    projected_at      TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (organization_id, permission_code),
+    CONSTRAINT chk_org_permission_projection_status
+        CHECK (projection_status IN ('PENDING', 'SYNCED', 'FAILED'))
+);
+
+CREATE TABLE miot_core.organization_role_assignments (
+    organization_id BIGINT       NOT NULL REFERENCES miot_core.organizations(id) ON DELETE CASCADE,
+    role_code       VARCHAR(96)  NOT NULL,
+    person_id       VARCHAR(255) NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (organization_id, role_code, person_id)
+);
+
+CREATE INDEX idx_org_role_assignments_role
+    ON miot_core.organization_role_assignments(role_code, organization_id);

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
@@ -1,0 +1,82 @@
+package com.microboxlabs.miot.core.permission;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microboxlabs.miot.core.alfresco.AlfrescoPerson;
+import com.microboxlabs.miot.core.alfresco.IAlfrescoDirectoryClient;
+import com.microboxlabs.miot.core.alfresco.IAlfrescoGroupAdminClient;
+import io.smallrye.mutiny.Uni;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AlfrescoGroupProjectorTest {
+
+    @Test
+    void reconcilesAllPagesWithDeterministicMembershipDelta() {
+        FakeAlfresco alfresco = new FakeAlfresco();
+        for (int index = 0; index < 51; index++) {
+            alfresco.current.add(person("existing-" + index));
+        }
+        AlfrescoGroupProjector projector = new AlfrescoGroupProjector(alfresco, alfresco);
+
+        projector.reconcile(
+                "GROUP_MINTRAL_AUTO_APPROVERS",
+                "Multimedia content auto approvers",
+                Set.of("existing-0", "new-user"))
+                .await().indefinitely();
+
+        assertEquals(List.of("GROUP_MINTRAL_AUTO_APPROVERS"), alfresco.createdGroups);
+        assertEquals(List.of("new-user"), alfresco.added);
+        assertEquals(50, alfresco.removed.size());
+        assertEquals(List.of(0, 50), alfresco.requestedOffsets);
+    }
+
+    private static AlfrescoPerson person(String id) {
+        return new AlfrescoPerson(id, id, null, null, id);
+    }
+
+    private static final class FakeAlfresco
+            implements IAlfrescoDirectoryClient, IAlfrescoGroupAdminClient {
+
+        private final List<AlfrescoPerson> current = new ArrayList<>();
+        private final List<String> createdGroups = new ArrayList<>();
+        private final List<String> added = new ArrayList<>();
+        private final List<String> removed = new ArrayList<>();
+        private final List<Integer> requestedOffsets = new ArrayList<>();
+
+        @Override
+        public Uni<List<AlfrescoPerson>> listGroupMembers(
+                String groupId, int maxItems, int skipCount) {
+            requestedOffsets.add(skipCount);
+            int end = Math.min(skipCount + maxItems, current.size());
+            return Uni.createFrom().item(skipCount >= current.size()
+                    ? List.of()
+                    : List.copyOf(current.subList(skipCount, end)));
+        }
+
+        @Override
+        public Uni<List<AlfrescoPerson>> searchPeople(String query, int maxItems) {
+            return Uni.createFrom().item(List.of());
+        }
+
+        @Override
+        public Uni<String> createGroup(String groupId, String displayName) {
+            createdGroups.add(groupId);
+            return Uni.createFrom().item(groupId);
+        }
+
+        @Override
+        public Uni<Void> addGroupMember(String groupId, String personId) {
+            added.add(personId);
+            return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public Uni<Void> removeGroupMember(String groupId, String personId) {
+            removed.add(personId);
+            return Uni.createFrom().voidItem();
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionServiceTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionServiceTest.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.core.permission;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+class ContentReviewPermissionServiceTest {
+
+    @Test
+    void derivesTheSameScopedGroupForFormattedAndNormalizedTaxIds() {
+        String prefix = "GROUP_MINTRAL_AUTO_APPROVERS_";
+
+        assertEquals(
+                "GROUP_MINTRAL_AUTO_APPROVERS_77856310K",
+                ContentReviewPermissionService.targetGroupForTaxId(prefix, "77.856.310-k"));
+        assertEquals(
+                "GROUP_MINTRAL_AUTO_APPROVERS_77856310K",
+                ContentReviewPermissionService.targetGroupForTaxId(prefix, "77856310-K"));
+    }
+
+    @Test
+    void rejectsOrganizationsWithoutATaxId() {
+        assertThrows(BadRequestException.class,
+                () -> ContentReviewPermissionService.targetGroupForTaxId("GROUP_", null));
+    }
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/permissions/content-review-auto-approval/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/permissions/content-review-auto-approval/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+
+const suffix = "/permissions/content-review-auto-approval";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  const { orgId } = await params;
+  return forwardToQuarkus(`/api/v1/orgs/${encodeURIComponent(orgId)}${suffix}`);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  const { orgId } = await params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(
+    `/api/v1/orgs/${encodeURIComponent(orgId)}${suffix}`,
+    { method: "PUT", body }
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  HiCheckCircle,
+  HiExclamationCircle,
+  HiPhotograph,
+} from "react-icons/hi";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { useContentReviewPermission } from "../hooks/use-content-review-permission";
+import type { OrgMember } from "../types";
+
+interface ContentReviewPermissionCardProps {
+  readonly orgSlug: string;
+  readonly members: OrgMember[];
+  readonly membersLoading: boolean;
+  readonly dict: I18nRecord;
+}
+
+export default function ContentReviewPermissionCard({
+  orgSlug,
+  members,
+  membersLoading,
+  dict,
+}: ContentReviewPermissionCardProps) {
+  const permissionDict = dict?.contentReviewPermission as I18nRecord;
+  const { permission, isLoading, isSaving, error, save } =
+    useContentReviewPermission(orgSlug);
+  const [enabled, setEnabled] = useState(false);
+  const [assigneeIds, setAssigneeIds] = useState<Set<string>>(new Set());
+  const [saveError, setSaveError] = useState(false);
+
+  useEffect(() => {
+    if (!permission) return;
+    setEnabled(permission.enabled);
+    setAssigneeIds(new Set(permission.assigneeIds));
+  }, [permission]);
+
+  const toggleAssignee = (personId: string) => {
+    setAssigneeIds((current) => {
+      const next = new Set(current);
+      if (next.has(personId)) next.delete(personId);
+      else next.add(personId);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaveError(false);
+    try {
+      await save({ enabled, assigneeIds: [...assigneeIds].sort() });
+    } catch {
+      setSaveError(true);
+    }
+  };
+
+  const busy = isLoading || membersLoading;
+  const memberIds = new Set(members.map((member) => member.id));
+  const unavailableAssigneeIds = [...assigneeIds]
+    .filter((personId) => !memberIds.has(personId))
+    .sort();
+  const hasAssigneesToRender =
+    members.length > 0 || unavailableAssigneeIds.length > 0;
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <HiPhotograph className="mt-0.5 h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" />
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-900 dark:text-white">
+            {tr("title", permissionDict)}
+          </h2>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {tr("description", permissionDict)}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {busy && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {tr("loading", dict)}
+          </p>
+        )}
+        {!busy && error && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {tr("loadError", permissionDict)}
+          </p>
+        )}
+        {!busy && !error && (
+          <>
+            <label className="flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(event) => setEnabled(event.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-900 dark:text-white">
+                  {tr("enabledLabel", permissionDict)}
+                </span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400">
+                  {tr("enabledHelp", permissionDict)}
+                </span>
+              </span>
+            </label>
+
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                {tr("assigneesLabel", permissionDict)}
+              </p>
+              {!hasAssigneesToRender ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {tr("noMembers", permissionDict)}
+                </p>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {members.map((member) => (
+                    <label
+                      key={member.id}
+                      className="flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 px-3 py-2 dark:border-gray-700"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={assigneeIds.has(member.id)}
+                        onChange={() => toggleAssignee(member.id)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm text-gray-900 dark:text-white">
+                          {member.displayName || member.email}
+                        </span>
+                        <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+                          {member.email}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                  {unavailableAssigneeIds.map((personId) => (
+                    <label
+                      key={personId}
+                      className="flex cursor-pointer items-center gap-2 rounded-md border border-amber-300 px-3 py-2 dark:border-amber-700"
+                    >
+                      <input
+                        type="checkbox"
+                        checked
+                        onChange={() => toggleAssignee(personId)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm text-gray-900 dark:text-white">
+                          {personId}
+                        </span>
+                        <span className="block text-xs text-amber-700 dark:text-amber-300">
+                          {tr("unavailableMember", permissionDict)}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {permission?.projectionStatus === "FAILED" && (
+              <p className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300">
+                <HiExclamationCircle className="h-4 w-4 shrink-0" />
+                {tr("projectionFailed", permissionDict)}
+              </p>
+            )}
+            {permission?.projectionStatus === "SYNCED" &&
+              permission.projectedAt && (
+                <p className="flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-300">
+                  <HiCheckCircle className="h-4 w-4 shrink-0" />
+                  {tr("projectionSynced", permissionDict)}
+                </p>
+              )}
+            {saveError && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {tr("saveError", permissionDict)}
+              </p>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSaving
+                  ? tr("saving", permissionDict)
+                  : tr("save", permissionDict)}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
@@ -49,7 +49,12 @@ export default function ContentReviewPermissionCard({
   const handleSave = async () => {
     setSaveError(false);
     try {
-      await save({ enabled, assigneeIds: [...assigneeIds].sort() });
+      await save({
+        enabled,
+        assigneeIds: [...assigneeIds].sort((left, right) =>
+          left.localeCompare(right)
+        ),
+      });
     } catch {
       setSaveError(true);
     }
@@ -59,7 +64,7 @@ export default function ContentReviewPermissionCard({
   const memberIds = new Set(members.map((member) => member.id));
   const unavailableAssigneeIds = [...assigneeIds]
     .filter((personId) => !memberIds.has(personId))
-    .sort();
+    .sort((left, right) => left.localeCompare(right));
   const hasAssigneesToRender =
     members.length > 0 || unavailableAssigneeIds.length > 0;
 
@@ -90,22 +95,30 @@ export default function ContentReviewPermissionCard({
         )}
         {!busy && !error && (
           <>
-            <label className="flex cursor-pointer items-start gap-3">
+            <div className="flex items-start gap-3">
               <input
                 type="checkbox"
                 checked={enabled}
                 onChange={(event) => setEnabled(event.target.checked)}
+                aria-labelledby="content-review-enabled-label"
+                aria-describedby="content-review-enabled-help"
                 className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600"
               />
               <span>
-                <span className="block text-sm font-medium text-gray-900 dark:text-white">
+                <span
+                  id="content-review-enabled-label"
+                  className="block text-sm font-medium text-gray-900 dark:text-white"
+                >
                   {tr("enabledLabel", permissionDict)}
                 </span>
-                <span className="block text-xs text-gray-500 dark:text-gray-400">
+                <span
+                  id="content-review-enabled-help"
+                  className="block text-xs text-gray-500 dark:text-gray-400"
+                >
                   {tr("enabledHelp", permissionDict)}
                 </span>
               </span>
-            </label>
+            </div>
 
             <div>
               <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
@@ -118,14 +131,15 @@ export default function ContentReviewPermissionCard({
               ) : (
                 <div className="grid gap-2 sm:grid-cols-2">
                   {members.map((member) => (
-                    <label
+                    <div
                       key={member.id}
-                      className="flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 px-3 py-2 dark:border-gray-700"
+                      className="flex items-center gap-2 rounded-md border border-gray-200 px-3 py-2 dark:border-gray-700"
                     >
                       <input
                         type="checkbox"
                         checked={assigneeIds.has(member.id)}
                         onChange={() => toggleAssignee(member.id)}
+                        aria-label={member.displayName || member.email}
                         className="h-4 w-4 rounded border-gray-300 text-blue-600"
                       />
                       <span className="min-w-0">
@@ -136,17 +150,21 @@ export default function ContentReviewPermissionCard({
                           {member.email}
                         </span>
                       </span>
-                    </label>
+                    </div>
                   ))}
                   {unavailableAssigneeIds.map((personId) => (
-                    <label
+                    <div
                       key={personId}
-                      className="flex cursor-pointer items-center gap-2 rounded-md border border-amber-300 px-3 py-2 dark:border-amber-700"
+                      className="flex items-center gap-2 rounded-md border border-amber-300 px-3 py-2 dark:border-amber-700"
                     >
                       <input
                         type="checkbox"
                         checked
                         onChange={() => toggleAssignee(personId)}
+                        aria-label={`${personId}: ${tr(
+                          "unavailableMember",
+                          permissionDict
+                        )}`}
                         className="h-4 w-4 rounded border-gray-300 text-blue-600"
                       />
                       <span className="min-w-0">
@@ -157,7 +175,7 @@ export default function ContentReviewPermissionCard({
                           {tr("unavailableMember", permissionDict)}
                         </span>
                       </span>
-                    </label>
+                    </div>
                   ))}
                 </div>
               )}

--- a/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
@@ -8,9 +8,11 @@ import MembersList from "./members-list";
 import ModulesList from "./modules-list";
 import GpsWebhookCard from "../gps-webhooks/gps-webhook-card";
 import WhatsAppChannelCard from "../whatsapp/whatsapp-channel-card";
+import ContentReviewPermissionCard from "./content-review-permission-card";
+import type { OrgSummary } from "../types";
 
 interface OrgDetailPanelProps {
-  readonly orgSlug: string | null;
+  readonly organization: OrgSummary | null;
   readonly dict: I18nRecord;
 }
 
@@ -19,7 +21,11 @@ interface OrgDetailPanelProps {
  * modules. Both sections load independently via SWR; the hooks skip the
  * fetch when orgSlug is null.
  */
-export default function OrgDetailPanel({ orgSlug, dict }: OrgDetailPanelProps) {
+export default function OrgDetailPanel({
+  organization,
+  dict,
+}: OrgDetailPanelProps) {
+  const orgSlug = organization?.slug ?? null;
   const {
     members,
     isLoading: membersLoading,
@@ -47,6 +53,14 @@ export default function OrgDetailPanel({ orgSlug, dict }: OrgDetailPanelProps) {
         error={modulesError}
         dict={dict}
       />
+      {organization?.taxId && (
+        <ContentReviewPermissionCard
+          orgSlug={orgSlug}
+          members={members}
+          membersLoading={membersLoading}
+          dict={dict}
+        />
+      )}
       <WhatsAppChannelCard orgSlug={orgSlug} dict={dict} />
       <GpsWebhookCard orgSlug={orgSlug} dict={dict} />
       <MembersList

--- a/turbo-repo/apps/app/src/features/settings-admin/components/organizations-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/organizations-page-content.tsx
@@ -39,6 +39,8 @@ export default function OrganizationsPageContent({
 
   const orgsDict = dict?.organizations as I18nRecord;
   const breadcrumbDict = dict?.breadcrumb as I18nRecord;
+  const selectedOrganization =
+    availableOrgs.find((org) => org.slug === selectedSlug) ?? null;
 
   return (
     <div className="flex flex-col h-full p-6 gap-4">
@@ -77,7 +79,7 @@ export default function OrganizationsPageContent({
           onSelect={setSelectedSlug}
           dict={orgsDict}
         />
-        <OrgDetailPanel orgSlug={selectedSlug} dict={orgsDict} />
+        <OrgDetailPanel organization={selectedOrganization} dict={orgsDict} />
       </div>
     </div>
   );

--- a/turbo-repo/apps/app/src/features/settings-admin/data/settings-admin-data-service.test.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/data/settings-admin-data-service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchContentReviewPermission,
+  updateContentReviewPermission,
+} from "./settings-admin-data-service";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("content review permission data service", () => {
+  const response = {
+    enabled: true,
+    permissionCode: "CONTENT_MULTIMEDIA_REVIEW_AUTO_APPROVE",
+    roleCode: "CONTENT_REVIEW_AUTO_APPROVER",
+    alfrescoGroupId: "GROUP_MINTRAL_AUTO_APPROVERS_77856310K",
+    assigneeIds: ["reviewer@example.com"],
+    projectionStatus: "SYNCED",
+    projectionError: null,
+    projectedAt: "2026-07-21T12:00:00Z",
+  };
+
+  it("loads the organization-scoped setting", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => response });
+
+    await expect(fetchContentReviewPermission("acme chile")).resolves.toEqual(
+      response
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/app/api/admin/orgs/acme%20chile/permissions/content-review-auto-approval"
+    );
+  });
+
+  it("replaces the setting with JSON", async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => response });
+
+    await updateContentReviewPermission("acme", {
+      enabled: true,
+      assigneeIds: ["reviewer@example.com"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/app/api/admin/orgs/acme/permissions/content-review-auto-approval",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          assigneeIds: ["reviewer@example.com"],
+        }),
+      }
+    );
+  });
+});

--- a/turbo-repo/apps/app/src/features/settings-admin/data/settings-admin-data-service.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/data/settings-admin-data-service.ts
@@ -1,6 +1,10 @@
 "use client";
 
-import type { OrgMember } from "../types";
+import type {
+  ContentReviewPermission,
+  OrgMember,
+  SetContentReviewPermission,
+} from "../types";
 
 /**
  * Thin client-side fetch wrappers around the Next.js admin proxy routes.
@@ -33,14 +37,46 @@ async function getJson<T>(url: string): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function putJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new ApiError({ status: res.status, url });
+  }
+  return (await res.json()) as T;
+}
+
 export function fetchOrgMembers(orgSlug: string): Promise<OrgMember[]> {
   return getJson<OrgMember[]>(
-    `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/members`,
+    `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/members`
   );
 }
 
 export function fetchOrgModules(orgSlug: string): Promise<string[]> {
   return getJson<string[]>(
-    `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/modules`,
+    `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/modules`
+  );
+}
+
+function contentReviewPermissionUrl(orgSlug: string): string {
+  return `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/permissions/content-review-auto-approval`;
+}
+
+export function fetchContentReviewPermission(
+  orgSlug: string
+): Promise<ContentReviewPermission> {
+  return getJson<ContentReviewPermission>(contentReviewPermissionUrl(orgSlug));
+}
+
+export function updateContentReviewPermission(
+  orgSlug: string,
+  value: SetContentReviewPermission
+): Promise<ContentReviewPermission> {
+  return putJson<ContentReviewPermission>(
+    contentReviewPermissionUrl(orgSlug),
+    value
   );
 }

--- a/turbo-repo/apps/app/src/features/settings-admin/hooks/use-content-review-permission.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/hooks/use-content-review-permission.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import {
+  fetchContentReviewPermission,
+  updateContentReviewPermission,
+} from "../data/settings-admin-data-service";
+import type {
+  ContentReviewPermission,
+  SetContentReviewPermission,
+} from "../types";
+
+export function useContentReviewPermission(orgSlug: string | null) {
+  const [isSaving, setIsSaving] = useState(false);
+  const { data, error, isLoading, mutate } = useSWR<
+    ContentReviewPermission,
+    Error
+  >(
+    orgSlug ? ["content-review-permission", orgSlug] : null,
+    ([, slug]: [string, string]) => fetchContentReviewPermission(slug),
+    { revalidateOnFocus: false, revalidateOnReconnect: false }
+  );
+
+  const save = async (value: SetContentReviewPermission) => {
+    if (!orgSlug) return;
+    setIsSaving(true);
+    try {
+      const updated = await updateContentReviewPermission(orgSlug, value);
+      await mutate(updated, { revalidate: false });
+      return updated;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    permission: data,
+    isLoading,
+    isSaving,
+    error: error ?? null,
+    save,
+  };
+}

--- a/turbo-repo/apps/app/src/features/settings-admin/types.ts
+++ b/turbo-repo/apps/app/src/features/settings-admin/types.ts
@@ -25,3 +25,19 @@ export interface OrgMember {
   lastName: string;
   displayName: string;
 }
+
+export interface ContentReviewPermission {
+  enabled: boolean;
+  permissionCode: string;
+  roleCode: string;
+  alfrescoGroupId: string;
+  assigneeIds: string[];
+  projectionStatus: "PENDING" | "SYNCED" | "FAILED";
+  projectionError: string | null;
+  projectedAt: string | null;
+}
+
+export interface SetContentReviewPermission {
+  enabled: boolean;
+  assigneeIds: string[];
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1272,6 +1272,21 @@
         "modulesTitle": "Modules",
         "modulesDescription": "Enabled product modules for this organization.",
         "modulesEmpty": "No modules enabled.",
+        "contentReviewPermission": {
+          "title": "Multimedia review permission",
+          "description": "Choose which organization members may have their multimedia reviews approved automatically. ModularIoT owns the setting and synchronizes it to Alfresco.",
+          "loadError": "Couldn't load the multimedia review permission.",
+          "enabledLabel": "Enable automatic approval",
+          "enabledHelp": "Assigned members receive the Content Review Auto Approver role while this setting is enabled.",
+          "assigneesLabel": "Role assignees",
+          "noMembers": "Add members to the organization before assigning this role.",
+          "unavailableMember": "No longer an organization member; uncheck to remove",
+          "projectionFailed": "The setting was saved, but Alfresco synchronization failed. Saving again will retry it.",
+          "projectionSynced": "Synchronized with Alfresco.",
+          "saveError": "Couldn't save the permission.",
+          "save": "Save permission",
+          "saving": "Saving…"
+        },
         "whatsappChannel": {
           "title": "WhatsApp Channel",
           "description": "Configure and test the WhatsApp connection used to reach drivers.",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1272,6 +1272,21 @@
         "modulesTitle": "Módulos",
         "modulesDescription": "Módulos de producto habilitados para esta organización.",
         "modulesEmpty": "No hay módulos habilitados.",
+        "contentReviewPermission": {
+          "title": "Permiso de revisión multimedia",
+          "description": "Elige qué miembros de la organización pueden aprobar automáticamente sus revisiones multimedia. ModularIoT administra la configuración y la sincroniza con Alfresco.",
+          "loadError": "No se pudo cargar el permiso de revisión multimedia.",
+          "enabledLabel": "Habilitar aprobación automática",
+          "enabledHelp": "Los miembros asignados reciben el rol de aprobación automática de contenido mientras esta opción esté habilitada.",
+          "assigneesLabel": "Usuarios asignados al rol",
+          "noMembers": "Agrega miembros a la organización antes de asignar este rol.",
+          "unavailableMember": "Ya no pertenece a la organización; desmarca para eliminar",
+          "projectionFailed": "La configuración se guardó, pero falló la sincronización con Alfresco. Guardar nuevamente volverá a intentarlo.",
+          "projectionSynced": "Sincronizado con Alfresco.",
+          "saveError": "No se pudo guardar el permiso.",
+          "save": "Guardar permiso",
+          "saving": "Guardando…"
+        },
         "whatsappChannel": {
           "title": "Canal WhatsApp",
           "description": "Configura y prueba la conexión de WhatsApp para contactar a los conductores.",


### PR DESCRIPTION
Closes #945

## What changed

- adds Modulith-owned organization permission settings and `CONTENT_REVIEW_AUTO_APPROVER` role assignments
- exposes an organization-scoped GET/PUT API protected by the existing parent `SITE_MANAGER` authorization
- projects enabled assignees idempotently to `GROUP_MINTRAL_AUTO_APPROVERS_<normalized tax id>` in Alfresco
- records projection status/errors while retaining PostgreSQL as the source of truth
- adds the apps/app settings card, proxy route, data hook, and English/Spanish translations
- scopes the setting to organizations with a tax ID so it aligns with the ECM behavior in microboxlabs/ecm-coordinator#332

## Why

Multimedia auto-approval must be configurable by organization without making Alfresco the permission authority. ModularIoT now governs role assignments and uses Alfresco only as the destination required by the repository behavior.

## Validation

- `mvn -pl miot-core -am -Dtest=AlfrescoGroupProjectorTest,ContentReviewPermissionServiceTest test`
- `npm run check-types --workspace=@modulariot/app`
- focused Vitest data-service tests
- ESLint on all changed apps/app files
- `git diff --check`

## Known baseline limitations

- the full Quarkus test suite requires a running Docker datasource in this environment
- full `miot-cli` packaging reaches Quarkus augmentation but is currently blocked by an unrelated existing CDI record producer error in `RetransmitDeliverySettings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-level settings for enabling automatic multimedia content-review approval.
  * Administrators can assign organization members as approval users and save changes from the organization details panel.
  * Added synchronization status and error feedback for permission updates.
  * Added English and Spanish interface text for the new settings.

* **Bug Fixes**
  * Group creation now handles existing groups without failing, improving permission synchronization reliability.

* **Tests**
  * Added coverage for permission updates, member synchronization, pagination, and organization tax ID normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->