### PR TITLE
fix: stabilize Alfresco permission projection

### DIFF
--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/auth/BasicAuthProvider.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/auth/BasicAuthProvider.java
@@ -1,9 +1,11 @@
 package com.microboxlabs.miot.core.alfresco.auth;
 
+import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -15,14 +17,17 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  * prefer {@link OAuthBearerAuthProvider}.
  */
 @ApplicationScoped
+@Unremovable
 @LookupIfProperty(name = "miot.alfresco.auth", stringValue = "basic")
 public class BasicAuthProvider implements AlfrescoAuthProvider {
 
     private final String headerValue;
 
     public BasicAuthProvider(
-            @ConfigProperty(name = "miot.alfresco.basic.username", defaultValue = "") String username,
-            @ConfigProperty(name = "miot.alfresco.basic.password", defaultValue = "") String password) {
+            @ConfigProperty(name = "miot.alfresco.basic.username") Optional<String> configuredUsername,
+            @ConfigProperty(name = "miot.alfresco.basic.password") Optional<String> configuredPassword) {
+        String username = configuredUsername.orElse("");
+        String password = configuredPassword.orElse("");
         if (username.isBlank() || password.isBlank()) {
             this.headerValue = null;
         } else {

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/auth/OAuthBearerAuthProvider.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/alfresco/auth/OAuthBearerAuthProvider.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.core.alfresco.auth;
 
+import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -19,6 +20,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
  * than a silent success against Alfresco.
  */
 @ApplicationScoped
+@Unremovable
 @LookupIfProperty(name = "miot.alfresco.auth", stringValue = "oauth")
 public class OAuthBearerAuthProvider implements AlfrescoAuthProvider {
 

--- a/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
+++ b/quarkus-srv/miot-core/src/main/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjector.java
@@ -6,6 +6,7 @@ import com.microboxlabs.miot.core.alfresco.IAlfrescoGroupAdminClient;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -37,7 +38,11 @@ public class AlfrescoGroupProjector {
                             .collect(java.util.stream.Collectors.toSet());
                     return applyMembershipDelta(groupId, current, desired);
                 })
-                .flatMap(ignored -> verifyMembership(groupId, desired));
+                .flatMap(ignored -> verifyMembership(groupId, desired)
+                        .onFailure(IllegalStateException.class)
+                        .retry()
+                        .withBackOff(Duration.ofMillis(200), Duration.ofSeconds(2))
+                        .atMost(5));
     }
 
     /**
@@ -45,7 +50,7 @@ public class AlfrescoGroupProjector {
      * responses as proof that Alfresco applied the requested membership.
      */
     public Uni<Void> verifyMembership(String groupId, Set<String> desired) {
-        return listAllMembers(groupId)
+        return Uni.createFrom().deferred(() -> listAllMembers(groupId))
                 .invoke(currentMembers -> {
                     Set<String> current = currentMembers.stream()
                             .map(AlfrescoPerson::id)

--- a/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
+++ b/quarkus-srv/miot-core/src/test/java/com/microboxlabs/miot/core/permission/AlfrescoGroupProjectorTest.java
@@ -51,6 +51,23 @@ class AlfrescoGroupProjectorTest {
         assertTrue(error.getMessage().contains("missing=[mdavid@sitrans.cl]"));
     }
 
+    @Test
+    void retriesVerificationWhileAlfrescoMembershipIsNotYetVisible() {
+        FakeAlfresco alfresco = new FakeAlfresco();
+        alfresco.staleReadsAfterMutation = 1;
+        AlfrescoGroupProjector projector = new AlfrescoGroupProjector(alfresco, alfresco);
+
+        projector.reconcile(
+                        "GROUP_MINTRAL_AUTO_APPROVERS_SITE_MINTRAL",
+                        "Multimedia content auto approvers",
+                        Set.of("mdavid@sitrans.cl"))
+                .await().indefinitely();
+
+        assertEquals(List.of("mdavid@sitrans.cl"), alfresco.added);
+        assertEquals(List.of("mdavid@sitrans.cl"),
+                alfresco.current.stream().map(AlfrescoPerson::id).toList());
+    }
+
     private static AlfrescoPerson person(String id) {
         return new AlfrescoPerson(id, id, null, null, id);
     }
@@ -63,12 +80,22 @@ class AlfrescoGroupProjectorTest {
         private final List<String> added = new ArrayList<>();
         private final List<String> removed = new ArrayList<>();
         private final List<Integer> requestedOffsets = new ArrayList<>();
+        private final List<AlfrescoPerson> pendingAdditions = new ArrayList<>();
         private boolean ignoreMutations;
+        private int staleReadsAfterMutation;
 
         @Override
         public Uni<List<AlfrescoPerson>> listGroupMembers(
                 String groupId, int maxItems, int skipCount) {
             requestedOffsets.add(skipCount);
+            if (!pendingAdditions.isEmpty()) {
+                if (staleReadsAfterMutation > 0) {
+                    staleReadsAfterMutation--;
+                } else {
+                    current.addAll(pendingAdditions);
+                    pendingAdditions.clear();
+                }
+            }
             int end = Math.min(skipCount + maxItems, current.size());
             return Uni.createFrom().item(skipCount >= current.size()
                     ? List.of()
@@ -95,7 +122,11 @@ class AlfrescoGroupProjectorTest {
         public Uni<Void> addGroupMember(String groupId, String personId) {
             added.add(personId);
             if (!ignoreMutations) {
-                current.add(person(personId));
+                if (staleReadsAfterMutation > 0) {
+                    pendingAdditions.add(person(personId));
+                } else {
+                    current.add(person(personId));
+                }
             }
             return Uni.createFrom().voidItem();
         }


### PR DESCRIPTION
## Summary
- keep Alfresco auth providers reachable when selected through programmatic CDI lookup
- tolerate missing Basic credentials while OAuth mode is active
- retry post-write membership verification to handle Alfresco read-after-write visibility delay
- preserve authoritative verification so real projection failures remain retryable

## Validation
- `./mvnw -pl miot-core -Dtest=AlfrescoGroupProjectorTest test`
- local Quarkus on port 8181 with tunneled dev PostgreSQL and Alfresco
- enabled Michel David, saved, verified membership with Alfresco JS Console, and refreshed the UI successfully

## Note
- the full `miot-core` test suite requires a Docker datasource; Docker is not running locally, so its Quarkus integration-test discovery could not start Dev Services.