### PR TITLE
feat(calendar): sync-status dot on planned-service chips

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
@@ -101,20 +101,21 @@ describe("PlannedServiceChip — sync status dot", () => {
   it("renders a grey dot for a PENDING sync", () => {
     renderChip(undefined, "PENDING");
     const dot = screen.getByLabelText("sync-status-pending");
-    expect(dot.className).toContain("bg-gray-400");
+    expect(dot.getAttribute("class")).toContain("text-gray-400");
   });
 
   it("renders a green dot for a CONFIRMED sync", () => {
     renderChip(undefined, "CONFIRMED");
     const dot = screen.getByLabelText("sync-status-confirmed");
-    expect(dot.className).toContain("bg-emerald-500");
+    expect(dot.getAttribute("class")).toContain("text-emerald-500");
   });
 
   it("renders a red dot for a REJECTED sync and shows the reason on hover", () => {
     renderChip(undefined, "REJECTED", "CONDUCTOR2 NO EXISTE");
     const dot = screen.getByLabelText("sync-status-rejected");
-    expect(dot.className).toContain("bg-red-500");
-    expect(dot.getAttribute("title")).toContain("CONDUCTOR2 NO EXISTE");
+    expect(dot.getAttribute("class")).toContain("text-red-500");
+    // Reason tooltip lives on the wrapper.
+    expect(screen.getByTitle(/CONDUCTOR2 NO EXISTE/)).toBeTruthy();
   });
 
   it("shows the sync dot independently of the workflow stage", () => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
@@ -10,7 +10,11 @@ vi.mock("@microboxlabs/miot-calendar-ui", () => ({
 import { PlannedServiceChip } from "./planned-service-chip";
 import type { PlannedService } from "./planning-selection-context";
 
-function plannedService(workflowStage?: string): PlannedService {
+function plannedService(
+  workflowStage?: string,
+  syncStatus?: PlannedService["syncStatus"],
+  syncDetail?: string
+): PlannedService {
   return {
     service: {
       id: "1658427-V",
@@ -34,13 +38,19 @@ function plannedService(workflowStage?: string): PlannedService {
     },
     slot: { date: new Date("2026-07-13T00:00:00Z"), hour: 5, minutes: 0 },
     ...(workflowStage ? { workflowStage } : {}),
+    ...(syncStatus ? { syncStatus } : {}),
+    ...(syncDetail ? { syncDetail } : {}),
   };
 }
 
-function renderChip(workflowStage?: string) {
+function renderChip(
+  workflowStage?: string,
+  syncStatus?: PlannedService["syncStatus"],
+  syncDetail?: string
+) {
   return render(
     <PlannedServiceChip
-      plannedService={plannedService(workflowStage)}
+      plannedService={plannedService(workflowStage, syncStatus, syncDetail)}
       onContextMenu={vi.fn()}
       dict={{}}
     />
@@ -79,5 +89,37 @@ describe("PlannedServiceChip — workflow stage rendering", () => {
   it("keeps planning-segment stages on the plain look", () => {
     renderChip("assignDriver");
     expect(screen.queryByLabelText(/^workflow-stage-/)).toBeNull();
+  });
+});
+
+describe("PlannedServiceChip — sync status dot", () => {
+  it("renders no sync dot when the booking is untracked", () => {
+    renderChip();
+    expect(screen.queryByLabelText(/^sync-status-/)).toBeNull();
+  });
+
+  it("renders a grey dot for a PENDING sync", () => {
+    renderChip(undefined, "PENDING");
+    const dot = screen.getByLabelText("sync-status-pending");
+    expect(dot.className).toContain("bg-gray-400");
+  });
+
+  it("renders a green dot for a CONFIRMED sync", () => {
+    renderChip(undefined, "CONFIRMED");
+    const dot = screen.getByLabelText("sync-status-confirmed");
+    expect(dot.className).toContain("bg-emerald-500");
+  });
+
+  it("renders a red dot for a REJECTED sync and shows the reason on hover", () => {
+    renderChip(undefined, "REJECTED", "CONDUCTOR2 NO EXISTE");
+    const dot = screen.getByLabelText("sync-status-rejected");
+    expect(dot.className).toContain("bg-red-500");
+    expect(dot.getAttribute("title")).toContain("CONDUCTOR2 NO EXISTE");
+  });
+
+  it("shows the sync dot independently of the workflow stage", () => {
+    renderChip("finished", "REJECTED");
+    expect(screen.getByLabelText("workflow-stage-finished")).toBeTruthy();
+    expect(screen.getByLabelText("sync-status-rejected")).toBeTruthy();
   });
 });

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -7,6 +7,7 @@ import {
   IoNavigate,
   IoCheckmarkCircle,
   IoCloseCircle,
+  IoEllipse,
 } from "react-icons/io5";
 import { useScrollIntoViewWhen } from "@microboxlabs/miot-calendar-ui";
 import type { PlannedService } from "./planning-selection-context";
@@ -97,9 +98,9 @@ const SYNC_DOT_COLOR: Record<
   NonNullable<PlannedService["syncStatus"]>,
   string
 > = {
-  PENDING: "bg-gray-400 dark:bg-gray-500",
-  CONFIRMED: "bg-emerald-500 dark:bg-emerald-400",
-  REJECTED: "bg-red-500 dark:bg-red-400",
+  PENDING: "text-gray-400 dark:text-gray-500",
+  CONFIRMED: "text-emerald-500 dark:text-emerald-400",
+  REJECTED: "text-red-500 dark:text-red-400",
 };
 
 /**
@@ -340,15 +341,15 @@ export function PlannedServiceChip({
         />
       )}
       {sync && (
-        <span
-          role="img"
-          aria-label={sync.ariaLabel}
-          title={sync.title}
-          className={twMerge(
-            "ml-1 shrink-0 w-2 h-2 rounded-full",
-            sync.colorClass
-          )}
-        />
+        // Wrapper carries the hover tooltip (the reason for a REJECTED sync);
+        // the icon carries the accessible name. Matches the react-icons +
+        // aria-label convention of the workflow-stage indicators above.
+        <span title={sync.title} className="ml-1 shrink-0 flex items-center">
+          <IoEllipse
+            aria-label={sync.ariaLabel}
+            className={twMerge("w-2.5 h-2.5", sync.colorClass)}
+          />
+        </span>
       )}
     </button>
   );

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -85,6 +85,45 @@ interface StageIndicator {
   readonly titleSuffix: string;
 }
 
+/** Sync-status dot presentation: color family + tooltip + a11y label. */
+interface SyncIndicator {
+  readonly colorClass: string;
+  readonly title: string;
+  readonly ariaLabel: string;
+}
+
+/** dot color per downstream ack — grey pending, green confirmed, red rejected. */
+const SYNC_DOT_COLOR: Record<
+  NonNullable<PlannedService["syncStatus"]>,
+  string
+> = {
+  PENDING: "bg-gray-400 dark:bg-gray-500",
+  CONFIRMED: "bg-emerald-500 dark:bg-emerald-400",
+  REJECTED: "bg-red-500 dark:bg-red-400",
+};
+
+/**
+ * Downstream sync acknowledgement → status-dot presentation. Null = untracked
+ * (no external mirror / legacy booking): the chip shows no dot. A REJECTED dot
+ * appends the reason to its tooltip so a hover explains why the slot is
+ * "planned but unconfirmed".
+ */
+function getSyncIndicator(
+  syncStatus: PlannedService["syncStatus"],
+  syncDetail: string | undefined,
+  dict: I18nRecord
+): SyncIndicator | null {
+  if (!syncStatus) return null;
+  const key = syncStatus.toLowerCase();
+  const label = tr(`pages.planning.sidebar.syncStatus.${key}`, dict);
+  return {
+    colorClass: SYNC_DOT_COLOR[syncStatus],
+    title:
+      syncStatus === "REJECTED" && syncDetail ? `${label}: ${syncDetail}` : label,
+    ariaLabel: `sync-status-${key}`,
+  };
+}
+
 function getStageIndicator(
   workflowStage: string | undefined,
   dict: I18nRecord
@@ -159,6 +198,14 @@ export function PlannedServiceChip({
   // with the per-resource breakdown as tooltip. Unknown levels (legacy
   // bookings) render nothing.
   const accreditation = getAssignmentAccreditation(plannedService.service);
+  // Downstream sync ack (grey pending / green confirmed / red rejected).
+  // Untracked bookings render no dot. A red dot means the slot is planned but
+  // the external system refused its current data — hover shows the reason.
+  const sync = getSyncIndicator(
+    plannedService.syncStatus,
+    plannedService.syncDetail,
+    dict
+  );
 
   return (
     <button
@@ -290,6 +337,17 @@ export function PlannedServiceChip({
         <IoCloseCircle
           aria-label="workflow-stage-cancelled"
           className="ml-1 shrink-0 w-4 h-4 text-red-500 dark:text-red-400"
+        />
+      )}
+      {sync && (
+        <span
+          role="img"
+          aria-label={sync.ariaLabel}
+          title={sync.title}
+          className={twMerge(
+            "ml-1 shrink-0 w-2 h-2 rounded-full",
+            sync.colorClass
+          )}
         />
       )}
     </button>

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
@@ -57,3 +57,29 @@ describe("mapBookingToPlannedService — workflowStage from booking status", () 
     expect(mapBookingToPlannedService(slotless)).toBeNull();
   });
 });
+
+describe("mapBookingToPlannedService — sync status", () => {
+  it("leaves syncStatus unset for untracked bookings (no external mirror)", () => {
+    const mapped = mapBookingToPlannedService(booking());
+    expect(mapped?.planned.syncStatus).toBeUndefined();
+    expect(mapped?.planned.syncDetail).toBeUndefined();
+  });
+
+  it("carries CONFIRMED through the map", () => {
+    const mapped = mapBookingToPlannedService(booking({ syncStatus: "CONFIRMED" }));
+    expect(mapped?.planned.syncStatus).toBe("CONFIRMED");
+  });
+
+  it("carries REJECTED and its detail through the map", () => {
+    const mapped = mapBookingToPlannedService(
+      booking({ syncStatus: "REJECTED", syncDetail: "CONDUCTOR2 NO EXISTE" })
+    );
+    expect(mapped?.planned.syncStatus).toBe("REJECTED");
+    expect(mapped?.planned.syncDetail).toBe("CONDUCTOR2 NO EXISTE");
+  });
+
+  it("carries PENDING through the map", () => {
+    const mapped = mapBookingToPlannedService(booking({ syncStatus: "PENDING" }));
+    expect(mapped?.planned.syncStatus).toBe("PENDING");
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
@@ -148,6 +148,14 @@ export function mapBookingToPlannedService(
         ...(_anden === undefined ? {} : { anden: _anden }),
       },
       ...(workflowStage === undefined ? {} : { workflowStage }),
+      // Downstream sync ack rides the booking row (the integration layer is the
+      // single writer). Absent = untracked, so the chip shows no sync dot.
+      ...(booking.syncStatus === undefined
+        ? {}
+        : { syncStatus: booking.syncStatus }),
+      ...(booking.syncDetail === undefined
+        ? {}
+        : { syncDetail: booking.syncDetail }),
     },
   };
 }

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -383,6 +383,12 @@
           "finished": "Finished",
           "cancelled": "Cancelled"
         },
+        "syncStatus": {
+          "label": "Sync",
+          "pending": "Sync pending",
+          "confirmed": "Synced",
+          "rejected": "Sync rejected"
+        },
         "contextMenu": {
           "service": "Service",
           "chipTitle": "Right-click for options",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -383,6 +383,12 @@
           "finished": "Finalizado",
           "cancelled": "Cancelado"
         },
+        "syncStatus": {
+          "label": "Sincronización",
+          "pending": "Sincronización pendiente",
+          "confirmed": "Sincronizado",
+          "rejected": "Sincronización rechazada"
+        },
         "contextMenu": {
           "service": "Servicio",
           "chipTitle": "Clic derecho para opciones",

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -72,12 +72,27 @@ export type BookingStatus =
   | "FINISHED"
   | "CANCELLED";
 
+/**
+ * External-system acknowledgement of the booking's current data (CALSYNC).
+ * Orthogonal to the monotonic {@link BookingStatus}: a booking can be ASSIGNED
+ * yet unconfirmed downstream, and a data change legitimately drops back to
+ * PENDING. Absent (field omitted) = untracked — calendars with no external
+ * mirror, or bookings created before the feature.
+ */
+export type BookingSyncStatus = "PENDING" | "CONFIRMED" | "REJECTED";
+
 export interface BookingResponse {
   id: string;
   calendarId: string;
   resource: ResourceData;
   slot: SlotData;
   status?: BookingStatus;
+  /** External-system acknowledgement of the booking's current data. */
+  syncStatus?: BookingSyncStatus;
+  /** Acknowledgement/rejection detail (e.g. the downstream refusal reason). */
+  syncDetail?: string;
+  /** ISO timestamp of the last syncStatus transition. */
+  syncAt?: string;
   createdAt: string;
   createdBy?: string;
   updatedAt?: string;

--- a/turbo-repo/packages/miot-calendar-ui/src/types/planning.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/types/planning.ts
@@ -2,6 +2,15 @@ import type { CalendarItem } from "./calendar-item";
 import type { SelectedSlot } from "./calendar-slot";
 
 /**
+ * Downstream acknowledgement of a planned item's current data, host-defined
+ * and orthogonal to {@link PlannedService.workflowStage}: the lifecycle can
+ * advance while the external mirror is still PENDING, and a data edit can drop
+ * a CONFIRMED item back to PENDING. Undefined = untracked (no external mirror,
+ * or an item planned before the feature).
+ */
+export type SyncStatus = "PENDING" | "CONFIRMED" | "REJECTED";
+
+/**
  * A host item that has been confirmed and placed into a grid slot. Generic over
  * the host's domain item type (defaults to the canonical {@link CalendarItem});
  * the package only relies on the item carrying a stable `id`.
@@ -19,6 +28,15 @@ export interface PlannedService<TItem extends { id: string } = CalendarItem> {
    * planned look.
    */
   workflowStage?: string;
+  /**
+   * Downstream sync acknowledgement of the item's current data (see
+   * {@link SyncStatus}), written at load time from the booking payload.
+   * Undefined = untracked. Renderers may surface it as a status dot; it does
+   * not affect placement.
+   */
+  syncStatus?: SyncStatus;
+  /** Human-readable detail for a REJECTED sync (the downstream reason). */
+  syncDetail?: string;
 }
 
 /** A planned item being reassigned, with its original slot for restoration. */


### PR DESCRIPTION
## Why

A booking can be **planned but unconfirmed downstream** — the external mirror queued it (PENDING), acknowledged it (CONFIRMED), or refused its current data (REJECTED). The backend already tracks this on `BookingResponse.syncStatus` (`BookingSyncStatus`, orthogonal to the monotonic lifecycle `status`), but the value was **dropped at every FE layer** on the way to the grid, so a planner had no way to see a service that failed to sync.

This adds the missing signal as a small colored dot on each grid chip:

- ⚪️ grey — **PENDING** (queued / in flight)
- 🟢 green — **CONFIRMED** (external system acknowledged the current data)
- 🔴 red — **REJECTED** (refused — the slot is planned but unconfirmed; hover shows the reason)
- untracked bookings (no external mirror / planned before the feature) show **no dot**

## What

Plumbing the value that already existed on the backend down to the chip:

| Layer | Change |
|---|---|
| `miot-calendar-client` | Hand-patch `syncStatus`/`syncDetail`/`syncAt` + a `BookingSyncStatus` type onto `BookingResponse` — mirrors the existing `status?` hand-patch beyond the (stale) OpenAPI export. |
| `miot-calendar-ui` | `syncStatus`/`syncDetail` + a `SyncStatus` type on the generic `PlannedService` wrapper, next to `workflowStage`. `mergeWorkflowStages` spreads `{...ps}`, so the render-time overlay preserves them. |
| `booking-service-mapper` | Carry `syncStatus`/`syncDetail` onto the mapped planned service (same conditional-spread pattern as `workflowStage`). |
| `planned-service-chip` | Render the dot in the right-side indicator cluster (`role="img"` + `aria-label`), REJECTED tooltip appends `syncDetail`. |
| `en.json` / `es.json` | `pages.planning.sidebar.syncStatus.*` keys (parity). |

No backend change (already present). Forward-compatible: chips render nothing when the field is absent, so it is safe against servers that don't yet return `syncStatus`.

## Verification

- `vitest run src/features/calendar` — **133 passed** (10 new: chip dot per status + independence from workflow stage; mapper carries `syncStatus`/`syncDetail`, unset when untracked)
- `turbo run check-types` (app + miot-calendar-ui + miot-calendar-client) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #948
