### PR TITLE
fix(integrations): park calendar_sync on a rejected explicit-slot 409 instead of retrying 5×

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -2,6 +2,7 @@ package com.microboxlabs.miot.integrations.calendar;
 
 import com.microboxlabs.miot.integrations.jobs.JobOutcome;
 import com.microboxlabs.miot.integrations.jobs.ModulithJobHandler;
+import com.microboxlabs.miot.integrations.jobs.NonRetryableJobException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
@@ -33,6 +34,16 @@ import org.jboss.logging.Logger;
  * carry that revert, and it reads 409 the opposite way: not "this job is late"
  * but "the booking has run ahead of the workflow". See
  * {@code executeUnassign}.
+ *
+ * <p><b>Slot 409s on ensure are different again.</b> A 409 on an
+ * <b>ensure move/create into an explicit slot</b> means that slot rejected the
+ * placement (e.g. it is at full capacity) — retrying the same slot cannot
+ * converge, so it is thrown as a {@link NonRetryableJobException} and parked
+ * immediately (alerting the planner) rather than retried. The one exception is a
+ * create 409 where a sibling won the race and a booking now exists: that re-runs
+ * (retryable) and converges via the move path. The ETD <b>auto-pick</b>
+ * no-capacity case stays retryable and self-heals separately (see
+ * {@code pickSlotFromEtd}).
  */
 @ApplicationScoped
 public class CalendarSyncExecutor implements ModulithJobHandler {
@@ -181,8 +192,16 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         }
         String resourceType = strOr(payload, CalendarSyncFeature.PAYLOAD_RESOURCE_TYPE,
                 CalendarSyncFeature.DEFAULT_RESOURCE_TYPE);
-        UUID bookingId = client.create(calendarId, slot.date(), slot.hour(), slot.minutes(),
-                resourceId, resourceType, resourceData);
+        UUID bookingId;
+        try {
+            bookingId = client.create(calendarId, slot.date(), slot.hour(), slot.minutes(),
+                    resourceId, resourceType, resourceData);
+        } catch (CalendarBookingsHttpException e) {
+            if (e.getStatus() == 409) {
+                throw createConflict(e, resourceId, calendarId, slot);
+            }
+            throw e;
+        }
         applyStatus(resourceId, calendarId, targetStatus);
         LOG.infof("calendar_sync ensure created booking %s for %s at %s %02d:%02d -> %s",
                 bookingId, resourceId, slot.date(), slot.hour(), slot.minutes(), targetStatus);
@@ -196,7 +215,19 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         boolean moved = false;
         SlotInfo explicit = resolveExplicitSlot(payload, calendarId);
         if (explicit != null && slotDiffers(booking, explicit)) {
-            client.move(booking.id(), explicit.date(), explicit.hour(), explicit.minutes());
+            try {
+                client.move(booking.id(), explicit.date(), explicit.hour(), explicit.minutes());
+            } catch (CalendarBookingsHttpException e) {
+                if (e.getStatus() == 409) {
+                    // The chosen slot rejected the move (e.g. it is at full capacity).
+                    // Retrying the same explicit slot cannot converge, so park now —
+                    // the planner is alerted — instead of backing off to the same 409.
+                    throw new NonRetryableJobException("Cannot move booking " + booking.id() + " for "
+                            + resourceId + " to " + slotLabel(explicit) + " — rejected by calendar (409): "
+                            + e.getMessage(), e);
+                }
+                throw e;
+            }
             moved = true;
         }
         // Forward-only status, plus a shallow resource-data merge so a re-plan keeps
@@ -331,6 +362,28 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
             LOG.infof("Booking %s already gone while cancelling %s", booking.id(), resourceId);
             return 0;
         }
+    }
+
+    /**
+     * Classify a 409 from an ensure-create. Either the explicit slot rejected the
+     * booking (e.g. full capacity) — terminal, since a retry hits the same wall —
+     * or a sibling won the race and a booking now exists, in which case a re-run
+     * converges via the move path. Re-list to tell them apart instead of coupling
+     * to the calendar's error text. Returns the exception to throw.
+     */
+    private RuntimeException createConflict(CalendarBookingsHttpException e, String resourceId,
+                                            UUID calendarId, SlotInfo slot) {
+        if (client.listByResource(resourceId, calendarId).isEmpty()) {
+            return new NonRetryableJobException("Cannot create booking for " + resourceId + " at "
+                    + slotLabel(slot) + " — rejected by calendar (409): " + e.getMessage(), e);
+        }
+        LOG.infof("calendar_sync ensure: create 409 for %s but a booking now exists — a sibling won the "
+                + "race; retrying to converge via the existing booking", resourceId);
+        return e;
+    }
+
+    private static String slotLabel(SlotInfo slot) {
+        return String.format("%s %02d:%02d", slot.date(), slot.hour(), slot.minutes());
     }
 
     /** 404/409 are benign for status pushes; anything else is not ours to absorb. */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorker.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorker.java
@@ -170,6 +170,15 @@ public class ModulithJobWorker {
                 outcome = result.outcome();
                 detail = result.detail();
             }
+        } catch (NonRetryableJobException e) {
+            // A retry cannot fix this (e.g. the chosen slot is full) — park now so
+            // the babysitter/notification fires immediately, rather than backing off
+            // through the whole attempt budget to the same terminal failure.
+            outcome = OUTCOME_FAILED;
+            detail = e.getMessage();
+            retryable = false;
+            LOG.warnf("modulith job %s (%s, service %s) failed non-retryably — parking now: %s",
+                    job.id(), job.jobType(), job.correlationKey(), e.getMessage());
         } catch (Exception e) {
             outcome = OUTCOME_FAILED;
             detail = e.getMessage();

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/NonRetryableJobException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/NonRetryableJobException.java
@@ -1,0 +1,27 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+/**
+ * Thrown by a {@link ModulithJobHandler} for a failure a retry cannot fix — a
+ * deterministic, terminal condition such as a chosen calendar slot being at
+ * full capacity. {@link ModulithJobWorker} reports it FAILED with
+ * {@code retryable=false}, so the ledger parks the job immediately (on the
+ * current attempt) and fires the park notification, instead of burning the
+ * whole attempt budget with exponential backoff first.
+ *
+ * <p>A plain thrown exception stays retryable — that path is for transient /
+ * transport / 5xx failures the ledger should back off and re-run. Throw this
+ * only when re-running the exact same payload is guaranteed to fail the same
+ * way.
+ */
+public class NonRetryableJobException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public NonRetryableJobException(String message) {
+        super(message);
+    }
+
+    public NonRetryableJobException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microboxlabs.miot.integrations.jobs.JobOutcome;
+import com.microboxlabs.miot.integrations.jobs.NonRetryableJobException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -395,6 +396,59 @@ class CalendarSyncExecutorTest {
         assertEquals(1, client.createCalls);
     }
 
+    /**
+     * A move into an explicit slot the calendar rejects (409 — e.g. full capacity)
+     * is terminal: retrying the same slot hits the same wall. It must surface as a
+     * NonRetryableJobException so the worker parks it now instead of backing off
+     * through the whole attempt budget.
+     */
+    @Test
+    void ensureMoveToRejectedSlotIsNonRetryable() {
+        FakeClient client = new FakeClient();
+        client.listResult = List.of(booking(LocalDate.of(2026, 7, 16))); // existing at 09:00
+        client.moveThrows = new CalendarBookingsHttpException(409, "Slot is at full capacity");
+        var payload = withExplicitSlot(ensurePayload("ASSIGNED"), LocalDate.of(2026, 7, 17), 14, 30);
+        var executor = new CalendarSyncExecutor(client, CLOCK);
+
+        var e = assertThrows(NonRetryableJobException.class, () -> executor.handle(payload));
+        assertTrue(e.getMessage().contains("full capacity"), e.getMessage());
+        assertEquals(1, client.moveCalls);
+        assertEquals(0, client.patchCalls, "a rejected move never reaches the status patch");
+    }
+
+    /** A create rejected by an explicit full slot (409, still no booking) is terminal. */
+    @Test
+    void ensureCreateIntoRejectedSlotIsNonRetryable() {
+        FakeClient client = new FakeClient();
+        client.listResult = List.of();            // absent → create path
+        client.listResultAfterCreate = List.of(); // still absent after the 409 → capacity, not a race
+        client.createThrows = new CalendarBookingsHttpException(409, "Slot is at full capacity");
+        var payload = withExplicitSlot(ensurePayload("PLANNED"), LocalDate.of(2026, 7, 17), 14, 30);
+        var executor = new CalendarSyncExecutor(client, CLOCK);
+
+        var e = assertThrows(NonRetryableJobException.class, () -> executor.handle(payload));
+        assertTrue(e.getMessage().contains("full capacity"), e.getMessage());
+        assertEquals(1, client.createCalls);
+    }
+
+    /**
+     * A create 409 where a sibling won the race (a booking now exists) stays
+     * retryable — the re-run finds it via listByResource and converges through the
+     * move path, so it must NOT be parked as non-retryable.
+     */
+    @Test
+    void ensureCreate409WhenSiblingWonTheRaceStaysRetryable() {
+        FakeClient client = new FakeClient();
+        client.listResult = List.of(); // absent at first list → create path
+        client.listResultAfterCreate = List.of(booking(LocalDate.of(2026, 7, 17))); // sibling created it
+        client.createThrows = new CalendarBookingsHttpException(409, "already exists");
+        var payload = withExplicitSlot(ensurePayload("PLANNED"), LocalDate.of(2026, 7, 17), 14, 30);
+        var executor = new CalendarSyncExecutor(client, CLOCK);
+
+        // Retryable (a plain CalendarBookingsHttpException, not NonRetryableJobException).
+        assertThrows(CalendarBookingsHttpException.class, () -> executor.handle(payload));
+    }
+
     @Test
     void ensureIncompleteExplicitSlotThrows() {
         FakeClient client = new FakeClient();
@@ -464,6 +518,12 @@ class CalendarSyncExecutorTest {
         LocalDate lastMoveDate;
         int lastMoveHour;
         int lastMoveMinutes;
+        RuntimeException moveThrows;
+        RuntimeException createThrows;
+        // What listByResource returns after the first call — lets a test model a
+        // create-409 race (a sibling booking appears) vs a capacity 409 (stays empty).
+        List<CalendarBookingsClient.BookingView> listResultAfterCreate;
+        int listCalls;
 
         @Override
         public boolean isConfigured() {
@@ -484,6 +544,10 @@ class CalendarSyncExecutorTest {
 
         @Override
         public List<CalendarBookingsClient.BookingView> listByResource(String resourceId, UUID calendarId) {
+            listCalls++;
+            if (listCalls > 1 && listResultAfterCreate != null) {
+                return listResultAfterCreate;
+            }
             return listResult;
         }
 
@@ -499,6 +563,9 @@ class CalendarSyncExecutorTest {
             lastCreateDate = slotDate;
             lastCreateHour = slotHour;
             lastCreateMinutes = slotMinutes;
+            if (createThrows != null) {
+                throw createThrows;
+            }
             return createdId;
         }
 
@@ -509,6 +576,9 @@ class CalendarSyncExecutorTest {
             lastMoveDate = slotDate;
             lastMoveHour = slotHour;
             lastMoveMinutes = slotMinutes;
+            if (moveThrows != null) {
+                throw moveThrows;
+            }
         }
 
         @Override

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
@@ -105,6 +105,20 @@ class ModulithJobWorkerTest {
         assertFalse(service.reports.get(0).retryable());
     }
 
+    @Test
+    void drainParksNonRetryableWhenHandlerSignalsTerminal() {
+        var service = new RecordingService();
+        service.claimResults.add(List.of(job("job-1", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of());
+        var handler = new FakeHandler(CALENDAR);
+        handler.throwWith = new NonRetryableJobException("slot at full capacity");
+        worker(service, true, handler).drain();
+
+        assertEquals("FAILED", service.reports.get(0).outcome());
+        assertFalse(service.reports.get(0).retryable(),
+                "a terminal failure parks now, no backoff");
+    }
+
     // --- gating --------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Why

Chasing a real dev symptom: a `calendar_sync` job was **retried 5× over ~17 minutes** before parking, then fired the ops WhatsApp. The failure was `409 Conflict — "Slot is at full capacity"` on an **ensure move/create into an explicit slot**. Retrying the same explicit slot can never converge, so the backoff was pure waste and the notification was delayed ~17 min.

Root cause: the modulith worker's failure model is binary — a handler **returns** `JobOutcome` (success/skip) or **throws** (retryable). `ensureExisting`'s `client.move(...)` and `ensureCreate`'s `client.create(...)` were unwrapped, so a 409 propagated as a plain throw → retryable. (The ledger's `report(retryable=false)` path already parks immediately; nothing was using it for this case.)

## What

- **`NonRetryableJobException`** (new): a handler throws it for a *terminal* failure a retry can't fix. `ModulithJobWorker` maps it to FAILED + `retryable=false`, so the ledger parks on the current attempt and fires the park notification **now**. A plain throw stays retryable for transient/transport/5xx failures.
- **`CalendarSyncExecutor`**: wrap the ensure `move`/`create` calls.
  - Explicit-slot **move** 409 → `NonRetryableJobException` (park now).
  - **create** 409 → re-list to distinguish: still absent = **capacity** (non-retryable); a booking now exists = a sibling won the **race** → stay retryable and converge via the move path on the next attempt. No coupling to the calendar's error text.
  - The ETD **auto-pick** no-capacity path (`pickSlotFromEtd`) is deliberately untouched — it still throws-to-retry and self-heals when a slot frees.

## Effect

For the exact dev case, the job now parks on attempt 1 and the notification fires in seconds instead of 17 minutes. Genuine transient failures and the auto-pick self-heal are unchanged.

## Verification

- `CalendarSyncExecutorTest` — **32 passed** (move-409 non-retryable; create-409-into-full-slot non-retryable; create-409-lost-race stays retryable)
- `ModulithJobWorkerTest` — **8 passed** (a `NonRetryableJobException` from a handler parks with `retryable=false`)

## Follow-up (not in this PR)

Deterministic payload-validation errors (`IllegalArgumentException` — malformed op/resourceId, the `SMOKE-*` poison jobs) are still retryable; they could throw `NonRetryableJobException` too. Left out to keep this focused on the reported 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)