### PR TITLE
fix(credentials): restore the space before the RETURNING column list

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileRepository.java
@@ -19,6 +19,11 @@ import java.util.UUID;
 @ApplicationScoped
 public class CredentialProfileRepository {
 
+    /**
+     * Shared projection. Every clause that appends this must leave the keyword before it on
+     * its own line: a text block strips trailing spaces from each line, so {@code RETURNING }
+     * followed by the closing delimiter loses its space and yields {@code RETURNINGid}.
+     */
     private static final String COLUMNS = """
             id, tenant_code, display_name, credential_type, auth_type, environment,
             public_config, encrypted_secret_json, secret_preview, secret_version,
@@ -42,14 +47,16 @@ public class CredentialProfileRepository {
                 public_config, encrypted_secret_json, secret_preview, secret_version,
                 created_at, updated_at, created_by, updated_by
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            RETURNING """ + COLUMNS;
+            RETURNING
+            """ + COLUMNS;
 
     private static final String UPDATE_SECRET = """
             UPDATE miot_integrations.credential_profiles
             SET encrypted_secret_json = $3, secret_preview = $4,
                 secret_version = secret_version + 1, updated_at = now()
             WHERE tenant_code = $1 AND id = $2 AND active
-            RETURNING """ + COLUMNS;
+            RETURNING
+            """ + COLUMNS;
 
     // Partial update: a null parameter leaves the column unchanged (explicit ::casts so
     // the NULL binds keep their type in the prepared statement). The secret is rotated
@@ -66,7 +73,8 @@ public class CredentialProfileRepository {
                 updated_by = COALESCE($8::text, updated_by),
                 updated_at = now()
             WHERE tenant_code = $1 AND id = $2 AND active
-            RETURNING """ + COLUMNS;
+            RETURNING
+            """ + COLUMNS;
 
     // Testing a credential is not editing it: updated_at stays put so a round of tests
     // does not reshuffle a list sorted by "last updated".
@@ -74,7 +82,8 @@ public class CredentialProfileRepository {
             UPDATE miot_integrations.credential_profiles
             SET last_tested_at = $3, last_test_result = $4
             WHERE tenant_code = $1 AND id = $2 AND active
-            RETURNING """ + COLUMNS;
+            RETURNING
+            """ + COLUMNS;
 
     // Soft delete: the row stays for audit and for anything still holding its id, but
     // drops out of every read path (all of which filter on active) and frees its name.

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileSqlIntegrityTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/persistence/CredentialProfileSqlIntegrityTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -65,6 +67,34 @@ class CredentialProfileSqlIntegrityTest {
         assertTrue(
                 sql.contains("encrypted_secret_json = COALESCE($6::text, encrypted_secret_json)"),
                 "UPDATE_PROFILE must keep the stored ciphertext when none is bound:\n" + sql);
+    }
+
+    /**
+     * A text block strips trailing spaces from every line, so {@code RETURNING """ + COLUMNS}
+     * emits {@code RETURNINGid, tenant_code, ...} — PostgreSQL answers
+     * {@code syntax error at or near "RETURNINGid"} and every write fails. It reached
+     * production once: create, update, secret rotation and test-result recording were all
+     * broken, while the reads (which build their projection differently) kept working, so
+     * the screen listed credentials perfectly and refused to save one.
+     *
+     * <p>This walks every SQL constant rather than the four known clauses, so the next
+     * keyword glued to an identifier is caught wherever it appears.
+     */
+    @Test
+    void noKeywordIsGluedToTheColumnListItPrecedes() throws Exception {
+        for (Field field : CredentialProfileRepository.class.getDeclaredFields()) {
+            if (!field.getType().equals(String.class) || !Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            field.setAccessible(true);
+            String sql = (String) field.get(null);
+            for (String keyword : List.of("RETURNING", "SELECT", "FROM", "WHERE", "SET", "VALUES")) {
+                assertFalse(
+                        Pattern.compile(keyword + "\\w").matcher(sql).find(),
+                        field.getName() + " has " + keyword + " glued to what follows it — a text block "
+                                + "dropped the separating space:\n" + sql);
+            }
+        }
     }
 
     /** Recording a test result is not an edit — see the comment on the query itself. */


### PR DESCRIPTION
Every write against `credential_profiles` fails:

```
io.vertx.pgclient.PgException: ERROR: syntax error at or near "RETURNINGid" (42601)
```

## Cause

A Java text block strips trailing spaces from each line, so

```java
RETURNING """ + COLUMNS
```

emits `RETURNING` immediately followed by the first column name. Putting the keyword on its own line lets the block's closing newline do the separating, which trailing-whitespace stripping cannot remove.

## Reach

Four statements carried it — `INSERT`, `UPDATE_SECRET`, `UPDATE_PROFILE`, `UPDATE_TEST_RESULT` — so **create, edit, secret rotation and test-result recording were all broken**.

Reads were unaffected: they build their projection by prefixing `"SELECT "` as an ordinary string literal, which keeps its space. That is why the failure looks so odd from the UI — the list renders correctly and the inline test passes (it never touches the database), but saving fails.

`UPDATE_SECRET` is the one that reaches past the new feature: the connection update path rotates a WhatsApp access token through it.

## Regression test

The guard walks **every** SQL constant in the class rather than the four known clauses, so the next keyword glued to an identifier is caught wherever it turns up:

```
INSERT has RETURNING glued to what follows it — a text block dropped the separating space
```

Confirmed it fails with the fix reverted and passes with it applied. 229 `miot-integrations` tests green.

## Why the existing guard missed it

`CredentialProfileSqlIntegrityTest` was written for exactly this class of defect — a query-analysis error that fires with zero matching rows and never surfaces in stubbed unit tests. It checked tenant scoping, the soft-delete filter, the NULL casts and the `secret_version` conditional, but nothing asserted the SQL was *lexically* well-formed. That gap is what this adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed SQL formatting in credential updates to prevent malformed queries caused by missing spaces.
  - Improved reliability for secret rotation and test-result updates.

- **Tests**
  - Added integrity checks to detect SQL keywords accidentally joined to column names or other query content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->