### PR TITLE
fix(credentials): restore column defaults V0.6.9 dropped

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.10__restore_credential_profile_column_defaults.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.10__restore_credential_profile_column_defaults.sql
@@ -1,0 +1,27 @@
+-- Closes a rollout window opened by V0.6.9.
+--
+-- V0.6.9 left credential_type and environment NOT NULL with no default. The release
+-- that populates them ships alongside it, but Flyway runs before the new pods serve
+-- and the previous image stays up for the whole rolling deploy — and that image
+-- INSERTs into credential_profiles without naming either column:
+--
+--     INSERT INTO miot_integrations.credential_profiles (
+--         id, tenant_code, display_name, auth_type, public_config,
+--         encrypted_secret_json, secret_preview, secret_version, created_at, updated_at)
+--
+-- so every write it attempts during the rollout fails on a not-null violation. In
+-- practice that is the WhatsApp channel silently unable to store an access token for
+-- the length of the deploy.
+--
+-- The defaults are what make the schema tolerate both images at once. BEARER_TOKEN is
+-- what the previous image creates (an access token), so its inserts land on the type
+-- it would have chosen anyway, and PRODUCTION matches how V0.6.9 backfilled the rows
+-- that predate the column. Nothing depends on either default: the current service
+-- always states both values explicitly.
+--
+-- This is a separate migration rather than an edit to V0.6.9 because V0.6.9 is already
+-- applied — editing it would fail validation with a checksum mismatch everywhere it
+-- has run.
+ALTER TABLE miot_integrations.credential_profiles
+    ALTER COLUMN credential_type SET DEFAULT 'BEARER_TOKEN',
+    ALTER COLUMN environment SET DEFAULT 'PRODUCTION';


### PR DESCRIPTION
Follow-up to #974, which is already merged and applied on dev.

## The problem

`V0.6.9` leaves `credential_type` and `environment` `NOT NULL` with no default. The release that populates them ships alongside it — but Flyway runs *before* the new pods serve, and the previous image stays up for the whole rolling deploy. That image inserts without naming either column:

```sql
INSERT INTO miot_integrations.credential_profiles (
    id, tenant_code, display_name, auth_type, public_config,
    encrypted_secret_json, secret_preview, secret_version, created_at, updated_at)
```

So every write it attempts during the rollout fails on a not-null violation. In practice that is the WhatsApp channel silently unable to store an access token until the deploy finishes.

## The fix

```sql
ALTER TABLE miot_integrations.credential_profiles
    ALTER COLUMN credential_type SET DEFAULT 'BEARER_TOKEN',
    ALTER COLUMN environment SET DEFAULT 'PRODUCTION';
```

The defaults are what let the schema tolerate both images at once. `BEARER_TOKEN` is what the previous image creates (an access token), so its inserts land on the type it would have chosen anyway; `PRODUCTION` matches how `V0.6.9` backfilled the rows that predate the column. Nothing depends on either default — the current service always states both values explicitly.

## Why a new migration rather than an edit

`V0.6.9` is merged and already applied on dev (the nightly deployed it at 14:27Z). Editing it fails validation with a checksum mismatch everywhere it has run — which is exactly what happened while testing this locally:

```
Migration checksum mismatch for migration version 0.6.9
-> Applied to database : 71965042
-> Resolved locally    : 1137395579
```

## Blast radius

- **dev** — already on `V0.6.9`, and running the image that supplies both columns, so it is functional today. This migration adds the defaults it is missing.
- **prod** — still at `0.6.1`, so it has not applied `V0.6.9` yet. Landing this first means prod applies `0.6.9` and `0.6.10` in the same Flyway run, closing the window before any prod rollout reaches it.

## Verification

Ran the modulith locally against a clone of dev's schema (structure for every module, data for `miot_core` + `miot_integrations`), configured from the dev deployment:

```
Migrating schema "miot_core" to version "0.6.10 - restore credential profile column defaults"
Successfully applied 1 migration to schema "miot_core", now at version v0.6.10
```

```
credential_type  nullable=NO  default='BEARER_TOKEN'
environment      nullable=NO  default='PRODUCTION'
```

228 `miot-integrations` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)