### PR TITLE
fix(calendar): make plan, re-plan and assign each answer to the workflow

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -59,7 +59,10 @@ import {
   getTaskDrivenUnassignTransition,
 } from "@/features/calendar/services/task-driven-assign";
 import { decidePlanTaskAdvance } from "@/features/calendar/services/task-driven-plan";
-import { refuseWorkflowlessPlan } from "@/features/calendar/services/task-driven-guard";
+import {
+  refuseAssign,
+  refuseWorkflowlessPlan,
+} from "@/features/calendar/services/task-driven-guard";
 import { useTaskDrivenOrigins } from "@/features/calendar/services/use-task-driven-origins";
 import { ShowNotification } from "@/features/notifications/notification";
 import { tr } from "@/features/i18n/tr.service";
@@ -501,16 +504,25 @@ export function PlanningSelectionProvider({
           );
           // Refuse before the package writes anything: for a task-driven
           // service ECM owns the row, so a booking with no workflow move is a
-          // divergence, not a lesser plan (#977). Throwing here rolls back the
-          // optimistic chip and surfaces the reason as an error toast.
-          const refusal = refuseWorkflowlessPlan({
-            stage: liveTask?.stage,
-            origin: service.origen,
-            enabledOrigins: taskDrivenOrigins,
-            hasTaskAdvance: !!taskAdvance,
-            hasReassign: !!reassign,
-            isReassigning: ctx.isReassigning,
-          });
+          // divergence, not a lesser plan (#977). Plan and assign are separate
+          // steps with separate rules, so each gesture answers to its own —
+          // the assign gate lives on the chip menu, this is its backstop.
+          const refusal = ctx.isAssigning
+            ? refuseAssign({
+                stage: liveTask?.stage,
+                origin: service.origen,
+                enabledOrigins: taskDrivenOrigins,
+                hasTaskAdvance: !!taskAdvance,
+                hasReassign: !!reassign,
+              })
+            : refuseWorkflowlessPlan({
+                stage: liveTask?.stage,
+                origin: service.origen,
+                enabledOrigins: taskDrivenOrigins,
+                hasTaskAdvance: !!taskAdvance,
+                hasReassign: !!reassign,
+                isReassigning: ctx.isReassigning,
+              });
           if (refusal) throw new Error(refusal);
           // A reassign drives workflow edges only; ECM re-writes the row, so
           // the package must not also PUT a booking (as with the initial assign).

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -59,6 +59,7 @@ import {
   getTaskDrivenUnassignTransition,
 } from "@/features/calendar/services/task-driven-assign";
 import { decidePlanTaskAdvance } from "@/features/calendar/services/task-driven-plan";
+import { refuseWorkflowlessPlan } from "@/features/calendar/services/task-driven-guard";
 import { useTaskDrivenOrigins } from "@/features/calendar/services/use-task-driven-origins";
 import { ShowNotification } from "@/features/notifications/notification";
 import { tr } from "@/features/i18n/tr.service";
@@ -493,11 +494,24 @@ export function PlanningSelectionProvider({
       hooks: {
         shouldPersistBooking: (item, slot, ctx) => {
           const service = item.raw as SelectedService;
-          const { taskAdvance, reassign } = computeTaskAdvance(
+          const { liveTask, taskAdvance, reassign } = computeTaskAdvance(
             service,
             slot,
             ctx
           );
+          // Refuse before the package writes anything: for a task-driven
+          // service ECM owns the row, so a booking with no workflow move is a
+          // divergence, not a lesser plan (#977). Throwing here rolls back the
+          // optimistic chip and surfaces the reason as an error toast.
+          const refusal = refuseWorkflowlessPlan({
+            stage: liveTask?.stage,
+            origin: service.origen,
+            enabledOrigins: taskDrivenOrigins,
+            hasTaskAdvance: !!taskAdvance,
+            hasReassign: !!reassign,
+            isReassigning: ctx.isReassigning,
+          });
+          if (refusal) throw new Error(refusal);
           // A reassign drives workflow edges only; ECM re-writes the row, so
           // the package must not also PUT a booking (as with the initial assign).
           return !(

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-selection-wrapper.tsx
@@ -61,8 +61,13 @@ import {
 import { decidePlanTaskAdvance } from "@/features/calendar/services/task-driven-plan";
 import {
   refuseAssign,
+  refuseReplan,
   refuseWorkflowlessPlan,
 } from "@/features/calendar/services/task-driven-guard";
+import {
+  decideReplan,
+  type ReplanEdge,
+} from "@/features/calendar/services/task-driven-replan";
 import { useTaskDrivenOrigins } from "@/features/calendar/services/use-task-driven-origins";
 import { ShowNotification } from "@/features/notifications/notification";
 import { tr } from "@/features/i18n/tr.service";
@@ -422,7 +427,25 @@ export function PlanningSelectionProvider({
         reassignTuple && liveTask?.taskId
           ? { presentTaskId: liveTask.taskId, tuple: reassignTuple }
           : undefined;
-      return { liveTask, taskAdvance, reassign };
+      // Re-plan of a task-driven service: ECM has no move listener — its
+      // re-plan mechanism is an `assignDriver` re-entry carrying the new slot,
+      // which enqueues ensure(PLANNED, <new slot>) and re-slots the booking.
+      // So the edges ARE the re-plan; the booking write is skipped below.
+      const replanPlan = ctx.isReassigning
+        ? decideReplan({
+            stage: liveTask?.stage,
+            origin: service.origen,
+            calendarId,
+            slot,
+            enabledOrigins: taskDrivenOrigins,
+            serviceCategory: service.serviceCategory,
+          })
+        : null;
+      const replan =
+        replanPlan && liveTask?.taskId
+          ? { taskId: liveTask.taskId, edges: replanPlan.edges }
+          : undefined;
+      return { liveTask, taskAdvance, reassign, replan };
     },
     [getLiveTask, calendarId, taskDrivenOrigins]
   );
@@ -465,6 +488,37 @@ export function PlanningSelectionProvider({
     [refreshLiveTasks]
   );
 
+  // Drive a re-plan through the workflow. Each edge fires from a known stage;
+  // between edges the live index is re-read, because Activiti commits
+  // synchronously and the next task is a different id. A stage mismatch throws
+  // rather than firing blind, leaving the service recoverable — the same
+  // posture as `reassignPresentedService`.
+  const runReplan = useCallback(
+    async (
+      plan: { taskId: string; edges: ReplanEdge[] },
+      serviceCode: string | undefined
+    ) => {
+      let taskId = plan.taskId;
+      for (const [index, edge] of plan.edges.entries()) {
+        if (index > 0) {
+          const fresh = await refreshLiveTasks();
+          const next = serviceCode
+            ? buildLiveTaskIndex(fresh).get(serviceCode)
+            : undefined;
+          if (next?.stage !== edge.fromStage) {
+            throw new Error(
+              `Replanificación detenida: el servicio ${serviceCode ?? "?"} no está en ${edge.fromStage}`
+            );
+          }
+          taskId = next.taskId;
+        }
+        await advanceWorkflowTask(taskId, edge.transition, edge.processVariables);
+      }
+      await refreshLiveTasks();
+    },
+    [refreshLiveTasks]
+  );
+
   const host = useMemo<CalendarHost<SelectedService>>(
     () => ({
       client: { baseUrl: "/app/api/calendar" },
@@ -497,11 +551,23 @@ export function PlanningSelectionProvider({
       hooks: {
         shouldPersistBooking: (item, slot, ctx) => {
           const service = item.raw as SelectedService;
-          const { liveTask, taskAdvance, reassign } = computeTaskAdvance(
+          const { liveTask, taskAdvance, reassign, replan } = computeTaskAdvance(
             service,
             slot,
             ctx
           );
+          // Re-plan is its own gesture with its own rule: allowed until the
+          // trip starts, and driven through the workflow rather than written
+          // here — ECM's assignDriver re-entry re-slots the booking.
+          if (ctx.isReassigning) {
+            const replanRefusal = refuseReplan({
+              stage: liveTask?.stage,
+              origin: service.origen,
+              enabledOrigins: taskDrivenOrigins,
+            });
+            if (replanRefusal) throw new Error(replanRefusal);
+            if (replan) return false;
+          }
           // Refuse before the package writes anything: for a task-driven
           // service ECM owns the row, so a booking with no workflow move is a
           // divergence, not a lesser plan (#977). Plan and assign are separate
@@ -534,11 +600,18 @@ export function PlanningSelectionProvider({
         },
         afterPlan: async (item, slot, ctx) => {
           const service = item.raw as SelectedService;
-          const { liveTask, taskAdvance, reassign } = computeTaskAdvance(
+          const { liveTask, taskAdvance, reassign, replan } = computeTaskAdvance(
             service,
             slot,
             ctx
           );
+          // Re-plan: drive the edges back into `assignDriver` carrying the new
+          // slot. ECM's create-listener enqueues ensure(PLANNED, <new slot>)
+          // and the worker re-slots the booking — nothing to write here.
+          if (replan) {
+            await runReplan(replan, service.mintral_serviceCode);
+            return;
+          }
           // Re-assign of an already-presented service: run the two-step dance
           // so the resource change re-pushes to Alerce — no manual
           // unassign→reassign, and the booking sync badge re-stamps.
@@ -688,6 +761,7 @@ export function PlanningSelectionProvider({
       getLiveTask,
       computeTaskAdvance,
       reassignPresentedService,
+      runReplan,
       taskDrivenOrigins,
       dict,
       canPlan,

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -13,7 +13,10 @@ import { Button } from "flowbite-react";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { useCalendarViewMode } from "./use-calendar-view-mode";
-import { canAssignAtStage } from "@/features/calendar/services/task-driven-guard";
+import {
+  canAssignAtStage,
+  canReplanAtStage,
+} from "@/features/calendar/services/task-driven-guard";
 import { useTaskDrivenOrigins } from "@/features/calendar/services/use-task-driven-origins";
 
 export interface ContextMenuPosition {
@@ -109,6 +112,21 @@ export function ServiceContextMenu({
 
   const canStartAssignment = canAssign && stageAllowsAssign;
 
+  // Planning authority ends where the trip starts: past `missionControl` there
+  // is no edge back into `assignDriver`, so neither re-planning nor un-planning
+  // has anywhere to go. Un-planning is gated with re-planning because it is the
+  // same authority — its transition would otherwise walk an in-flight trip all
+  // the way back to `planService` from a right-click.
+  const stageAllowsReplan =
+    plannedService !== null &&
+    canReplanAtStage(
+      plannedService.workflowStage,
+      plannedService.service.origen,
+      taskDrivenOrigins
+    );
+
+  const canReplan = canPlan && stageAllowsReplan;
+
   const canDeleteAssignment =
     plannedService !== null &&
     canAssign &&
@@ -124,7 +142,7 @@ export function ServiceContextMenu({
   const buttonCount =
     (canStartAssignment ? 1 : 0) +
     (canDeleteAssignment ? 1 : 0) +
-    (canPlan ? 2 : 0) +
+    (canReplan ? 2 : 0) +
     (canTogglePreview ? 1 : 0);
   const MENU_HEIGHT =
     MENU_HEADER_HEIGHT + MENU_PADDING + buttonCount * MENU_BUTTON_HEIGHT;
@@ -279,7 +297,7 @@ export function ServiceContextMenu({
           </Button>
         )}
 
-        {canPlan && (
+        {canReplan && (
           <Button
             color={"alternative"}
             type="button"
@@ -291,7 +309,7 @@ export function ServiceContextMenu({
           </Button>
         )}
 
-        {canPlan && (
+        {canReplan && (
           <Button
             color={"alternative"}
             type="button"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -13,6 +13,8 @@ import { Button } from "flowbite-react";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { useCalendarViewMode } from "./use-calendar-view-mode";
+import { canAssignAtStage } from "@/features/calendar/services/task-driven-guard";
+import { useTaskDrivenOrigins } from "@/features/calendar/services/use-task-driven-origins";
 
 export interface ContextMenuPosition {
   x: number;
@@ -87,14 +89,30 @@ export function ServiceContextMenu({
   // permissions load and while the override is active.
   const { canPlan, canAssign, forceViewer, canTogglePreview } =
     useCalendarViewMode();
+  const taskDrivenOrigins = useTaskDrivenOrigins();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { inspectPlannedService } = usePlanningSelection();
 
+  // Role says who may assign; the workflow stage says whether assigning is
+  // still a move this service can make. Past `presentDriver` there is no edge
+  // to carry a resource change, so offering the action would only produce an
+  // error at the persist boundary — don't offer it. Same rule for its inverse.
+  const stageAllowsAssign =
+    plannedService !== null &&
+    canAssignAtStage(
+      plannedService.workflowStage,
+      plannedService.service.origen,
+      taskDrivenOrigins
+    );
+
+  const canStartAssignment = canAssign && stageAllowsAssign;
+
   const canDeleteAssignment =
     plannedService !== null &&
     canAssign &&
+    stageAllowsAssign &&
     hasRequiredAssignedResources(plannedService);
 
   // Estimated menu dimensions for initial position calculation
@@ -104,7 +122,7 @@ export function ServiceContextMenu({
   const MENU_BUTTON_HEIGHT = 38;
   const MENU_PADDING = 8;
   const buttonCount =
-    (canAssign ? 1 : 0) +
+    (canStartAssignment ? 1 : 0) +
     (canDeleteAssignment ? 1 : 0) +
     (canPlan ? 2 : 0) +
     (canTogglePreview ? 1 : 0);
@@ -235,7 +253,7 @@ export function ServiceContextMenu({
           confirmation that the chip was selected, paired with the sidebar
           opening via inspectPlannedService in use-planning-grid. */}
       <div className="py-1">
-        {canAssign && (
+        {canStartAssignment && (
           <Button
             color={"alternative"}
             type="button"

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -143,7 +143,9 @@ export function ServiceContextMenu({
     (canStartAssignment ? 1 : 0) +
     (canDeleteAssignment ? 1 : 0) +
     (canReplan ? 2 : 0) +
-    (canTogglePreview ? 1 : 0);
+    (canTogglePreview ? 1 : 0) +
+    // "Abrir servicio (Solo Lectura)" always renders.
+    1;
   const MENU_HEIGHT =
     MENU_HEADER_HEIGHT + MENU_PADDING + buttonCount * MENU_BUTTON_HEIGHT;
 
@@ -209,6 +211,16 @@ export function ServiceContextMenu({
     onClose();
   };
 
+  // Read the service without acting on it. Always available: looking at a
+  // chip is never an operation the workflow can refuse, and left-click is no
+  // substitute — `selectChipSlot` nulls the selected service to open the slot
+  // for a NEW one. Without this, a service whose actions are all gated (a
+  // trip already under way) has no entry to the sidebar at all.
+  const handleOpenReadOnly = () => {
+    inspectPlannedService(plannedService);
+    onClose();
+  };
+
   // Flip the `?as=viewer` URL param without losing any other params
   // (`date`, `view`, `groupCode`, etc.). Push, don't replace, so back
   // navigates out of the preview. Closes the menu so the click feels
@@ -266,10 +278,10 @@ export function ServiceContextMenu({
         </span>
       </div>
 
-      {/* Menu items. For a pure GROUP_CALENDAR_VIEWER, every gate below is
-          false and only the service-ID header above renders — intentional
-          confirmation that the chip was selected, paired with the sidebar
-          opening via inspectPlannedService in use-planning-grid. */}
+      {/* Menu items. Every action below is gated by role AND workflow stage, so
+          a service far enough along (or a pure viewer) can leave all of them
+          hidden — "Abrir servicio (Solo Lectura)" is deliberately ungated so
+          the menu always offers a way in rather than a dead end. */}
       <div className="py-1">
         {canStartAssignment && (
           <Button
@@ -323,12 +335,24 @@ export function ServiceContextMenu({
           </Button>
         )}
 
+        <Button
+          color={"alternative"}
+          type="button"
+          onClick={handleOpenReadOnly}
+          className="border-0 rounded-none w-full justify-start gap-2 border-t border-gray-200 dark:border-gray-700"
+        >
+          <HiEye className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+          <span>
+            {tr("pages.planning.sidebar.contextMenu.openReadOnly", dict)}
+          </span>
+        </Button>
+
         {canTogglePreview && (
           <Button
             color={"alternative"}
             type="button"
             onClick={handleTogglePreview}
-            className="border-0 rounded-none w-full justify-start gap-2 border-t border-gray-200 dark:border-gray-700"
+            className="border-0 rounded-none w-full justify-start gap-2"
           >
             <HiEye className="w-4 h-4 text-gray-500 dark:text-gray-400" />
             <span>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-planning-grid.ts
@@ -130,9 +130,9 @@ export function usePlanningGrid(options: UsePlanningGridOptions = {}) {
   // menu. The highlight is purely visual — `selectChipResource` does not
   // touch slot/service selection, so the sidebar stays as-is. For pure
   // viewers (GROUP_CALENDAR_VIEWER only) we also call `inspectPlannedService`
-  // because right-click is their sole entry to the sidebar; for planners
-  // the sidebar opens via the menu's "Abrir servicio (Solo Lectura)"
-  // action instead, which flips the URL and inspects in one step.
+  // so right-click alone fills the sidebar; planners pick the menu's
+  // "Abrir servicio (Solo Lectura)" instead, keeping right-click from
+  // clobbering a selection they are mid-way through.
   const handleChipContextMenu = useCallback(
     (e: React.MouseEvent, plannedService: PlannedService) => {
       selectChipResource(plannedService);

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { refuseWorkflowlessPlan } from "./task-driven-guard";
+import {
+  canAssignAtStage,
+  refuseAssign,
+  refuseWorkflowlessPlan,
+} from "./task-driven-guard";
 
 const ORIGINS = new Set(["SCL", "ANF"]);
 
@@ -61,5 +65,97 @@ describe("refuseWorkflowlessPlan", () => {
 
   it("is case-sensitive on the origin, like every other task-driven helper", () => {
     expect(refuseWorkflowlessPlan(input({ origin: "scl" }))).toBeNull();
+  });
+});
+
+describe("canAssignAtStage", () => {
+  it("allows the two stages the assign edge connects", () => {
+    expect(canAssignAtStage("assignDriver", "SCL", ORIGINS)).toBe(true);
+    expect(canAssignAtStage("presentDriver", "SCL", ORIGINS)).toBe(true);
+  });
+
+  it("refuses stages with no edge to carry a resource change", () => {
+    // The 1625094 / 1524620 case: planned long ago, now at missionControl —
+    // planning and assigning are different steps, and this one is past both.
+    expect(canAssignAtStage("missionControl", "SCL", ORIGINS)).toBe(false);
+    expect(canAssignAtStage("prepareService", "SCL", ORIGINS)).toBe(false);
+    // Not yet planned: assigning is not the gesture that plans it.
+    expect(canAssignAtStage("planService", "SCL", ORIGINS)).toBe(false);
+  });
+
+  it("refuses the terminal stages a booking row can carry", () => {
+    expect(canAssignAtStage("finished", "SCL", ORIGINS)).toBe(false);
+    expect(canAssignAtStage("cancelled", "SCL", ORIGINS)).toBe(false);
+  });
+
+  it("fails open on what it cannot prove", () => {
+    // Flag-off origin — ECM owns nothing there.
+    expect(canAssignAtStage("missionControl", "IQQ", ORIGINS)).toBe(true);
+    // Stage unknown: the live task index is still loading. Hiding the action
+    // on every chip during that window would be worse than a late refusal.
+    expect(canAssignAtStage(undefined, "SCL", ORIGINS)).toBe(true);
+  });
+});
+
+describe("refuseAssign", () => {
+  function assignInput(
+    overrides: Partial<Parameters<typeof refuseAssign>[0]> = {}
+  ) {
+    return {
+      stage: "assignDriver" as const,
+      origin: "SCL",
+      enabledOrigins: ORIGINS,
+      hasTaskAdvance: true,
+      hasReassign: false,
+      ...overrides,
+    };
+  }
+
+  it("allows the forward assign edge", () => {
+    expect(refuseAssign(assignInput())).toBeNull();
+  });
+
+  it("allows the presented-service re-assign dance", () => {
+    expect(
+      refuseAssign(
+        assignInput({
+          stage: "presentDriver",
+          hasTaskAdvance: false,
+          hasReassign: true,
+        })
+      )
+    ).toBeNull();
+  });
+
+  it("refuses past the assign edge, naming the stage", () => {
+    const reason = refuseAssign(
+      assignInput({ stage: "missionControl", hasTaskAdvance: false })
+    );
+    expect(reason).toContain("missionControl");
+    expect(reason).toContain("No se puede asignar");
+  });
+
+  it("refuses an incomplete tuple at an assignable stage", () => {
+    // presentDriver with nothing resolved: `buildAssignProcessVariables`
+    // returned null, so a write would move no workflow.
+    const reason = refuseAssign(
+      assignInput({ stage: "presentDriver", hasTaskAdvance: false })
+    );
+    expect(reason).toContain("faltan datos");
+  });
+
+  it("leaves flag-off origins and unknown stages alone", () => {
+    expect(
+      refuseAssign(
+        assignInput({
+          stage: "missionControl",
+          origin: "IQQ",
+          hasTaskAdvance: false,
+        })
+      )
+    ).toBeNull();
+    expect(
+      refuseAssign(assignInput({ stage: undefined, hasTaskAdvance: false }))
+    ).toBeNull();
   });
 });

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { refuseWorkflowlessPlan } from "./task-driven-guard";
+
+const ORIGINS = new Set(["SCL", "ANF"]);
+
+function input(overrides: Partial<Parameters<typeof refuseWorkflowlessPlan>[0]> = {}) {
+  return {
+    stage: "presentDriver" as const,
+    origin: "SCL",
+    enabledOrigins: ORIGINS,
+    hasTaskAdvance: false,
+    hasReassign: false,
+    isReassigning: false,
+    ...overrides,
+  };
+}
+
+describe("refuseWorkflowlessPlan", () => {
+  it("refuses a task-driven service whose task sits past the plannable stages", () => {
+    // The 78265602 case: SCL, live task at presentDriver, no transition
+    // resolves — today this silently wrote a booking with no workflow move.
+    const reason = refuseWorkflowlessPlan(input());
+    expect(reason).toContain("presentDriver");
+    expect(reason).toContain("No se puede planificar");
+  });
+
+  it("refuses at every stage the transition table does not cover", () => {
+    for (const stage of ["presentDriver", "prepareService", "missionControl"] as const) {
+      expect(refuseWorkflowlessPlan(input({ stage })), stage).not.toBeNull();
+    }
+  });
+
+  it("allows the gestures that do move the workflow", () => {
+    // A resolved forward transition (planService / assignDriver)…
+    expect(refuseWorkflowlessPlan(input({ hasTaskAdvance: true }))).toBeNull();
+    // …and the presented-service re-assign dance, which drives two edges.
+    expect(refuseWorkflowlessPlan(input({ hasReassign: true }))).toBeNull();
+  });
+
+  it("allows a slot-only move", () => {
+    // Reassignment changes the cell, not the stage — the workflow is already
+    // where it belongs, so there is nothing to refuse.
+    expect(refuseWorkflowlessPlan(input({ isReassigning: true }))).toBeNull();
+  });
+
+  it("leaves flag-off origins alone", () => {
+    // ECM does not own the booking lifecycle there, so a direct write is the
+    // correct behaviour, not a divergence.
+    expect(refuseWorkflowlessPlan(input({ origin: "IQQ" }))).toBeNull();
+    expect(refuseWorkflowlessPlan(input({ origin: undefined }))).toBeNull();
+    expect(
+      refuseWorkflowlessPlan(input({ enabledOrigins: new Set() }))
+    ).toBeNull();
+  });
+
+  it("leaves a service with no live task alone", () => {
+    // We cannot prove it is workflow-backed; refusing would block planning for
+    // services whose workflow is genuinely missing, which is a separate bug.
+    expect(refuseWorkflowlessPlan(input({ stage: undefined }))).toBeNull();
+  });
+
+  it("is case-sensitive on the origin, like every other task-driven helper", () => {
+    expect(refuseWorkflowlessPlan(input({ origin: "scl" }))).toBeNull();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   canAssignAtStage,
+  canReplanAtStage,
   refuseAssign,
+  refuseReplan,
   refuseWorkflowlessPlan,
 } from "./task-driven-guard";
 
@@ -157,5 +159,66 @@ describe("refuseAssign", () => {
     expect(
       refuseAssign(assignInput({ stage: undefined, hasTaskAdvance: false }))
     ).toBeNull();
+  });
+});
+
+describe("canReplanAtStage", () => {
+  it("allows re-planning right up to the trip start", () => {
+    // Erick's rule: replan until missionControl. prepareService still counts —
+    // the trip has not started there.
+    for (const stage of [
+      "planService",
+      "assignDriver",
+      "presentDriver",
+      "prepareService",
+    ]) {
+      expect(canReplanAtStage(stage, "SCL", ORIGINS), stage).toBe(true);
+    }
+  });
+
+  it("refuses once the trip has started", () => {
+    // missionControl is the trip start ("Iniciar Viaje") — past it there is no
+    // edge back into assignDriver, so a re-plan has nowhere to go.
+    for (const stage of [
+      "missionControl",
+      "monitorTrip",
+      "confirmArrival",
+      "closeMonitoring",
+    ]) {
+      expect(canReplanAtStage(stage, "SCL", ORIGINS), stage).toBe(false);
+    }
+  });
+
+  it("refuses the terminal states a booking row can carry", () => {
+    expect(canReplanAtStage("finished", "SCL", ORIGINS)).toBe(false);
+    expect(canReplanAtStage("cancelled", "SCL", ORIGINS)).toBe(false);
+  });
+
+  it("fails open on what it cannot prove", () => {
+    expect(canReplanAtStage("missionControl", "IQQ", ORIGINS)).toBe(true);
+    expect(canReplanAtStage(undefined, "SCL", ORIGINS)).toBe(true);
+  });
+});
+
+describe("refuseReplan", () => {
+  const base = { origin: "SCL", enabledOrigins: ORIGINS };
+
+  it("allows the replannable stages", () => {
+    expect(refuseReplan({ ...base, stage: "presentDriver" })).toBeNull();
+    expect(refuseReplan({ ...base, stage: "prepareService" })).toBeNull();
+  });
+
+  it("refuses past the trip start, naming the stage", () => {
+    // Service 1625094: the case that started this.
+    const reason = refuseReplan({ ...base, stage: "missionControl" });
+    expect(reason).toContain("missionControl");
+    expect(reason).toContain("No se puede replanificar");
+  });
+
+  it("leaves flag-off origins and unknown stages alone", () => {
+    expect(
+      refuseReplan({ ...base, origin: "IQQ", stage: "missionControl" })
+    ).toBeNull();
+    expect(refuseReplan({ ...base, stage: undefined })).toBeNull();
   });
 });

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
@@ -87,6 +87,56 @@ export function canAssignAtStage(
 }
 
 /**
+ * Stages the calendar may still re-plan from. Planning is the calendar's job
+ * right up until the trip starts — `missionControl` is that start, so it and
+ * everything after belong to the process, not the planner.
+ *
+ * Re-planning past `presentDriver` costs the assignment: the only way back into
+ * `assignDriver` is the same edge "Eliminar Asignación" uses, so the driver is
+ * dropped and the planner re-assigns. That is the intended trade, not a side
+ * effect — moving the date means re-confirming who drives it.
+ */
+const REPLANNABLE_STAGES: ReadonlySet<string> = new Set([
+  "planService",
+  "assignDriver",
+  "presentDriver",
+  "prepareService",
+]);
+
+/**
+ * Whether the calendar may still re-plan (or un-plan) this service — the menu
+ * gate for "Volver a planificar" / "Eliminar planificación". Same fail-open
+ * stance as {@link canAssignAtStage}: a flag-off origin or an unknown stage
+ * answers `true`, so a loading task index never hides a legitimate action.
+ */
+export function canReplanAtStage(
+  stage: string | undefined,
+  origin: string | undefined,
+  enabledOrigins: ReadonlySet<string>
+): boolean {
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return true;
+  if (!stage) return true;
+  return REPLANNABLE_STAGES.has(stage);
+}
+
+/**
+ * Persist-boundary backstop for a re-plan whose stage the menu should already
+ * have refused. Reaching this means the gate was bypassed.
+ */
+export function refuseReplan(input: {
+  stage: TaskStage | undefined;
+  origin: string | undefined;
+  enabledOrigins: ReadonlySet<string>;
+}): string | null {
+  const { stage, origin, enabledOrigins } = input;
+  if (canReplanAtStage(stage, origin, enabledOrigins)) return null;
+  return (
+    `No se puede replanificar: el viaje ya inició («${stage}»). ` +
+    `Gestione el cambio desde el proceso.`
+  );
+}
+
+/**
  * Persist-boundary counterpart of {@link canAssignAtStage}: the assign gesture
  * must move the workflow, or it must not write. Reaching a refusal here means
  * the menu gate was bypassed — or the tuple is incomplete for a stage that

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
@@ -56,3 +56,67 @@ export function refuseWorkflowlessPlan(input: {
     `Use el menú del bloque en el calendario para reasignar o replanificar.`
   );
 }
+
+/**
+ * Assigning IS the `assignDriver → presentDriver` edge: a task at
+ * `assignDriver` takes it forward, one at `presentDriver` re-drives it through
+ * the step-back dance (`decidePresentedReassign`). No other stage has an edge
+ * to carry the resource tuple.
+ */
+const ASSIGNABLE_STAGES: ReadonlySet<string> = new Set([
+  "assignDriver",
+  "presentDriver",
+]);
+
+/**
+ * Whether the assign gesture has anywhere to go — the menu gate. Planning and
+ * assigning are separate steps, so being planned does not make a service
+ * assignable. Fail-open on what we cannot prove (flag-off origin, unknown
+ * stage) so a still-loading task index never hides a legitimate action. Takes
+ * the loose `workflowStage` a planned item carries, which may hold a terminal
+ * value such as `finished` — not assignable either.
+ */
+export function canAssignAtStage(
+  stage: string | undefined,
+  origin: string | undefined,
+  enabledOrigins: ReadonlySet<string>
+): boolean {
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return true;
+  if (!stage) return true;
+  return ASSIGNABLE_STAGES.has(stage);
+}
+
+/**
+ * Persist-boundary counterpart of {@link canAssignAtStage}: the assign gesture
+ * must move the workflow, or it must not write. Reaching a refusal here means
+ * the menu gate was bypassed — or the tuple is incomplete for a stage that
+ * otherwise accepts one.
+ */
+export function refuseAssign(input: {
+  /** The live Alfresco task's stage, or undefined when there is no live task. */
+  stage: TaskStage | undefined;
+  origin: string | undefined;
+  enabledOrigins: ReadonlySet<string>;
+  /** Whether a forward workflow transition resolved for this gesture. */
+  hasTaskAdvance: boolean;
+  /** Whether the presented-service re-assign dance will run instead. */
+  hasReassign: boolean;
+}): string | null {
+  const { stage, origin, enabledOrigins, hasTaskAdvance, hasReassign } = input;
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return null;
+  if (!stage) return null;
+  if (!ASSIGNABLE_STAGES.has(stage)) {
+    return (
+      `No se puede asignar: el servicio ya avanzó a «${stage}». ` +
+      `La asignación de recursos se gestiona desde el proceso.`
+    );
+  }
+  if (hasTaskAdvance || hasReassign) return null;
+  // Assignable stage, nothing to fire: the tuple is incomplete
+  // (`buildAssignProcessVariables` also needs the service type, which is not a
+  // form field), so a write would change the calendar and not the workflow.
+  return (
+    `No se puede asignar: faltan datos de la asignación ` +
+    `(transportista, conductor, camión o tipo de servicio).`
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-guard.ts
@@ -1,0 +1,58 @@
+import type { TaskStage } from "../components/planning/planning-selection-types";
+import { isOriginTaskDriven } from "./task-driven-origin";
+
+/**
+ * Guard for the one thing that must never happen on a task-driven service:
+ * writing a booking row without moving the workflow.
+ *
+ * ECM owns the booking lifecycle for a task-driven origin — its task listeners
+ * write and reconcile `cld_bookings` and enqueue the Alerce chain. So a booking
+ * written by the BFF with no accompanying transition is not a lesser version of
+ * planning; it is a divergence. The calendar says planned, the workflow says
+ * otherwise, no async job exists, and nobody finds out until someone asks why
+ * Alerce is stale days later (dev service 78265602 sat that way for six
+ * months).
+ *
+ * That state was reachable because the pool advertised five stages while
+ * `task-stage-transitions.ts` can only act on two, and a stage with no entry
+ * silently fell through to the legacy write. #977 phase 1 closed the entry
+ * point by scoping the queue to `planService`; this closes the hole itself, so
+ * a future entry point cannot reopen it.
+ *
+ * Deliberately narrow. It refuses only what is provably wrong: a task-driven
+ * origin whose live task sits at a stage no transition covers. A service with
+ * no live task at all is left alone — we cannot prove it is workflow-backed,
+ * and refusing would block planning for services whose workflow is genuinely
+ * missing, which is a different bug (see #977).
+ */
+export function refuseWorkflowlessPlan(input: {
+  /** The live Alfresco task's stage, or undefined when there is no live task. */
+  stage: TaskStage | undefined;
+  origin: string | undefined;
+  enabledOrigins: ReadonlySet<string>;
+  /** Whether a forward workflow transition resolved for this gesture. */
+  hasTaskAdvance: boolean;
+  /** Whether the presented-service re-assign dance will run instead. */
+  hasReassign: boolean;
+  /** Whether this is a slot-only move of an existing booking. */
+  isReassigning: boolean;
+}): string | null {
+  const {
+    stage,
+    origin,
+    enabledOrigins,
+    hasTaskAdvance,
+    hasReassign,
+    isReassigning,
+  } = input;
+  // A slot move carries no stage change; the workflow is already where it
+  // belongs and the move route handles the row.
+  if (isReassigning) return null;
+  if (hasTaskAdvance || hasReassign) return null;
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return null;
+  if (!stage) return null;
+  return (
+    `No se puede planificar: el servicio ya avanzó a «${stage}». ` +
+    `Use el menú del bloque en el calendario para reasignar o replanificar.`
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-replan.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-replan.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { decideReplan } from "./task-driven-replan";
+
+const ORIGINS = new Set(["SCL", "ANF"]);
+const SLOT = { date: "2026-07-30", hour: 14, minutes: 30 };
+
+function input(overrides: Partial<Parameters<typeof decideReplan>[0]> = {}) {
+  return {
+    stage: "presentDriver" as const,
+    origin: "SCL",
+    calendarId: "cal-1",
+    slot: SLOT,
+    enabledOrigins: ORIGINS,
+    ...overrides,
+  };
+}
+
+describe("decideReplan", () => {
+  it("re-plans a presented service with the single remove-assignment edge", () => {
+    // presentDriver → assignDriver is the same edge "Eliminar Asignación"
+    // uses, so the driver is dropped. That is the agreed trade: moving the
+    // date means re-confirming who drives it.
+    const plan = decideReplan(input());
+    expect(plan?.edges).toHaveLength(1);
+    expect(plan?.edges[0]).toMatchObject({
+      fromStage: "presentDriver",
+      transition: "Asignar Conductor/Transporte",
+    });
+  });
+
+  it("carries the new slot so ECM re-slots rather than re-asserting the old one", () => {
+    // The slot vars are the whole point: OnCreateAssignDriverBinding reads them
+    // on the assignDriver create and enqueues ensure(PLANNED, <new slot>).
+    const vars = decideReplan(input())?.edges[0].processVariables;
+    expect(vars).toMatchObject({
+      calendar_id: "cal-1",
+      slot_date: "2026-07-30",
+      slot_hour: "14",
+      slot_minutes: "30",
+    });
+  });
+
+  it("goes out to planService and back for stages with no direct edge", () => {
+    for (const stage of ["assignDriver", "prepareService"] as const) {
+      const plan = decideReplan(input({ stage }));
+      expect(plan?.edges, stage).toHaveLength(2);
+      expect(plan?.edges[0]).toMatchObject({
+        fromStage: stage,
+        transition: "Planificar Servicio",
+      });
+      // Only the re-entry carries the slot — the way out is a plain back-edge.
+      expect(plan?.edges[0].processVariables).toBeUndefined();
+      expect(plan?.edges[1]).toMatchObject({
+        fromStage: "planService",
+        transition: "Asignar Conductor/Transporte",
+      });
+      expect(plan?.edges[1].processVariables).toBeDefined();
+    }
+  });
+
+  it("passes the service category through when set", () => {
+    const vars = decideReplan(input({ serviceCategory: "ST001" }))?.edges[0]
+      .processVariables;
+    expect(vars?.mintral_serviceCategory).toBe("ST001");
+  });
+
+  it("refuses once the trip has started", () => {
+    for (const stage of ["missionControl", "monitorTrip"] as const) {
+      expect(decideReplan(input({ stage })), stage).toBeNull();
+    }
+  });
+
+  it("has nothing to re-plan at planService", () => {
+    // Not planned yet — there is no booking to re-slot.
+    expect(decideReplan(input({ stage: "planService" }))).toBeNull();
+  });
+
+  it("leaves flag-off origins to the legacy move", () => {
+    expect(decideReplan(input({ origin: "IQQ" }))).toBeNull();
+    expect(decideReplan(input({ origin: undefined }))).toBeNull();
+  });
+
+  it("returns null without a stage or a calendar", () => {
+    expect(decideReplan(input({ stage: undefined }))).toBeNull();
+    expect(decideReplan(input({ calendarId: undefined }))).toBeNull();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/services/task-driven-replan.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/task-driven-replan.ts
@@ -1,0 +1,90 @@
+import type { PlanProcessVariables } from "@/features/common/providers/client-api.provider";
+import type { TaskStage } from "../components/planning/planning-selection-types";
+import { canReplanAtStage } from "./task-driven-guard";
+import { isOriginTaskDriven } from "./task-driven-origin";
+import {
+  buildPlanProcessVariables,
+  type PlanSlotInput,
+} from "./task-driven-plan";
+
+/** Transition names declared in `WorkflowShippingCoordinationModel` (ecm-coordinator). */
+const TO_ASSIGN_DRIVER = "Asignar Conductor/Transporte";
+const TO_PLAN_SERVICE = "Planificar Servicio";
+
+/** One workflow move in a re-plan, with the stage it must fire from. */
+export type ReplanEdge = {
+  /** Stage the task must be sitting at before this edge fires. */
+  fromStage: TaskStage;
+  transition: string;
+  processVariables?: PlanProcessVariables;
+};
+
+export type ReplanPlan = { edges: ReplanEdge[] };
+
+/**
+ * The workflow moves that re-plan a task-driven service into a new slot.
+ *
+ * ECM has no move listener — by design. Its re-plan mechanism is an
+ * `assignDriver` **re-entry carrying the new slot vars**, which enqueues
+ * `ensure(PLANNED, <new slot>)` and lets the worker re-slot the existing
+ * booking (idempotent by `(calendarId, <serviceCode>-V)`). So re-planning is
+ * not a booking write with a transition bolted on: driving these edges IS the
+ * re-plan, and the caller must skip its own booking write entirely.
+ *
+ * Two shapes, because only one stage has a direct edge back:
+ * - `presentDriver` → a single `"Asignar Conductor/Transporte"`, the same edge
+ *   "Eliminar Asignación" uses. It lands on `assignDriver` **unassigned** —
+ *   moving the date means re-confirming the driver.
+ * - `assignDriver` / `prepareService` → out to `planService` first, then back
+ *   in carrying the slot.
+ *
+ * Returns `null` when this is not a task-driven re-plan we can drive: a
+ * flag-off origin, a stage past the trip start (see {@link canReplanAtStage}),
+ * `planService` (nothing planned yet to re-plan), or a missing calendar. The
+ * caller then keeps its legacy behaviour.
+ */
+export function decideReplan(input: {
+  stage: TaskStage | undefined;
+  origin: string | undefined;
+  calendarId: string | undefined;
+  slot: PlanSlotInput;
+  enabledOrigins: ReadonlySet<string>;
+  serviceCategory?: string;
+}): ReplanPlan | null {
+  const { stage, origin, calendarId, slot, enabledOrigins, serviceCategory } =
+    input;
+  if (!stage) return null;
+  if (!isOriginTaskDriven(origin, enabledOrigins)) return null;
+  if (!canReplanAtStage(stage, origin, enabledOrigins)) return null;
+
+  const slotVars = buildPlanProcessVariables(calendarId, slot, serviceCategory);
+  if (!slotVars) return null;
+
+  // The edge that re-enters assignDriver; carrying the slot is what makes the
+  // ECM listener re-slot the booking rather than assert the old slot.
+  const reenter: ReplanEdge = {
+    fromStage: "planService",
+    transition: TO_ASSIGN_DRIVER,
+    processVariables: slotVars,
+  };
+
+  if (stage === "presentDriver") {
+    return {
+      edges: [
+        {
+          fromStage: "presentDriver",
+          transition: TO_ASSIGN_DRIVER,
+          processVariables: slotVars,
+        },
+      ],
+    };
+  }
+
+  if (stage === "assignDriver" || stage === "prepareService") {
+    return {
+      edges: [{ fromStage: stage, transition: TO_PLAN_SERVICE }, reenter],
+    };
+  }
+
+  return null;
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -401,7 +401,8 @@
           "deleteConfirmTitle": "Confirm deletion",
           "deleteConfirmMessage": "Are you sure you want to delete the assignment for service {serviceId}?",
           "cancelReassignment": "Cancel reassignment",
-          "previewAsViewer": "Open service (Read-only)",
+          "openReadOnly": "Open service (Read-only)",
+          "previewAsViewer": "Preview as viewer",
           "exitPreview": "Exit preview"
         },
         "notifications": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -401,7 +401,8 @@
           "deleteConfirmTitle": "Confirmar eliminación",
           "deleteConfirmMessage": "¿Está seguro de eliminar la asignación del servicio {serviceId}?",
           "cancelReassignment": "Cancelar reasignación",
-          "previewAsViewer": "Abrir servicio (Solo Lectura)",
+          "openReadOnly": "Abrir servicio (Solo Lectura)",
+          "previewAsViewer": "Previsualizar como visor",
           "exitPreview": "Salir de previsualización"
         },
         "notifications": {

--- a/turbo-repo/packages/miot-calendar-ui/src/context/planning-selection-context.tsx
+++ b/turbo-repo/packages/miot-calendar-ui/src/context/planning-selection-context.tsx
@@ -43,6 +43,7 @@ import {
   buildBookingRequest,
   buildMoveRequest,
   buildResource,
+  preEditSnapshot,
   rollbackPlannedService,
 } from "../services/booking-persistence";
 import { mergeWorkflowStages } from "../services/workflow-stage-merge";
@@ -605,7 +606,12 @@ export function PlanningSelectionProvider<
       }
 
       const wasReassigning = reassigningService !== null;
-      const originalPlannedService = reassigningService?.service ?? null;
+      const wasAssigning = assigningService !== null;
+      const originalPlannedService = preEditSnapshot(
+        plannedServices,
+        effectiveItem.id,
+        reassigningService?.service ?? null
+      );
 
       // Optimistic update: replace any existing entry with the new slot.
       setPlannedServices((prev) => [
@@ -619,6 +625,7 @@ export function PlanningSelectionProvider<
         const ctx: BookingPersistContext = {
           oldBookingId,
           isReassigning: wasReassigning,
+          isAssigning: wasAssigning,
         };
         try {
           let booking: BookingResponse | undefined;
@@ -664,7 +671,9 @@ export function PlanningSelectionProvider<
       selectedSlot,
       selectedService,
       getServicesForSlot,
+      plannedServices,
       reassigningService,
+      assigningService,
       calendarId,
       host,
       bookingIds,

--- a/turbo-repo/packages/miot-calendar-ui/src/contract/booking-api.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/contract/booking-api.ts
@@ -37,6 +37,14 @@ export interface BookingPersistContext {
   /** True when the confirm completes an in-progress reassignment. */
   isReassigning: boolean;
   /**
+   * True when the confirm completes an in-progress assignment — the sidebar's
+   * assignment-only mode on an already-planned item, which changes resources
+   * and leaves the slot alone. Planning and assigning are distinct gestures a
+   * host may need to decide on separately; without this the two are
+   * indistinguishable here.
+   */
+  isAssigning: boolean;
+  /**
    * The booking the core just wrote (legacy persist path). Absent when the
    * host's `shouldPersistBooking` returned false, i.e. the row is owned by a
    * task-driven backend listener.

--- a/turbo-repo/packages/miot-calendar-ui/src/services/booking-persistence.test.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/services/booking-persistence.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { preEditSnapshot } from "./booking-persistence";
+import type { PlannedService } from "../types/planning";
+
+type Item = { id: string; label?: string };
+
+function planned(
+  id: string,
+  hour: number,
+  label?: string
+): PlannedService<Item> {
+  return {
+    service: { id, ...(label ? { label } : {}) },
+    slot: { date: new Date("2026-07-23"), hour, minutes: 0 },
+  };
+}
+
+describe("preEditSnapshot", () => {
+  it("keeps the reassignment snapshot, which alone carries the pre-move slot", () => {
+    const current = planned("s1", 14);
+    const beforeMove = planned("s1", 9);
+    expect(preEditSnapshot([current], "s1", beforeMove)).toBe(beforeMove);
+  });
+
+  it("restores the current entry when an assignment fails", () => {
+    // The item is already planned and the confirm only changed its resources;
+    // a refused assign must leave the chip exactly where it was.
+    const current = planned("s1", 14, "driver-a");
+    const grid = [current, planned("s2", 15)];
+    expect(preEditSnapshot(grid, "s1", null)).toBe(current);
+  });
+
+  it("returns null for a first-time plan", () => {
+    // Nothing to restore — dropping the optimistic entry is the whole rollback.
+    expect(preEditSnapshot([planned("s2", 15)], "s1", null)).toBeNull();
+    expect(preEditSnapshot([], "s1", null)).toBeNull();
+  });
+});

--- a/turbo-repo/packages/miot-calendar-ui/src/services/booking-persistence.ts
+++ b/turbo-repo/packages/miot-calendar-ui/src/services/booking-persistence.ts
@@ -73,8 +73,27 @@ export function buildMoveRequest(
 }
 
 /**
+ * The entry a failed confirm must restore: what this item looked like before
+ * the optimistic replace. The reassignment snapshot wins because it alone
+ * carries the pre-move slot; otherwise the item's current entry, which is what
+ * an assignment edits in place. Null only when the item was not planned yet —
+ * there, dropping the optimistic entry IS the restore.
+ *
+ * Getting this wrong erases an item that is still planned: a confirm that
+ * throws has written nothing, so the row survives and only the grid forgets it.
+ */
+export function preEditSnapshot<TItem extends { id: string }>(
+  plannedServices: readonly PlannedService<TItem>[],
+  itemId: string,
+  reassignSnapshot: PlannedService<TItem> | null
+): PlannedService<TItem> | null {
+  if (reassignSnapshot) return reassignSnapshot;
+  return plannedServices.find((p) => p.service.id === itemId) ?? null;
+}
+
+/**
  * Restore plannedServices after a failed persist: drop the optimistic entry
- * and re-add the pre-edit snapshot (the reassignment case) when present.
+ * and re-add the pre-edit snapshot (see {@link preEditSnapshot}) when present.
  */
 export function rollbackPlannedService<TItem extends { id: string }>(
   setPlannedServices: Dispatch<SetStateAction<PlannedService<TItem>[]>>,


### PR DESCRIPTION
Closes #989. Continues the planning work from #977 (phase 1 shipped as #978).

For a task-driven origin ECM owns the booking lifecycle — its task listeners write and reconcile `cld_bookings` and enqueue the Alerce chain. So a booking the BFF writes with **no accompanying workflow move** is not a lesser version of the operation, it is a divergence: the calendar says one thing, the workflow says another, no `async_job` exists, and nobody finds out until someone asks why Alerce is stale. Dev service `78265602` sat that way from 2026-01-26 until it was found.

This makes each of the three gestures answer to the workflow, and gates each one where the workflow has nowhere to go.

## Plan

`shouldPersistBooking` refuses a plan whose stage no transition covers, **before** the package writes anything. Throwing there surfaces the reason as an error toast and rolls the chip back, so the planner is told instead of shown a success that didn't happen.

## Assign

Plan and assign are separate steps, taken at different times by different users, and they were sharing one rule. Assigning IS the `assignDriver → presentDriver` edge, so those two stages accept it and no other does (`canAssignAtStage`). Past `presentDriver` a resource change needs a supervisor — out of scope for now, so it's blocked rather than silently written.

Testing surfaced a second defect this made reachable: **a refused confirm erased the service from the grid.** `confirmService` only snapshotted for rollback when *reassigning*, so an assignment — which edits an already-planned item in place — rolled back to "not planned". Nothing had been written, so the row survived and only the grid forgot it. `preEditSnapshot` now restores the pre-edit state for every gesture.

## Re-plan

The interesting one. ECM has **no move listener, by design**:

> *"The move (re-plan) path folds into this same ensure — an `assignDriver` re-entry carrying new slot vars enqueues `ensure(PLANNED, <new slot>)` and the worker re-slots the existing booking. There is no separate move listener."*

The FE wasn't using it — `isReassigning` zeroed the transition, so re-planning fell through to a bare `moveBooking`. Now the edges **are** the re-plan, and the FE stops writing the row (same shape the plan and assign paths already use):

| Stage | Edges |
|---|---|
| `presentDriver` | `"Asignar Conductor/Transporte"` + new slot — one edge, lands **unassigned** |
| `assignDriver` / `prepareService` | `"Planificar Servicio"` → `planService`, then `"Asignar Conductor/Transporte"` + new slot |
| `missionControl`+ | refused — no edge back |

The `presentDriver` case dropping the driver is the agreed trade, not a side effect: that edge is the one *Eliminar Asignación* uses, and moving the date means re-confirming who drives it.

**Un-planning shares the re-plan gate.** It's the same authority, and its transition would otherwise walk an in-flight trip all the way back to `planService` from a right-click.

## Where the lines sit

Planning authority ends where the trip starts — `missionControl` is that start. Assignment ends one stage earlier, at `presentDriver`. Both rules **fail open** on what they can't prove (flag-off origin, unknown stage), so a still-loading task index never hides a legitimate action.

## Read-only access

Gating every action by stage left a far-enough-along service with a menu containing nothing but its own ID, and no way in — left-click is no substitute, since `selectChipSlot` nulls the selected service to open the slot for a **new** one. "Abrir servicio (Solo Lectura)" existed only as a *label* on the `?as=viewer` toggle, which flips the whole calendar and needs `GROUP_CALENDAR_VIEWER`.

Split: the read-only open is a plain ungated `inspectPlannedService` (reading is not an operation the workflow can refuse); the URL flip keeps its own name, "Previsualizar como visor", and its gate.

## Verification

- `tsc --noEmit` clean (app + both packages)
- **174** app calendar tests, **20** package tests — 27 new across `task-driven-guard`, `task-driven-replan` and `booking-persistence`
- Trunk merged in, so this carries the default-calendar FE (#982) and was runtime-tested against deployed ECM + miot-calendar

## Follow-ups (not here)

- Supervisor escalation for assignment past `presentDriver`
- Dropping `TASK_DRIVEN_ORIGINS` now that microboxlabs/ecm-coordinator#340 makes the mapping settings-driven

🤖 Generated with [Claude Code](https://claude.com/claude-code)
