### PR TITLE
[web-admin] Update Prisma Auth adapter

### DIFF
--- a/turbo-repo/apps/web-admin/package.json
+++ b/turbo-repo/apps/web-admin/package.json
@@ -14,7 +14,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^2.10.0",
+    "@auth/prisma-adapter": "^2.11.3",
     "@hookform/resolvers": "^3.3.0",
     "@modulariot/db": "*",
     "@modulariot/ui": "*",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -750,7 +750,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@auth/prisma-adapter": "^2.10.0",
+        "@auth/prisma-adapter": "^2.11.3",
         "@hookform/resolvers": "^3.3.0",
         "@modulariot/db": "*",
         "@modulariot/ui": "*",
@@ -829,6 +829,17 @@
       "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "apps/web-admin/node_modules/@auth/prisma-adapter": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.3.tgz",
+      "integrity": "sha512-jZbpVAO6PTc9zNtdTWc0RLWG8qap4iMc54/3oWaWbuKdj92wHxzPrs3HivWB2mB9975GPW0l3YM/wFUWiUlTlg==",
+      "dependencies": {
+        "@auth/core": "0.41.3"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "apps/web-admin/node_modules/@eslint/eslintrc": {
@@ -1468,84 +1479,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@auth/prisma-adapter": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.2.tgz",
-      "integrity": "sha512-GyNEUNtrPgDPs0M4xX6F5i7jTsCKwU6BXV9zutctcoo6K1Ud+juckrmQS11uyNgeWsw6sliextHbU/e+8lsizQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.41.2"
-      },
-      "peerDependencies": {
-        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
-      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
-      "license": "ISC",
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^6.0.6",
-        "oauth4webapi": "^3.3.0",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7.0.7"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/oauth4webapi": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
-      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/preact-render-to-string": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "preact": ">=10"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",


### PR DESCRIPTION
## What changed

Updated `@auth/prisma-adapter` from the `^2.10.0` range to `^2.11.3` in web-admin and regenerated the npm lockfile.

## Why

The previously resolved adapter version (`2.11.2`) pinned a nested vulnerable `@auth/core@0.41.2`, leaving three Dependabot alerts open after the prior remediation.

## Impact

`@auth/prisma-adapter@2.11.3` pins `@auth/core@0.41.3`. All workspace `@auth/core` resolutions now use the patched version, so alerts #323–#325 should close after GitHub rescans the merged lockfile.

## Validation

- `npm ls @auth/prisma-adapter @auth/core --workspace=@modulariot/web-admin` confirms adapter `2.11.3` and core `0.41.3`
- Verified every `@auth/core` lockfile resolution is `0.41.3`
- `npm audit --audit-level=low`: 0 vulnerabilities

## Known baseline

web-admin's standalone type check and build fail on existing unrelated issues: missing Bun globals/Prisma generated client, a Recharts formatter type error, and Flowbite's unsupported Tailwind `version.js` import. This change does not modify those areas.