### PR TITLE
fix(calendar): scope the to-plan queue to planService

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -293,19 +293,31 @@ export function PlanningSidebarClient({
     return params.join("&");
   }, [searchTags, calendarId, searchQuery]);
 
-  // Fetch tasks from API
+  // The to-plan queue: `planService` ONLY.
+  //
+  // Planning *is* the `planService → assignDriver` transition, so a service at
+  // `assignDriver` or beyond has already been planned by definition — it holds
+  // a slot and draws a chip. Listing those made the pool advertise five stages
+  // while `task-stage-transitions.ts` can only act on two, and a drop on the
+  // other three silently wrote a booking row with no workflow move (#977).
+  //
+  // This is NOT the workflow index. `planning-selection-wrapper` keeps its own
+  // `useMyTasks` over every stage to answer "which task represents service X
+  // right now" — that is what `getLiveTask` and the re-assign dance read, and
+  // it is unaffected by this narrowing.
+  //
+  // Nothing else regressed by scoping this down: grid chips render from
+  // `cld_bookings` via `mapBookingToPlannedService`, calendar search sweeps the
+  // same bookings (`use-calendar-search`), and Asignar / Replanificar / Eliminar
+  // on an already-planned service come off the chip's context menu, not a row
+  // here. An advanced service therefore stays visible and actionable on the
+  // grid; it just stops queueing for work it has already had done.
   const {
     data: myTasksData,
     isLoading: isLoadingTasks,
     refresh: refreshTasks,
   } = useMyTasks(
-    [
-      "planService",
-      "assignDriver",
-      "presentDriver",
-      "prepareService",
-      "missionControl",
-    ],
+    ["planService"],
     false, // showFinished
     1, // page (1-based, but API uses 0-based internally)
     100, // limit

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-client.tsx
@@ -293,25 +293,10 @@ export function PlanningSidebarClient({
     return params.join("&");
   }, [searchTags, calendarId, searchQuery]);
 
-  // The to-plan queue: `planService` ONLY.
-  //
-  // Planning *is* the `planService → assignDriver` transition, so a service at
-  // `assignDriver` or beyond has already been planned by definition — it holds
-  // a slot and draws a chip. Listing those made the pool advertise five stages
-  // while `task-stage-transitions.ts` can only act on two, and a drop on the
-  // other three silently wrote a booking row with no workflow move (#977).
-  //
-  // This is NOT the workflow index. `planning-selection-wrapper` keeps its own
-  // `useMyTasks` over every stage to answer "which task represents service X
-  // right now" — that is what `getLiveTask` and the re-assign dance read, and
-  // it is unaffected by this narrowing.
-  //
-  // Nothing else regressed by scoping this down: grid chips render from
-  // `cld_bookings` via `mapBookingToPlannedService`, calendar search sweeps the
-  // same bookings (`use-calendar-search`), and Asignar / Replanificar / Eliminar
-  // on an already-planned service come off the chip's context menu, not a row
-  // here. An advanced service therefore stays visible and actionable on the
-  // grid; it just stops queueing for work it has already had done.
+  // The to-plan queue: planning IS the `planService → assignDriver` transition,
+  // so anything beyond it has already been planned (#977). Not the workflow
+  // index — `planning-selection-wrapper` keeps its own `useMyTasks` over every
+  // stage for `getLiveTask`.
   const {
     data: myTasksData,
     isLoading: isLoadingTasks,


### PR DESCRIPTION
Phase 1 of #977. One-line behaviour change; the rest of the diff is the reasoning.

## What

The sidebar pool queried five stages — `planService, assignDriver, presentDriver, prepareService, missionControl` — while `task-stage-transitions.ts` can only act on two. A service dropped from the other three resolved no transition and fell through to the legacy booking-POST: a `cld_bookings` row written, the workflow never moved, no listener fired, no async job enqueued, **and no error shown**.

Dev service `78265602` has been diverged that way since **2026-01-26**: booking planned, task still at `presentDriver`, zero jobs in the ledger.

Planning **is** the `planService → assignDriver` transition, so a service at `assignDriver` or beyond has already been planned by definition — it holds a slot and draws a chip. Four of the five stages were, by construction, no longer candidates for planning. The queue is now strictly `planService`.

## Why nothing else breaks

Checked each thing that looked like it might depend on the broad query:

| | |
|---|---|
| **Grid chips** | render from `cld_bookings` via `mapBookingToPlannedService` — an advanced service keeps its cell |
| **Calendar search** | sweeps those same bookings (`use-calendar-search.ts:82,89`), never this task list |
| **Asignar / Replanificar / Eliminar** | come off the chip's **context menu**, acting on a `PlannedService` built from the booking row, gated by role (`useCalendarViewMode`) — not by stage, and not by a sidebar row |
| **Stage resolution** | a **different query**: `planning-selection-wrapper.tsx:311` keeps its own `useMyTasks` over every `CALENDAR_LIVE_TASK_COLUMNS`. That is what `getLiveTask` and the #965 re-assign dance read, and it is untouched |

That last one is what makes this safe rather than hopeful — the dance cannot regress, because it never read the query being narrowed.

An advanced service therefore stays visible and actionable on the grid; it just stops queueing for work it has already had done.

## Scope

This narrows what the silent fallback can be *reached* with. It does not remove the fallback — that is phase 2 (drop the `TASK_DRIVEN_ORIGINS` gate, make a booking write with no workflow move an error). Phase 3 moves transition resolution to ECM (microboxlabs/ecm-coordinator#336).

## Verification

- `tsc --noEmit` clean
- `vitest` full app suite: **807 passed**, 1 skipped (pre-existing)

Worth a planner's eye in dev before merge: confirm the to-plan list only shows unplanned services, and that an already-planned one is still selectable and assignable from its chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)