### PR TITLE
feat(jobs-console): record each attempt's HTTP timeline

### DIFF
--- a/quarkus-srv/miot-integrations/docs/job-http-tracing.md
+++ b/quarkus-srv/miot-integrations/docs/job-http-tracing.md
@@ -1,0 +1,73 @@
+# Job HTTP tracing
+
+The ledger stored a job's **request payload** and a one-line `detail` per
+attempt. That is enough to know a push failed, not why: the downstream's status
+code and response body — `ERROR_ACCION … "REMOLQUE NO EXISTE"`, a 409
+regression, a validation list — were discarded the moment the handler returned.
+
+Each attempt now also carries the HTTP calls it made, under
+`attempt_history[].http`, and the console renders them as a timeline in the
+job detail's **Attempts** tab.
+
+## Shape
+
+```jsonc
+// async_jobs.attempt_history[n]
+{
+  "at": "2026-07-23T12:44:29Z",
+  "outcome": "FAILED",
+  "detail": "409 conflict",
+  "by": "modulith-worker-3f9c1c2a",
+  "http": [
+    {
+      "at": "2026-07-23T12:44:29Z",
+      "method": "PATCH",
+      "url": "https://calendar.example/api/v1/miot-calendar/bookings/resource/1658427",
+      "status": 409,             // absent when the call never got a response
+      "durationMs": 42,
+      "requestBody": "{\"status\":\"ASSIGNED\"}",
+      "responseBody": "{\"error\":\"status regression\"}",
+      "error": null              // set instead of status on a transport failure
+    }
+  ]
+}
+```
+
+## How it is collected
+
+`JobHttpTrace` is a thread-local recording window. `ModulithJobWorker` opens one
+around `ModulithJobHandler.handle` and closes it in a `finally`; jobs run one at
+a time on the thread, so the window needs no correlation and cannot mix two
+jobs. `CalendarBookingsClient.send` — the single point every modulith-lane call
+leaves through — records each exchange.
+
+Outside a window, `record` is a **no-op**. That is what makes it safe to call
+from a client shared with non-job traffic: nothing accumulates when nobody is
+listening.
+
+## Deliberate limits
+
+- **Headers are never recorded.** That is where the bearer tokens are, and this
+  data is rendered in a browser and lives as long as the job row.
+- **Bodies are capped** at `MAX_BODY_CHARS` (4000), **exchanges** at
+  `MAX_EXCHANGES` (20) per attempt. Both caps announce themselves in the
+  recorded data (`… [N more chars]`, a trailing `note` entry) rather than
+  truncating silently.
+- Request bodies are stored as sent. They are the same data the row's `payload`
+  column already holds, so this is not a new class of stored data — but it is a
+  second copy, and it inherits whatever the payload carries.
+
+## Other executor lanes
+
+`ReportJobRequest.exchanges` is part of the REST report contract, so any worker
+can send a timeline — including the `ecm` lane, which executes
+`alerce_assignment` in ecm-coordinator. The field is optional and additive: a
+worker that does not send it reports exactly as before, and the console simply
+shows no timeline for that attempt. `AsyncJobService` re-applies the caps to
+anything that arrives from outside this JVM, since they are ours to enforce and
+not the reporter's.
+
+**ecm-coordinator does not populate it yet** — its Alerce and calendar calls go
+through `IntegrationJobClient.report(...)` without exchanges. Adopting it there
+is a separate change in that repo: record around the handler's HTTP calls and
+pass the list to `report`.

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
@@ -1,5 +1,6 @@
 package com.microboxlabs.miot.integrations.calendar;
 
+import com.microboxlabs.miot.integrations.jobs.JobHttpTrace;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -224,6 +225,12 @@ public class CalendarBookingsClient {
                 "miot.integrations.calendar-sync.miot-calendar.base-url is not configured"));
     }
 
+    /**
+     * The single point every call leaves through — and therefore the one place
+     * that records the exchange for the job console (see {@link JobHttpTrace}).
+     * Recording is a no-op outside a job's attempt window, so callers that are
+     * not a job pay nothing.
+     */
     private HttpResponse<String> send(String method, String url, String body) {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -235,16 +242,25 @@ public class CalendarBookingsClient {
                 ? HttpRequest.BodyPublishers.noBody()
                 : HttpRequest.BodyPublishers.ofString(body);
         builder.method(method, publisher);
+        long startedAt = System.nanoTime();
         try {
-            return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            JobHttpTrace.record(method, url, response.statusCode(), elapsedMs(startedAt), body, response.body(), null);
+            return response;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new CalendarBookingsHttpException(-1,
-                    "miot-calendar " + method + " " + url + " interrupted: " + e.getMessage());
+            String message = "miot-calendar " + method + " " + url + " interrupted: " + e.getMessage();
+            JobHttpTrace.record(method, url, null, elapsedMs(startedAt), body, null, message);
+            throw new CalendarBookingsHttpException(-1, message);
         } catch (java.io.IOException e) {
-            throw new CalendarBookingsHttpException(-1,
-                    "miot-calendar " + method + " " + url + " io error: " + e.getMessage());
+            String message = "miot-calendar " + method + " " + url + " io error: " + e.getMessage();
+            JobHttpTrace.record(method, url, null, elapsedMs(startedAt), body, null, message);
+            throw new CalendarBookingsHttpException(-1, message);
         }
+    }
+
+    private static long elapsedMs(long startedAtNanos) {
+        return (System.nanoTime() - startedAtNanos) / 1_000_000;
     }
 
     private static JsonObject slotJson(LocalDate date, int hour, int minutes) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java
@@ -1,5 +1,8 @@
 package com.microboxlabs.miot.integrations.dto;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Worker outcome report. {@code outcome} is SUCCEEDED, SKIPPED (nothing to do —
  * recorded as SUCCEEDED with detail) or FAILED. {@code retryable=false} parks a
@@ -7,11 +10,25 @@ package com.microboxlabs.miot.integrations.dto;
  * echoes the attempt number the worker observed at claim time and is used as a
  * compare-and-set guard so stale reports (expired lease, job reclaimed) are
  * rejected.
+ *
+ * <p>{@code exchanges} is the attempt's HTTP timeline — what the worker sent
+ * downstream and what came back — stored under {@code attempt_history[].http}
+ * and rendered by the job console. Optional and additive: a worker that does
+ * not send it (an {@code ecm}-lane worker that has not adopted tracing yet, or
+ * a job that makes no HTTP call) reports exactly as before. See
+ * {@link com.microboxlabs.miot.integrations.jobs.JobHttpTrace} for the entry
+ * shape and the caps re-applied on arrival.
  */
 public record ReportJobRequest(
         String workerId,
         String outcome,
         String detail,
         Boolean retryable,
-        Integer attempts) {
+        Integer attempts,
+        List<Map<String, Object>> exchanges) {
+
+    /** Report with no HTTP timeline — the shape every caller used before tracing. */
+    public ReportJobRequest(String workerId, String outcome, String detail, Boolean retryable, Integer attempts) {
+        this(workerId, outcome, detail, retryable, attempts, null);
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobHttpTrace.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobHttpTrace.java
@@ -1,0 +1,168 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Records the HTTP exchanges an async job made, so the console can show what
+ * actually went over the wire instead of only the request payload.
+ *
+ * <p>The ledger stored the job's <b>payload</b> and a one-line {@code detail}
+ * per attempt, which is enough to know that a push failed but not <i>why</i>:
+ * the downstream's status code and response body — the part that carries the
+ * real reason ("REMOLQUE NO EXISTE", a 409 regression, a validation list) —
+ * were lost the moment the handler returned. Each attempt now carries the whole
+ * exchange list under {@code attempt_history[].http}.
+ *
+ * <p><b>Scope is one attempt on one thread.</b> {@link ModulithJobWorker} runs
+ * jobs one at a time and opens a recording window around
+ * {@link ModulithJobHandler#handle}, so a thread-local needs no correlation and
+ * cannot mix two jobs. Outside a window every {@link #record} call is a no-op,
+ * which is what makes it safe to call unconditionally from a shared HTTP client
+ * that also serves non-job traffic.
+ *
+ * <p><b>What is deliberately not recorded: headers.</b> That is where the
+ * bearer tokens live, and this data is rendered in a browser console and kept
+ * as long as the job row. Bodies are capped at {@link #MAX_BODY_CHARS} and the
+ * list at {@link #MAX_EXCHANGES} so one chatty job cannot bloat the row; both
+ * caps announce themselves in the recorded data rather than truncating
+ * silently.
+ */
+public final class JobHttpTrace {
+
+    /** Per-attempt exchange cap. Beyond this a marker entry records the overflow. */
+    public static final int MAX_EXCHANGES = 20;
+    /** Per-body character cap, applied to request and response alike. */
+    public static final int MAX_BODY_CHARS = 4000;
+
+    private static final ThreadLocal<Recording> ACTIVE = new ThreadLocal<>();
+
+    private JobHttpTrace() {
+    }
+
+    /** Opens a recording window on this thread, discarding any stale one. */
+    public static void begin() {
+        ACTIVE.set(new Recording());
+    }
+
+    /**
+     * Closes the window and returns what was recorded (never null). Always call
+     * this in a {@code finally} — a leaked thread-local would attribute the next
+     * job's calls to this one.
+     */
+    public static List<Map<String, Object>> end() {
+        Recording recording = ACTIVE.get();
+        ACTIVE.remove();
+        return recording == null ? List.of() : recording.drain();
+    }
+
+    /**
+     * Records one exchange. A no-op outside a recording window, and never throws
+     * — tracing must not be able to fail the job it is observing.
+     *
+     * @param status the HTTP status, or null when the call never got one (a
+     *        timeout, a DNS failure, a dropped connection)
+     * @param error the transport failure message, or null on a completed call
+     */
+    public static void record(String method, String url, Integer status, long durationMs,
+                              String requestBody, String responseBody, String error) {
+        Recording recording = ACTIVE.get();
+        if (recording == null) {
+            return;
+        }
+        try {
+            recording.add(method, url, status, durationMs, requestBody, responseBody, error);
+        } catch (RuntimeException e) {
+            // Deliberately swallowed: a broken trace is never worth failing a
+            // delivery over. The exchange is simply missing from the timeline.
+            recording.dropped++;
+        }
+    }
+
+    /**
+     * Normalizes an exchange list that arrived from outside this JVM (an
+     * {@code ecm}-lane worker reporting over REST). The caps are ours to
+     * enforce, not the reporter's, so they are re-applied here.
+     */
+    public static List<Map<String, Object>> sanitize(List<Map<String, Object>> exchanges) {
+        if (exchanges == null || exchanges.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> out = new ArrayList<>(Math.min(exchanges.size(), MAX_EXCHANGES));
+        for (Map<String, Object> exchange : exchanges) {
+            if (exchange == null) {
+                continue;
+            }
+            if (out.size() == MAX_EXCHANGES) {
+                out.add(overflow(exchanges.size() - MAX_EXCHANGES));
+                break;
+            }
+            out.add(truncateValues(exchange));
+        }
+        return out;
+    }
+
+    private static Map<String, Object> truncateValues(Map<String, Object> exchange) {
+        Map<String, Object> copy = new LinkedHashMap<>();
+        exchange.forEach((key, value) ->
+                copy.put(key, value instanceof String text ? truncate(text) : value));
+        return copy;
+    }
+
+    private static Map<String, Object> overflow(int dropped) {
+        Map<String, Object> marker = new LinkedHashMap<>();
+        marker.put("note", dropped + " further exchange(s) not recorded (cap " + MAX_EXCHANGES + ")");
+        return marker;
+    }
+
+    private static String truncate(String body) {
+        if (body == null || body.length() <= MAX_BODY_CHARS) {
+            return body;
+        }
+        return body.substring(0, MAX_BODY_CHARS) + "… [" + (body.length() - MAX_BODY_CHARS) + " more chars]";
+    }
+
+    /** One attempt's worth of exchanges, plus what the cap turned away. */
+    private static final class Recording {
+
+        private final List<Map<String, Object>> exchanges = new ArrayList<>();
+        private int dropped;
+
+        void add(String method, String url, Integer status, long durationMs,
+                 String requestBody, String responseBody, String error) {
+            if (exchanges.size() >= MAX_EXCHANGES) {
+                dropped++;
+                return;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("at", OffsetDateTime.now(ZoneOffset.UTC).toString());
+            entry.put("method", method);
+            entry.put("url", url);
+            if (status != null) {
+                entry.put("status", status);
+            }
+            entry.put("durationMs", durationMs);
+            if (requestBody != null && !requestBody.isBlank()) {
+                entry.put("requestBody", truncate(requestBody));
+            }
+            if (responseBody != null && !responseBody.isBlank()) {
+                entry.put("responseBody", truncate(responseBody));
+            }
+            if (error != null) {
+                entry.put("error", error);
+            }
+            exchanges.add(entry);
+        }
+
+        List<Map<String, Object>> drain() {
+            if (dropped > 0) {
+                exchanges.add(overflow(dropped));
+            }
+            return List.copyOf(exchanges);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorker.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorker.java
@@ -149,6 +149,21 @@ public class ModulithJobWorker {
     }
 
     private void executeAndReport(AsyncJob job) {
+        // Record the attempt's HTTP calls so the report carries what the
+        // downstream actually said, not just our one-line verdict on it. Jobs
+        // run one at a time on this thread, so the window is unambiguous — and
+        // the outer finally guarantees it is closed even on a Throwable the
+        // catches below do not cover, which would otherwise attribute this
+        // job's calls to the next one.
+        JobHttpTrace.begin();
+        try {
+            runAndReport(job);
+        } finally {
+            JobHttpTrace.end();
+        }
+    }
+
+    private void runAndReport(AsyncJob job) {
         String outcome;
         String detail;
         boolean retryable = true;
@@ -185,15 +200,18 @@ public class ModulithJobWorker {
             LOG.warnf("modulith job %s (%s, service %s) failed: %s",
                     job.id(), job.jobType(), job.correlationKey(), e.getMessage());
         }
-        report(job, outcome, detail, retryable);
+        // Read (not closed) here: the window must outlive the catch blocks so a
+        // failed attempt keeps the exchanges that explain the failure.
+        report(job, outcome, detail, retryable, JobHttpTrace.end());
     }
 
-    private void report(AsyncJob job, String outcome, String detail, boolean retryable) {
+    private void report(AsyncJob job, String outcome, String detail, boolean retryable,
+                        List<Map<String, Object>> exchanges) {
         try {
             // Echo the claimed attempt number: the ledger CAS rejects this report
             // if the lease expired and the job was reclaimed meanwhile.
             jobService.report(job.tenantCode(), job.id(),
-                    new ReportJobRequest(workerId, outcome, detail, retryable, job.attempts()));
+                    new ReportJobRequest(workerId, outcome, detail, retryable, job.attempts(), exchanges));
         } catch (Exception e) {
             // The lease expires and the job becomes claimable again; the re-run is
             // safe because handlers are idempotent.

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java
@@ -9,6 +9,7 @@ import com.microboxlabs.miot.integrations.dto.EnqueueJobsResponse;
 import com.microboxlabs.miot.integrations.dto.ReportJobRequest;
 import com.microboxlabs.miot.integrations.events.JobEventEmitter;
 import com.microboxlabs.miot.integrations.events.JobParkedEvent;
+import com.microboxlabs.miot.integrations.jobs.JobHttpTrace;
 import com.microboxlabs.miot.integrations.persistence.AsyncJobRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
@@ -182,7 +183,8 @@ public class AsyncJobService {
         // workerId via fast path + poller overlap) cannot overwrite the newer
         // attempt's state.
         int expectedAttempts = request.attempts() != null ? request.attempts() : job.attempts();
-        Map<String, Object> entry = attemptEntry(request.outcome(), request.detail(), request.workerId());
+        Map<String, Object> entry = attemptEntry(request.outcome(), request.detail(), request.workerId(),
+                request.exchanges());
         AsyncJob updated = repository.report(jobId, request.workerId(), expectedAttempts, newState, nextRetryAt,
                 lastError, entry);
         if (updated == null) {
@@ -320,6 +322,18 @@ public class AsyncJobService {
     }
 
     private Map<String, Object> attemptEntry(String outcome, String detail, String by) {
+        return attemptEntry(outcome, detail, by, null);
+    }
+
+    /**
+     * One {@code attempt_history} entry. {@code http} carries the attempt's HTTP
+     * timeline when the worker recorded one — the downstream's status and
+     * response body, which is what turns "failed" into a diagnosable failure.
+     * Re-sanitized here because a report can arrive over REST from another
+     * process, so the size caps are ours to enforce rather than the reporter's.
+     */
+    private Map<String, Object> attemptEntry(String outcome, String detail, String by,
+            List<Map<String, Object>> exchanges) {
         Map<String, Object> entry = new LinkedHashMap<>();
         entry.put("at", OffsetDateTime.now(ZoneOffset.UTC).toString());
         entry.put("outcome", outcome);
@@ -328,6 +342,10 @@ public class AsyncJobService {
         }
         if (by != null) {
             entry.put("by", by);
+        }
+        List<Map<String, Object>> http = JobHttpTrace.sanitize(exchanges);
+        if (!http.isEmpty()) {
+            entry.put("http", http);
         }
         return entry;
     }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobHttpTraceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobHttpTraceTest.java
@@ -1,0 +1,148 @@
+package com.microboxlabs.miot.integrations.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class JobHttpTraceTest {
+
+    /** No test may leak a window into the next one — the thread is reused. */
+    @AfterEach
+    void closeAnyOpenWindow() {
+        JobHttpTrace.end();
+    }
+
+    @Test
+    void recordsTheExchangeInsideAWindow() {
+        JobHttpTrace.begin();
+        JobHttpTrace.record("PATCH", "http://calendar/bookings/resource/1658427", 409, 42,
+                "{\"status\":\"ASSIGNED\"}", "{\"error\":\"status regression\"}", null);
+
+        List<Map<String, Object>> exchanges = JobHttpTrace.end();
+
+        assertEquals(1, exchanges.size());
+        Map<String, Object> entry = exchanges.get(0);
+        assertEquals("PATCH", entry.get("method"));
+        assertEquals("http://calendar/bookings/resource/1658427", entry.get("url"));
+        assertEquals(409, entry.get("status"));
+        assertEquals(42L, entry.get("durationMs"));
+        assertEquals("{\"status\":\"ASSIGNED\"}", entry.get("requestBody"));
+        assertEquals("{\"error\":\"status regression\"}", entry.get("responseBody"));
+        assertNotNullAt(entry);
+    }
+
+    @Test
+    void recordsATransportFailureWithNoStatus() {
+        JobHttpTrace.begin();
+        JobHttpTrace.record("POST", "http://calendar/bookings", null, 5000, "{}", null, "io error: timeout");
+
+        Map<String, Object> entry = JobHttpTrace.end().get(0);
+        assertNull(entry.get("status"), "a call that never got a response has no status");
+        assertEquals("io error: timeout", entry.get("error"));
+    }
+
+    @Test
+    void recordingOutsideAWindowIsANoOp() {
+        // The client is shared with non-job traffic; recording must not accumulate
+        // anywhere when nobody opened a window.
+        JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null);
+        assertTrue(JobHttpTrace.end().isEmpty());
+    }
+
+    @Test
+    void endIsIdempotentAndClosesTheWindow() {
+        JobHttpTrace.begin();
+        JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null);
+        assertEquals(1, JobHttpTrace.end().size());
+        assertTrue(JobHttpTrace.end().isEmpty(), "a second end sees a closed window");
+
+        // And a call after closing does not resurrect it.
+        JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null);
+        assertTrue(JobHttpTrace.end().isEmpty());
+    }
+
+    @Test
+    void beginDiscardsAStaleWindow() {
+        JobHttpTrace.begin();
+        JobHttpTrace.record("GET", "http://calendar/a", 200, 1, null, "a", null);
+        JobHttpTrace.begin();
+        JobHttpTrace.record("GET", "http://calendar/b", 200, 1, null, "b", null);
+
+        List<Map<String, Object>> exchanges = JobHttpTrace.end();
+        assertEquals(1, exchanges.size(), "the new window starts empty");
+        assertEquals("http://calendar/b", exchanges.get(0).get("url"));
+    }
+
+    @Test
+    void truncatesAnOversizedBodyAndSaysSo() {
+        JobHttpTrace.begin();
+        String huge = "x".repeat(JobHttpTrace.MAX_BODY_CHARS + 500);
+        JobHttpTrace.record("POST", "http://calendar/bookings", 200, 1, huge, huge, null);
+
+        String recorded = (String) JobHttpTrace.end().get(0).get("responseBody");
+        assertTrue(recorded.length() < huge.length());
+        assertTrue(recorded.startsWith("x".repeat(JobHttpTrace.MAX_BODY_CHARS)));
+        assertTrue(recorded.contains("500 more chars"), "truncation announces itself: " + recorded);
+    }
+
+    @Test
+    void capsTheExchangeCountAndRecordsTheOverflow() {
+        JobHttpTrace.begin();
+        int over = 3;
+        for (int i = 0; i < JobHttpTrace.MAX_EXCHANGES + over; i++) {
+            JobHttpTrace.record("GET", "http://calendar/slots?page=" + i, 200, 1, null, "[]", null);
+        }
+
+        List<Map<String, Object>> exchanges = JobHttpTrace.end();
+        assertEquals(JobHttpTrace.MAX_EXCHANGES + 1, exchanges.size(), "capped, plus one overflow marker");
+        Map<String, Object> marker = exchanges.get(exchanges.size() - 1);
+        assertEquals(over + " further exchange(s) not recorded (cap " + JobHttpTrace.MAX_EXCHANGES + ")",
+                marker.get("note"), "the cap is never silent");
+    }
+
+    @Test
+    void sanitizeReappliesTheCapsToAForeignReport() {
+        List<Map<String, Object>> reported = new ArrayList<>();
+        int over = 5;
+        for (int i = 0; i < JobHttpTrace.MAX_EXCHANGES + over; i++) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("url", "http://alerce/svc/" + i);
+            entry.put("responseBody", "y".repeat(JobHttpTrace.MAX_BODY_CHARS + 10));
+            entry.put("status", 200);
+            reported.add(entry);
+        }
+
+        List<Map<String, Object>> sanitized = JobHttpTrace.sanitize(reported);
+
+        assertEquals(JobHttpTrace.MAX_EXCHANGES + 1, sanitized.size());
+        assertTrue(((String) sanitized.get(0).get("responseBody")).contains("10 more chars"),
+                "an oversized body from another process is truncated here too");
+        assertEquals(200, sanitized.get(0).get("status"), "non-string values pass through untouched");
+        assertTrue(sanitized.get(sanitized.size() - 1).containsKey("note"));
+    }
+
+    @Test
+    void sanitizeToleratesNullEmptyAndNullEntries() {
+        assertTrue(JobHttpTrace.sanitize(null).isEmpty());
+        assertTrue(JobHttpTrace.sanitize(List.of()).isEmpty());
+
+        List<Map<String, Object>> withNull = new ArrayList<>();
+        withNull.add(null);
+        withNull.add(Map.of("url", "http://alerce/svc"));
+        List<Map<String, Object>> sanitized = JobHttpTrace.sanitize(withNull);
+        assertEquals(1, sanitized.size());
+        assertFalse(sanitized.get(0).isEmpty());
+    }
+
+    private static void assertNotNullAt(Map<String, Object> entry) {
+        assertTrue(entry.get("at") instanceof String at && !at.isBlank(), "every exchange is stamped");
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java
@@ -119,6 +119,66 @@ class ModulithJobWorkerTest {
                 "a terminal failure parks now, no backoff");
     }
 
+    // --- http tracing --------------------------------------------------------
+
+    @Test
+    void reportCarriesTheHttpExchangesTheHandlerMade() {
+        var service = new RecordingService();
+        service.claimResults.add(List.of(job("job-1", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of());
+        var handler = new FakeHandler(CALENDAR);
+        handler.onHandle = () -> JobHttpTrace.record("PATCH", "http://calendar/r/1658427", 409, 12,
+                "{\"status\":\"ASSIGNED\"}", "{\"error\":\"regression\"}", null);
+        worker(service, true, handler).drain();
+
+        List<Map<String, Object>> exchanges = service.reports.get(0).exchanges();
+        assertEquals(1, exchanges.size());
+        assertEquals(409, exchanges.get(0).get("status"));
+        assertEquals("{\"error\":\"regression\"}", exchanges.get(0).get("responseBody"));
+    }
+
+    @Test
+    void aFailedAttemptKeepsTheExchangesThatExplainIt() {
+        var service = new RecordingService();
+        service.claimResults.add(List.of(job("job-1", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of());
+        var handler = new FakeHandler(CALENDAR);
+        handler.onHandle = () -> JobHttpTrace.record("POST", "http://alerce/svc", 500, 30,
+                "{}", "ERROR_ACCION: REMOLQUE NO EXISTE", null);
+        handler.throwWith = new RuntimeException("boom");
+        worker(service, true, handler).drain();
+
+        ReportJobRequest report = service.reports.get(0);
+        assertEquals("FAILED", report.outcome());
+        assertEquals("ERROR_ACCION: REMOLQUE NO EXISTE", report.exchanges().get(0).get("responseBody"),
+                "the downstream's reason survives the failure — that is the point");
+    }
+
+    @Test
+    void aJobThatMakesNoCallReportsAnEmptyTimeline() {
+        var service = new RecordingService();
+        service.claimResults.add(List.of(job("job-1", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of());
+        worker(service, true, new FakeHandler(CALENDAR)).drain();
+
+        assertTrue(service.reports.get(0).exchanges().isEmpty());
+    }
+
+    @Test
+    void oneJobsExchangesNeverLeakIntoTheNext() {
+        var service = new RecordingService();
+        service.claimResults.add(List.of(job("job-1", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of(job("job-2", ModulithJobHandler.EXECUTOR, CALENDAR, 1)));
+        service.claimResults.add(List.of());
+        var handler = new FakeHandler(CALENDAR);
+        handler.onHandle = () -> JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null);
+        worker(service, true, handler).drain();
+
+        assertEquals(2, service.reports.size());
+        assertEquals(1, service.reports.get(0).exchanges().size());
+        assertEquals(1, service.reports.get(1).exchanges().size(), "the window is per attempt, not cumulative");
+    }
+
     // --- gating --------------------------------------------------------------
 
     @Test
@@ -145,6 +205,8 @@ class ModulithJobWorkerTest {
         private final String jobType;
         boolean ready = true;
         RuntimeException throwWith;
+        /** Stands in for the HTTP calls a real handler makes. */
+        Runnable onHandle;
 
         FakeHandler(String jobType) {
             this.jobType = jobType;
@@ -162,6 +224,9 @@ class ModulithJobWorkerTest {
 
         @Override
         public JobOutcome handle(Map<String, Object> payload) {
+            if (onHandle != null) {
+                onHandle.run();
+            }
             if (throwWith != null) {
                 throw throwWith;
             }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java
@@ -181,6 +181,38 @@ class AsyncJobServiceTest {
     }
 
     @Test
+    void reportStoresTheHttpTimelineOnTheAttemptEntry() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
+        var exchange = Map.<String, Object>of(
+                "method", "PATCH", "url", "http://calendar/r/1", "status", 409,
+                "responseBody", "{\"error\":\"status regression\"}");
+
+        service.report("t", "job-1",
+                new ReportJobRequest("w", "FAILED", "409 conflict", null, 1, List.of(exchange)));
+
+        @SuppressWarnings("unchecked")
+        var http = (List<Map<String, Object>>) repo.reportedEntry.get("http");
+        assertEquals(1, http.size());
+        assertEquals(409, http.get(0).get("status"));
+        assertEquals("{\"error\":\"status regression\"}", http.get(0).get("responseBody"));
+    }
+
+    @Test
+    void reportOmitsHttpWhenTheWorkerSentNoTimeline() {
+        var repo = new FakeRepository(runningJob(1, 5));
+        var service = new AsyncJobService(repo, noEvents(), noParked(), BASE_SECONDS, MAX_SECONDS);
+
+        // The pre-tracing report shape, and an explicitly empty one: neither
+        // should leave an empty `http` key behind for the console to render.
+        service.report("t", "job-1", new ReportJobRequest("w", "SUCCEEDED", "ok", null, 1));
+        assertNull(repo.reportedEntry.get("http"));
+
+        service.report("t", "job-1", new ReportJobRequest("w", "SUCCEEDED", "ok", null, 1, List.of()));
+        assertNull(repo.reportedEntry.get("http"));
+    }
+
+    @Test
     void reportEmitsTransitionEvents() {
         var emitter = new RecordingEmitter();
         var service = new AsyncJobService(new FakeRepository(runningJob(1, 5)), emitter, noParked(), BASE_SECONDS, MAX_SECONDS);
@@ -361,6 +393,7 @@ class AsyncJobServiceTest {
         OffsetDateTime reportedNextRetryAt;
         String reportedWorkerId;
         Integer reportedExpectedAttempts;
+        Map<String, Object> reportedEntry;
         String claimedTenant;
         boolean reportStale;
 
@@ -381,6 +414,7 @@ class AsyncJobServiceTest {
             this.reportedNextRetryAt = nextRetryAt;
             this.reportedWorkerId = workerId;
             this.reportedExpectedAttempts = expectedAttempts;
+            this.reportedEntry = attemptEntry;
             return reportStale ? null : existing;
         }
 

--- a/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
+++ b/turbo-repo/apps/app/src/features/integration-jobs/components/job-detail-panel.tsx
@@ -9,11 +9,14 @@ import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import {
   canRetry,
   countdownTo,
+  exchangePath,
+  exchangeStatusTone,
   formatClock,
   formatDateTime,
   formatDurationMs,
   jobDurationMs,
   jobLabel,
+  readAttemptExchanges,
   readJobOp,
   relativeAge,
   shortJobId,
@@ -21,6 +24,7 @@ import {
   JOB_STATE_DOT,
   type AsyncJob,
   type AsyncJobAttempt,
+  type JobHttpExchange,
 } from "../integration-job.types";
 import { useIntegrationJob, useIntegrationJobChain, useRetryJob } from "../use-integration-jobs";
 import JobStateBadge from "./job-state-badge";
@@ -67,6 +71,87 @@ interface TimelineNode {
   readonly title: string;
   readonly meta: string;
   readonly error?: string | null;
+  readonly exchanges?: JobHttpExchange[];
+}
+
+/**
+ * One recorded HTTP call: the line an operator scans (method, path, status,
+ * duration) with the bodies folded away behind a native `<details>` — the panel
+ * is 400px wide, so a response body has to be opt-in, and `<details>` keeps
+ * that free of state and keyboard-accessible.
+ */
+function HttpExchangeRow({
+  exchange,
+  dict,
+}: {
+  readonly exchange: JobHttpExchange;
+  readonly dict: I18nRecord;
+}) {
+  if (exchange.note) {
+    return (
+      <li className="py-1 text-[11px] italic text-gray-400 dark:text-gray-500">{exchange.note}</li>
+    );
+  }
+  const hasBody = Boolean(exchange.requestBody || exchange.responseBody || exchange.error);
+  const status = exchange.status;
+  return (
+    <li className="border-t border-gray-100 py-1.5 first:border-t-0 dark:border-gray-700/60">
+      <div className="flex items-center gap-1.5">
+        <span className="font-mono text-[10px] font-semibold text-gray-500 dark:text-gray-400">
+          {exchange.method ?? "—"}
+        </span>
+        <span
+          className="min-w-0 flex-1 truncate font-mono text-[11px] text-gray-700 dark:text-gray-300"
+          title={exchange.url}
+        >
+          {exchangePath(exchange.url)}
+        </span>
+        <span
+          className={`flex-shrink-0 rounded px-1 py-0.5 font-mono text-[10px] font-semibold ${exchangeStatusTone(status)}`}
+        >
+          {status ?? tr("timeline.httpNoResponse", dict)}
+        </span>
+        {exchange.durationMs !== undefined && (
+          <span className="flex-shrink-0 font-mono text-[10px] text-gray-400 dark:text-gray-500">
+            {formatDurationMs(exchange.durationMs)}
+          </span>
+        )}
+      </div>
+      {hasBody && (
+        <details className="mt-1">
+          <summary className="cursor-pointer text-[10px] text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300">
+            {tr("timeline.httpBodies", dict)}
+          </summary>
+          <div className="mt-1 flex flex-col gap-1">
+            {exchange.error && (
+              <div className="rounded bg-red-50 px-2 py-1 text-[11px] text-red-700 dark:bg-red-900/20 dark:text-red-300">
+                {exchange.error}
+              </div>
+            )}
+            {exchange.requestBody && (
+              <Body label={tr("timeline.httpRequest", dict)} value={exchange.requestBody} />
+            )}
+            {exchange.responseBody && (
+              <Body label={tr("timeline.httpResponse", dict)} value={exchange.responseBody} />
+            )}
+          </div>
+        </details>
+      )}
+    </li>
+  );
+}
+
+function Body({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div>
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        {label}
+      </div>
+      <pre className="mt-0.5 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-gray-900 p-2 font-mono text-[10px] leading-relaxed text-gray-200">
+        {value}
+      </pre>
+    </div>
+  );
 }
 
 function historyDotClass(outcome: string): string {
@@ -102,6 +187,7 @@ function timelineNodes(job: AsyncJob, dict: I18nRecord, nowMs: number): Timeline
         .filter(Boolean)
         .join(" · "),
       error: isFailure && typeof entry.detail === "string" ? entry.detail : null,
+      exchanges: readAttemptExchanges(entry),
     });
   });
   if (job.state === "RUNNING") {
@@ -283,6 +369,17 @@ export default function JobDetailPanel({
                     <div className="mt-1 rounded bg-red-50 px-2 py-1 text-[11px] text-red-700 dark:bg-red-900/20 dark:text-red-300">
                       {node.error}
                     </div>
+                  )}
+                  {node.exchanges && node.exchanges.length > 0 && (
+                    <ul className="mt-1.5 rounded-lg border border-gray-200 px-2 dark:border-gray-700">
+                      {node.exchanges.map((exchange, exchangeIndex) => (
+                        <HttpExchangeRow
+                          key={`${node.key}-x-${exchangeIndex}`}
+                          exchange={exchange}
+                          dict={dict}
+                        />
+                      ))}
+                    </ul>
                   )}
                 </div>
               </li>

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   canRetry,
   countdownTo,
+  exchangePath,
+  exchangeStatusTone,
+  readAttemptExchanges,
   formatClock,
   formatDateTime,
   jobContextLine,
@@ -14,6 +17,7 @@ import {
   sortChain,
   toEpochMs,
   type AsyncJob,
+  type AsyncJobAttempt,
 } from "./integration-job.types";
 
 const NOW = Date.parse("2026-07-19T12:00:00Z");
@@ -79,6 +83,36 @@ describe("integration-job.types", () => {
     expect(jobLabel("calendar_confirm", null)).toBe("Calendar confirm");
     expect(jobLabel("calendar_sync", "rebook")).toBe("Calendar sync · rebook");
     expect(jobLabel("alerce_arrival", "notify")).toBe("Alerce arrival · notify");
+  });
+
+  it("readAttemptExchanges treats the free-form jsonb as untrusted", () => {
+    const exchange = { method: "PATCH", url: "http://calendar/r/1", status: 409 };
+    expect(readAttemptExchanges({ outcome: "FAILED", http: [exchange] })).toEqual([exchange]);
+    expect(readAttemptExchanges({ outcome: "SUCCEEDED" })).toEqual([]);
+    // A worker could write anything into attempt_history — none of it may throw.
+    expect(readAttemptExchanges({ http: "nope" } as unknown as AsyncJobAttempt)).toEqual([]);
+    expect(
+      readAttemptExchanges({ http: [null, 7, exchange] } as unknown as AsyncJobAttempt),
+    ).toEqual([exchange]);
+  });
+
+  it("exchangePath strips the origin and survives a malformed url", () => {
+    expect(exchangePath("https://calendar.test/api/v1/miot-calendar/bookings?calendarId=7")).toBe(
+      "/api/v1/miot-calendar/bookings?calendarId=7",
+    );
+    expect(exchangePath("/relative/path")).toBe("/relative/path");
+    expect(exchangePath(undefined)).toBe("—");
+  });
+
+  it("exchangeStatusTone separates ok, caller error and no-response", () => {
+    const ok = exchangeStatusTone(200);
+    const clientError = exchangeStatusTone(409);
+    const serverError = exchangeStatusTone(500);
+    expect(ok).toContain("green");
+    expect(clientError).toContain("amber");
+    expect(serverError).toContain("rose");
+    // A call that never got a response reads as badly as a 5xx.
+    expect(exchangeStatusTone(undefined)).toBe(serverError);
   });
 
   it("shortJobId keeps the first uuid segment", () => {

--- a/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
+++ b/turbo-repo/apps/app/src/features/integration-jobs/integration-job.types.ts
@@ -16,11 +16,33 @@ export const JOB_STATES = [
 
 export type JobState = (typeof JOB_STATES)[number];
 
+/**
+ * One HTTP call an attempt made, as recorded by the backend's `JobHttpTrace`
+ * and stored under `attempt_history[].http`.
+ *
+ * `status` is absent when the call never got a response (timeout, DNS, dropped
+ * connection) — `error` carries the transport failure instead. Headers are
+ * deliberately never recorded: that is where the bearer tokens are.
+ */
+export interface JobHttpExchange {
+  readonly at?: string;
+  readonly method?: string;
+  readonly url?: string;
+  readonly status?: number;
+  readonly durationMs?: number;
+  readonly requestBody?: string;
+  readonly responseBody?: string;
+  readonly error?: string;
+  /** Overflow marker emitted when the per-attempt cap turned exchanges away. */
+  readonly note?: string;
+}
+
 export interface AsyncJobAttempt {
   readonly at?: string;
   readonly outcome?: string;
   readonly detail?: string;
   readonly by?: string;
+  readonly http?: JobHttpExchange[];
   readonly [key: string]: unknown;
 }
 
@@ -201,6 +223,39 @@ export function jobLabel(jobType: string, op?: string | null): string {
 
 export function shortJobId(id: string): string {
   return id.slice(0, 8);
+}
+
+/**
+ * The HTTP exchanges an attempt recorded. `attempt_history` is free-form jsonb
+ * written by more than one worker, so this treats the shape as untrusted rather
+ * than as its declared type: a non-array, or entries that are not objects, read
+ * as "no timeline" instead of crashing the panel.
+ */
+export function readAttemptExchanges(entry: AsyncJobAttempt): JobHttpExchange[] {
+  if (!Array.isArray(entry.http)) return [];
+  return entry.http.filter(
+    (exchange): exchange is JobHttpExchange =>
+      typeof exchange === "object" && exchange !== null
+  );
+}
+
+/** "POST /api/v1/miot-calendar/bookings" — the URL's path, sans origin. */
+export function exchangePath(url: string | undefined): string {
+  if (!url) return "—";
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url; // a relative or malformed URL is shown as-is
+  }
+}
+
+/** Tailwind classes for a status pill: 2xx ok, 4xx caller's fault, else bad. */
+export function exchangeStatusTone(status: number | undefined): string {
+  if (status === undefined) return "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300";
+  if (status < 300) return "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300";
+  if (status < 500) return "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300";
+  return "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300";
 }
 
 /**

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -1598,7 +1598,11 @@
         "report": "Report",
         "running": "Running",
         "retryScheduled": "Retry scheduled, attempt",
-        "backoff": "exponential backoff"
+        "backoff": "exponential backoff",
+        "httpBodies": "Show bodies",
+        "httpRequest": "Request",
+        "httpResponse": "Response",
+        "httpNoResponse": "no resp."
       },
       "bell": {
         "title": "Notifications",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -1598,7 +1598,11 @@
         "report": "Reporte",
         "running": "En curso",
         "retryScheduled": "Reintento agendado, intento",
-        "backoff": "backoff exponencial"
+        "backoff": "backoff exponencial",
+        "httpBodies": "Ver cuerpos",
+        "httpRequest": "Solicitud",
+        "httpResponse": "Respuesta",
+        "httpNoResponse": "sin resp."
       },
       "bell": {
         "title": "Notificaciones",


### PR DESCRIPTION
Closes #969

Stacked on #968 conceptually (same console), but independent — this branch is cut from `trunk` and touches different files.

## Problem

The ledger stored a job's **request payload** and a one-line `detail` per attempt. Enough to know a push failed; not why. The downstream's status and response body — `ERROR_ACCION … "REMOLQUE NO EXISTE"`, a 409 regression, a validation list — were discarded the moment the handler returned, so diagnosing meant going to the pod logs.

## What changed

Each attempt now carries the calls it made under `attempt_history[].http`:

```jsonc
{
  "at": "…", "outcome": "FAILED", "detail": "409 conflict", "by": "modulith-worker-3f9c1c2a",
  "http": [{
    "method": "PATCH", "url": "…/bookings/resource/1658427",
    "status": 409, "durationMs": 42,
    "requestBody": "{\"status\":\"ASSIGNED\"}",
    "responseBody": "{\"error\":\"status regression\"}"
  }]
}
```

The console's **Attempts** tab renders it as `METHOD /path · status · duration`, status colour-coded (2xx green / 4xx amber / 5xx and no-response rose), with request and response bodies folded behind a native `<details>` — the panel is 400px wide, so bodies have to be opt-in, and `<details>` keeps that free of state and keyboard-accessible.

## How it is collected

`JobHttpTrace` is a thread-local recording window. `ModulithJobWorker` opens one around `handle` and closes it in a `finally`; jobs run one at a time on that thread, so it needs no correlation and cannot mix two jobs. Outside a window `record` is a **no-op** — that is what makes it safe to call from an HTTP client shared with non-job traffic.

`CalendarBookingsClient.send` is the single point every modulith-lane call leaves through, so one seam covers the whole lane, transport failures included (recorded with no `status` and the error instead).

- `attempt_history` is already free-form `JSONB` → **no migration**.
- `ReportJobRequest.exchanges` carries the timeline over the REST report contract for other lanes. Optional and additive: a worker that does not send it reports exactly as before. `AsyncJobService` re-applies the caps on arrival, since they are ours to enforce and not the reporter's.

## Deliberate limits

- **Headers are never recorded.** That is where the bearer tokens are, and this data is rendered in a browser and lives as long as the job row.
- Bodies capped at 4000 chars, exchanges at 20 per attempt. Both caps **announce themselves** in the recorded data (`… [N more chars]`, a trailing `note` entry) rather than truncating silently.
- Request bodies are the same data the `payload` column already holds — not a new class of stored data, but a second copy of it.

## Known gap

The **`ecm` lane does not populate `exchanges` yet**, so `alerce_assignment` — the Alerce push — still shows no timeline. The contract accepts it; adopting it is a change in ecm-coordinator.

## Verification

- `mvn test` on miot-integrations — **182/182, BUILD SUCCESS** (was 167; +15 covering the window, the no-op outside it, per-attempt isolation, both caps and their markers, transport failures, and the ledger entry)
- `vitest` full app suite — **807 passed**, 1 skipped (pre-existing); was 802
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)