### PR TITLE
[miot-harness] Add credentials page to search inventory

### DIFF
--- a/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
+++ b/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
@@ -118,6 +118,7 @@ value you have confirmed; never emit a literal placeholder.
 | `/notifications` | notifications, notificaciones | User notifications | — |
 | `/integrations/jobs` | integration jobs, trabajos de integración, job console, consola de trabajos | Asynchronous integration job activity and status | — |
 | `/users/settings` | settings, configuración, ajustes | User settings; organizations at `/users/settings/organizations`, data sources at `/users/settings/data-sources` | — |
+| `/users/settings/credentials` | credentials, credenciales, API credentials, credenciales API | Reusable organization credentials for data sources, integrations, and jobs | — |
 | `/admin/console/logs` | admin logs, logs, registros (admins only) | Operational logs | — |
 | `/admin/console/message-templates` | message templates, plantillas de mensaje (admins only) | Message templates | — |
 


### PR DESCRIPTION
## What changed

Added `/users/settings/credentials` to the packaged `miot-search` page inventory.

## Why

The frontend navigation registry exposes this real page, but the runtime skill did not list it. The parity test therefore failed in Harness CI.

## Impact

Search agents can now link users to the credentials-management page, and the inventory stays aligned with the app navigation registry.

## Validation

- `uv sync --locked`
- `uv run pytest -q tests/context_skills/test_miot_search_pages_parity.py` — 3 passed
- Full Harness suite before rebase — 1,021 passed, 4 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `/users/settings/credentials` to the list of supported deep-link routes.
  * Documented the page as providing reusable credentials for data sources, integrations, and jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->