### PR TITLE
fix(calendar): show Alerce observations in the planning Obs field

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/services/data.service.ts
@@ -95,7 +95,13 @@ function toKanbanBoardTask(task: Record<string, unknown>): KanbanBoardTask {
     name,
     mintral_serviceCode:
       task.mintral_serviceCode == null ? undefined : String(serviceCode),
-    description: task.bpm_description as string,
+    // The calendar planning "Obs" field must show the observations the
+    // external service (Alerce) sends via the ext-service feed — persisted as
+    // the `mintral_observations` process variable (feed key
+    // `service_definitions_oservations`) — not the generic workflow
+    // description ("Shipping Coordination for <key>"). Falls back to empty
+    // when a service carries no observations.
+    description: (task.mintral_observations as string) ?? "",
     completed: task.state === "COMPLETED",
     daysLeft: 2,
     origin,


### PR DESCRIPTION
## What

The calendar Planificación sidebar's **Obs** (Observaciones) field now shows the observations the external service (**Alerce**) sends via the ext-service feed, instead of the generic Activiti workflow description.

## Why

`toKanbanBoardTask` mapped `description` from `bpm_description`, which is the workflow description ECM sets at process start — literally `"Shipping Coordination for <key>"`. That boilerplate was surfacing in the sidebar's Notes/Obs section, carrying no operational value.

The observations Alerce sends (feed key `service_definitions_oservations`) are already ingested by ECM into the `mintral:observations` property and exposed as the `mintral_observations` process variable — the same path every other `mintral_*` field on the card already uses.

## Change

`turbo-repo/apps/app/src/features/shipping/services/data.service.ts` — map `description` from `task.mintral_observations` (falling back to empty when a service has none).

## Scope / safety

- The only live consumer of `KanbanBoardTask.description` is the calendar sidebar (`observaciones`); the shipping kanban-card usage is commented out — so this is scoped to the Obs field.
- Verified against production: `mintral_observations` has 56,609 process-variable instances (same count as the working `mintral_expectedDepartureDate`), carrying real text such as `CAMION DESTINO POZO`, `MIXTO BODEGA`, `CARGA SUELTA LAGUNA / DEPOSITO F31`.

## Note

This PR covers **only** the Obs field. The related "planning times show 4h late" report is a separate item pending user validation — investigation so far shows the feed→ECM→frontend datetime pipeline stores and serves correct `America/Santiago` instants, so that fix (if any) is not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)