### PR TITLE
fix(security): constrain Alfresco request identifiers

### DIFF
--- a/turbo-repo/apps/app/src/app/api/bento/content/route.ts
+++ b/turbo-repo/apps/app/src/app/api/bento/content/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { logError } from "@/lib/logger";
+import { alfrescoNodeIdSchema } from "@/features/common/providers/alfresco-api/alfresco-identifiers";
 import { prepareAlfrescoAuth } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,6 +18,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Missing nodeId" }, { status: 400 });
   }
 
+  const parsedNodeId = alfrescoNodeIdSchema.safeParse(nodeId);
+  if (!parsedNodeId.success) {
+    return NextResponse.json({ error: "Invalid nodeId" }, { status: 400 });
+  }
+  const safeNodeId = encodeURIComponent(parsedNodeId.data);
+
   try {
     let userAgent: Record<string, string> = {};
     if (process.env.USER_AGENT) {
@@ -24,7 +31,7 @@ export async function GET(req: NextRequest) {
     }
 
     const { url, headers } = prepareAlfrescoAuth(
-      `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/content`,
+      `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${safeNodeId}/content`,
       session
     );
 
@@ -38,10 +45,7 @@ export async function GET(req: NextRequest) {
     });
 
     if (response.status === 404) {
-      return NextResponse.json(
-        { error: "Content not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Content not found" }, { status: 404 });
     }
 
     if (!response.ok) {

--- a/turbo-repo/apps/app/src/app/api/bento/thumbnails/route.ts
+++ b/turbo-repo/apps/app/src/app/api/bento/thumbnails/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { logError } from "@/lib/logger";
+import { alfrescoNodeIdSchema } from "@/features/common/providers/alfresco-api/alfresco-identifiers";
 import { prepareAlfrescoAuth } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,9 +18,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Missing nodeId" }, { status: 400 });
   }
 
+  const parsedNodeId = alfrescoNodeIdSchema.safeParse(nodeId);
+  if (!parsedNodeId.success) {
+    return NextResponse.json({ error: "Invalid nodeId" }, { status: 400 });
+  }
+  const safeNodeId = encodeURIComponent(parsedNodeId.data);
+
   try {
-    const nodeRef = `workspace://SpacesStore/${nodeId}`;
-    const path = nodeRef.replace(/:\//, "");
+    const path = `workspace/SpacesStore/${safeNodeId}`;
 
     let userAgent: Record<string, string> = {};
     if (process.env.USER_AGENT) {

--- a/turbo-repo/apps/app/src/app/api/document/download/route.ts
+++ b/turbo-repo/apps/app/src/app/api/document/download/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { normalizeAlfrescoNodeReference } from "@/features/common/providers/alfresco-api/alfresco-identifiers";
 import { prepareAlfrescoAuth } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import { NextRequest, NextResponse } from "next/server";
 export async function GET(req: NextRequest) {
@@ -14,14 +15,17 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Missing documentId" }, { status: 400 });
   }
 
+  const nodeId = normalizeAlfrescoNodeReference(documentId);
+  if (!nodeId) {
+    return NextResponse.json({ error: "Invalid documentId" }, { status: 400 });
+  }
+
   try {
     // documentId can arrive as:
     // 1. Just the UUID: "1c903be0-..."
     // 2. Full path: "workspace/SpacesStore/1c903be0-..."
     // Normalize to full path format for Alfresco legacy API
-    const nodeContentPath = documentId.includes("/")
-      ? documentId
-      : `workspace/SpacesStore/${documentId}`;
+    const nodeContentPath = `workspace/SpacesStore/${encodeURIComponent(nodeId)}`;
 
     const { url, headers } = prepareAlfrescoAuth(
       `${process.env.ECM_API_URL}/alfresco/s/api/node/content/${nodeContentPath}?a=true`,

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -44,12 +44,10 @@ import { GetEntityInfoResponse } from "../microboxlabs-api/microboxlabs-api.type
 import type { Session } from "next-auth";
 import { createManagedLogger, logError } from "@/lib/logger";
 import { z } from "zod";
-
-/** Alfresco node IDs are UUIDs or well-known aliases like -root-, -my-, -shared-. */
-const alfrescoNodeIdSchema = z.string().regex(
-  /^(-root-|-my-|-shared-|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
-  "Invalid Alfresco node ID"
-);
+import {
+  alfrescoNodeIdSchema,
+  normalizeAlfrescoTaskId,
+} from "./alfresco-identifiers";
 
 function validateNodeId(nodeId: string): string {
   return alfrescoNodeIdSchema.parse(nodeId);
@@ -634,11 +632,12 @@ export async function getChildrenNodes(
   nodeId: string,
   options: NodeChildrenRequest
 ): Promise<NodeChildAssociationPaging> {
+  const safeNodeId = encodeURIComponent(validateNodeId(nodeId));
   const queryParams = new URLSearchParams();
   Object.entries(options).forEach(([key, value]) => {
     queryParams.set(key, value.toString());
   });
-  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/children?${queryParams.toString()}`;
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${safeNodeId}/children?${queryParams.toString()}`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
   const children = await fetcher(url, {
     method: "GET",
@@ -651,10 +650,11 @@ export async function getContentNode(
   session: Session,
   nodeId: string
 ): Promise<string> {
+  const safeNodeId = encodeURIComponent(validateNodeId(nodeId));
   const queryParams = new URLSearchParams({
     attachment: "true",
   });
-  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/content?${queryParams.toString()}`;
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${safeNodeId}/content?${queryParams.toString()}`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
   const result = await fetch(url, {
     method: "GET",
@@ -668,10 +668,11 @@ export async function getPlainTextNode(
   session: Session,
   nodeId: string
 ): Promise<string> {
+  const safeNodeId = encodeURIComponent(validateNodeId(nodeId));
   const queryParams = new URLSearchParams({
     attachment: "true",
   });
-  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/content?${queryParams.toString()}`;
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${safeNodeId}/content?${queryParams.toString()}`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
   const result = await fetch(url, {
     method: "GET",
@@ -774,15 +775,11 @@ export async function getStatisticsTasks(
 
 export async function formProcessor(
   session: Session,
-  itemKind: string,
   itemId: string,
   data: Record<string, unknown>
 ): Promise<TaskResponse> {
-  const normalizedItemId =
-    itemKind === "task" && !itemId.startsWith("activiti$")
-      ? `activiti$${itemId}`
-      : itemId;
-  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/api/${itemKind}/${normalizedItemId}/formprocessor`;
+  const normalizedItemId = encodeURIComponent(normalizeAlfrescoTaskId(itemId));
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/api/task/${normalizedItemId}/formprocessor`;
   const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
 
   const result = await fetcher(url, {
@@ -801,7 +798,7 @@ export async function updateTask(
   taskId: string,
   data: Record<string, unknown>
 ): Promise<TaskResponse> {
-  return formProcessor(session, "task", taskId, data);
+  return formProcessor(session, taskId, data);
 }
 
 export async function getServiceValidation(
@@ -861,7 +858,8 @@ export async function checkDocumentExists(
   nodeId: string
 ): Promise<boolean> {
   try {
-    const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}`;
+    const safeNodeId = encodeURIComponent(validateNodeId(nodeId));
+    const baseUrl = `${process.env.ECM_API_URL}/alfresco/api/-default-/public/alfresco/versions/1/nodes/${safeNodeId}`;
     const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
     // This will throw an error if the node doesn't exist
     const node = (await fetcher(url, {
@@ -1976,7 +1974,7 @@ export async function updateTaskServiceCategory(
   taskId: string,
   serviceTypeCode: string
 ): Promise<void> {
-  await formProcessor(session, "task", taskId, {
+  await formProcessor(session, taskId, {
     prop_mintral_serviceCategory: serviceTypeCode,
   });
 }

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-identifiers.test.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-identifiers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  alfrescoNodeIdSchema,
+  normalizeAlfrescoNodeReference,
+  normalizeAlfrescoTaskId,
+} from "./alfresco-identifiers";
+
+const NODE_ID = "1c903be0-1234-4abc-8def-0123456789ab";
+
+describe("Alfresco identifier validation", () => {
+  it("accepts Alfresco node UUIDs and supported aliases", () => {
+    expect(alfrescoNodeIdSchema.parse(NODE_ID)).toBe(NODE_ID);
+    expect(alfrescoNodeIdSchema.parse("-shared-")).toBe("-shared-");
+  });
+
+  it("rejects node IDs that can alter a URL path or query", () => {
+    expect(alfrescoNodeIdSchema.safeParse("../admin").success).toBe(false);
+    expect(alfrescoNodeIdSchema.safeParse(`${NODE_ID}?a=true`).success).toBe(
+      false
+    );
+    expect(alfrescoNodeIdSchema.safeParse("https://example.test").success).toBe(
+      false
+    );
+  });
+
+  it("normalizes only supported legacy workspace references", () => {
+    expect(normalizeAlfrescoNodeReference(NODE_ID)).toBe(NODE_ID);
+    expect(
+      normalizeAlfrescoNodeReference(`workspace/SpacesStore/${NODE_ID}`)
+    ).toBe(NODE_ID);
+    expect(
+      normalizeAlfrescoNodeReference(`workspace://SpacesStore/${NODE_ID}`)
+    ).toBe(NODE_ID);
+    expect(
+      normalizeAlfrescoNodeReference("workspace/SpacesStore/../admin")
+    ).toBeNull();
+    expect(
+      normalizeAlfrescoNodeReference("other/SpacesStore/" + NODE_ID)
+    ).toBeNull();
+  });
+
+  it("normalizes form-processor task IDs to one safe path segment", () => {
+    expect(normalizeAlfrescoTaskId("task-1")).toBe("activiti$task-1");
+    expect(normalizeAlfrescoTaskId("activiti$task-1")).toBe("activiti$task-1");
+    expect(() => normalizeAlfrescoTaskId("task-1/../../admin")).toThrow(
+      "Invalid Alfresco task ID"
+    );
+  });
+});

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-identifiers.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-identifiers.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+/** Alfresco node IDs are UUIDs or well-known aliases like -root-, -my-, -shared-. */
+export const alfrescoNodeIdSchema = z
+  .string()
+  .regex(
+    /^(-root-|-my-|-shared-|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
+    "Invalid Alfresco node ID"
+  );
+
+/** Task IDs are used as one path segment by Alfresco's form processor. */
+const alfrescoTaskIdSchema = z
+  .string()
+  .regex(/^(?:activiti\$)?[A-Za-z0-9._-]+$/, "Invalid Alfresco task ID");
+
+/**
+ * Returns the node ID from a bare ID or a legacy workspace node reference.
+ * Only the exact workspace/SpacesStore form is accepted to keep it a single
+ * URL path segment when the caller builds an Alfresco endpoint.
+ */
+export function normalizeAlfrescoNodeReference(
+  reference: string
+): string | null {
+  const directNodeId = alfrescoNodeIdSchema.safeParse(reference);
+  if (directNodeId.success) {
+    return directNodeId.data;
+  }
+
+  const match = /^workspace(?::\/\/|\/)SpacesStore\/(.+)$/i.exec(reference);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const referencedNodeId = alfrescoNodeIdSchema.safeParse(match[1]);
+  return referencedNodeId.success ? referencedNodeId.data : null;
+}
+
+/** Normalizes a task ID to Alfresco's form-processor path format. */
+export function normalizeAlfrescoTaskId(taskId: string): string {
+  const parsedTaskId = alfrescoTaskIdSchema.parse(taskId);
+  return parsedTaskId.startsWith("activiti$")
+    ? parsedTaskId
+    : `activiti$${parsedTaskId}`;
+}


### PR DESCRIPTION
## Summary

Constrain user-controlled Alfresco identifiers before they are interpolated into server-side request URLs.

- validate and encode node IDs for bento content, thumbnails, document download, child/content lookups, and document verification
- accept only documented UUID and `workspace/SpacesStore/<UUID>` reference forms for legacy downloads
- constrain form-processor task IDs to one path segment while preserving the `activiti$` convention
- add regression tests for hostile node and task values

## Root cause

Several authenticated API routes passed request parameters directly into Alfresco URL paths. CodeQL reported these as request-forgery/SSRF flows, including aggregate flows through the shared fetcher.

## Validation

- `npm run test:run` — 859 passed, 1 skipped
- focused identifier tests — 4 passed
- changed-file ESLint — no errors (existing warnings remain)
- `npm run check-types` remains blocked by five pre-existing calendar `isDefault` mismatches on `trunk`, unrelated to this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of document, content, thumbnail, and task identifiers.
  - Invalid or unsafe identifiers now receive clear `400` error responses.
  - Improved compatibility with legacy Alfresco document references.
  - Ensured identifiers are safely encoded when retrieving content and navigation data.

- **Tests**
  - Added coverage for valid identifiers, legacy formats, aliases, malformed URLs, and path traversal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->