### PR TITLE
feat(calendar): mark a calendar as the default for its origin

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/[calendarId]/route.ts
@@ -22,6 +22,7 @@ const CalendarPatchSchema = z.object({
   active: z.boolean().optional(),
   filter: CalendarFilterSchema,
   autoSlotManager: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
 });
 
 export async function PUT(
@@ -52,6 +53,9 @@ export async function PUT(
       parallelism: parsed.data.parallelism ?? current.parallelism,
       filter: parsed.data.filter ?? current.filter,
       autoSlotManager: parsed.data.autoSlotManager,
+      // Read-modify-write: carry the flag forward so an unrelated edit cannot
+      // silently strip a calendar's default status.
+      isDefault: parsed.data.isDefault ?? current.isDefault,
       groups: current.groups?.map((g) => g.code),
     });
     return NextResponse.json(updated);

--- a/turbo-repo/apps/app/src/app/api/calendar/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/route.ts
@@ -24,6 +24,7 @@ const CalendarRequestSchema = z.object({
   groups: z.array(z.string()).optional(),
   filter: CalendarFilterSchema,
   autoSlotManager: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
 });
 
 export async function GET() {

--- a/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.config.ts
@@ -78,6 +78,14 @@ export const CREATE_CALENDAR_FORM_CONFIG: DynamicFormConfig = {
       type: "checkbox",
       defaultValue: true,
     },
+    {
+      // Scoped by filterOrigin above — the calendar that receives services
+      // created for that origin outside the planner.
+      name: "isDefault",
+      labelKey: "create.isDefaultLabel",
+      type: "checkbox",
+      defaultValue: false,
+    },
   ],
 };
 

--- a/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/calendar-landing/create-calendar-modal.tsx
@@ -96,6 +96,7 @@ export function CreateCalendarModal({
         groups: selectedGroupCode ? [selectedGroupCode] : [],
         filter,
         autoSlotManager: true,
+        isDefault: (formValues.isDefault as boolean) ?? false,
       };
 
       const calendar = await createCalendar(body);
@@ -196,9 +197,9 @@ export function CreateCalendarModal({
             ))}
         </div>
 
-        {/* active checkbox */}
+        {/* active + default-for-origin checkboxes */}
         {standardFields
-          .filter((f) => f.name === "active")
+          .filter((f) => f.name === "active" || f.name === "isDefault")
           .map((field) => (
             <DynamicFormField
               key={field.name}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/calendar-rules.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/calendar-rules.tsx
@@ -230,10 +230,11 @@ interface CalendarRulesProps {
   messages: CalendarRulesMessages;
   andenesCount?: number;
   taskFilter?: CalendarFilter;
+  isDefaultCalendar?: boolean;
   onRulesChange?: (windows: TimeWindow[]) => void;
   onBlocksChange?: (blocks: TimeBlock[]) => void;
   onAndenesChange?: (config: PlatformConfig) => void;
-  onTaskFilterChange?: (filter: CalendarFilter) => void;
+  onTaskFilterChange?: (filter: CalendarFilter, isDefault: boolean) => void;
 }
 
 export default function CalendarRules({
@@ -241,6 +242,7 @@ export default function CalendarRules({
   messages,
   andenesCount,
   taskFilter,
+  isDefaultCalendar,
   onRulesChange,
   onBlocksChange,
   onAndenesChange,
@@ -327,8 +329,9 @@ export default function CalendarRules({
             <FilterManager
               messages={getFilterManagerMessages(dict)}
               initialFilter={taskFilter}
-              onFilterChange={(filter) => {
-                onTaskFilterChange?.(filter);
+              initialIsDefault={isDefaultCalendar}
+              onFilterChange={(filter, isDefault) => {
+                onTaskFilterChange?.(filter, isDefault);
                 closePanel();
               }}
             />

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/filter-manager.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/filter-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, TextInput, Label } from "flowbite-react";
+import { Button, Checkbox, TextInput, Label } from "flowbite-react";
 import { useCallback, useEffect, useState } from "react";
 import { HiCheck } from "react-icons/hi";
 import type { CalendarFilter } from "@microboxlabs/miot-calendar-client";
@@ -14,6 +14,9 @@ export interface FilterManagerMessages {
   destinationPlaceholder: string;
   hint: string;
   save: string;
+  defaultLabel: string;
+  defaultHint: string;
+  defaultNeedsOrigin: string;
 }
 
 const FILTER_MANAGER_BASE = "layout.planning.calendarRules.taskFilter" as const;
@@ -31,27 +34,38 @@ export function getFilterManagerMessages(
     ),
     hint: tr(`${FILTER_MANAGER_BASE}.hint`, dict),
     save: tr(`${FILTER_MANAGER_BASE}.save`, dict),
+    defaultLabel: tr(`${FILTER_MANAGER_BASE}.defaultLabel`, dict),
+    defaultHint: tr(`${FILTER_MANAGER_BASE}.defaultHint`, dict),
+    defaultNeedsOrigin: tr(`${FILTER_MANAGER_BASE}.defaultNeedsOrigin`, dict),
   };
 }
 
 interface FilterManagerProps {
   messages: FilterManagerMessages;
   initialFilter?: CalendarFilter;
-  onFilterChange?: (filter: CalendarFilter) => void;
+  initialIsDefault?: boolean;
+  onFilterChange?: (filter: CalendarFilter, isDefault: boolean) => void;
 }
 
 /**
  * Task filter manager — lets the user constrain the planning sidebar's
- * task list to a specific origin and/or destination delegate code.
+ * task list to a specific origin and/or destination delegate code, and mark
+ * the calendar as the default for that origin: the one a service created
+ * outside the planner gets booked into. Both live here because the default is
+ * scoped by the very origin the field above sets.
  */
 export default function FilterManager({
   messages,
   initialFilter,
+  initialIsDefault,
   onFilterChange,
 }: Readonly<FilterManagerProps>) {
   const [origin, setOrigin] = useState<string>(initialFilter?.origin ?? "");
   const [destination, setDestination] = useState<string>(
     initialFilter?.destination ?? ""
+  );
+  const [isDefault, setIsDefault] = useState<boolean>(
+    initialIsDefault ?? false
   );
 
   useEffect(() => {
@@ -59,14 +73,22 @@ export default function FilterManager({
     setDestination(initialFilter?.destination ?? "");
   }, [initialFilter?.origin, initialFilter?.destination]);
 
+  useEffect(() => {
+    setIsDefault(initialIsDefault ?? false);
+  }, [initialIsDefault]);
+
+  // A default with no origin is the catch-all for every origin nothing else
+  // claims. Reachable on purpose, but not by leaving a field blank.
+  const defaultWithoutOrigin = isDefault && origin.trim() === "";
+
   const handleSave = useCallback(() => {
     const next: CalendarFilter = {};
     const o = origin.trim();
     const d = destination.trim();
     if (o) next.origin = o;
     if (d) next.destination = d;
-    onFilterChange?.(next);
-  }, [origin, destination, onFilterChange]);
+    onFilterChange?.(next, isDefault);
+  }, [origin, destination, isDefault, onFilterChange]);
 
   return (
     <div className="p-4 space-y-4">
@@ -108,6 +130,28 @@ export default function FilterManager({
 
       <div className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 rounded-lg p-3">
         {messages.hint}
+      </div>
+
+      <div className="space-y-2 border-t border-gray-200 dark:border-gray-700 pt-3">
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="filter-is-default"
+            checked={isDefault}
+            onChange={(e) => setIsDefault(e.target.checked)}
+            className="mt-0.5"
+          />
+          <Label
+            htmlFor="filter-is-default"
+            className="text-xs font-medium text-gray-700 dark:text-gray-300"
+          >
+            {messages.defaultLabel}
+          </Label>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {defaultWithoutOrigin
+            ? messages.defaultNeedsOrigin
+            : messages.defaultHint}
+        </p>
       </div>
 
       <Button color="blue" size="sm" className="w-full" onClick={handleSave}>

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-header.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-header.tsx
@@ -198,6 +198,7 @@ export default function PlanningHeader({
           messages={getCalendarRulesMessages(dict)}
           andenesCount={andenesCount}
           taskFilter={activeCalendar?.filter}
+          isDefaultCalendar={activeCalendar?.isDefault}
           onAndenesChange={async (config) => {
             setAndenesCount(config.count);
             if (!calendarId) return;
@@ -215,10 +216,10 @@ export default function PlanningHeader({
               });
             }
           }}
-          onTaskFilterChange={async (filter: CalendarFilter) => {
+          onTaskFilterChange={async (filter: CalendarFilter, isDefault: boolean) => {
             if (!calendarId) return;
             try {
-              await updateCalendar(calendarId, { filter });
+              await updateCalendar(calendarId, { filter, isDefault });
               await refreshCalendars();
               ShowNotification({
                 type: "success",

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2053,6 +2053,9 @@
           "destinationPlaceholder": "Select a destination",
           "hint": "Only tasks matching the selected filters will be shown.",
           "save": "Save",
+          "defaultLabel": "Default calendar for this origin",
+          "defaultHint": "Services created automatically (outside the planner) for this origin will be booked into this calendar. If no calendar for the origin is marked, those services move on with no booking.",
+          "defaultNeedsOrigin": "With no origin, this calendar receives the services of every origin that has none of its own.",
           "saveSuccess": "Task filter saved successfully",
           "saveError": "Error saving the task filter"
         }
@@ -3840,6 +3843,7 @@
       "timezoneLabel": "Timezone",
       "groupLabel": "Group",
       "activeLabel": "Active",
+      "isDefaultLabel": "Default calendar for the origin",
       "submit": "Create Calendar",
       "group": {
         "searchPlaceholder": "Search or create a group...",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2053,6 +2053,9 @@
           "destinationPlaceholder": "Selecciona un destino",
           "hint": "Solo se mostrarán las tareas que coincidan con los filtros seleccionados.",
           "save": "Guardar",
+          "defaultLabel": "Calendario por defecto para este origen",
+          "defaultHint": "Los servicios creados automáticamente (fuera del planificador) para este origen se reservarán en este calendario. Si ningún calendario del origen está marcado, esos servicios avanzan sin reserva.",
+          "defaultNeedsOrigin": "Sin origen, este calendario recibirá los servicios de cualquier origen que no tenga uno propio.",
           "saveSuccess": "Filtro de tareas guardado correctamente",
           "saveError": "Error al guardar el filtro de tareas"
         }
@@ -3840,6 +3843,7 @@
       "timezoneLabel": "Zona Horaria",
       "groupLabel": "Grupo",
       "activeLabel": "Activo",
+      "isDefaultLabel": "Calendario por defecto para el origen",
       "submit": "Crear Calendario",
       "group": {
         "searchPlaceholder": "Buscar o crear un grupo...",

--- a/turbo-repo/packages/miot-calendar-client/src/types.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/types.ts
@@ -139,6 +139,13 @@ export interface CalendarRequest {
   groups?: string[];
   filter?: CalendarFilter;
   autoSlotManager?: boolean;
+  /**
+   * Mark this calendar as the default for its {@link CalendarFilter.origin} —
+   * the one an integrating system books into when it was given no calendar.
+   * Setting it demotes the previous default for the same origin; omitting it
+   * leaves the current value alone.
+   */
+  isDefault?: boolean;
 }
 
 export interface CalendarResponse {
@@ -154,6 +161,8 @@ export interface CalendarResponse {
   groups?: CalendarGroupResponse[];
   filter?: CalendarFilter;
   hasSlotManager?: boolean;
+  /** Whether this is the default calendar for its filter origin. */
+  isDefault?: boolean;
 }
 
 // --- Time Windows ---


### PR DESCRIPTION
Companion to **microboxlabs/miot-calendar#42**, which adds the `isDefault` field and the `GET /calendars/default?origin=X` lookup. Follows microboxlabs/ecm-coordinator#337.

## Why

The origin a calendar serves is already *on* the calendar — `filter.origin`, edited in the same settings panel this touches. What was missing is which of them receives a service created outside the planner. That answer lived in backend configuration, redeployed whenever a delegación got a calendar.

## Where the control lives

In the **task-filter section**, not one of its own, because it is scoped by the very origin the field above it sets. *"This calendar serves SCL"* and *"and it is the SCL default"* are one thought; splitting them would let someone set the second while looking at a stale first.

Marking it demotes whatever held that origin before (handled server-side), so this is a single save with no incumbent to clear first.

Leaving the origin blank is legal — it means the catch-all for every origin nothing else claims. The hint swaps to say so rather than blocking the save, since a global default is a real configuration and not a slip.

## Also

- **Create modal** — a new delegación is one step instead of create-then-edit.
- **BFF `PUT`** — the flag is carried through the read-modify-write, so an unrelated edit (parallelism, filter) cannot silently strip a calendar's default status.
- **`miot-calendar-client`** — `isDefault` on `CalendarRequest` (optional, `null` = no change) and `CalendarResponse`.

## Verification

- `tsc --noEmit` clean (app + both packages)
- `vitest` calendar suite: 143 pass
- Both dictionaries updated; JSON revalidated, diff is 3 lines each

## Order of merge

miot-calendar#42 first — the app sends `isDefault` and an older server ignores unknown request fields, so nothing breaks either way, but the checkbox does nothing until #42 is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)