### PR TITLE
feat(jobs-console): label each async job by its payload op

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/events/JobEventEmitter.java
@@ -101,6 +101,7 @@ public class JobEventEmitter {
         JsonObject payload = new JsonObject()
                 .put("jobId", job.id())
                 .put("jobType", job.jobType())
+                .put("jobOp", op(job))
                 .put("executor", job.executor())
                 .put("state", job.state() != null ? job.state().name() : null)
                 .put("transition", transition)
@@ -118,5 +119,20 @@ public class JobEventEmitter {
                 .put("tenantId", job.tenantCode())
                 .put("timestamp", Instant.now().toString())
                 .put("payload", payload);
+    }
+
+    /**
+     * The payload's {@code op}, lifted onto the frame. A job type is not always
+     * one operation — {@code calendar_sync} alone carries ensure/patch/unassign/
+     * cancel — and the frame has no room for the whole payload, so without this
+     * the notification bell can only say "Calendar sync" for four different
+     * writes. {@code null} for job types that have no op.
+     */
+    private static String op(AsyncJob job) {
+        Object op = job.payload() == null ? null : job.payload().get("op");
+        if (!(op instanceof String text) || text.isBlank()) {
+            return null;
+        }
+        return text.trim();
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/events/JobEventEmitterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/events/JobEventEmitterTest.java
@@ -53,11 +53,30 @@ class JobEventEmitterTest {
         assertEquals("chain-1", payload.getString("chainKey"));
         assertEquals("409 conflict", payload.getString("lastError"));
         assertNull(payload.getString("updatedAt"));
+        assertNull(payload.getString("jobOp"), "a payload with no op emits none");
+    }
+
+    @Test
+    void eventDataLiftsThePayloadOpOntoTheFrame() {
+        var emitter = new JobEventEmitter(Optional.of("http://quarkus-sse:8080"));
+
+        assertEquals("unassign",
+                emitter.eventData(job(Map.of("op", "unassign")), "enqueued")
+                        .getJsonObject("payload").getString("jobOp"));
+        // Blank / non-string ops are not ops.
+        assertNull(emitter.eventData(job(Map.of("op", "  ")), "enqueued")
+                .getJsonObject("payload").getString("jobOp"));
+        assertNull(emitter.eventData(job(Map.of("op", 42)), "enqueued")
+                .getJsonObject("payload").getString("jobOp"));
     }
 
     private static AsyncJob job() {
+        return job(Map.of());
+    }
+
+    private static AsyncJob job(Map<String, Object> payload) {
         return new AsyncJob("job-1", "tenant-code-1", "ecm-1", "modulith", "calendar_sync", "VJ-26-0001",
-                "chain-1", 0, "dk-1", Map.of(), JobState.PENDING, 2, 5,
+                "chain-1", 0, "dk-1", payload, JobState.PENDING, 2, 5,
                 OffsetDateTime.now(ZoneOffset.UTC), null, null, "409 conflict", List.of(), "listener",
                 null, null);
     }

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-console-page-content.tsx
@@ -10,7 +10,9 @@ import {
   JOB_STATE_DOT,
   formatDateTime,
   jobContextLine,
+  jobLabel,
   jobTypeLabel,
+  readJobOp,
   relativeAge,
   shortJobId,
   type AsyncJob,
@@ -296,7 +298,7 @@ export default function JobConsolePageContent({ dict }: JobConsolePageContentPro
                         className="block text-left"
                       >
                         <span className="block text-[13px] font-semibold text-gray-900 dark:text-white">
-                          {jobTypeLabel(job.jobType)}
+                          {jobLabel(job.jobType, readJobOp(job.payload))}
                         </span>
                         <span className="block font-mono text-[10px] text-gray-400 dark:text-gray-500">
                           {shortJobId(job.id)}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
@@ -13,7 +13,8 @@ import {
   formatDateTime,
   formatDurationMs,
   jobDurationMs,
-  jobTypeLabel,
+  jobLabel,
+  readJobOp,
   relativeAge,
   shortJobId,
   sortChain,
@@ -170,7 +171,7 @@ export default function JobDetailPanel({
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <span className="text-base font-semibold text-gray-900 dark:text-white">
-                {jobTypeLabel(job.jobType)}
+                {jobLabel(job.jobType, readJobOp(job.payload))}
               </span>
               <JobStateBadge state={job.state} label={stateLabel} />
             </div>
@@ -342,7 +343,7 @@ export default function JobDetailPanel({
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-semibold text-gray-900 dark:text-white">
-                      {jobTypeLabel(member.jobType)}
+                      {jobLabel(member.jobType, readJobOp(member.payload))}
                     </span>
                     <span className="block truncate font-mono text-[10px] text-gray-400 dark:text-gray-500">
                       {shortJobId(member.id)}

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/notification-bell.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/notification-bell.tsx
@@ -15,7 +15,7 @@ import { tr } from "@/features/i18n/tr.service";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { useLoadNotifications } from "@/features/notifications/hooks/use-load-notifications";
 import { useOrgScopes } from "@/features/layout/components/secured-navbar/org-switcher/use-org-scopes";
-import { jobTypeLabel, relativeAge, shortJobId, type JobEventPayload } from "../integration-job.types";
+import { jobLabel, relativeAge, shortJobId, type JobEventPayload } from "../integration-job.types";
 import { useJobEvents } from "../use-job-events";
 
 /**
@@ -139,7 +139,7 @@ export default function NotificationBell({ dict }: NotificationBellProps) {
             )}
             {shown.map((entry) => {
               const { icon: Icon, className } = TRANSITION_ICON[entry.payload.transition];
-              const title = `${jobTypeLabel(entry.payload.jobType)} — ${tr(
+              const title = `${jobLabel(entry.payload.jobType, entry.payload.jobOp)} — ${tr(
                 `pages.integrationJobs.transitions.${entry.payload.transition}`,
                 bellDict,
               )}`;

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
@@ -6,7 +6,9 @@ import {
   formatDateTime,
   jobContextLine,
   jobDurationMs,
+  jobLabel,
   jobTypeLabel,
+  readJobOp,
   relativeAge,
   shortJobId,
   sortChain,
@@ -48,6 +50,35 @@ describe("integration-job.types", () => {
     expect(jobTypeLabel("calendar_sync")).toBe("Calendar sync");
     expect(jobTypeLabel("alerce_arrival")).toBe("Alerce arrival");
     expect(jobTypeLabel("my_custom-type")).toBe("My custom type");
+    // ECM mints these; they must not read as ALL-CAPS shouting in the table.
+    expect(jobTypeLabel("WHATSAPP_POD_NOTIFY")).toBe("WhatsApp POD notice");
+    expect(jobTypeLabel("SOME_NEW_JOB")).toBe("Some new job");
+    expect(jobTypeLabel("calendar_confirm")).toBe("Calendar confirm");
+    expect(jobTypeLabel("alerce_assignment")).toBe("Alerce assignment");
+  });
+
+  it("readJobOp reads a non-blank string op and nothing else", () => {
+    expect(readJobOp({ op: "ensure" })).toBe("ensure");
+    expect(readJobOp({ op: "  unassign  " })).toBe("unassign");
+    expect(readJobOp({ op: "   " })).toBeNull();
+    expect(readJobOp({ op: 42 })).toBeNull();
+    expect(readJobOp({})).toBeNull();
+    expect(readJobOp(undefined)).toBeNull();
+  });
+
+  it("labels each calendar_sync op distinctly", () => {
+    expect(jobLabel("calendar_sync", "ensure")).toBe("Calendar ensure");
+    expect(jobLabel("calendar_sync", "patch")).toBe("Calendar status");
+    expect(jobLabel("calendar_sync", "unassign")).toBe("Calendar unassign");
+    expect(jobLabel("calendar_sync", "cancel")).toBe("Calendar cancel");
+  });
+
+  it("jobLabel falls back to the type label without an op, and shows unknown ops verbatim", () => {
+    expect(jobLabel("calendar_sync")).toBe("Calendar sync");
+    expect(jobLabel("calendar_sync", null)).toBe("Calendar sync");
+    expect(jobLabel("calendar_confirm", null)).toBe("Calendar confirm");
+    expect(jobLabel("calendar_sync", "rebook")).toBe("Calendar sync · rebook");
+    expect(jobLabel("alerce_arrival", "notify")).toBe("Alerce arrival · notify");
   });
 
   it("shortJobId keeps the first uuid segment", () => {

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
@@ -59,6 +59,13 @@ export interface JobsOverview {
 export interface JobEventPayload {
   readonly jobId: string;
   readonly jobType: string;
+  /**
+   * The job payload's `op`, lifted onto the frame by `JobEventEmitter` so the
+   * bell can label a job as precisely as the console table does (the frame
+   * carries no payload). Absent on job types that have no ops — and on frames
+   * emitted by a backend older than that change.
+   */
+  readonly jobOp?: string | null;
   readonly executor: string;
   readonly state: JobState;
   readonly transition:
@@ -141,10 +148,55 @@ export function jobTypeLabel(jobType: string): string {
     calendar_sync: "Calendar sync",
     alerce_arrival: "Alerce arrival",
     whatsapp_send: "WhatsApp message",
+    WHATSAPP_POD_NOTIFY: "WhatsApp POD notice",
   };
   if (known[jobType]) return known[jobType];
-  const words = jobType.replaceAll(/[_-]+/g, " ").trim();
+  // Job types are free-form and the enqueuers do not agree on a case: most are
+  // snake_case, a few are SCREAMING_CASE. Lowercase the shouting ones first so
+  // an unknown type reads as a sentence rather than as an alarm.
+  const cased = /[a-z]/.test(jobType) ? jobType : jobType.toLowerCase();
+  const words = cased.replaceAll(/[_-]+/g, " ").trim();
   return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Per-op labels, because a job type is not always one operation.
+ *
+ * `calendar_sync` is a single type carrying four unrelated writes (see
+ * `CalendarSyncFeature.OP_*`), so labelling by type alone renders a whole
+ * chain as an indistinguishable stack of "Calendar sync" rows and the operator
+ * has to open each one to learn what it did.
+ */
+const JOB_OP_LABELS: Record<string, Record<string, string>> = {
+  calendar_sync: {
+    // Upsert: create-if-absent at the slot / re-slot, then set the stage status.
+    ensure: "Calendar ensure",
+    // Status-only push (plus a resource-data merge) — no slot decision.
+    patch: "Calendar status",
+    unassign: "Calendar unassign",
+    cancel: "Calendar cancel",
+  },
+};
+
+/** The `op` a job payload carries, when it has one. */
+export function readJobOp(
+  payload: Record<string, unknown> | null | undefined
+): string | null {
+  const op = payload?.op;
+  if (typeof op !== "string") return null;
+  const trimmed = op.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Human label for a job, op included. Falls back to {@link jobTypeLabel} when
+ * the job carries no op, and to `"<Type> · <op>"` for an op we have no label
+ * for — so a new backend op shows up as itself instead of collapsing into its
+ * siblings.
+ */
+export function jobLabel(jobType: string, op?: string | null): string {
+  if (!op) return jobTypeLabel(jobType);
+  return JOB_OP_LABELS[jobType]?.[op] ?? `${jobTypeLabel(jobType)} · ${op}`;
 }
 
 export function shortJobId(id: string): string {


### PR DESCRIPTION
Closes #967

## Problem

`calendar_sync` is one job type carrying four unrelated writes, selected by the payload's `op` (`CalendarSyncFeature.OP_*`). The console labelled rows by job type alone, so all four rendered as **"Calendar sync"** — a chain read as an indistinguishable stack of identical rows, and an operator had to open each one to learn what it did.

## What changed

Labels now derive from `(jobType, payload.op)`:

| op | label | what it does |
|---|---|---|
| `ensure` | **Calendar ensure** | create-if-absent at the slot / re-slot, then set the stage status |
| `patch` | **Calendar status** | status-only push + resource-data merge |
| `unassign` | **Calendar unassign** | back to PLANNED, clear the assignment keys, keep the slot |
| `cancel` | **Calendar cancel** | DELETE a future slot / PATCH CANCELLED on a past one |

Applied in the table, the detail-panel header and the chain tab — the chain tab benefits most, since that is where the rows pile up.

- A job with no op keeps its type label; an op with no entry renders as `<Type> · <op>`, so a **new backend op shows up as itself** instead of collapsing into its siblings. No coordinated deploy needed to name a future op.
- The type-filter dropdown and the failure-notification rules deliberately stay **per-type**: a rule covers every op of a type, and the backend filter is by type.
- `JobEventEmitter` lifts `op` onto the SSE frame as `jobOp` (blank / non-string ignored), so the notification bell labels as precisely as the table — the frame carries no payload. The client field is optional, so frames from an older backend degrade to today's behavior.
- Drive-by: SCREAMING_CASE job types (ECM's `WHATSAPP_POD_NOTIFY`) no longer render as all-caps shouting.

Existing ledger rows pick up the new labels on next render — labels are derived, nothing to backfill. The **bell** stays type-only until the modulith is deployed, since `jobOp` comes off the wire.

## No ecm-coordinator change needed

ECM only enqueues/claims/reports against the modulith jobs API (`IntegrationJobClient`); every transition is written and emitted by `AsyncJobService` in miot-integrations, so ECM-enqueued and `ecm`-lane jobs get `jobOp` for free. Its `CalendarSyncFeature` mints exactly the same four op values — the payload stays the wire contract and is untouched.

## Verification

- `vitest` full app suite — **802 passed**, 1 skipped (pre-existing)
- `tsc --noEmit` — clean
- `mvn test` on miot-integrations — **167/167, BUILD SUCCESS**

Note: `mvn -am` cannot reach miot-integrations because `miot-core`'s `AuthTestInfrastructureTest` fails to resolve (known pre-existing discovery failure, unrelated). Worked around by installing deps with `-DskipTests` and running the module suite directly, so miot-integrations was genuinely tested rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job activity events now include operation details when available.
  * Job labels in tables, detail views, and notifications now show both the job type and operation.
  * Added clearer labels for calendar operations and improved formatting for job types.

* **Bug Fixes**
  * Blank or invalid operation values are now handled cleanly without affecting job labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->