### PR TITLE
fix(calendar): recover mintral_serviceType from resource id so task-driven assigns don't silently downgrade

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
@@ -83,3 +83,35 @@ describe("mapBookingToPlannedService — sync status", () => {
     expect(mapped?.planned.syncStatus).toBe("PENDING");
   });
 });
+
+describe("mapBookingToPlannedService — service type recovery", () => {
+  // Without this, a task-driven assign silently downgrades to the legacy
+  // GET-endTask path: the assigned tuple is dropped and nothing is pushed to
+  // Alerce. ECM-written booking rows do not persist mintral_serviceType, so it
+  // must be recovered from the `${code}-${type}` resource id.
+  it("recovers mintral_serviceType from the resource id when not stored", () => {
+    // fixture id is 1658427-V, data carries no mintral_serviceType
+    const mapped = mapBookingToPlannedService(booking());
+    expect(mapped?.planned.service.mintral_serviceType).toBe("V");
+  });
+
+  it("prefers a stored mintral_serviceType over the id suffix", () => {
+    const mapped = mapBookingToPlannedService(
+      booking({
+        resource: {
+          id: "1658427-V",
+          type: "service",
+          data: { mintral_serviceType: "R" },
+        },
+      })
+    );
+    expect(mapped?.planned.service.mintral_serviceType).toBe("R");
+  });
+
+  it("leaves mintral_serviceType unset when the id has no suffix and none is stored", () => {
+    const mapped = mapBookingToPlannedService(
+      booking({ resource: { id: "1658427", type: "service", data: {} } })
+    );
+    expect(mapped?.planned.service.mintral_serviceType).toBeUndefined();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
@@ -85,6 +85,17 @@ export interface MappedBooking {
 }
 
 /**
+ * Recover the service-type suffix from the canonical `${code}-${type}` resource
+ * id — the same rule the bookings BFF uses (`binding-extractor.ts`
+ * `serviceTypeFromResourceId`). `undefined` when the id has no `-` suffix, so
+ * the optional field stays unset rather than becoming "".
+ */
+function serviceTypeFromResourceId(id: string): string | undefined {
+  const dash = id.lastIndexOf("-");
+  return dash >= 0 ? id.slice(dash + 1) || undefined : undefined;
+}
+
+/**
  * Canonical booking → planned-service transform.
  *
  * Shared by the grid loader and the calendar search on purpose: if search
@@ -128,6 +139,13 @@ export function mapBookingToPlannedService(
     // legacy bookings written before mintral_serviceCode was persisted.
     mintral_serviceCode:
       storedService.mintral_serviceCode ?? booking.resource.id.split("-")[0],
+    // Recover the type suffix the same way. ECM-written booking rows don't
+    // persist mintral_serviceType, and without it a task-driven assign silently
+    // downgrades to the legacy GET-endTask path — dropping the assigned tuple
+    // and never pushing to Alerce (booking sync_status stays null).
+    mintral_serviceType:
+      storedService.mintral_serviceType ??
+      serviceTypeFromResourceId(booking.resource.id),
   };
 
   // Terminal stages ride the booking row itself (ECM writes the status);


### PR DESCRIPTION
## Symptom

Assigning a service in the planner produced a booking that looked `ASSIGNED` but:
- the `assignedCarrier`/`assignedDriver`/`assignedTruck` you sent were **not persisted** on the booking, and
- the assignment was **never pushed to Alerce** — no `alerce_assignment`/`calendar_confirm` job ever ran, so `cld_bookings.sync_status` stayed `null`.

Verified on dev (service `1586586`): the move produced exactly one job — `calendar_sync op=patch target=ASSIGNED`, `enqueuedBy=listener`, **empty resourceData**, no `syncStatus` — and never an Alerce leg.

## Root cause — a single missing field cascades

1. ECM-written booking rows persist `mintral_serviceCode` but **not** `mintral_serviceType`.
2. `mapBookingToPlannedService` recovers `mintral_serviceCode` from the `${code}-${type}` resource id, but had **no fallback for `mintral_serviceType`** → `service.mintral_serviceType` is `undefined`.
3. `buildAssignProcessVariables` (`task-driven-assign.ts`) **requires** it and returns `null` when absent.
4. `null` → `decideAssignTaskAdvance` null → `isTaskDrivenAssignUpdate` false → `shouldPersistBooking` **true** → the package sends the frozen drag blob to the move route (which strips it for task-driven origins, by #938 design) **and** `afterPlan` takes the **legacy GET `/tasks/end`** branch (no `processVariables`).
5. GET end-task never stamps `transition_origin=calendar`, so ECM's `OnCreatePresentDriverBinding` runs its **status-only branch** — the exact observed job, with no resourceData and no Alerce chain.

Both symptoms collapse to one silent downgrade caused by `mintral_serviceType === undefined`.

## Fix

Give the mapper the same id-fallback for `mintral_serviceType` it already has for `mintral_serviceCode`, mirroring the BFF's `serviceTypeFromResourceId` (`binding-extractor.ts`):

```ts
mintral_serviceType:
  storedService.mintral_serviceType ??
  serviceTypeFromResourceId(booking.resource.id),   // "1586586-V" → "V"
```

With the field populated, `buildAssignProcessVariables` succeeds → the assign posts `processVariables` → `EndTaskPostWebscript` stamps `transition_origin=calendar` → `OnCreatePresentDriverBinding` takes the **calendar-origin** branch → `enqueueAssignChain`: an ASSIGNED patch **with** resourceData (the tuple lands on the booking) **+** `alerce_assignment` (+ the confirm leg that stamps `sync_status`).

### Why it can't re-introduce the #938 stale-blob bug
Pure FE data recovery — it does **not** touch the move route or ECM. Because `shouldPersistBooking` becomes **false**, the frozen drag blob is never sent to the move route, so there's nothing to stale-write; Alerce is pushed via the **idempotent async leg**, not the legacy synchronous `stage=assigned` binding (still skipped). No double-push.

## Verification

- `booking-service-mapper.test.ts` — recovers the type from the id, prefers a stored value, stays unset when the id has no suffix (**13 mapper tests**).
- `vitest run src/features/calendar src/app/api/calendar` — **158 passed**.
- `turbo run check-types --filter=@modulariot/app` — clean.

End-to-end (resources persisted + Alerce push + green sync badge) needs a dev deploy to confirm on a live assign.

## Follow-ups (not in this PR)
- **Hardening:** make the downgrade loud — for a task-driven origin at assign, if `buildAssignProcessVariables` returns `null`, block instead of silently falling back to GET end-task.
- **ECM defense-in-depth:** persist `mintral_serviceType` in `OnCreateAssignDriverBinding.buildResourceData` so future rows carry it (not required — the id fallback covers existing rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar booking mapping to correctly recover a service type from booking resource identifiers when stored data is unavailable.
  * Preserved explicitly stored service types as the authoritative value.
  * Prevented incorrect or empty service type values when no valid information is available.

* **Tests**
  * Added coverage for stored, inferred, and unavailable service types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->