### PR TITLE
fix: verify Alfresco permission projection

### DIFF
--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
@@ -36,7 +36,32 @@ public class AlfrescoGroupProjector {
                             .map(AlfrescoPerson::id)
                             .collect(java.util.stream.Collectors.toSet());
                     return applyMembershipDelta(groupId, current, desired);
-                });
+                })
+                .flatMap(ignored -> verifyMembership(groupId, desired));
+    }
+
+    /**
+     * Verify the repository state instead of treating successful mutation
+     * responses as proof that Alfresco applied the requested membership.
+     */
+    public Uni<Void> verifyMembership(String groupId, Set<String> desired) {
+        return listAllMembers(groupId)
+                .invoke(currentMembers -> {
+                    Set<String> current = currentMembers.stream()
+                            .map(AlfrescoPerson::id)
+                            .collect(java.util.stream.Collectors.toSet());
+                    Set<String> missing = new TreeSet<>(desired);
+                    missing.removeAll(current);
+                    Set<String> unexpected = new TreeSet<>(current);
+                    unexpected.removeAll(desired);
+                    if (!missing.isEmpty() || !unexpected.isEmpty()) {
+                        throw new IllegalStateException(
+                                "Alfresco group " + groupId
+                                        + " is out of sync; missing=" + missing
+                                        + ", unexpected=" + unexpected);
+                    }
+                })
+                .replaceWithVoid();
     }
 
     private Uni<Void> applyMembershipDelta(

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/ContentReviewPermissionService.java
@@ -69,7 +69,8 @@ public class ContentReviewPermissionService {
                                 "Organization not found: " + organizationSlug));
                     }
                     return loadDto(org.id, targetGroupFor(org));
-                }));
+                }))
+                .flatMap(this::verifyReportedProjection);
     }
 
     public Uni<ContentReviewPermissionDto> replace(
@@ -88,8 +89,11 @@ public class ContentReviewPermissionService {
                             return markProjection(target.organizationId(), "FAILED",
                                     abbreviate(error.getMessage()), null);
                         }))
-                .flatMap(organizationId -> Panache.withSession(() -> Organization.<Organization>findById(organizationId)
-                        .flatMap(org -> loadDto(organizationId, targetGroupFor(org)))));
+                .flatMap(organizationId -> Panache.withSession(
+                        () -> Organization.<Organization>findById(organizationId)
+                                .flatMap(org -> loadDto(
+                                        organizationId, targetGroupFor(org)))))
+                .flatMap(this::verifyReportedProjection);
     }
 
     private Uni<OrganizationTarget> authorizeAndResolve(String organizationSlug) {
@@ -222,6 +226,27 @@ public class ContentReviewPermissionService {
                 setting == null ? "SYNCED" : setting.projectionStatus,
                 setting == null ? null : setting.projectionError,
                 setting == null ? null : setting.projectedAt);
+    }
+
+    private Uni<ContentReviewPermissionDto> verifyReportedProjection(
+            ContentReviewPermissionDto dto) {
+        if (!"SYNCED".equals(dto.projectionStatus()) || dto.projectedAt() == null) {
+            return Uni.createFrom().item(dto);
+        }
+        Set<String> desired = dto.enabled()
+                ? Set.copyOf(dto.assigneeIds())
+                : Set.of();
+        return groupProjector.verifyMembership(dto.alfrescoGroupId(), desired)
+                .replaceWith(dto)
+                .onFailure().recoverWithItem(error -> new ContentReviewPermissionDto(
+                        dto.enabled(),
+                        dto.permissionCode(),
+                        dto.roleCode(),
+                        dto.alfrescoGroupId(),
+                        dto.assigneeIds(),
+                        "FAILED",
+                        abbreviate(error.getMessage()),
+                        dto.projectedAt()));
     }
 
     private static Set<String> normalize(SetContentReviewPermissionRequest request) {

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
@@ -1,6 +1,8 @@
 package com.microboxlabs.miot.core.permission;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.core.alfresco.AlfrescoPerson;
 import com.microboxlabs.miot.core.alfresco.IAlfrescoDirectoryClient;
@@ -30,7 +32,23 @@ class AlfrescoGroupProjectorTest {
         assertEquals(List.of("GROUP_MINTRAL_AUTO_APPROVERS"), alfresco.createdGroups);
         assertEquals(List.of("new-user"), alfresco.added);
         assertEquals(50, alfresco.removed.size());
-        assertEquals(List.of(0, 50), alfresco.requestedOffsets);
+        assertEquals(List.of(0, 50, 0), alfresco.requestedOffsets);
+    }
+
+    @Test
+    void rejectsAFalsePositiveWhenAlfrescoDoesNotApplyTheDelta() {
+        FakeAlfresco alfresco = new FakeAlfresco();
+        alfresco.ignoreMutations = true;
+        AlfrescoGroupProjector projector = new AlfrescoGroupProjector(alfresco, alfresco);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> projector.reconcile(
+                                "GROUP_MINTRAL_AUTO_APPROVERS_SITE_MINTRAL",
+                                "Multimedia content auto approvers",
+                                Set.of("mdavid@sitrans.cl"))
+                        .await().indefinitely());
+
+        assertTrue(error.getMessage().contains("missing=[mdavid@sitrans.cl]"));
     }
 
     private static AlfrescoPerson person(String id) {
@@ -45,6 +63,7 @@ class AlfrescoGroupProjectorTest {
         private final List<String> added = new ArrayList<>();
         private final List<String> removed = new ArrayList<>();
         private final List<Integer> requestedOffsets = new ArrayList<>();
+        private boolean ignoreMutations;
 
         @Override
         public Uni<List<AlfrescoPerson>> listGroupMembers(
@@ -75,12 +94,18 @@ class AlfrescoGroupProjectorTest {
         @Override
         public Uni<Void> addGroupMember(String groupId, String personId) {
             added.add(personId);
+            if (!ignoreMutations) {
+                current.add(person(personId));
+            }
             return Uni.createFrom().voidItem();
         }
 
         @Override
         public Uni<Void> removeGroupMember(String groupId, String personId) {
             removed.add(personId);
+            if (!ignoreMutations) {
+                current.removeIf(person -> personId.equals(person.id()));
+            }
             return Uni.createFrom().voidItem();
         }
     }

--- a/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.test.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.test.tsx
@@ -10,7 +10,7 @@ const { permission, save } = vi.hoisted(() => ({
     roleCode: "CONTENT_REVIEW_AUTO_APPROVER",
     alfrescoGroupId: "GROUP_MINTRAL_AUTO_APPROVERS_SITE_MINTRAL",
     assigneeIds: ["antonia"],
-    projectionStatus: "SYNCED" as const,
+    projectionStatus: "SYNCED" as "SYNCED" | "FAILED",
     projectionError: null,
     projectedAt: null,
   },
@@ -134,5 +134,27 @@ describe("ContentReviewPermissionCard", () => {
     expect(
       screen.queryByRole("button", { name: "Save permission" })
     ).not.toBeInTheDocument();
+  });
+
+  it("allows retrying a failed Alfresco projection without changing settings", () => {
+    permission.projectionStatus = "FAILED";
+
+    render(
+      <ContentReviewPermissionCard
+        orgSlug="mintral"
+        members={members}
+        membersLoading={false}
+        membersError={null}
+        canManage
+        dict={dict}
+      />
+    );
+
+    expect(screen.getByText("Projection failed")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Save permission" })
+    ).toBeEnabled();
+
+    permission.projectionStatus = "SYNCED";
   });
 });

--- a/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
+++ b/turbo-repo/apps/app/src/features/settings-admin/components/content-review-permission-card.tsx
@@ -88,7 +88,8 @@ export default function ContentReviewPermissionCard({
   );
   const hasChanges =
     permission != null &&
-    (enabled !== permission.enabled ||
+    (permission.projectionStatus === "FAILED" ||
+      enabled !== permission.enabled ||
       assigneeIds.size !== permission.assigneeIds.length ||
       permission.assigneeIds.some((personId) => !assigneeIds.has(personId)));
 


### PR DESCRIPTION
## What changed

- verify Alfresco group membership after applying every permission delta
- re-check stored `SYNCED` projections when the settings are loaded
- report the projection as `FAILED` when desired and actual Alfresco members differ
- keep the save action enabled for failed projections so administrators can retry without changing the configuration

## Root cause

The projection treated successful Alfresco REST responses as proof of convergence. A JS Console check showed that `GROUP_MINTRAL_AUTO_APPROVERS_SITE_MINTRAL` existed while `mdavid@sitrans.cl` was neither a direct nor nested member, despite the UI reporting “Sincronizado con Alfresco.”

## Validation

- focused miot-core tests: 7 passed
- focused settings-admin Vitest suites: 4 passed
- affected frontend ESLint files: passed
- TypeScript check: passed
