### PR TITLE
fix: support parent content review permissions

### DIFF
--- a/quarkus-srv/miot-cli/src/main/resources/application.properties
+++ b/quarkus-srv/miot-cli/src/main/resources/application.properties
@@ -206,6 +206,7 @@ miot.alfresco.basic.password=${ALFRESCO_PASSWORD:}
 # The normalized organization tax id is appended to this prefix. Keep aligned
 # with mintral.features.review.autoApprove.groupPrefix in ecm-coordinator.
 miot.permissions.content-review.alfresco-group-prefix=${MIOT_CONTENT_REVIEW_AUTO_APPROVERS_GROUP_PREFIX:GROUP_MINTRAL_AUTO_APPROVERS_}
+miot.permissions.content-review.alfresco-site-group-prefix=${MIOT_CONTENT_REVIEW_AUTO_APPROVERS_SITE_GROUP_PREFIX:GROUP_MINTRAL_AUTO_APPROVERS_SITE_}
 # REST client base — points the typed client at the public v1 core API.
 quarkus.rest-client.alfresco-core.url=${miot.alfresco.url}/api/-default-/public/alfresco/versions/1
 quarkus.rest-client.alfresco-core.connect-timeout=10000

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoDirectoryClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoDirectoryClient.java
@@ -8,7 +8,11 @@ import io.quarkus.arc.lookup.LookupUnlessProperty;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.logging.Logger;
 
@@ -18,12 +22,11 @@ import org.jboss.logging.Logger;
  * is set to anything other than {@code stub}; in {@code stub} mode the
  * {@link StubAlfrescoDirectoryClient} {@code @DefaultBean} wins.
  *
- * <p>{@code listGroupMembers} filters to {@code PERSON} entries
- * (subgroups are ignored) and then hydrates each member by calling
- * {@code GET /people/{id}}. Alfresco's group-members endpoint returns
- * only id + displayName; the admin UI needs email + firstName/lastName.
- * Hydration is bounded by {@link #MAX_PAGE_SIZE} and performed sequentially
- * to avoid unbounded outbound bursts.
+ * <p>{@code listGroupMembers} recursively expands nested groups before hydrating
+ * each distinct person through {@code GET /people/{id}}. Alfresco site groups
+ * contain role groups rather than people directly, so flattening is required to
+ * expose a useful organization roster. Traversal and hydration are sequential to
+ * avoid unbounded outbound bursts.
  */
 @ApplicationScoped
 @LookupUnlessProperty(name = "miot.alfresco.auth", stringValue = "stub", lookupIfMissing = false)
@@ -42,7 +45,30 @@ public class RealAlfrescoDirectoryClient implements IAlfrescoDirectoryClient {
     public Uni<List<AlfrescoPerson>> listGroupMembers(String groupId, int maxItems, int skipCount) {
         int safeMaxItems = sanitizeMaxItems(maxItems);
         int safeSkipCount = sanitizeSkipCount(skipCount);
-        return coreApi.listGroupMembers(groupId, safeMaxItems, safeSkipCount)
+        if (safeMaxItems == 0) {
+            return Uni.createFrom().item(List.of());
+        }
+        return collectGroupMembers(groupId, new HashSet<>(), new LinkedHashMap<>())
+                .flatMap(this::hydrateMembers)
+                .map(members -> page(members, safeMaxItems, safeSkipCount));
+    }
+
+    private Uni<Map<String, AlfrescoGroupMemberEntry>> collectGroupMembers(
+            String groupId,
+            Set<String> visitedGroups,
+            Map<String, AlfrescoGroupMemberEntry> people) {
+        if (!visitedGroups.add(groupId)) {
+            return Uni.createFrom().item(people);
+        }
+        return collectGroupPage(groupId, 0, visitedGroups, people);
+    }
+
+    private Uni<Map<String, AlfrescoGroupMemberEntry>> collectGroupPage(
+            String groupId,
+            int skipCount,
+            Set<String> visitedGroups,
+            Map<String, AlfrescoGroupMemberEntry> people) {
+        return coreApi.listGroupMembers(groupId, MAX_PAGE_SIZE, skipCount)
                 .onFailure(AlfrescoClientException.class).recoverWithItem(ex -> {
                     if (ex.isNotFound()) {
                         LOG.debugf("Group %s not found in Alfresco", groupId);
@@ -52,21 +78,39 @@ public class RealAlfrescoDirectoryClient implements IAlfrescoDirectoryClient {
                 })
                 .flatMap(response -> {
                     if (response == null) {
-                        return Uni.createFrom().item(List.<AlfrescoPerson>of());
+                        return Uni.createFrom().item(people);
                     }
-                    List<AlfrescoGroupMemberEntry> personEntries = response.unwrap().stream()
-                            .filter(m -> "PERSON".equalsIgnoreCase(m.memberType()))
-                            .toList();
-                    if (personEntries.isEmpty()) {
-                        return Uni.createFrom().item(List.of());
+                    List<AlfrescoGroupMemberEntry> entries = response.unwrap();
+                    Uni<Map<String, AlfrescoGroupMemberEntry>> chain =
+                            collectEntries(entries, visitedGroups, people);
+                    if (entries.size() < MAX_PAGE_SIZE) {
+                        return chain;
                     }
-                    return hydrateMembers(personEntries);
+                    return chain.flatMap(collected -> collectGroupPage(
+                            groupId, skipCount + MAX_PAGE_SIZE, visitedGroups, collected));
                 });
     }
 
-    private Uni<List<AlfrescoPerson>> hydrateMembers(List<AlfrescoGroupMemberEntry> members) {
+    private Uni<Map<String, AlfrescoGroupMemberEntry>> collectEntries(
+            List<AlfrescoGroupMemberEntry> entries,
+            Set<String> visitedGroups,
+            Map<String, AlfrescoGroupMemberEntry> people) {
+        Uni<Map<String, AlfrescoGroupMemberEntry>> chain = Uni.createFrom().item(people);
+        for (AlfrescoGroupMemberEntry entry : entries) {
+            if ("PERSON".equalsIgnoreCase(entry.memberType())) {
+                people.putIfAbsent(entry.id(), entry);
+            } else if ("GROUP".equalsIgnoreCase(entry.memberType())) {
+                chain = chain.flatMap(collected -> collectGroupMembers(
+                        entry.id(), visitedGroups, collected));
+            }
+        }
+        return chain;
+    }
+
+    private Uni<List<AlfrescoPerson>> hydrateMembers(
+            Map<String, AlfrescoGroupMemberEntry> members) {
         Uni<List<AlfrescoPerson>> chain = Uni.createFrom().item(new ArrayList<>());
-        for (AlfrescoGroupMemberEntry member : members) {
+        for (AlfrescoGroupMemberEntry member : members.values()) {
             chain = chain.flatMap(list -> hydrateMember(member)
                     .map(person -> {
                         list.add(person);
@@ -74,6 +118,15 @@ public class RealAlfrescoDirectoryClient implements IAlfrescoDirectoryClient {
                     }));
         }
         return chain.map(List::copyOf);
+    }
+
+    private static List<AlfrescoPerson> page(
+            List<AlfrescoPerson> members, int maxItems, int skipCount) {
+        if (skipCount >= members.size()) {
+            return List.of();
+        }
+        int end = Math.min(skipCount + maxItems, members.size());
+        return List.copyOf(members.subList(skipCount, end));
     }
 
     private Uni<AlfrescoPerson> hydrateMember(AlfrescoGroupMemberEntry member) {

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoMembershipClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoMembershipClient.java
@@ -1,0 +1,68 @@
+package com.microboxlabs.miot.core.alfresco;
+
+import io.quarkus.arc.lookup.LookupUnlessProperty;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Resolves organization membership and site roles from Alfresco groups.
+ * Active whenever the deployment selects a real Alfresco authentication mode.
+ */
+@ApplicationScoped
+@LookupUnlessProperty(name = "miot.alfresco.auth", stringValue = "stub", lookupIfMissing = false)
+public class RealAlfrescoMembershipClient implements IAlfrescoMembershipClient {
+
+    private static final int PAGE_SIZE = 50;
+    private static final String SITE_GROUP_PREFIX = "GROUP_site_";
+    private static final List<SiteRole> SITE_ROLES = List.of(
+            new SiteRole("_SiteManager", "SITE_MANAGER"),
+            new SiteRole("_SiteCollaborator", "SITE_COLLABORATOR"),
+            new SiteRole("_SiteContributor", "SITE_CONTRIBUTOR"),
+            new SiteRole("_SiteConsumer", "SITE_CONSUMER"));
+
+    private final IAlfrescoDirectoryClient directoryClient;
+
+    public RealAlfrescoMembershipClient(IAlfrescoDirectoryClient directoryClient) {
+        this.directoryClient = directoryClient;
+    }
+
+    @Override
+    public Uni<Boolean> isMember(String personId, String groupId) {
+        return getRole(personId, groupId).map(role -> role != null);
+    }
+
+    @Override
+    public Uni<String> getRole(String personId, String groupId) {
+        if (groupId.startsWith(SITE_GROUP_PREFIX)) {
+            return findSiteRole(personId, groupId, 0);
+        }
+        return containsPerson(groupId, personId, 0)
+                .map(found -> found ? "GROUP_MEMBER" : null);
+    }
+
+    private Uni<String> findSiteRole(String personId, String siteGroupId, int roleIndex) {
+        if (roleIndex >= SITE_ROLES.size()) {
+            return Uni.createFrom().nullItem();
+        }
+        SiteRole role = SITE_ROLES.get(roleIndex);
+        return containsPerson(siteGroupId + role.groupSuffix(), personId, 0)
+                .flatMap(found -> found
+                        ? Uni.createFrom().item(role.roleName())
+                        : findSiteRole(personId, siteGroupId, roleIndex + 1));
+    }
+
+    private Uni<Boolean> containsPerson(String groupId, String personId, int skipCount) {
+        return directoryClient.listGroupMembers(groupId, PAGE_SIZE, skipCount)
+                .flatMap(page -> {
+                    boolean found = page.stream().anyMatch(person -> personId.equals(person.id()));
+                    if (found || page.size() < PAGE_SIZE) {
+                        return Uni.createFrom().item(found);
+                    }
+                    return containsPerson(groupId, personId, skipCount + PAGE_SIZE);
+                });
+    }
+
+    private record SiteRole(String groupSuffix, String roleName) {
+    }
+}

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/StubAlfrescoMembershipClient.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/StubAlfrescoMembershipClient.java
@@ -7,7 +7,7 @@ import org.jboss.logging.Logger;
 
 /**
  * Stub implementation — always approves membership.
- * Active by default until a real Alfresco REST client is registered.
+ * Used only by local/test profiles that explicitly exclude the real client.
  */
 @ApplicationScoped
 @DefaultBean

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/client/AlfrescoCoreApi.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/client/AlfrescoCoreApi.java
@@ -49,9 +49,8 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 public interface AlfrescoCoreApi {
 
     /**
-     * List the direct members of an Alfresco group. Returns only
-     * {@code PERSON} entries; nested subgroups are filtered out on
-     * the caller side.
+     * List the direct members of an Alfresco group. The directory adapter
+     * recursively follows returned {@code GROUP} entries to flatten site roles.
      */
     @GET
     @Path("/groups/{groupId}/members")

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/model/AlfrescoGroupMemberEntry.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/model/AlfrescoGroupMemberEntry.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * record here ({@code id}, {@code displayName}, {@code memberType}) — it does
  * NOT include the full person projection (no email, no firstName/lastName).
  *
- * <p>{@code memberType} is {@code "PERSON"} or {@code "GROUP"}. We filter to
- * people on the caller side; nested subgroups are intentionally ignored
- * (see plan: we don't model module entitlements as nested Alfresco groups).
+ * <p>{@code memberType} is {@code "PERSON"} or {@code "GROUP"}. The directory
+ * adapter recursively expands groups because Alfresco site users are members of
+ * nested role groups rather than the site container group itself.
  *
  * <p>Admin UI consumers that need the full person projection should resolve
  * each member's {@code id} against {@code /people/{id}} separately, or use

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
@@ -41,6 +41,7 @@ public class ContentReviewPermissionService {
     private final AlfrescoGroupProjector groupProjector;
     private final WriteAuthorizer writeAuthorizer;
     private final String targetGroupPrefix;
+    private final String siteTargetGroupPrefix;
 
     @Inject
     public ContentReviewPermissionService(
@@ -49,11 +50,15 @@ public class ContentReviewPermissionService {
             WriteAuthorizer writeAuthorizer,
             @ConfigProperty(
                     name = "miot.permissions.content-review.alfresco-group-prefix",
-                    defaultValue = "GROUP_MINTRAL_AUTO_APPROVERS_") String targetGroupPrefix) {
+                    defaultValue = "GROUP_MINTRAL_AUTO_APPROVERS_") String targetGroupPrefix,
+            @ConfigProperty(
+                    name = "miot.permissions.content-review.alfresco-site-group-prefix",
+                    defaultValue = "GROUP_MINTRAL_AUTO_APPROVERS_SITE_") String siteTargetGroupPrefix) {
         this.directoryClient = directoryClient;
         this.groupProjector = groupProjector;
         this.writeAuthorizer = writeAuthorizer;
         this.targetGroupPrefix = targetGroupPrefix;
+        this.siteTargetGroupPrefix = siteTargetGroupPrefix;
     }
 
     public Uni<ContentReviewPermissionDto> get(String organizationSlug) {
@@ -240,7 +245,11 @@ public class ContentReviewPermissionService {
     }
 
     private String targetGroupFor(Organization organization) {
-        return targetGroupForTaxId(targetGroupPrefix, organization.taxId);
+        if (organization.taxId != null && !organization.taxId.isBlank()) {
+            return targetGroupForTaxId(targetGroupPrefix, organization.taxId);
+        }
+        return targetGroupForSite(
+                siteTargetGroupPrefix, organization.alfrescoGroupId);
     }
 
     static String targetGroupForTaxId(String groupPrefix, String taxId) {
@@ -251,6 +260,22 @@ public class ContentReviewPermissionService {
         String normalizedTaxId = taxId.toUpperCase(Locale.ROOT)
                 .replaceAll("[^A-Z0-9]", "");
         return groupPrefix + normalizedTaxId;
+    }
+
+    static String targetGroupForSite(String groupPrefix, String alfrescoGroupId) {
+        final String siteGroupPrefix = "GROUP_site_";
+        if (alfrescoGroupId == null || !alfrescoGroupId.startsWith(siteGroupPrefix)) {
+            throw new BadRequestException(
+                    "Parent content-review permissions require an Alfresco site group binding");
+        }
+        String siteId = alfrescoGroupId.substring(siteGroupPrefix.length())
+                .toUpperCase(Locale.ROOT)
+                .replaceAll("[^A-Z0-9]", "");
+        if (siteId.isEmpty()) {
+            throw new BadRequestException(
+                    "Parent content-review permissions require an Alfresco site id");
+        }
+        return groupPrefix + siteId;
     }
 
     private record OrganizationTarget(

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoDirectoryClientTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoDirectoryClientTest.java
@@ -1,0 +1,116 @@
+package com.microboxlabs.miot.core.alfresco;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microboxlabs.miot.core.alfresco.client.AddGroupMemberRequest;
+import com.microboxlabs.miot.core.alfresco.client.AlfrescoCoreApi;
+import com.microboxlabs.miot.core.alfresco.client.CreateGroupRequest;
+import com.microboxlabs.miot.core.alfresco.model.AlfrescoGroupMemberEntry;
+import com.microboxlabs.miot.core.alfresco.model.AlfrescoListResponse;
+import com.microboxlabs.miot.core.alfresco.model.AlfrescoPersonEntry;
+import io.smallrye.mutiny.Uni;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RealAlfrescoDirectoryClientTest {
+
+    @Test
+    void recursivelyFlattensSiteRoleGroupsAndDeduplicatesPeople() {
+        FakeAlfrescoCoreApi api = new FakeAlfrescoCoreApi();
+        RealAlfrescoDirectoryClient client = new RealAlfrescoDirectoryClient(api);
+
+        List<AlfrescoPerson> members = client.listGroupMembers(
+                "GROUP_site_mintral", 50, 0).await().indefinitely();
+
+        assertEquals(List.of("alice@example.com", "bob@example.com"),
+                members.stream().map(AlfrescoPerson::id).toList());
+        assertEquals("Alice Reviewer", members.getFirst().displayName());
+    }
+
+    @Test
+    void appliesPaginationAfterFlatteningNestedGroups() {
+        RealAlfrescoDirectoryClient client =
+                new RealAlfrescoDirectoryClient(new FakeAlfrescoCoreApi());
+
+        List<AlfrescoPerson> members = client.listGroupMembers(
+                "GROUP_site_mintral", 1, 1).await().indefinitely();
+
+        assertEquals(List.of("bob@example.com"),
+                members.stream().map(AlfrescoPerson::id).toList());
+    }
+
+    static final class FakeAlfrescoCoreApi implements AlfrescoCoreApi {
+
+        private final Map<String, List<AlfrescoGroupMemberEntry>> groups = Map.of(
+                "GROUP_site_mintral", List.of(
+                        group("GROUP_site_mintral_SiteManager"),
+                        group("GROUP_site_mintral_SiteCollaborator")),
+                "GROUP_site_mintral_SiteManager", List.of(
+                        person("alice@example.com", "Alice Reviewer")),
+                "GROUP_site_mintral_SiteCollaborator", List.of(
+                        person("bob@example.com", "Bob Operator"),
+                        person("alice@example.com", "Alice Reviewer"),
+                        group("GROUP_site_mintral")));
+
+        @Override
+        public Uni<AlfrescoListResponse<AlfrescoGroupMemberEntry>> listGroupMembers(
+                String groupId, int maxItems, int skipCount) {
+            List<AlfrescoGroupMemberEntry> entries = groups.getOrDefault(groupId, List.of());
+            int end = Math.min(skipCount + maxItems, entries.size());
+            List<AlfrescoGroupMemberEntry> page = skipCount >= entries.size()
+                    ? List.of()
+                    : entries.subList(skipCount, end);
+            return Uni.createFrom().item(response(page));
+        }
+
+        @Override
+        public Uni<SinglePersonEntry> getPerson(String personId) {
+            String firstName = personId.startsWith("alice") ? "Alice" : "Bob";
+            String lastName = personId.startsWith("alice") ? "Reviewer" : "Operator";
+            return Uni.createFrom().item(new SinglePersonEntry(new AlfrescoPersonEntry(
+                    personId, firstName, lastName, firstName + " " + lastName, personId)));
+        }
+
+        @Override
+        public Uni<AlfrescoListResponse<AlfrescoPersonEntry>> searchPeople(
+                String term, int maxItems) {
+            return unsupported();
+        }
+
+        @Override
+        public Uni<SingleGroupEntry> createGroup(CreateGroupRequest body) {
+            return unsupported();
+        }
+
+        @Override
+        public Uni<SingleMemberEntry> addGroupMember(
+                String groupId, AddGroupMemberRequest body) {
+            return unsupported();
+        }
+
+        @Override
+        public Uni<Void> removeGroupMember(String groupId, String personId) {
+            return unsupported();
+        }
+
+        private static <T> Uni<T> unsupported() {
+            return Uni.createFrom().failure(new UnsupportedOperationException());
+        }
+
+        private static AlfrescoListResponse<AlfrescoGroupMemberEntry> response(
+                List<AlfrescoGroupMemberEntry> members) {
+            List<AlfrescoListResponse.AlfrescoEntry<AlfrescoGroupMemberEntry>> entries =
+                    members.stream().map(AlfrescoListResponse.AlfrescoEntry::new).toList();
+            return new AlfrescoListResponse<>(new AlfrescoListResponse.AlfrescoList<>(entries));
+        }
+
+        private static AlfrescoGroupMemberEntry group(String id) {
+            return new AlfrescoGroupMemberEntry(id, id, "GROUP");
+        }
+
+        private static AlfrescoGroupMemberEntry person(String id, String displayName) {
+            return new AlfrescoGroupMemberEntry(id, displayName, "PERSON");
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoMembershipClientTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/alfresco/RealAlfrescoMembershipClientTest.java
@@ -1,0 +1,57 @@
+package com.microboxlabs.miot.core.alfresco;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.smallrye.mutiny.Uni;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RealAlfrescoMembershipClientTest {
+
+    @Test
+    void resolvesSiteManagerFromNestedSiteRoleGroup() {
+        RealAlfrescoMembershipClient client = new RealAlfrescoMembershipClient(
+                new FakeDirectory(Map.of(
+                        "GROUP_site_mintral_SiteManager", List.of(person("manager@example.com")))));
+
+        assertTrue(client.isMember("manager@example.com", "GROUP_site_mintral")
+                .await().indefinitely());
+        assertEquals("SITE_MANAGER", client.getRole(
+                "manager@example.com", "GROUP_site_mintral").await().indefinitely());
+    }
+
+    @Test
+    void rejectsPersonOutsideEverySiteRoleGroup() {
+        RealAlfrescoMembershipClient client =
+                new RealAlfrescoMembershipClient(new FakeDirectory(Map.of()));
+
+        assertFalse(client.isMember("outsider@example.com", "GROUP_site_mintral")
+                .await().indefinitely());
+    }
+
+    private static AlfrescoPerson person(String id) {
+        return new AlfrescoPerson(id, id, null, null, id);
+    }
+
+    private record FakeDirectory(Map<String, List<AlfrescoPerson>> groups)
+            implements IAlfrescoDirectoryClient {
+
+        @Override
+        public Uni<List<AlfrescoPerson>> listGroupMembers(
+                String groupId, int maxItems, int skipCount) {
+            List<AlfrescoPerson> members = groups.getOrDefault(groupId, List.of());
+            int end = Math.min(skipCount + maxItems, members.size());
+            return Uni.createFrom().item(skipCount >= members.size()
+                    ? List.of()
+                    : List.copyOf(members.subList(skipCount, end)));
+        }
+
+        @Override
+        public Uni<List<AlfrescoPerson>> searchPeople(String query, int maxItems) {
+            return Uni.createFrom().item(List.of());
+        }
+    }
+}

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/auth/HarnessProxyTestProfile.java
@@ -52,7 +52,8 @@ public class HarnessProxyTestProfile implements QuarkusTestProfile {
         overrides.put("miot.alfresco.auth", "stub");
         overrides.put("quarkus.arc.exclude-types",
                 "com.microboxlabs.miot.core.alfresco.RealAlfrescoDirectoryClient,"
-                        + "com.microboxlabs.miot.core.alfresco.RealAlfrescoGroupAdminClient");
+                        + "com.microboxlabs.miot.core.alfresco.RealAlfrescoGroupAdminClient,"
+                        + "com.microboxlabs.miot.core.alfresco.RealAlfrescoMembershipClient");
 
         // Permission policy: miot-core has no application.properties; without
         // these /api/* would be permit-all and the 401/403 split would not fire.

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionServiceTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionServiceTest.java
@@ -25,4 +25,19 @@ class ContentReviewPermissionServiceTest {
         assertThrows(BadRequestException.class,
                 () -> ContentReviewPermissionService.targetGroupForTaxId("GROUP_", null));
     }
+
+    @Test
+    void derivesSiteWideGroupForParentOrganization() {
+        assertEquals(
+                "GROUP_MINTRAL_AUTO_APPROVERS_SITE_MINTRAL",
+                ContentReviewPermissionService.targetGroupForSite(
+                        "GROUP_MINTRAL_AUTO_APPROVERS_SITE_", "GROUP_site_mintral"));
+    }
+
+    @Test
+    void rejectsParentOrganizationWithoutSiteGroupBinding() {
+        assertThrows(BadRequestException.class,
+                () -> ContentReviewPermissionService.targetGroupForSite(
+                        "GROUP_MINTRAL_AUTO_APPROVERS_SITE_", "GROUP_MINTRAL_CLIENTS"));
+    }
 }

--- a/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.test.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import OrgDetailPanel from "./org-detail-panel";
+
+vi.mock("../hooks/use-org-members", () => ({
+  useOrgMembers: () => ({ members: [], isLoading: false, error: undefined }),
+}));
+
+vi.mock("../hooks/use-org-modules", () => ({
+  useOrgModules: () => ({ modules: [], isLoading: false, error: undefined }),
+}));
+
+vi.mock("./content-review-permission-card", () => ({
+  default: ({ orgSlug }: Readonly<{ orgSlug: string }>) => (
+    <div data-testid="content-review-permission">{orgSlug}</div>
+  ),
+}));
+
+vi.mock("./members-list", () => ({ default: () => null }));
+vi.mock("./modules-list", () => ({ default: () => null }));
+vi.mock("../gps-webhooks/gps-webhook-card", () => ({ default: () => null }));
+vi.mock("../whatsapp/whatsapp-channel-card", () => ({ default: () => null }));
+
+describe("OrgDetailPanel", () => {
+  it("shows content-review permissions for a parent organization without a tax id", () => {
+    render(
+      <OrgDetailPanel
+        organization={{
+          id: 1,
+          slug: "mintral",
+          displayName: "Mintral",
+          taxId: null,
+          isParent: true,
+        }}
+        dict={{}}
+      />
+    );
+
+    expect(screen.getByTestId("content-review-permission").textContent).toBe(
+      "mintral"
+    );
+  });
+});

--- a/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/org-detail-panel.tsx
@@ -53,14 +53,12 @@ export default function OrgDetailPanel({
         error={modulesError}
         dict={dict}
       />
-      {organization?.taxId && (
-        <ContentReviewPermissionCard
-          orgSlug={orgSlug}
-          members={members}
-          membersLoading={membersLoading}
-          dict={dict}
-        />
-      )}
+      <ContentReviewPermissionCard
+        orgSlug={orgSlug}
+        members={members}
+        membersLoading={membersLoading}
+        dict={dict}
+      />
       <WhatsAppChannelCard orgSlug={orgSlug} dict={dict} />
       <GpsWebhookCard orgSlug={orgSlug} dict={dict} />
       <MembersList


### PR DESCRIPTION
## Summary

- expose multimedia auto-approval settings for parent organizations without a tax ID
- derive parent projection groups from the Alfresco site (`GROUP_MINTRAL_AUTO_APPROVERS_SITE_<SITE>`) while retaining RUT-scoped child groups
- recursively flatten Alfresco site role groups so the members endpoint returns real users
- replace stubbed organization membership/role checks with Alfresco-backed checks

## Root cause

The UI and permission service assumed every configurable organization was a child with a tax ID. Alfresco site container groups also contain nested role groups rather than direct person entries, so the Mintral parent roster appeared empty.

## Impact

Mintral administrators can configure site-wide multimedia auto-approvers directly on the parent organization, and authorization/member discovery uses Alfresco data.

## Validation

- 8 focused Quarkus unit tests pass
- frontend parent-organization component test passes
- app TypeScript check passes
- focused ESLint and Prettier checks pass
- complete miot-core suite was attempted but requires a running Docker daemon for Quarkus DevServices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alfresco membership and role detection, including nested group support.
  * Expanded content-review auto-approver permissions to site-specific groups.
  * Content-review permissions are now available for organizations without a tax ID when a valid site binding is provided.
  * Added recursive group expansion, deduplication, and pagination for directory members.

* **Bug Fixes**
  * Improved handling of nested Alfresco groups and invalid site bindings.
  * Fixed settings so the content-review permission card appears for eligible organizations.

* **Tests**
  * Added coverage for nested memberships, pagination, site-group resolution, and settings display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->