### PR TITLE
fix(i18n): label the missionControl stage "Iniciar Viaje"

### DIFF
--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -376,7 +376,7 @@
           "assignDriver": "Assign driver",
           "presentDriver": "Present driver",
           "prepareService": "Prepare service",
-          "missionControl": "Mission control",
+          "missionControl": "Start trip",
           "monitorTrip": "Trip in progress",
           "confirmArrival": "Confirm arrival",
           "closeMonitoring": "Close monitoring",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -376,7 +376,7 @@
           "assignDriver": "Asignar conductor",
           "presentDriver": "Presentar conductor",
           "prepareService": "Preparar servicio",
-          "missionControl": "Control de misión",
+          "missionControl": "Iniciar Viaje",
           "monitorTrip": "Viaje en curso",
           "confirmArrival": "Confirmar arribo",
           "closeMonitoring": "Cierre de monitoreo",


### PR DESCRIPTION
## What

`pages.planning.sidebar.taskStage.missionControl` was the only place still labelled **"Control de misión"**. Every other `missionControl` label in the app already reads **"Iniciar viaje"**, so this one was inconsistent with what the rest of the UI (and the workflow) calls that stage.

- **ES:** `Control de misión` → `Iniciar Viaje`
- **EN:** `Mission control` → `Start trip` (matching the app's other EN `missionControl` labels)

This is the stage label shown on a planned-service chip / sidebar when a service sits at `missionControl`.

## Scope

Two lines, one per dictionary. No code changes; both JSON files revalidated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the planning task stage label in English to “Start trip.”
  * Updated the corresponding Spanish label to “Iniciar Viaje.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->