### PR TITLE
fix(calendar): one-click re-assign for presented services + keep planner fields across a move

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.test.ts
@@ -217,6 +217,86 @@ describe("bookings move POST — task-driven flag gating", () => {
     expect(runCalendarBindingMock).not.toHaveBeenCalled();
   });
 
+  // Regression: a task-driven move used to drop the resource blob wholesale, so
+  // the planner's category/andén were written nowhere — ECM never writes them,
+  // and the grid renders from the booking row — and silently vanished on the
+  // next page load. They now ride the move, merged onto the PERSISTED resource
+  // so ECM's fields stay authoritative and no `assigned*` field ever leaks.
+  it("flag ON: merges serviceCategory onto the persisted resource, dropping the tuple", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(TASK_DRIVEN_ORIGIN, {
+      mintral_serviceKind: "rampla",
+    });
+    const body = makeMoveBody(TASK_DRIVEN_ORIGIN, {
+      ...ASSIGNMENT_TUPLE,
+      serviceCategory: "DIRECT_PICKUP",
+    });
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(TASK_DRIVEN_ORIGIN));
+
+    const { POST } = await loadRoute();
+    const response = await POST(makeMoveRequest(body), routeParams);
+
+    expect(response.status).toBe(200);
+    expect(bookingsMoveMock).toHaveBeenCalledWith(BOOKING_ID, {
+      slot: body.slot,
+      resource: {
+        id: snapshot.resource.id,
+        type: snapshot.resource.type,
+        label: snapshot.resource.label,
+        data: {
+          // ECM-owned fields survive untouched...
+          mintral_serviceCode: "1586586",
+          origen: TASK_DRIVEN_ORIGIN,
+          mintral_serviceKind: "rampla",
+          // ...and the planner's choice now persists.
+          serviceCategory: "DIRECT_PICKUP",
+        },
+      },
+    });
+    // The stale tuple must never reach the calendar service.
+    const [, forwarded] = bookingsMoveMock.mock.calls[0];
+    expect(forwarded.resource.data).not.toHaveProperty("assignedCarrier");
+    expect(forwarded.resource.data).not.toHaveProperty("assignedDriver");
+    expect(forwarded.resource.data).not.toHaveProperty("assignedTruck");
+    expect(runCalendarBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("flag ON: merges the andén (_anden) the same way", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(TASK_DRIVEN_ORIGIN);
+    const body = makeMoveBody(TASK_DRIVEN_ORIGIN, { _anden: 1 });
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(TASK_DRIVEN_ORIGIN));
+
+    const { POST } = await loadRoute();
+    await POST(makeMoveRequest(body), routeParams);
+
+    const [, forwarded] = bookingsMoveMock.mock.calls[0];
+    expect(forwarded.resource.data).toMatchObject({
+      _anden: 1,
+      mintral_serviceCode: "1586586",
+    });
+  });
+
+  it("flag ON: a request field that is not planner-owned is still dropped", async () => {
+    process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
+    const snapshot = makeBooking(TASK_DRIVEN_ORIGIN);
+    const body = makeMoveBody(TASK_DRIVEN_ORIGIN, {
+      serviceCategory: "DIRECT_PICKUP",
+      destino: "TAMPERED",
+    });
+    bookingsGetMock.mockResolvedValue(snapshot);
+    bookingsMoveMock.mockResolvedValue(makeBooking(TASK_DRIVEN_ORIGIN));
+
+    const { POST } = await loadRoute();
+    await POST(makeMoveRequest(body), routeParams);
+
+    const [, forwarded] = bookingsMoveMock.mock.calls[0];
+    expect(forwarded.resource.data.serviceCategory).toBe("DIRECT_PICKUP");
+    expect(forwarded.resource.data).not.toHaveProperty("destino");
+  });
+
   it("flag ON: reads the origin from the persisted booking when the body has none", async () => {
     process.env[ENV_KEY] = TASK_DRIVEN_ORIGIN;
     const snapshot = makeBooking(TASK_DRIVEN_ORIGIN);

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -46,6 +46,57 @@ type Result<T> =
   | { ok: false; error: NextResponse };
 
 /**
+ * Planner-owned, non-tuple fields that survive a task-driven move.
+ *
+ * A task-driven move is otherwise slot-only (see the POST handler) because the
+ * planner's frozen drag payload can carry a stale assignment tuple. But these
+ * fields are owned by the planner, not by ECM, and ECM never writes them — so
+ * dropping the whole blob silently discarded the user's choice: the category
+ * and andén vanished on the next page load, since the grid renders from the
+ * booking row (`mapBookingToPlannedService`), not from the workflow task.
+ *
+ * Deliberately excludes every `assigned*` field, so the stale-tuple hazard the
+ * slot-only rule guards against is unchanged.
+ */
+const PLANNER_OWNED_FIELDS = ["serviceCategory", "_anden"] as const;
+
+function pickPlannerFields(
+  data: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!data) return {};
+  const picked: Record<string, unknown> = {};
+  for (const key of PLANNER_OWNED_FIELDS) {
+    if (data[key] !== undefined) picked[key] = data[key];
+  }
+  return picked;
+}
+
+/**
+ * Task-driven move body: the requested slot, plus the *persisted* resource with
+ * only {@link PLANNER_OWNED_FIELDS} overlaid. Merging onto the snapshot (rather
+ * than the request) keeps ECM's fields authoritative — the request blob never
+ * clobbers them. Falls back to a slot-only body when the request carries none
+ * of those fields, preserving the previous behavior byte-for-byte.
+ */
+export function buildTaskDrivenMoveBody(
+  body: MoveBody,
+  snapshot: BookingResponse
+): MoveBody {
+  const plannerFields = pickPlannerFields(body.resource?.data);
+  if (Object.keys(plannerFields).length === 0) return { slot: body.slot };
+  const { id, type, label, data } = snapshot.resource;
+  return {
+    slot: body.slot,
+    resource: {
+      id,
+      ...(type == null ? {} : { type }),
+      ...(label == null ? {} : { label }),
+      data: { ...(data ?? {}), ...plannerFields },
+    },
+  };
+}
+
+/**
  * Reverse-move compensation: re-issue a move using the pre-move snapshot so
  * the booking lands back where it started. Only logs on failure — the caller
  * still surfaces the original (binding) error to the user.
@@ -175,13 +226,14 @@ export async function POST(
 
   // Task-driven origins: ECM owns the calendar binding AND the booking's
   // resource payload (the assign chain patches the tuple onto the booking via
-  // the async-job ledger), so a move is slot-only. The request body's
-  // resource blob is the planner's frozen drag payload — after a workflow
-  // revert it can still carry an assignment tuple nobody holds, and merging
-  // it would both corrupt the booking and (below) fire a stage=assigned
-  // Alerce push for a stale assignment. Dropping it also makes the binding
-  // call and its reverse-move compensation dead for this path. Flag-off
-  // origins keep today's behavior byte-for-byte. The origin is read from the
+  // the async-job ledger), so a move is slot-only apart from the planner-owned
+  // fields merged by `buildTaskDrivenMoveBody`. The request body's resource
+  // blob is the planner's frozen drag payload — after a workflow revert it can
+  // still carry an assignment tuple nobody holds, and merging it wholesale
+  // would both corrupt the booking and (below) fire a stage=assigned Alerce
+  // push for a stale assignment. Dropping the rest also makes the binding call
+  // and its reverse-move compensation dead for this path. Flag-off origins
+  // keep today's behavior byte-for-byte. The origin is read from the
   // persisted booking first, falling back to the request body.
   const enabledOrigins = parseTaskDrivenOrigins(
     process.env.TASK_DRIVEN_ORIGINS
@@ -194,7 +246,9 @@ export async function POST(
   const move = await executeMove(
     client,
     bookingId,
-    taskDriven ? { slot: body.value.slot } : body.value
+    taskDriven
+      ? buildTaskDrivenMoveBody(body.value, snapshot.value)
+      : body.value
   );
   if (!move.ok) return move.error;
   const moved = move.value;

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/[bookingId]/move/route.ts
@@ -91,7 +91,7 @@ export function buildTaskDrivenMoveBody(
       id,
       ...(type == null ? {} : { type }),
       ...(label == null ? {} : { label }),
-      data: { ...(data ?? {}), ...plannerFields },
+      data: { ...data, ...plannerFields },
     },
   };
 }

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -30,7 +30,9 @@ import {
   advanceWorkflowTask,
   notifyCalendarBinding,
   type BookingTaskAdvance,
+  type AssignProcessVariables,
 } from "@/features/common/providers/client-api.provider";
+import type { KanbanBoardTaskResponse } from "@/features/shipping/types/common.types";
 import {
   parseUrlDate,
   isValidViewMode,
@@ -53,6 +55,7 @@ import {
 } from "@/features/calendar/services/task-driven-binding-gate";
 import {
   decideAssignTaskAdvance,
+  decidePresentedReassign,
   getTaskDrivenUnassignTransition,
 } from "@/features/calendar/services/task-driven-assign";
 import { decidePlanTaskAdvance } from "@/features/calendar/services/task-driven-plan";
@@ -66,6 +69,35 @@ import { ServiceEvent } from "./service-event";
 import { mapBookingToPlannedService } from "@/features/calendar/services/booking-service-mapper";
 import { CALENDAR_LIVE_TASK_COLUMNS } from "@/features/calendar/services/workflow-stage";
 
+
+/** The live Alfresco task representing a service right now. */
+type LiveTask = { taskId: string; stage: TaskStage };
+
+/** A pending re-assign of an already-presented service (the two-step dance). */
+type ReassignPlan = { presentTaskId: string; tuple: AssignProcessVariables };
+
+/**
+ * Build the `mintral_serviceCode → live task` index from a kanban board
+ * response. Extracted from the provider memo so the same mapping can be run
+ * against a *freshly refreshed* board — the reassign dance re-resolves the
+ * newly-minted `assignDriver` task from `refreshLiveTasks()`'s return value,
+ * which the memo (bound to the previous render's data) cannot see in time.
+ */
+function buildLiveTaskIndex(
+  data: KanbanBoardTaskResponse | undefined
+): Map<string, LiveTask> {
+  const map = new Map<string, LiveTask>();
+  if (!data?.data) return map;
+  for (const [columnKey, board] of Object.entries(data.data)) {
+    const stage = asTaskStageFromColumn(columnKey);
+    if (!stage) continue;
+    for (const task of board.tasks) {
+      const code = task.mintral_serviceCode;
+      if (code) map.set(code, { taskId: task.id, stage });
+    }
+  }
+  return map;
+}
 
 async function cancelBookingWithWarning(
   bookingId: string,
@@ -283,21 +315,10 @@ export function PlanningSelectionProvider({
     500
   );
 
-  const serviceCodeToLiveTask = useMemo<
-    Map<string, { taskId: string; stage: TaskStage }>
-  >(() => {
-    const map = new Map<string, { taskId: string; stage: TaskStage }>();
-    if (!liveTasksData?.data) return map;
-    for (const [columnKey, board] of Object.entries(liveTasksData.data)) {
-      const stage = asTaskStageFromColumn(columnKey);
-      if (!stage) continue;
-      for (const task of board.tasks) {
-        const code = task.mintral_serviceCode;
-        if (code) map.set(code, { taskId: task.id, stage });
-      }
-    }
-    return map;
-  }, [liveTasksData]);
+  const serviceCodeToLiveTask = useMemo<Map<string, LiveTask>>(
+    () => buildLiveTaskIndex(liveTasksData),
+    [liveTasksData]
+  );
 
   const getLiveTask = useCallback(
     (serviceCode: string | undefined) =>
@@ -380,9 +401,64 @@ export function PlanningSelectionProvider({
               ...(processVariables ? { processVariables } : {}),
             }
           : undefined;
-      return { liveTask, taskAdvance };
+      // Re-assign of an ALREADY-presented service: the assign tuple only rides
+      // the assignDriver→presentDriver edge, so `getNextTransition` yields
+      // nothing here and the change would never reach Alerce. Signal the
+      // step-back/step-forward dance (see `reassignPresentedService`) instead.
+      // Excludes slot reassignment (`isReassigning`), which only moves the slot.
+      const reassignTuple = ctx.isReassigning
+        ? null
+        : decidePresentedReassign(
+            liveTask?.stage,
+            service.origen,
+            service,
+            taskDrivenOrigins
+          );
+      const reassign: ReassignPlan | undefined =
+        reassignTuple && liveTask?.taskId
+          ? { presentTaskId: liveTask.taskId, tuple: reassignTuple }
+          : undefined;
+      return { liveTask, taskAdvance, reassign };
     },
     [getLiveTask, calendarId, taskDrivenOrigins]
+  );
+
+  // Re-push a resource change on an already-presented service to Alerce by
+  // driving the two workflow edges the planner would otherwise have to fire by
+  // hand (Eliminar Asignación → Asignar): step back to `assignDriver`, then
+  // re-present with the new tuple. ECM's create-listeners reconcile the booking
+  // and re-enqueue the Alerce assign chain, so the change lands and the booking
+  // `sync_status` re-stamps. Throws (surfaced as an assign error) if the task is
+  // not at `assignDriver` after the step-back, leaving the service recoverable.
+  const reassignPresentedService = useCallback(
+    async (
+      presentTaskId: string,
+      serviceCode: string | undefined,
+      tuple: AssignProcessVariables
+    ) => {
+      // Step back: presentDriver → assignDriver (fires OnCreateAssignDriverBinding:
+      // Alerce unassign placeholder + booking → PLANNED).
+      await advanceWorkflowTask(presentTaskId, "Asignar Conductor/Transporte");
+      // Activiti completes synchronously, so the new assignDriver task is
+      // already committed — re-resolve it from a fresh live index.
+      const fresh = await refreshLiveTasks();
+      const assignTask = serviceCode
+        ? buildLiveTaskIndex(fresh).get(serviceCode)
+        : undefined;
+      if (assignTask?.stage !== "assignDriver") {
+        throw new Error(
+          `Reassignment stalled: service ${serviceCode ?? "?"} is not at assignDriver after step-back`
+        );
+      }
+      // Step forward: assignDriver → presentDriver with the new tuple.
+      await advanceWorkflowTask(
+        assignTask.taskId,
+        "Presentar Conductor",
+        tuple
+      );
+      await refreshLiveTasks();
+    },
+    [refreshLiveTasks]
   );
 
   const host = useMemo<CalendarHost<SelectedService>>(
@@ -417,19 +493,37 @@ export function PlanningSelectionProvider({
       hooks: {
         shouldPersistBooking: (item, slot, ctx) => {
           const service = item.raw as SelectedService;
-          const { taskAdvance } = computeTaskAdvance(service, slot, ctx);
-          return !(
-            isTaskDrivenPlanCreate(ctx.oldBookingId, taskAdvance) ||
-            isTaskDrivenAssignUpdate(taskAdvance)
-          );
-        },
-        afterPlan: async (item, slot, ctx) => {
-          const service = item.raw as SelectedService;
-          const { liveTask, taskAdvance } = computeTaskAdvance(
+          const { taskAdvance, reassign } = computeTaskAdvance(
             service,
             slot,
             ctx
           );
+          // A reassign drives workflow edges only; ECM re-writes the row, so
+          // the package must not also PUT a booking (as with the initial assign).
+          return !(
+            isTaskDrivenPlanCreate(ctx.oldBookingId, taskAdvance) ||
+            isTaskDrivenAssignUpdate(taskAdvance) ||
+            !!reassign
+          );
+        },
+        afterPlan: async (item, slot, ctx) => {
+          const service = item.raw as SelectedService;
+          const { liveTask, taskAdvance, reassign } = computeTaskAdvance(
+            service,
+            slot,
+            ctx
+          );
+          // Re-assign of an already-presented service: run the two-step dance
+          // so the resource change re-pushes to Alerce — no manual
+          // unassign→reassign, and the booking sync badge re-stamps.
+          if (reassign) {
+            await reassignPresentedService(
+              reassign.presentTaskId,
+              service.mintral_serviceCode,
+              reassign.tuple
+            );
+            return;
+          }
           // Task-driven PLAN: ECM writes the row; sync the category onto the
           // live task (best-effort, no booking to roll back) then advance.
           if (isTaskDrivenPlanCreate(ctx.oldBookingId, taskAdvance) && taskAdvance) {
@@ -567,6 +661,7 @@ export function PlanningSelectionProvider({
       calendarId,
       getLiveTask,
       computeTaskAdvance,
+      reassignPresentedService,
       taskDrivenOrigins,
       dict,
       canPlan,

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-assign.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-assign.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildAssignProcessVariables,
   decideAssignTaskAdvance,
+  decidePresentedReassign,
   getTaskDrivenUnassignTransition,
 } from "./task-driven-assign";
 
@@ -152,6 +153,65 @@ describe("decideAssignTaskAdvance — P3 assign flag gating", () => {
           // no truck
           mintral_serviceType: "Sider",
         },
+        FLAG_ON
+      )
+    ).toBeNull();
+  });
+});
+
+describe("decidePresentedReassign — re-push a change on an already-presented service", () => {
+  it("flag ON + stage=presentDriver + full tuple: returns the re-push tuple", () => {
+    expect(
+      decidePresentedReassign(
+        "presentDriver",
+        "ANTOFAGASTA",
+        FULL_TUPLE,
+        FLAG_ON
+      )
+    ).toMatchObject({
+      carrier_id: "carrier-uuid",
+      driver_id: "driver-uuid",
+      truck_id: "truck-uuid",
+      tipo_servicio: "SIDER",
+    });
+  });
+
+  it("stage=assignDriver (first-time assign): returns null — the forward edge already carries it", () => {
+    expect(
+      decidePresentedReassign("assignDriver", "ANTOFAGASTA", FULL_TUPLE, FLAG_ON)
+    ).toBeNull();
+  });
+
+  it("stage=planService: returns null", () => {
+    expect(
+      decidePresentedReassign("planService", "ANTOFAGASTA", FULL_TUPLE, FLAG_ON)
+    ).toBeNull();
+  });
+
+  it("flag OFF origin: returns null (un-migrated origins unchanged)", () => {
+    expect(
+      decidePresentedReassign("presentDriver", "CALAMA", FULL_TUPLE, FLAG_ON)
+    ).toBeNull();
+  });
+
+  it("empty enabled set: every origin is treated as flag-off", () => {
+    expect(
+      decidePresentedReassign("presentDriver", "ANTOFAGASTA", FULL_TUPLE, FLAG_OFF)
+    ).toBeNull();
+  });
+
+  it("missing origin: treated as flag-off", () => {
+    expect(
+      decidePresentedReassign("presentDriver", undefined, FULL_TUPLE, FLAG_ON)
+    ).toBeNull();
+  });
+
+  it("presentDriver but incomplete tuple: returns null (nothing valid to re-push)", () => {
+    expect(
+      decidePresentedReassign(
+        "presentDriver",
+        "ANTOFAGASTA",
+        { assignedCarrier: "c", assignedDriver: "d", mintral_serviceType: "Sider" },
         FLAG_ON
       )
     ).toBeNull();

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-assign.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-assign.ts
@@ -96,3 +96,34 @@ export function getTaskDrivenUnassignTransition(
   if (stage !== "presentDriver") return undefined;
   return "Asignar Conductor/Transporte";
 }
+
+/**
+ * Returns the assign tuple to RE-PUSH when the planner changes the assigned
+ * driver/transport on a service whose live task is already at `presentDriver`
+ * — i.e. past the initial `assignDriver → presentDriver` assign.
+ *
+ * The assign tuple only rides that one forward edge (see
+ * {@link decideAssignTaskAdvance}), so a resource change on an already-presented
+ * service has no forward transition to carry it to Alerce, and a plain booking
+ * update would silently diverge the calendar from Alerce. The caller instead
+ * runs the tested step-back/step-forward dance — `presentDriver → assignDriver`
+ * (`"Asignar Conductor/Transporte"`, the same edge "Eliminar Asignación" uses)
+ * then `assignDriver → presentDriver` (`"Presentar Conductor"`) carrying THIS
+ * tuple — which re-enqueues the Alerce assign chain and re-stamps the booking
+ * `sync_status`.
+ *
+ * Returns `null` unless the origin is task-driven, the live stage is
+ * `presentDriver`, and the full assign tuple is present — so a first-time
+ * assign (task at `assignDriver`), a flag-off origin, or a partial tuple all
+ * fall through to today's behavior unchanged.
+ */
+export function decidePresentedReassign(
+  stage: string | undefined,
+  origin: string | undefined,
+  service: AssignTupleInput,
+  enabledOrigins: ReadonlySet<string>
+): AssignProcessVariables | null {
+  if (stage !== "presentDriver") return null;
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return null;
+  return buildAssignProcessVariables(service);
+}

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -1256,7 +1256,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1266,7 +1266,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1300,7 +1300,7 @@
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1359,7 +1359,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -6748,7 +6748,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6762,7 +6761,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6776,7 +6774,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6790,7 +6787,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6804,7 +6800,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6818,7 +6813,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6832,7 +6826,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6846,7 +6839,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6860,7 +6852,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6874,7 +6865,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6888,7 +6878,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6902,7 +6891,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6916,7 +6904,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6930,7 +6917,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6944,7 +6930,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6958,7 +6943,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6972,7 +6956,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6986,7 +6969,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7000,7 +6982,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7014,7 +6995,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7028,7 +7008,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7042,7 +7021,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7056,7 +7034,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7070,7 +7047,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7084,7 +7060,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17667,7 +17642,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -25604,7 +25579,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25622,7 +25596,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25640,7 +25613,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25658,7 +25630,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25676,7 +25647,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25694,7 +25664,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25712,7 +25681,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25730,7 +25698,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25748,7 +25715,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25766,7 +25732,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25784,7 +25749,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25802,7 +25766,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25820,7 +25783,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25838,7 +25800,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25856,7 +25817,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25874,7 +25834,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25892,7 +25851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25910,7 +25868,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25928,7 +25885,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25946,7 +25902,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25964,7 +25919,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25982,7 +25936,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26000,7 +25953,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26018,7 +25970,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26036,7 +25987,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26054,7 +26004,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -26112,7 +26061,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
Two independent calendar fixes, one commit each (plus an unrelated lockfile commit that can be dropped).

## 1. Re-assign an already-presented service without the unassign dance

**Problem.** The assign tuple only rides the `assignDriver → presentDriver` edge. A service already at `presentDriver` has no forward transition to carry a resource change, so changing the driver/truck updated the booking row but **never reached Alerce** — the calendar silently diverged from Alerce. The only workaround was a manual *Eliminar asignación → Asignar* round-trip, re-typing the tuple.

**Fix.** `Asignar` on a `presentDriver` task-driven service now drives that round-trip itself:

1. step back `presentDriver → assignDriver` (`"Asignar Conductor/Transporte"` — the same edge *Eliminar asignación* already uses),
2. re-resolve the freshly-minted task from a refreshed live index (Activiti completes synchronously, so it is already committed),
3. step forward with the new tuple.

ECM's create-listeners then reconcile the booking and re-enqueue the Alerce assign chain, so the change lands and `sync_status` re-stamps.

**No backend change was needed** — the BPMN back-edge already exists and Alerce's `ModificacionRecursoServicios` is an upsert.

## 2. Keep `serviceCategory` and andén across a task-driven move

**Problem.** A task-driven move dropped the request's entire `resource` blob, so the planner's `serviceCategory` and `_anden` were written **nowhere**: ECM never authors them, and the task-property fallback is skipped when the service has no live Alfresco task. Since the grid renders from the booking row, both silently vanished on the next page load. The plan path already persists the category to `cld_bookings.resource_data.serviceCategory` — only the move path lost it.

**Fix.** Merge only the planner-owned, non-tuple fields onto the **persisted snapshot** (not the request), so ECM's fields stay authoritative and cannot be clobbered, and no `assigned*` field can leak — the stale-tuple hazard the slot-only rule guards against is unchanged. Falls back to a slot-only move when the request carries none of those fields, preserving prior behaviour exactly.

## Verification

- `tsc --noEmit` clean
- **799/800** vitest (1 pre-existing skip); 10 new tests
- lint clean on changed files
- Bruno calendar integration suites **180 / 190 / 200 all PASS** (40/40 requests, 74/74 tests) against `Coordinador Dev Evals`
- Fix 1 exercised live on dev service `1586566`: the two transitions enqueue a chain **identical** to the manual round-trip (`calendar_sync ASSIGNED → alerce_assignment → calendar_confirm`)

## Known limits (deliberate, documented in the commits)

- **Fix 1 scope:** only `presentDriver`. There is no back-edge from `prepareService`/`missionControl`, so resource changes after the trip is underway are still unsupported.
- **Fix 1 is not atomic.** A failed step-forward leaves the task at `assignDriver`, recoverable by retrying `Asignar` — the same end state as a manual unassign that succeeded followed by a failed re-assign. There is a brief "unassigned" blip in Alerce mid-round-trip, exactly as the manual flow produced.
- **Not yet seen green through real Alerce.** Fix 1 is proven at the workflow/ledger layer, but the test service was rejected by Alerce for an unrelated data reason (`REMOLQUE NO EXISTE` — the assignment has no trailer), so `sync_status` ended `REJECTED` rather than `CONFIRMED`. The chain fired correctly; Alerce declined the payload. Suite 180 covers the green path against the RM mock with a complete tuple.
- Suite 180 validates against the **RM mock**, not real Alerce — it proves the chain and ECM's handling, not Alerce's own validation rules.

## Note on the third commit

`chore(deps): sync package-lock…` is **unrelated** to both fixes and was not authored by this work. It is metadata-only npm churn (dev/peer/optional flag reclassification) with **zero** `version`/`resolved`/`integrity` changes. Kept as its own commit so it can be dropped without touching the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved task-driven booking moves by preserving supported planner-entered service details.
  * Added handling for reassigning services that are already presented to drivers.
  * Enhanced task-driven workflows to refresh live tasks and advance services correctly.

* **Bug Fixes**
  * Prevented unsupported or stale booking fields from being forwarded during moves.
  * Ensured task-driven moves avoid unnecessary booking persistence and external binding calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #966
