### PR TITLE
feat(integrations): review-channel dispatch — plan + Phase 1 (operation invoker)

### DIFF
--- a/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
+++ b/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
@@ -1,6 +1,6 @@
 # Review-channel dispatch — executing a connection operation from a review verdict
 
-**Status:** Phase 1 implemented. Phases 2–5 planned.
+**Status:** Phases 1–2 implemented. Phases 3–5 planned.
 
 ## Problem
 
@@ -248,17 +248,40 @@ Each phase is independently shippable and independently useful.
 **Still open from this phase:** `GenericConnectionTester` can now become a real
 probe instead of a stub — not done here to keep the change reviewable.
 
-### Phase 2 — payload rendering
+### Phase 2 — payload rendering — **DONE**
 
-- `PayloadTemplateRenderer` — renders `fieldId -> template` into a JSON object
-  against a context `{task, content, review, session}`.
-- **Engine decision: a `{{dotted.path}}` substitution subset, not full
-  Handlebars.** No templating dependency exists in `quarkus-srv`, and the UI only
-  emits variable tokens. See the parity risk below.
-- **Type coercion** off `request_schema`: a `boolean` field must leave as JSON
-  `true`, not `"true"`. Render → coerce → fail the field if it can't coerce.
-- `TemplateValidator` — parses a template, rejects unsupported constructs and
-  unknown variable roots, used both on binding save and by a preview endpoint.
+- `PayloadTemplate` — the template language: literal text interleaved with
+  `{{dotted.path}}` over `{task, content, review, session}`. A **strict subset of
+  Handlebars**: blocks, helpers, partials, comments, inverted sections and
+  `{{{unescaped}}}` are all **rejected**, as are unknown variable roots and a bare
+  `{{task}}` (a whole object stringified into the payload is a half-typed path, not
+  an intent). No HTML escaping — Jackson escapes the JSON body, and escaping here
+  would corrupt it.
+- `PayloadSchema` — reads `integration_operations.request_schema` as a JSON-Schema
+  subset (`properties` + `required`). **This is that column's first reader.**
+  Richer schemas are ignored rather than rejected; `string`/`date-time`/unknown all
+  pass through as text.
+- `PayloadRenderer` — render → coerce → decide, collecting **every** problem before
+  throwing so a broken six-field mapping is seen in one pass. Also does the
+  save-time `validate(...)` that backs the binding save and the preview endpoint.
+
+Two behaviours worth knowing:
+
+- **An empty optional field is omitted, not sent blank.** Partners generally treat
+  an absent key and `""` differently, and "no reviewer comment" means the former.
+  An empty *required* field is an error — silently writing a blank into a required
+  slot is worse than failing.
+- **A template that is exactly one variable keeps the context value's own type**, so
+  `{{review.verdict}}` over a real boolean sends JSON `false`, not `"false"`,
+  without depending on a string round-trip. Text forms (`true`/`false`/`1`/`0`) are
+  still accepted; anything else is refused, because treating any non-empty string
+  as true would turn a mapping slip into a wrong verdict.
+
+**How the parity risk is actually closed:** validation runs at **save**, not
+dispatch. A template the UI's Handlebars would render differently never reaches
+storage, so preview and runtime cannot drift. If helpers are wanted later, add a
+real Handlebars dependency and relax the validator — but do not let the two sides
+diverge in the meantime.
 
 ### Phase 3 — binding schema + CRUD API
 

--- a/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
+++ b/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
@@ -1,0 +1,249 @@
+# Review-channel dispatch — executing a connection operation from a review verdict
+
+**Status:** planned. Nothing implemented yet.
+
+## Problem
+
+A workflow column can be marked as a *reviewed* stage: when a service in it is
+approved or rejected, the verdict must be pushed to an external system —
+authenticated by a stored credential, with a per-field payload the operator maps
+themselves (no code change per partner).
+
+Most of the nouns already exist in this module:
+
+| Piece | Where | State |
+|---|---|---|
+| Auth material | `credential_profiles` + `IntegrationSecretCipher` | done |
+| Provider endpoint | `integration_connections` (base URL, provider, credential, status) | done |
+| Endpoint contract | `integration_operations` (method, path, request/response schema) | done |
+| Durable queue | `async_jobs` + `AsyncJobService` (dedupe, lease, backoff, park) | done |
+| Generic worker | `ModulithJobWorker` → `ModulithJobHandler` by `job_type` | done |
+| Ops visibility | `OrgAsyncJobsConsoleResource`, `JobEventEmitter`, `JobHttpTrace` | done |
+
+The **verb** is what's missing. Nothing in the codebase ever executes an
+`integration_operation` — the catalog is write-only. Every outbound call today is
+a bespoke hardcoded client (`CalendarBookingsClient`, `MetaWhatsAppClient`,
+`WhatsAppConnectionTester`), each re-implementing URL joining, auth and error
+mapping. `GenericConnectionTester.supports()` returns `false` and its test is a
+stub that returns "runtime probe pending" without making a call.
+
+So this feature is mostly **finishing the connection framework** — a generic
+invoker any integration can use — plus a small review-specific binding on top.
+That framing matters for sequencing: phases 1–2 are reusable infrastructure with
+value independent of the review process.
+
+## What's missing
+
+1. **A connection+operation invoker.** No class resolves an operation, joins
+   `{baseUrl}{path}`, applies method/body/auth, and calls.
+2. **Operation lookup by name.** `IntegrationOperationRepository` only has
+   `listByConnection(connectionId)`, and has **no tenant filter** — callers must
+   go through `IntegrationConnectionService.getConnection(tenantCode, …)` first
+   or they leak cross-tenant.
+3. **`AuthType` → `AuthStrategy` dispatch.** Four strategies exist
+   (bearer/basic/apikey/oauth2) but there is no registry (contrast
+   `ConnectionTesterRegistry`) and no code that applies a `ResolvedAuth` to a
+   request. The only consumer is `OAuth2CredentialTester`.
+4. **`ResolvedConnection` carries no auth.** It exposes a raw `secret` map; the
+   resolver drops `credential.authType()` on the floor.
+5. **Resolution by connection id.** `resolve()` takes a `ProviderType` and
+   returns *the* single active connection for it — fine for WhatsApp, wrong when
+   a tenant has several partner endpoints.
+6. **Payload templating.** No templating engine exists anywhere in `quarkus-srv`
+   (no Qute/Handlebars/Mustache dependency). The only variable rendering is
+   `WhatsAppTemplateRenderer`, a hardcoded map of 5 bodies.
+7. **The binding + trigger.** No storage for "this column dispatches to that
+   operation", and no verdict event.
+
+## Design
+
+### Vocabulary
+
+The UI's **channel** is a `(connection, operation)` pair. The channel's **field
+contract** is `integration_operations.request_schema` — a column that exists,
+is already writable through the API, and is currently read by nothing. This plan
+gives it its first reader, rather than adding a parallel concept.
+
+`request_schema` is interpreted as a JSON-Schema subset:
+
+```json
+{ "type": "object",
+  "properties": { "<fieldId>": { "type": "string|boolean|integer|number", "title": "…" } },
+  "required": ["<fieldId>", "…"] }
+```
+
+### The binding
+
+One new table. A binding attaches a reviewed column to a channel:
+
+```sql
+CREATE TABLE miot_integrations.review_channel_bindings (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_code     VARCHAR(128) NOT NULL,
+    board_key       VARCHAR(128) NOT NULL,   -- which board
+    lane_key        VARCHAR(255) NOT NULL,   -- the workflow stage (stable lane title)
+    connection_id   UUID NOT NULL REFERENCES miot_integrations.integration_connections(id) ON DELETE RESTRICT,
+    operation_id    UUID NOT NULL REFERENCES miot_integrations.integration_operations(id)  ON DELETE RESTRICT,
+    trigger_mode    VARCHAR(32)  NOT NULL DEFAULT 'ON_REJECT',
+    field_templates JSONB        NOT NULL DEFAULT '{}'::jsonb,  -- fieldId -> template string
+    enabled         BOOLEAN      NOT NULL DEFAULT false,
+    active          BOOLEAN      NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_by      TEXT,
+    updated_by      TEXT,
+    CONSTRAINT chk_review_channel_bindings_trigger CHECK (trigger_mode IN ('ON_REJECT','ON_REVIEW'))
+);
+CREATE UNIQUE INDEX idx_review_channel_bindings_lane
+    ON miot_integrations.review_channel_bindings (tenant_code, board_key, lane_key) WHERE active;
+```
+
+`ON DELETE RESTRICT` so a connection still in use by a binding can't be deleted
+out from under it — the same protection credentials already get (409 + `usedBy`).
+
+### Dispatch flow
+
+```
+verdict produced (ECM)
+  → POST /review-verdicts            (modulith owns binding resolution)
+  → look up binding by (tenant, board, lane); skip if absent/disabled
+  → trigger filter: ON_REJECT drops approvals
+  → enqueue async_job  jobType=review_verdict_dispatch  executor=modulith
+                       dedupeKey=review-dispatch:{bindingId}:{mediaId}:{verdict}
+  → ModulithJobWorker claims (lease/CAS/backoff for free)
+  → ReviewVerdictDispatchHandler:
+        render field_templates against the payload's context snapshot
+        → coerce each field to its declared type
+        → IntegrationOperationInvoker.invoke(tenant, connectionId, operationId, body)
+        → 2xx: SUCCEEDED · 4xx: NonRetryableJobException (park) · 5xx/timeout: throw (retry)
+```
+
+**The context is snapshotted at enqueue time** and carried in the job payload —
+not re-read at execution. A retry three hours later must send the state that was
+reviewed, not whatever the task looks like now. It also keeps the handler free of
+ECM/Alfresco reads.
+
+## Phases
+
+Each phase is independently shippable and independently useful.
+
+### Phase 1 — the operation invoker (reusable infrastructure)
+
+- `AuthStrategyRegistry` — `AuthStrategy strategyFor(AuthType)`, CDI-indexed over
+  `Instance<AuthStrategy>` via `supportedTypes()`, duplicate = startup failure.
+  Mirrors `ConnectionTesterRegistry`.
+- Extend `ResolvedConnection` with `authType` + the credential's `publicConfig`
+  (the resolver already loads the profile; it just discards these).
+- `IntegrationConnectionResolver.resolve(tenantCode, connectionId)` — the
+  by-id sibling of the existing by-provider resolve.
+- `IntegrationOperationRepository.findByConnectionAndId/Name` — reached only
+  through a tenant-checked connection load.
+- `IntegrationOperationInvoker` — the engine: build `{baseUrl}{path}`,
+  `OutboundUrlGuard.requirePublicHttpUrl`, apply method + JSON body, apply
+  `ResolvedAuth` headers/query, execute (blocking JDK `HttpClient` on the worker
+  pool, per module precedent), record via `JobHttpTrace`, return status + body.
+
+**Bonus:** `GenericConnectionTester` can finally become a real probe instead of a
+stub, and the `POST /connections/{id}/test` endpoint starts meaning something.
+
+### Phase 2 — payload rendering
+
+- `PayloadTemplateRenderer` — renders `fieldId -> template` into a JSON object
+  against a context `{task, content, review, session}`.
+- **Engine decision: a `{{dotted.path}}` substitution subset, not full
+  Handlebars.** No templating dependency exists in `quarkus-srv`, and the UI only
+  emits variable tokens. See the parity risk below.
+- **Type coercion** off `request_schema`: a `boolean` field must leave as JSON
+  `true`, not `"true"`. Render → coerce → fail the field if it can't coerce.
+- `TemplateValidator` — parses a template, rejects unsupported constructs and
+  unknown variable roots, used both on binding save and by a preview endpoint.
+
+### Phase 3 — binding schema + CRUD API
+
+- Migration **`V0.6.11__create_review_channel_bindings.sql`** (0.6.10 is current
+  head; Flyway compares numerically, so 11 > 10).
+- `ReviewChannelBinding` record, repository, service.
+- `OrgReviewChannelBindingsResource`, owner-gated, under
+  `/api/v1/orgs/{organizationId}/integrations/review-bindings`, carrying
+  `@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")`
+  and the `ownerWork` / `tenantCode(organizationId)` idiom copied verbatim.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/review-bindings` | list (UI: which columns are reviewed) |
+| GET | `/review-bindings/{id}` | one |
+| PUT | `/review-bindings` | upsert by `(board, lane)` — matches the drawer's Save |
+| DELETE | `/review-bindings/{id}` | unbind |
+| GET | `/dispatch-targets` | **channel picker feed**: ACTIVE connections × operations, each with its parsed field contract, so the UI doesn't join two endpoints |
+| POST | `/review-bindings/preview` | render the templates against a sample context — the server-side twin of the drawer's live preview |
+
+Save-time validation: connection exists and is `ACTIVE`, operation belongs to it,
+every `required` field has a non-blank template, all templates parse.
+
+### Phase 4 — verdict intake + job handler
+
+- `ReviewDispatchFeature` — payload key constants (house style, per
+  `CalendarConfirmFeature` / `JobFailureNotificationFeature`).
+- `POST /review-verdicts` — intake; resolves the binding, applies the trigger
+  filter, enqueues. Returns the job id (or `204` when no binding matches).
+- `ReviewVerdictDispatchHandler implements ModulithJobHandler`,
+  `jobType = "review_verdict_dispatch"` (23 chars, fits `VARCHAR(64)`),
+  `EXECUTOR = "modulith"`; `isReady()` false when the secret key is unconfigured.
+- Enqueue with the `JobFailureNotifyOnPark` idiom, including
+  `worker.onEnqueued(response)` for the fast-path drain.
+
+`async_jobs` needs **no migration** — `job_type` is unconstrained text and
+`payload` is free JSONB.
+
+### Phase 5 — frontend swap (separate PR, `apps/app`)
+
+Replace the mocked channel catalog with `/dispatch-targets`, the mocked
+credential list with the real profiles, and the localStorage config with the
+binding endpoints.
+
+## Decisions
+
+- **Reuse `ProviderType.CUSTOM_HTTP`.** A generic JSON-over-HTTP partner needs no
+  new provider constant, which avoids a `chk_integration_connections_provider_type`
+  CHECK migration and its rolling-deploy hazard. Add a constant only if a partner
+  needs bespoke auth or response handling.
+- **Intake as REST, not a direct ECM enqueue.** ECM *could* enqueue a
+  `modulith`-lane job itself (it already speaks the jobs API), but then ECM owns
+  binding lookup, trigger filtering and the payload contract. Keeping intake in
+  the modulith means the review binding is configurable without an ECM deploy.
+- **Snapshot the context at enqueue**, per the retry argument above.
+- **Dedupe on `(binding, media, verdict)`** so a re-delivered verdict is a no-op
+  via the existing partial unique index, not a duplicate partner call.
+
+## Risks
+
+- **Template parity.** The drawer previews with real Handlebars (helpers, `#if`);
+  a substitution-subset backend would silently render those differently. This is
+  the one place preview and runtime can diverge, so Phase 2 ships
+  `TemplateValidator` and rejects unsupported constructs **on save** — a template
+  that can't round-trip never reaches storage. If helpers are wanted later, add
+  `com.github.jknack:handlebars` and drop the restriction; do not let the two
+  sides drift in the meantime.
+- **Rolling deploys.** Phase 3 is a new table only. Should any later phase add a
+  column to an existing table, it needs `NOT NULL` **with a default** — the
+  previous image keeps inserting without it. (`V0.6.9` shipped `NOT NULL` with no
+  default and had to be repaired by `V0.6.10`.)
+- **Cross-tenant leak via operations.** `integration_operations` has no
+  `tenant_code`; every new query must be reached through a tenant-checked
+  connection load, never by operation id alone.
+- **Partner 4xx semantics.** Parking on all 4xx is right for validation errors but
+  wrong for `429`/`408` — treat those as retryable.
+
+## Open questions
+
+1. **Lane identity.** `lane_key` as the stable workflow-stage title is what the
+   UI keys on today (`use-lane-view-state`), but titles are display strings. Is
+   there a stable stage id to key on instead?
+2. **Who is `session.*` at dispatch time?** The reviewer (from the verdict) or the
+   service account making the outbound call? They differ, and the mapping UI
+   offers both.
+3. **Verdict source of truth.** Review state currently lives as forum data on the
+   document node, not `mintral:reviewStatus` — the intake contract should carry
+   the verdict explicitly rather than have the modulith infer it.
+4. **Per-binding retry budget.** Ride the global default (5 attempts) or make
+   `max_attempts` a binding column?

--- a/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
+++ b/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
@@ -1,6 +1,6 @@
 # Review-channel dispatch — executing a connection operation from a review verdict
 
-**Status:** planned. Nothing implemented yet.
+**Status:** Phase 1 implemented. Phases 2–5 planned.
 
 ## Problem
 
@@ -127,24 +127,51 @@ ECM/Alfresco reads.
 
 Each phase is independently shippable and independently useful.
 
-### Phase 1 — the operation invoker (reusable infrastructure)
+### Phase 1 — the operation invoker (reusable infrastructure) — **DONE**
 
-- `AuthStrategyRegistry` — `AuthStrategy strategyFor(AuthType)`, CDI-indexed over
-  `Instance<AuthStrategy>` via `supportedTypes()`, duplicate = startup failure.
-  Mirrors `ConnectionTesterRegistry`.
-- Extend `ResolvedConnection` with `authType` + the credential's `publicConfig`
-  (the resolver already loads the profile; it just discards these).
-- `IntegrationConnectionResolver.resolve(tenantCode, connectionId)` — the
-  by-id sibling of the existing by-provider resolve.
-- `IntegrationOperationRepository.findByConnectionAndId/Name` — reached only
-  through a tenant-checked connection load.
-- `IntegrationOperationInvoker` — the engine: build `{baseUrl}{path}`,
-  `OutboundUrlGuard.requirePublicHttpUrl`, apply method + JSON body, apply
-  `ResolvedAuth` headers/query, execute (blocking JDK `HttpClient` on the worker
-  pool, per module precedent), record via `JobHttpTrace`, return status + body.
+- `CredentialAuthProvider` + `CredentialAuthRegistry` — a uniform, CDI-indexed
+  face over the auth types, duplicate claim = startup failure (mirrors
+  `ConnectionTesterRegistry`). Six providers ship: none, bearer, basic, api-key
+  (header/query), OAuth2 client-credentials, custom-headers.
+  - *Why a new interface rather than a registry over `AuthStrategy`:* a strategy
+    is generic over a **typed** config record (`AuthStrategy<BearerTokenConfig>`),
+    so nothing can dispatch over strategies by `AuthType` without unchecked casts
+    — and building each config from a credential's two halves is per-type work
+    regardless. A provider owns that construction and delegates the grant to its
+    strategy, which stays untouched.
+  - *No fallback provider.* An unhandled auth type raises rather than quietly
+    sending the request unauthenticated.
+- `ResolvedConnection` now carries `authType` / `credentialType` / `publicConfig`
+  and exposes `authContext()`. A 4-arg back-compat constructor keeps the WhatsApp
+  channel (which hand-builds its own auth) compiling unchanged.
+- `IntegrationConnectionResolver.resolve(tenantCode, connectionId)` — the by-id
+  sibling. Deliberately does **not** require `ACTIVE`: a test probe may exercise a
+  `DRAFT` connection, a production dispatch may not, so the caller decides.
+- `IntegrationOperationRepository.findByConnectionAndId/Name` — both scoped by
+  `connection_id`, because the table has no `tenant_code` and an operation is only
+  tenant-safe when reached through an already-resolved connection.
+- `IntegrationOperationInvoker` — the engine. Joins `{baseUrl}{path}` (tolerating
+  slashes on either side, preserving an existing query string), appends auth query
+  params URL-encoded, SSRF-guards via `OutboundUrlGuard.requirePublicHttpUrl`,
+  sends a JSON body only on POST/PUT/PATCH, and records the exchange through
+  `JobHttpTrace` (never headers — that is where the token is).
+  Timeout: `miot.integrations.operation-invoker.timeout-seconds` (default 20).
+- A completed non-2xx is an `OperationInvocationResult`, not an exception —
+  `retryable()` treats 5xx plus `408`/`429` as "later", every other 4xx as "never".
 
-**Bonus:** `GenericConnectionTester` can finally become a real probe instead of a
-stub, and the `POST /connections/{id}/test` endpoint starts meaning something.
+**Credential shapes this establishes** (the contract for creating one):
+
+| Auth type | non-secret `publicConfig` | decrypted `secret` |
+|---|---|---|
+| `NONE` | — | — |
+| `BEARER_TOKEN` | — | `token` |
+| `BASIC` | `username` | `password` |
+| `API_KEY_HEADER` / `API_KEY_QUERY` | `name` (header/param name) | `value` |
+| `OAUTH2_CLIENT_CREDENTIALS` | `clientId`, `tokenUrl` \| `tenantId`+`scope`, … | `clientSecret` |
+| `CUSTOM_HEADERS` | — | `headers` (object; CRLF rejected) |
+
+**Still open from this phase:** `GenericConnectionTester` can now become a real
+probe instead of a stub — not done here to keep the change reviewable.
 
 ### Phase 2 — payload rendering
 

--- a/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
+++ b/quarkus-srv/miot-integrations/docs/review-channel-dispatch.md
@@ -74,32 +74,107 @@ gives it its first reader, rather than adding a parallel concept.
 
 ### The binding
 
-One new table. A binding attaches a reviewed column to a channel:
+An earlier draft of this table keyed on `board_key` + `lane_key` with a
+`trigger_mode` of `ON_REJECT`/`ON_REVIEW`, and was called
+`review_channel_bindings`. That leaked one caller into the schema three times
+over: reviews are only *an* instance of the general shape, which is
+
+> when **event** happens in **scope**, if **condition**, send to
+> **connection**/**operation**, shaped by **templates**.
+
+A WhatsApp notification from the symptoms dashboard is the same sentence with
+different nouns, and would otherwise have needed its own near-identical table.
+So the binding is event-shaped, not kanban-shaped:
 
 ```sql
-CREATE TABLE miot_integrations.review_channel_bindings (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    tenant_code     VARCHAR(128) NOT NULL,
-    board_key       VARCHAR(128) NOT NULL,   -- which board
-    lane_key        VARCHAR(255) NOT NULL,   -- the workflow stage (stable lane title)
-    connection_id   UUID NOT NULL REFERENCES miot_integrations.integration_connections(id) ON DELETE RESTRICT,
-    operation_id    UUID NOT NULL REFERENCES miot_integrations.integration_operations(id)  ON DELETE RESTRICT,
-    trigger_mode    VARCHAR(32)  NOT NULL DEFAULT 'ON_REJECT',
-    field_templates JSONB        NOT NULL DEFAULT '{}'::jsonb,  -- fieldId -> template string
-    enabled         BOOLEAN      NOT NULL DEFAULT false,
-    active          BOOLEAN      NOT NULL DEFAULT true,
-    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    created_by      TEXT,
-    updated_by      TEXT,
-    CONSTRAINT chk_review_channel_bindings_trigger CHECK (trigger_mode IN ('ON_REJECT','ON_REVIEW'))
+CREATE TABLE miot_integrations.integration_event_bindings (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_client_id VARCHAR(128) NOT NULL,   -- the Auth0 M2M client (see Terminology)
+    owner_org_slug   VARCHAR(100) NOT NULL,   -- which org configured it
+    event_type       VARCHAR(128) NOT NULL,   -- 'review.verdict', 'symptom.reported'
+    scope_kind       VARCHAR(64),             -- 'kanban_lane', 'symptom_board'; NULL = every scope
+    scope_key        VARCHAR(255),            -- opaque here; the producer defines its meaning
+    connection_id    UUID NOT NULL REFERENCES miot_integrations.integration_connections(id) ON DELETE RESTRICT,
+    operation_id     UUID     REFERENCES miot_integrations.integration_operations(id) ON DELETE RESTRICT,
+    condition        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    field_templates  JSONB        NOT NULL DEFAULT '{}'::jsonb,  -- fieldId -> template string
+    enabled          BOOLEAN      NOT NULL DEFAULT false,
+    active           BOOLEAN      NOT NULL DEFAULT true,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    created_by       TEXT,
+    updated_by       TEXT
 );
-CREATE UNIQUE INDEX idx_review_channel_bindings_lane
-    ON miot_integrations.review_channel_bindings (tenant_code, board_key, lane_key) WHERE active;
+CREATE UNIQUE INDEX idx_integration_event_bindings_target
+    ON miot_integrations.integration_event_bindings
+       (tenant_client_id, owner_org_slug, event_type, scope_kind, scope_key, connection_id)
+    WHERE active;
 ```
+
+Both product cases land on it as **data, not schema**:
+
+| | `event_type` | `scope_kind` / `scope_key` | connection |
+|---|---|---|---|
+| Kanban review | `review.verdict` | `kanban_lane` / `shipping:confirmCierre` | partner HTTP |
+| Symptoms → WhatsApp | `symptom.reported` | `symptom_board` / `<boardId>` or NULL | WhatsApp |
+
+Four things this buys:
+
+- **`scope_kind`/`scope_key` are opaque to this module.** It never parses them.
+  The producer decides what they mean — the discipline that stops the kanban (or
+  the next caller) leaking back into the schema.
+- **`condition` replaces `trigger_mode`.** "Only rejections" is one condition
+  among many, not an enum member. The module already has prior art for a
+  declarative filter in `WebhookFilterCompiler` / `WebhookFilterSpec` (GPS
+  webhooks) rather than inventing a second filter language.
+- **Fan-out is possible.** `connection_id` is in the unique key, so one event can
+  notify WhatsApp *and* the partner API. The old `UNIQUE(tenant, board, lane)`
+  permitted exactly one channel per column.
+- **`operation_id` is nullable** — see the dispatcher SPI below.
 
 `ON DELETE RESTRICT` so a connection still in use by a binding can't be deleted
 out from under it — the same protection credentials already get (409 + `usedBy`).
+
+### Org scoping: who a binding belongs to
+
+`tenant_client_id` is **not an org identifier**. It is an Auth0 M2M client id, and
+several orgs can share one — the seed script creates a child org with the *same*
+`tenant_client_id` as its parent ("shared Auth0 M2M"). Orgs are identified by
+**slug**. Every existing integrations query filters `WHERE tenant_code = $1`, so
+today a child sharing its parent's M2M client already sees all of its connections,
+credentials and jobs, and there is no way to give that child its own.
+
+Bindings therefore carry `owner_org_slug` alongside the tenant key, and reads are
+**parent-inclusive**: an org sees its own bindings plus its parent's.
+
+```
+read(org = traza) → WHERE tenant_client_id = :tenant
+                      AND owner_org_slug IN ('traza', 'gama')
+```
+
+A parent configures once for its children; a child can still add its own. When
+both define a binding for the same event+scope+connection, the child's wins —
+the more specific owner is the more deliberate one.
+
+### Channels other than HTTP: a dispatcher SPI
+
+WhatsApp outbound does not go through `integration_operations` at all — it goes
+through `MetaWhatsAppClient`, with `phone_number_id` in connection metadata and a
+nested template-parameter body that a flat `fieldId -> template` map cannot
+express. Forcing it into an operation row would be jamming it into a shape it
+doesn't have.
+
+So dispatch routes by the connection's `ProviderType` to a `ChannelDispatcher`,
+the module's registry idiom for the third time (after `ConnectionTesterRegistry`
+and `CredentialAuthRegistry`):
+
+- **default** — the generic HTTP dispatcher, `IntegrationOperationInvoker` over the
+  binding's `operation_id` (Phase 1, done).
+- **WHATSAPP** — reuses `WhatsAppMessagingService`; ignores `operation_id`.
+
+The dispatcher also **declares its field contract**, which is what the settings UI
+renders: HTTP reads `integration_operations.request_schema`; WhatsApp declares its
+template parameters. One table, one configuration UX, no per-channel schema.
 
 ### Dispatch flow
 
@@ -187,35 +262,45 @@ probe instead of a stub — not done here to keep the change reviewable.
 
 ### Phase 3 — binding schema + CRUD API
 
-- Migration **`V0.6.11__create_review_channel_bindings.sql`** (0.6.10 is current
-  head; Flyway compares numerically, so 11 > 10).
-- `ReviewChannelBinding` record, repository, service.
-- `OrgReviewChannelBindingsResource`, owner-gated, under
-  `/api/v1/orgs/{organizationId}/integrations/review-bindings`, carrying
+- Migration `V0.6.1x__create_integration_event_bindings.sql` (pick the version
+  against `origin/trunk` at the time — concurrent PRs collide only at app boot).
+- `IntegrationEventBinding` record, repository, service.
+- `OrgIntegrationBindingsResource`, owner-gated, under
+  `/api/v1/orgs/{organizationId}/integrations/bindings`, carrying
   `@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")`
-  and the `ownerWork` / `tenantCode(organizationId)` idiom copied verbatim.
+  and the `ownerWork` / tenant-resolution idiom copied verbatim.
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/review-bindings` | list (UI: which columns are reviewed) |
-| GET | `/review-bindings/{id}` | one |
-| PUT | `/review-bindings` | upsert by `(board, lane)` — matches the drawer's Save |
-| DELETE | `/review-bindings/{id}` | unbind |
-| GET | `/dispatch-targets` | **channel picker feed**: ACTIVE connections × operations, each with its parsed field contract, so the UI doesn't join two endpoints |
-| POST | `/review-bindings/preview` | render the templates against a sample context — the server-side twin of the drawer's live preview |
+| GET | `/bindings?eventType=&scopeKind=` | list (UI: which scopes are bound) |
+| GET | `/bindings/{id}` | one |
+| PUT | `/bindings` | upsert by the unique key — matches the drawer's Save |
+| DELETE | `/bindings/{id}` | unbind |
+| GET | `/dispatch-targets` | **channel picker feed**: eligible connections with each dispatcher's field contract, so the UI doesn't join two endpoints |
+| POST | `/bindings/preview` | render the templates against a sample context — the server-side twin of the drawer's live preview |
 
-Save-time validation: connection exists and is `ACTIVE`, operation belongs to it,
-every `required` field has a non-blank template, all templates parse.
+Reads are parent-inclusive (`owner_org_slug IN (own, parent)`); writes always
+stamp the calling org, so a child can never author a binding on its parent's
+behalf.
 
-### Phase 4 — verdict intake + job handler
+Save-time validation: connection exists and is `ACTIVE`, the dispatcher accepts
+the binding (HTTP requires an `operation_id` belonging to that connection), every
+`required` field in the dispatcher's contract has a non-blank template, and all
+templates parse.
 
-- `ReviewDispatchFeature` — payload key constants (house style, per
+### Phase 4 — event intake + job handler
+
+- `EventDispatchFeature` — payload key constants (house style, per
   `CalendarConfirmFeature` / `JobFailureNotificationFeature`).
-- `POST /review-verdicts` — intake; resolves the binding, applies the trigger
-  filter, enqueues. Returns the job id (or `204` when no binding matches).
-- `ReviewVerdictDispatchHandler implements ModulithJobHandler`,
-  `jobType = "review_verdict_dispatch"` (23 chars, fits `VARCHAR(64)`),
-  `EXECUTOR = "modulith"`; `isReady()` false when the secret key is unconfigured.
+- `POST /integration-events` — generic intake: `{eventType, scope, context}`.
+  Resolves matching bindings, applies each one's `condition`, enqueues one job per
+  surviving binding. Returns the job ids (or `204` when nothing matched).
+  The review verdict is simply `eventType = "review.verdict"`.
+- `IntegrationEventDispatchHandler implements ModulithJobHandler`,
+  `jobType = "integration_event_dispatch"` (26 chars, fits `VARCHAR(64)`),
+  `EXECUTOR = "modulith"`. Loads the binding, renders the templates against the
+  payload's context snapshot, routes to the `ChannelDispatcher` for the
+  connection's provider type.
 - Enqueue with the `JobFailureNotifyOnPark` idiom, including
   `worker.onEnqueued(response)` for the fast-path drain.
 
@@ -227,6 +312,40 @@ every `required` field has a non-blank template, all templates parse.
 Replace the mocked channel catalog with `/dispatch-targets`, the mocked
 credential list with the real profiles, and the localStorage config with the
 binding endpoints.
+
+## Terminology: `tenant_code` is the Auth0 M2M client id
+
+`TenantRequestFilter` resolves one value from the JWT (`aud`/`azp`, or the
+`X-Client-Id` header in dev) and assigns it to both fields:
+
+```java
+tenantContext.setClientId(clientId);
+tenantContext.setTenantCode(clientId);   // the same value
+```
+
+So `tenant_code` across `miot_integrations` **holds the client id**. Nothing
+derives a distinct "tenant code", and the resources' `getTenantCode() != null ?
+… : getClientId()` fallback is unreachable. The vestigial
+`tenant_id BIGINT REFERENCES miot_core.tenants(id)` on these tables is never
+written by any repository — the fossil of a tenants registry that never landed.
+
+The org model already names this value properly:
+
+```sql
+-- miot_core.organizations
+tenant_client_id VARCHAR(255) NOT NULL, -- Auth0 M2M client ID = Tenant.code
+```
+
+**Decision: standardize on `tenant_client_id` / `tenantClientId`**, matching the
+org model and the name `miot-core` already uses (`HarnessProxyResource`). New
+tables in this feature use it from the start.
+
+Renaming the *existing* columns is deliberately **not** part of this feature —
+see "Deferred" below. Note `client_id` was rejected as the target name: in this
+module `clientId` already means the OAuth2 app-registration id
+(`OAuth2CredentialConfigs.require(publicConfig, "clientId")`,
+`params.put("client_id", …)`), so `credential_profiles.client_id` would sit beside
+`public_config->>'clientId'` meaning something else entirely.
 
 ## Decisions
 
@@ -260,6 +379,29 @@ binding endpoints.
   connection load, never by operation id alone.
 - **Partner 4xx semantics.** Parking on all 4xx is right for validation errors but
   wrong for `429`/`408` — treat those as retryable.
+
+## Deferred: renaming the existing `tenant_code` columns
+
+Agreed to do, scoped out of this feature because it is a migration in its own
+right, not a side effect of shipping dispatch. What it touches:
+
+- **~10 tables in two schemas** — `miot_integrations` (credential_profiles,
+  integration_connections, async_jobs, interaction_episodes, knowledge_candidates,
+  gps_webhook_subscriptions, job_notification_rules, …) and `miot_conversational`.
+- **~65 Java files** across `miot-integrations`, `miot-conversational` and
+  `miot-core`. Mechanical and compiler-checked: `tenantCode` and `tenant_code` are
+  distinct tokens that collide with nothing.
+- **The wire contract.** Three response DTOs expose `tenantCode`
+  (`CredentialProfileResponse`, `GpsWebhookResponse`, `WebhookDeliveryResponse`),
+  and the app reads it — the jobs console renders `job.tenantCode`, plus the
+  WhatsApp and GPS-webhook settings types. Responses should emit **both** names
+  for one release so backend and frontend can deploy in either order.
+- **A rolling-deploy hazard.** A bare `RENAME COLUMN` breaks the running image the
+  moment Flyway applies it: old pods still query `tenant_code`. It needs
+  expand/contract — add + backfill + keep in sync, switch reads, drop the old
+  column in a later release — the same lesson as `V0.6.9` → `V0.6.10`.
+- **Ad-hoc SQL.** db-scripts queries and any dashboards against these tables break
+  silently on rename; worth a grep before the contract step.
 
 ## Open questions
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthContext.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthContext.java
@@ -1,0 +1,72 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import com.microboxlabs.miot.integrations.domain.CredentialType;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Everything a {@link CredentialAuthProvider} needs to turn a stored credential into
+ * request auth: which grant to run ({@code authType}), which flavour of it
+ * ({@code credentialType} — e.g. Entra vs a generic OAuth2 provider), the non-secret
+ * half, and the decrypted secret half.
+ *
+ * <p>Deliberately not the {@code CredentialProfile} record: the invoker works from a
+ * {@link com.microboxlabs.miot.integrations.service.ResolvedConnection}, which already
+ * dropped the persistence fields, and providers have no business seeing them.
+ *
+ * <p>The {@code secret} map is sensitive — never log or serialize it. {@link #toString()}
+ * is overridden to keep it out of stack traces and debug output.
+ */
+public record CredentialAuthContext(
+        AuthType authType,
+        CredentialType credentialType,
+        Map<String, Object> publicConfig,
+        Map<String, Object> secret) {
+
+    public CredentialAuthContext {
+        publicConfig = publicConfig == null ? Map.of() : Map.copyOf(publicConfig);
+        secret = secret == null ? Map.of() : Map.copyOf(secret);
+    }
+
+    /** A non-blank value from the non-secret half, or empty. */
+    public Optional<String> publicValue(String key) {
+        return value(publicConfig, key);
+    }
+
+    /** A non-blank value from the decrypted half, or empty. */
+    public Optional<String> secretValue(String key) {
+        return value(secret, key);
+    }
+
+    /**
+     * @throws AuthResolutionException naming the field, so a misconfigured credential
+     *         reports which key it is missing rather than failing as a null downstream
+     */
+    public String requirePublic(String key) {
+        return publicValue(key).orElseThrow(() -> missing(key, "public config"));
+    }
+
+    /** @throws AuthResolutionException naming the field (never its value) */
+    public String requireSecret(String key) {
+        return secretValue(key).orElseThrow(() -> missing(key, "secret config"));
+    }
+
+    private AuthResolutionException missing(String key, String half) {
+        return new AuthResolutionException(
+                authType + " credential is missing '" + key + "' in its " + half);
+    }
+
+    private static Optional<String> value(Map<String, Object> map, String key) {
+        Object raw = map == null ? null : map.get(key);
+        return Optional.ofNullable(raw).map(Object::toString).filter(text -> !text.isBlank());
+    }
+
+    @Override
+    public String toString() {
+        return "CredentialAuthContext[authType=" + authType
+                + ", credentialType=" + credentialType
+                + ", publicConfig=" + publicConfig.keySet()
+                + ", secret=<redacted>]";
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthProvider.java
@@ -1,0 +1,31 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.util.Set;
+
+/**
+ * Turns a stored credential into the headers/query params an outbound request needs.
+ *
+ * <p>Why this exists alongside {@link AuthStrategy}: a strategy is generic over a
+ * <i>typed</i> config record ({@code AuthStrategy<BearerTokenConfig>}), so nothing can
+ * dispatch over strategies by {@link AuthType} without unchecked casts — and building
+ * each config from a credential's key/value halves is per-type work anyway. A provider
+ * is the uniform, castable-free face of that pair: it owns the config construction and
+ * delegates the actual grant to its strategy.
+ *
+ * <p>Register one {@code @ApplicationScoped} implementation per auth type;
+ * {@link CredentialAuthRegistry} discovers them via CDI and indexes them by
+ * {@link #supportedTypes()} — adding an auth type is a new bean, not a branch in the
+ * invoker. Mirrors the {@code ConnectionTesterRegistry} idiom.
+ */
+public interface CredentialAuthProvider {
+
+    /** The auth types this provider handles. Must not overlap another provider's. */
+    Set<AuthType> supportedTypes();
+
+    /**
+     * @throws AuthResolutionException when the credential is incomplete for its type or
+     *         an upstream token grant fails
+     */
+    ResolvedAuth resolve(CredentialAuthContext context);
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthRegistry.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/CredentialAuthRegistry.java
@@ -1,0 +1,72 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Routes a credential to the {@link CredentialAuthProvider} that handles its
+ * {@link AuthType}.
+ *
+ * <p>The index is built once at construction from every CDI-visible provider. Two
+ * providers claiming the same auth type is a <b>startup failure</b>, not a
+ * last-one-wins surprise at 3am — the same fail-fast contract {@code ModulithJobWorker}
+ * applies to duplicate job types.
+ *
+ * <p>Unlike {@code ConnectionTesterRegistry} there is no fallback: silently sending an
+ * unauthenticated request because nobody handles the type would turn a configuration
+ * mistake into a 401 from the partner (or worse, an accepted anonymous write).
+ */
+@ApplicationScoped
+public class CredentialAuthRegistry {
+
+    private final Map<AuthType, CredentialAuthProvider> byType;
+
+    @Inject
+    public CredentialAuthRegistry(Instance<CredentialAuthProvider> providers) {
+        this((Iterable<CredentialAuthProvider>) providers);
+    }
+
+    /** Takes the plain {@link Iterable} that {@code Instance} already is, so tests need no CDI. */
+    CredentialAuthRegistry(Iterable<CredentialAuthProvider> providers) {
+        this.byType = index(providers);
+    }
+
+    static Map<AuthType, CredentialAuthProvider> index(Iterable<CredentialAuthProvider> providers) {
+        Map<AuthType, CredentialAuthProvider> index = new EnumMap<>(AuthType.class);
+        for (CredentialAuthProvider provider : providers) {
+            for (AuthType type : provider.supportedTypes()) {
+                CredentialAuthProvider existing = index.put(type, provider);
+                if (existing != null) {
+                    throw new IllegalStateException(
+                            "Two credential auth providers claim " + type + ": "
+                                    + existing.getClass().getName() + " and "
+                                    + provider.getClass().getName());
+                }
+            }
+        }
+        return Map.copyOf(index);
+    }
+
+    /**
+     * @throws AuthResolutionException when no provider handles the credential's auth type
+     */
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        return providerFor(context.authType()).resolve(context);
+    }
+
+    /**
+     * @throws AuthResolutionException when the type is unhandled
+     */
+    public CredentialAuthProvider providerFor(AuthType authType) {
+        CredentialAuthProvider provider = byType.get(authType);
+        if (provider == null) {
+            throw new AuthResolutionException(
+                    "No credential auth provider is registered for " + authType);
+        }
+        return provider;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/NoAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/NoAuthProvider.java
@@ -1,0 +1,27 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link AuthType#NONE} — an endpoint that needs no credential (an open webhook, a
+ * partner that authenticates by source IP).
+ *
+ * <p>Registered explicitly rather than defaulted to, so "no auth" is a configuration the
+ * operator chose and not the silent outcome of an unhandled type.
+ */
+@ApplicationScoped
+public class NoAuthProvider implements CredentialAuthProvider {
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.NONE);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        return new ResolvedAuth(Map.of(), Map.of(), null);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyCredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/apikey/ApiKeyCredentialAuthProvider.java
@@ -1,0 +1,50 @@
+package com.microboxlabs.miot.integrations.auth.apikey;
+
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.ApiKeyPlacement;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+
+/**
+ * {@link AuthType#API_KEY_HEADER} and {@link AuthType#API_KEY_QUERY} — a key sent under
+ * a provider-chosen name, either as a header or a query parameter.
+ *
+ * <p>Credential shape: {@code publicConfig.name} (the header/param name, e.g.
+ * {@code X-Api-Key}) + {@code secret.value}. The placement comes from the auth type
+ * rather than from config, so the two can't contradict each other.
+ */
+@ApplicationScoped
+public class ApiKeyCredentialAuthProvider implements CredentialAuthProvider {
+
+    /** The non-secret key holding the header or query-parameter name. */
+    public static final String PUBLIC_NAME = "name";
+    /** The decrypted key holding the api key itself. */
+    public static final String SECRET_VALUE = "value";
+
+    private final ApiKeyStrategy strategy;
+
+    @Inject
+    public ApiKeyCredentialAuthProvider(ApiKeyStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.API_KEY_HEADER, AuthType.API_KEY_QUERY);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        ApiKeyPlacement placement = context.authType() == AuthType.API_KEY_QUERY
+                ? ApiKeyPlacement.QUERY
+                : ApiKeyPlacement.HEADER;
+        return strategy.resolve(new ApiKeyConfig(
+                context.requirePublic(PUBLIC_NAME),
+                context.requireSecret(SECRET_VALUE),
+                placement));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicCredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/basic/BasicCredentialAuthProvider.java
@@ -1,0 +1,44 @@
+package com.microboxlabs.miot.integrations.auth.basic;
+
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+
+/**
+ * {@link AuthType#BASIC} — RFC 7617 username/password.
+ *
+ * <p>Credential shape: {@code publicConfig.username} + {@code secret.password}. The
+ * username is non-secret on purpose: it identifies the credential in a list without
+ * decrypting anything, the same way {@code clientId} does for OAuth2.
+ */
+@ApplicationScoped
+public class BasicCredentialAuthProvider implements CredentialAuthProvider {
+
+    /** The non-secret key holding the username. */
+    public static final String PUBLIC_USERNAME = "username";
+    /** The decrypted key holding the password. */
+    public static final String SECRET_PASSWORD = "password";
+
+    private final BasicAuthStrategy strategy;
+
+    @Inject
+    public BasicCredentialAuthProvider(BasicAuthStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.BASIC);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        return strategy.resolve(new BasicAuthConfig(
+                context.requirePublic(PUBLIC_USERNAME),
+                context.requireSecret(SECRET_PASSWORD)));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerCredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/bearer/BearerCredentialAuthProvider.java
@@ -1,0 +1,40 @@
+package com.microboxlabs.miot.integrations.auth.bearer;
+
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+
+/**
+ * {@link AuthType#BEARER_TOKEN} — a static token sent as {@code Authorization: Bearer …}.
+ *
+ * <p>Credential shape: {@code secret.token}. That key matches what the WhatsApp
+ * connection already stores ({@code secretString("token")}), so a bearer credential
+ * reads the same whoever created it.
+ */
+@ApplicationScoped
+public class BearerCredentialAuthProvider implements CredentialAuthProvider {
+
+    /** The decrypted key holding the token. */
+    public static final String SECRET_TOKEN = "token";
+
+    private final BearerTokenStrategy strategy;
+
+    @Inject
+    public BearerCredentialAuthProvider(BearerTokenStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.BEARER_TOKEN);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        return strategy.resolve(new BearerTokenConfig(context.requireSecret(SECRET_TOKEN)));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/customheaders/CustomHeadersCredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/customheaders/CustomHeadersCredentialAuthProvider.java
@@ -1,0 +1,74 @@
+package com.microboxlabs.miot.integrations.auth.customheaders;
+
+import com.microboxlabs.miot.integrations.auth.AuthResolutionException;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link AuthType#CUSTOM_HEADERS} — the escape hatch for providers whose scheme is none
+ * of the standard ones (a signed vendor header, a paired key/secret, a tenant header
+ * alongside a token).
+ *
+ * <p>Credential shape: {@code secret.headers}, an object of header name → value. The
+ * whole map is secret because a custom scheme usually carries the key <i>in</i> a
+ * header, and we cannot tell which of them is sensitive.
+ *
+ * <p>Unlike the other providers this has no {@code AuthStrategy} behind it — there is
+ * nothing to compute, only to copy — so it builds the {@link ResolvedAuth} directly.
+ */
+@ApplicationScoped
+public class CustomHeadersCredentialAuthProvider implements CredentialAuthProvider {
+
+    /** The decrypted key holding the header map. */
+    public static final String SECRET_HEADERS = "headers";
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.CUSTOM_HEADERS);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        Object raw = context.secret().get(SECRET_HEADERS);
+        if (!(raw instanceof Map<?, ?> map) || map.isEmpty()) {
+            throw new AuthResolutionException(
+                    "CUSTOM_HEADERS credential is missing a non-empty 'headers' object in its secret config");
+        }
+        Map<String, String> headers = new LinkedHashMap<>();
+        map.forEach((name, value) -> {
+            if (name == null || value == null) {
+                return;
+            }
+            String header = name.toString();
+            String text = value.toString();
+            // A newline here would let a stored credential inject extra headers or a
+            // body into every request this connection makes.
+            if (containsControlChar(header) || containsControlChar(text)) {
+                throw new AuthResolutionException(
+                        "CUSTOM_HEADERS credential has an illegal character in header '" + header + "'");
+            }
+            headers.put(header, text);
+        });
+        if (headers.isEmpty()) {
+            throw new AuthResolutionException(
+                    "CUSTOM_HEADERS credential resolved to no usable headers");
+        }
+        return ResolvedAuth.headers(headers, null);
+    }
+
+    private static boolean containsControlChar(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\r' || c == '\n' || c < 0x20) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2CredentialAuthProvider.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/auth/oauth/OAuth2CredentialAuthProvider.java
@@ -1,0 +1,52 @@
+package com.microboxlabs.miot.integrations.auth.oauth;
+
+import com.microboxlabs.miot.integrations.auth.AuthResolutionException;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+
+/**
+ * {@link AuthType#OAUTH2_CLIENT_CREDENTIALS} — exchanges the stored client credentials
+ * for a token, then sends it as a bearer header.
+ *
+ * <p>Config construction is delegated to {@link OAuth2CredentialConfigs#toConfig}, the
+ * same mapper the credential tester uses, so what the Test button verifies and what a
+ * live call actually sends can never disagree about where the token comes from.
+ *
+ * <p>Note this performs a token request per invocation — there is no token cache yet.
+ * {@link ResolvedAuth#expiresAt()} is populated, which is what a cache would key on.
+ */
+@ApplicationScoped
+public class OAuth2CredentialAuthProvider implements CredentialAuthProvider {
+
+    private final OAuth2ClientCredentialsStrategy strategy;
+
+    @Inject
+    public OAuth2CredentialAuthProvider(OAuth2ClientCredentialsStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Override
+    public Set<AuthType> supportedTypes() {
+        return Set.of(AuthType.OAUTH2_CLIENT_CREDENTIALS);
+    }
+
+    @Override
+    public ResolvedAuth resolve(CredentialAuthContext context) {
+        OAuth2ClientCredentialsConfig config;
+        try {
+            config = OAuth2CredentialConfigs.toConfig(
+                    context.credentialType(), context.publicConfig(), context.secret());
+        } catch (IllegalArgumentException e) {
+            // The mapper names the offending field; re-thrown as an auth failure so the
+            // caller sees one exception type for "this credential can't be used".
+            throw new AuthResolutionException(
+                    "OAuth2 credential is incomplete: " + e.getMessage(), e);
+        }
+        return strategy.resolve(config);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationOperationRepository.java
@@ -22,6 +22,22 @@ public class IntegrationOperationRepository {
             ORDER BY name
             """;
 
+    // Both lookups are scoped by connection_id as well as the operation's own key. The
+    // table has no tenant_code column, so an operation is only ever tenant-safe when it
+    // is reached through a connection the caller already resolved for that tenant —
+    // querying by operation id alone would cross orgs.
+    private static final String SELECT_BY_CONNECTION_AND_ID = """
+            SELECT id, connection_id, name, method, path, request_schema, response_schema, test_operation
+            FROM miot_integrations.integration_operations
+            WHERE connection_id = $1 AND id = $2 AND active
+            """;
+
+    private static final String SELECT_BY_CONNECTION_AND_NAME = """
+            SELECT id, connection_id, name, method, path, request_schema, response_schema, test_operation
+            FROM miot_integrations.integration_operations
+            WHERE connection_id = $1 AND lower(name) = lower($2) AND active
+            """;
+
     private static final String INSERT = """
             INSERT INTO miot_integrations.integration_operations (
                 id, connection_id, name, method, path, request_schema, response_schema, test_operation
@@ -44,6 +60,28 @@ public class IntegrationOperationRepository {
                 .toList();
     }
 
+    /**
+     * @return the operation, or {@code null} when the id is unknown, inactive, or belongs
+     *         to a different connection
+     */
+    public IntegrationOperation findByConnectionAndId(String connectionId, String operationId) {
+        UUID id = toUuid(operationId);
+        if (id == null) {
+            return null;
+        }
+        return first(SELECT_BY_CONNECTION_AND_ID,
+                Tuple.of(UUID.fromString(connectionId), id));
+    }
+
+    /** Name match is case-insensitive, mirroring the unique index on {@code lower(name)}. */
+    public IntegrationOperation findByConnectionAndName(String connectionId, String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return first(SELECT_BY_CONNECTION_AND_NAME,
+                Tuple.of(UUID.fromString(connectionId), name.trim()));
+    }
+
     public IntegrationOperation create(IntegrationOperation operation) {
         Tuple params = Tuple.tuple()
                 .addUUID(UUID.fromString(operation.id()))
@@ -62,6 +100,23 @@ public class IntegrationOperationRepository {
 
     private Pool client() {
         return clientInstance.get();
+    }
+
+    private IntegrationOperation first(String sql, Tuple params) {
+        var iterator = client().preparedQuery(sql).execute(params).await().indefinitely().iterator();
+        return iterator.hasNext() ? mapRow(iterator.next()) : null;
+    }
+
+    /** Blank or non-UUID ids short-circuit before any DB access, so they never reach the pool. */
+    private UUID toUuid(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private IntegrationOperation mapRow(Row row) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionResolver.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionResolver.java
@@ -44,24 +44,67 @@ public class IntegrationConnectionResolver {
             throw new ConnectionResolutionException(
                     "No usable " + providerType + " connection is configured for this organization");
         }
+        return withCredential(tenantCode, connection, providerType.toString());
+    }
 
-        Map<String, Object> secret = Map.of();
-        if (connection.credentialProfileId() != null) {
-            CredentialProfile credential =
-                    credentialProfileRepository.findByTenantAndId(tenantCode, connection.credentialProfileId());
-            if (credential == null) {
-                throw new ConnectionResolutionException(
-                        "The credential profile linked to the " + providerType
-                                + " connection could not be found");
-            }
-            try {
-                secret = secretCipher.decrypt(credential.encryptedSecretJson());
-            } catch (RuntimeException e) {
-                throw new ConnectionResolutionException(
-                        "Could not read the credential for the " + providerType + " connection", e);
-            }
+    /**
+     * Resolves one specific connection. The by-provider {@link #resolve(String, ProviderType)}
+     * returns <i>the</i> active connection for a provider, which is right for a channel a
+     * tenant has exactly one of (WhatsApp) but wrong once several endpoints share a provider
+     * type — a tenant can have many {@code CUSTOM_HTTP} partners, and a caller that stored a
+     * connection id means that one.
+     *
+     * <p>Unlike the by-provider lookup this does <b>not</b> require {@code ACTIVE}: the caller
+     * decides whether a {@code DRAFT} connection may be exercised (a test probe may, a
+     * production dispatch may not). Check {@link IntegrationConnection#status()} if it matters.
+     *
+     * @throws ConnectionResolutionException if the id is unknown to this tenant, or its
+     *         credential is missing or cannot be decrypted
+     */
+    public ResolvedConnection resolve(String tenantCode, String connectionId) {
+        IntegrationConnection connection = connectionRepository.findByTenantAndId(tenantCode, connectionId);
+        if (connection == null) {
+            throw new ConnectionResolutionException(
+                    "Connection " + connectionId + " does not exist for this organization");
         }
-        return new ResolvedConnection(connection.id(), connection.baseUrl(), connection.metadata(), secret);
+        return withCredential(tenantCode, connection, "connection " + connectionId);
+    }
+
+    /**
+     * Loads and decrypts the attached credential, if any, and describes how to authenticate
+     * with it. A connection without a credential profile resolves with empty auth — legal for
+     * an endpoint that needs none.
+     *
+     * @param label how to name the connection in an error the operator will read
+     */
+    private ResolvedConnection withCredential(
+            String tenantCode, IntegrationConnection connection, String label) {
+        if (connection.credentialProfileId() == null) {
+            return new ResolvedConnection(
+                    connection.id(), connection.baseUrl(), connection.metadata(), Map.of());
+        }
+
+        CredentialProfile credential =
+                credentialProfileRepository.findByTenantAndId(tenantCode, connection.credentialProfileId());
+        if (credential == null) {
+            throw new ConnectionResolutionException(
+                    "The credential profile linked to the " + label + " could not be found");
+        }
+        Map<String, Object> secret;
+        try {
+            secret = secretCipher.decrypt(credential.encryptedSecretJson());
+        } catch (RuntimeException e) {
+            throw new ConnectionResolutionException(
+                    "Could not read the credential for the " + label, e);
+        }
+        return new ResolvedConnection(
+                connection.id(),
+                connection.baseUrl(),
+                connection.metadata(),
+                secret,
+                credential.authType(),
+                credential.credentialType(),
+                credential.publicConfig());
     }
 
     /**

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
@@ -1,0 +1,228 @@
+package com.microboxlabs.miot.integrations.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.integrations.auth.AuthResolutionException;
+import com.microboxlabs.miot.integrations.auth.CredentialAuthRegistry;
+import com.microboxlabs.miot.integrations.auth.ResolvedAuth;
+import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import com.microboxlabs.miot.integrations.jobs.JobHttpTrace;
+import com.microboxlabs.miot.integrations.net.OutboundUrlGuard;
+import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Executes a stored {@link IntegrationOperation} against its connection.
+ *
+ * <p>This is the piece the module was missing. {@code integration_operations} has always
+ * been a catalog — a method, a path and a schema that nothing ever called — so every
+ * outbound integration (calendar, WhatsApp, Gauss) had to ship its own hand-rolled client
+ * repeating the same URL joining, auth and error mapping. Anything with a connection and an
+ * operation can now be called without new code:
+ *
+ * <pre>{@code
+ * OperationInvocationResult result =
+ *         invoker.invoke(tenantCode, connectionId, operationId, Map.of("field", "value"));
+ * }</pre>
+ *
+ * <p><b>Blocking.</b> Uses the JDK client on the calling thread, matching every other
+ * outbound client in this module; call it from a worker thread (async-job handlers already
+ * are) and never from the event loop.
+ *
+ * <p><b>Not a status check.</b> The invoker calls whatever connection it is given, including
+ * a {@code DRAFT} one — a test probe legitimately needs that. Callers that require an
+ * {@code ACTIVE} connection must assert it themselves.
+ */
+@ApplicationScoped
+public class IntegrationOperationInvoker {
+
+    /** Methods that carry a request body; anything else is sent without one. */
+    private static final Set<String> BODY_METHODS = Set.of("POST", "PUT", "PATCH");
+
+    private final IntegrationConnectionResolver connectionResolver;
+    private final IntegrationOperationRepository operationRepository;
+    private final CredentialAuthRegistry authRegistry;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final Duration timeout;
+
+    @Inject
+    public IntegrationOperationInvoker(
+            IntegrationConnectionResolver connectionResolver,
+            IntegrationOperationRepository operationRepository,
+            CredentialAuthRegistry authRegistry,
+            @ConfigProperty(name = "miot.integrations.operation-invoker.timeout-seconds", defaultValue = "20")
+            int timeoutSeconds) {
+        this(connectionResolver, operationRepository, authRegistry,
+                HttpClient.newHttpClient(), new ObjectMapper(), Duration.ofSeconds(timeoutSeconds));
+    }
+
+    IntegrationOperationInvoker(
+            IntegrationConnectionResolver connectionResolver,
+            IntegrationOperationRepository operationRepository,
+            CredentialAuthRegistry authRegistry,
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            Duration timeout) {
+        this.connectionResolver = connectionResolver;
+        this.operationRepository = operationRepository;
+        this.authRegistry = authRegistry;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.timeout = timeout;
+    }
+
+    /**
+     * @param body sent as a JSON object on POST/PUT/PATCH; ignored for other methods
+     * @throws OperationInvocationException when the operation is unknown to the connection,
+     *         the credential is unusable, the URL is not a public HTTP(S) one, or the call
+     *         never completed
+     */
+    public OperationInvocationResult invoke(
+            String tenantCode, String connectionId, String operationId, Map<String, Object> body) {
+        ResolvedConnection connection = connectionResolver.resolve(tenantCode, connectionId);
+        IntegrationOperation operation =
+                operationRepository.findByConnectionAndId(connectionId, operationId);
+        if (operation == null) {
+            throw new OperationInvocationException(
+                    "Operation " + operationId + " does not belong to connection " + connectionId);
+        }
+        return execute(connection, operation, body);
+    }
+
+    /** As {@link #invoke}, addressing the operation by its (case-insensitive) name. */
+    public OperationInvocationResult invokeByName(
+            String tenantCode, String connectionId, String operationName, Map<String, Object> body) {
+        ResolvedConnection connection = connectionResolver.resolve(tenantCode, connectionId);
+        IntegrationOperation operation =
+                operationRepository.findByConnectionAndName(connectionId, operationName);
+        if (operation == null) {
+            throw new OperationInvocationException(
+                    "Connection " + connectionId + " has no operation named '" + operationName + "'");
+        }
+        return execute(connection, operation, body);
+    }
+
+    private OperationInvocationResult execute(
+            ResolvedConnection connection, IntegrationOperation operation, Map<String, Object> body) {
+        ResolvedAuth auth = resolveAuth(connection);
+        URI url = buildUrl(connection.baseUrl(), operation.path(), auth.queryParams());
+        // Resolves the host: a stored base URL is operator input and could point at the
+        // cluster's own metadata service or a private address.
+        OutboundUrlGuard.requirePublicHttpUrl(url, "connection base URL");
+
+        String method = method(operation);
+        String requestBody = BODY_METHODS.contains(method) ? serialize(body) : null;
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder(url).timeout(timeout);
+        auth.headers().forEach(builder::header);
+        if (requestBody != null) {
+            builder.header("Content-Type", "application/json");
+            builder.method(method, HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8));
+        } else {
+            builder.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        builder.header("Accept", "application/json");
+
+        long startedAt = System.nanoTime();
+        try {
+            HttpResponse<String> response =
+                    httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            trace(method, url, response.statusCode(), startedAt, requestBody, response.body(), null);
+            return new OperationInvocationResult(response.statusCode(), response.body());
+        } catch (IOException e) {
+            trace(method, url, null, startedAt, requestBody, null, e.toString());
+            throw new OperationInvocationException(
+                    "Call to " + operation.name() + " failed: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            trace(method, url, null, startedAt, requestBody, null, e.toString());
+            throw new OperationInvocationException("Call to " + operation.name() + " was interrupted", e);
+        }
+    }
+
+    private ResolvedAuth resolveAuth(ResolvedConnection connection) {
+        if (!connection.hasAuth()) {
+            // No credential attached — legal for an endpoint that needs none.
+            return new ResolvedAuth(Map.of(), Map.of(), null);
+        }
+        try {
+            return authRegistry.resolve(connection.authContext());
+        } catch (AuthResolutionException e) {
+            throw new OperationInvocationException(
+                    "Could not authenticate connection " + connection.connectionId() + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Joins the connection's base URL with the operation's path, then appends any auth
+     * query parameters. Tolerates a trailing slash on the base and a missing leading slash
+     * on the path, and preserves a query string the path already carries.
+     */
+    static URI buildUrl(URI baseUrl, String path, Map<String, String> queryParams) {
+        if (baseUrl == null) {
+            throw new OperationInvocationException("The connection has no base URL");
+        }
+        String base = baseUrl.toString();
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        String suffix = path == null ? "" : path.trim();
+        if (!suffix.isEmpty() && !suffix.startsWith("/")) {
+            suffix = "/" + suffix;
+        }
+        StringBuilder url = new StringBuilder(base).append(suffix);
+
+        if (queryParams != null && !queryParams.isEmpty()) {
+            boolean hasQuery = url.indexOf("?") >= 0;
+            for (Map.Entry<String, String> param : queryParams.entrySet()) {
+                url.append(hasQuery ? '&' : '?')
+                        .append(URLEncoder.encode(param.getKey(), StandardCharsets.UTF_8))
+                        .append('=')
+                        .append(URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8));
+                hasQuery = true;
+            }
+        }
+        try {
+            return URI.create(url.toString());
+        } catch (IllegalArgumentException e) {
+            throw new OperationInvocationException("Operation URL is not valid: " + url, e);
+        }
+    }
+
+    private static String method(IntegrationOperation operation) {
+        String method = operation.method() == null ? "" : operation.method().trim().toUpperCase();
+        if (method.isEmpty()) {
+            throw new OperationInvocationException(
+                    "Operation " + operation.name() + " has no HTTP method");
+        }
+        return method;
+    }
+
+    private String serialize(Map<String, Object> body) {
+        try {
+            return objectMapper.writeValueAsString(body == null ? Map.of() : body);
+        } catch (JsonProcessingException e) {
+            throw new OperationInvocationException("Request body could not be serialized", e);
+        }
+    }
+
+    private static void trace(String method, URI url, Integer status, long startedAt,
+                              String requestBody, String responseBody, String error) {
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        // Headers are deliberately not passed: that is where the token is.
+        JobHttpTrace.record(method, url.toString(), status, durationMs, requestBody, responseBody, error);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/OperationInvocationException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/OperationInvocationException.java
@@ -1,0 +1,20 @@
+package com.microboxlabs.miot.integrations.service;
+
+/**
+ * The call could not be made, or could not be completed — an unknown operation, a
+ * malformed or non-public URL, an unusable credential, a timeout, a dropped connection.
+ *
+ * <p>Distinct from a completed call that returned a non-2xx: that is an
+ * {@link OperationInvocationResult}, because the partner's status and body are the useful
+ * part and the caller decides what they mean.
+ */
+public class OperationInvocationException extends RuntimeException {
+
+    public OperationInvocationException(String message) {
+        super(message);
+    }
+
+    public OperationInvocationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/OperationInvocationResult.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/OperationInvocationResult.java
@@ -1,0 +1,37 @@
+package com.microboxlabs.miot.integrations.service;
+
+/**
+ * A completed call to a provider operation: whatever it answered, verdict included.
+ *
+ * <p>A non-2xx is a <i>result</i>, not an exception — the status and body are the useful
+ * part (a validation list, a business rejection, a rate-limit notice) and only the caller
+ * knows whether they mean "give up" or "try later".
+ */
+public record OperationInvocationResult(int status, String body) {
+
+    public boolean successful() {
+        return status >= 200 && status < 300;
+    }
+
+    /**
+     * Whether trying the same request again could plausibly succeed.
+     *
+     * <p>5xx is the server's own admission that this was its fault. {@code 408} and
+     * {@code 429} are 4xx by number but explicitly mean "later, not never" — treating them
+     * as permanent would park a job over a transient rate limit. Every other 4xx is the
+     * request's fault and will fail identically on retry.
+     */
+    public boolean retryable() {
+        return status >= 500 || status == 408 || status == 429;
+    }
+
+    /** A short, log-safe description. The body is capped — it can be a whole HTML page. */
+    public String summary() {
+        String text = body == null ? "" : body.strip();
+        if (text.isEmpty()) {
+            return "HTTP " + status;
+        }
+        String trimmed = text.length() <= 300 ? text : text.substring(0, 300) + "…";
+        return "HTTP " + status + ": " + trimmed;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/ResolvedConnection.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/ResolvedConnection.java
@@ -1,5 +1,8 @@
 package com.microboxlabs.miot.integrations.service;
 
+import com.microboxlabs.miot.integrations.auth.CredentialAuthContext;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import com.microboxlabs.miot.integrations.domain.CredentialType;
 import java.net.URI;
 import java.util.Map;
 
@@ -11,12 +14,31 @@ import java.util.Map;
  *
  * <p>The {@code secret} map is the decrypted credential config (e.g. {@code {"token": "..."}});
  * treat it as sensitive and never log or serialize it.
+ *
+ * <p>{@code authType} / {@code credentialType} / {@code publicConfig} describe <i>how</i> to
+ * authenticate, instead of leaving each caller to infer it from the secret's shape; together
+ * they feed {@link #authContext()}. They are absent on a connection with no credential
+ * attached, and on the back-compat constructor below.
  */
 public record ResolvedConnection(
         String connectionId,
         URI baseUrl,
         Map<String, Object> metadata,
-        Map<String, Object> secret) {
+        Map<String, Object> secret,
+        AuthType authType,
+        CredentialType credentialType,
+        Map<String, Object> publicConfig) {
+
+    /**
+     * Back-compat view for callers that hand-build their own auth from the secret map
+     * (the WhatsApp channel predates the generic invoker). Leaves the auth description
+     * empty, so {@link #authContext()} is unavailable — use the canonical constructor
+     * when the credential is known.
+     */
+    public ResolvedConnection(
+            String connectionId, URI baseUrl, Map<String, Object> metadata, Map<String, Object> secret) {
+        this(connectionId, baseUrl, metadata, secret, null, null, Map.of());
+    }
 
     public String metadataString(String key) {
         return stringValue(metadata, key);
@@ -24,6 +46,25 @@ public record ResolvedConnection(
 
     public String secretString(String key) {
         return stringValue(secret, key);
+    }
+
+    /** Whether this connection carries enough to authenticate a request generically. */
+    public boolean hasAuth() {
+        return authType != null;
+    }
+
+    /**
+     * The input {@link com.microboxlabs.miot.integrations.auth.CredentialAuthRegistry}
+     * needs to produce request auth.
+     *
+     * @throws IllegalStateException when no credential is attached to the connection
+     */
+    public CredentialAuthContext authContext() {
+        if (!hasAuth()) {
+            throw new IllegalStateException(
+                    "Connection " + connectionId + " has no credential profile to authenticate with");
+        }
+        return new CredentialAuthContext(authType, credentialType, publicConfig, secret);
     }
 
     private static String stringValue(Map<String, Object> map, String key) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderException.java
@@ -1,0 +1,28 @@
+package com.microboxlabs.miot.integrations.template;
+
+import java.util.List;
+
+/**
+ * The mapping could not produce a payload the channel will accept — a required field left
+ * blank, or a value that will not coerce to its declared type.
+ *
+ * <p>Carries <b>every</b> problem, not just the first. An operator fixing a six-field mapping
+ * should see all of it in one pass rather than rediscovering the next fault on each retry;
+ * the same list backs the save-time check and the preview endpoint.
+ *
+ * <p>This is a permanent failure by nature: the same binding and the same context will fail
+ * identically forever, so a dispatch that raises it should park rather than retry.
+ */
+public class PayloadRenderException extends RuntimeException {
+
+    private final transient List<String> problems;
+
+    public PayloadRenderException(List<String> problems) {
+        super(String.join("; ", problems));
+        this.problems = List.copyOf(problems);
+    }
+
+    public List<String> problems() {
+        return problems;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
@@ -1,0 +1,174 @@
+package com.microboxlabs.miot.integrations.template;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builds a channel's outbound JSON body from the binding's field templates.
+ *
+ * <p>Per field: render the template, coerce the result to the type the channel's
+ * {@link PayloadSchema} declares, and decide whether an empty result may be sent. Every
+ * problem is collected before throwing, so an operator sees a whole broken mapping at once
+ * rather than one fault per attempt.
+ *
+ * <p>Two rules worth knowing:
+ *
+ * <ul>
+ *   <li><b>An empty optional field is omitted, not sent blank.</b> Most partners treat an
+ *       absent key and {@code ""} differently, and "no reviewer comment" means the former.
+ *       An empty <i>required</i> field is an error — silently writing a blank into a
+ *       required slot is worse than failing.
+ *   <li><b>A template that is exactly one variable keeps the context value's own type.</b>
+ *       {@code {{review.verdict}}} over a real boolean sends JSON {@code false}, not
+ *       {@code "false"}, without depending on a string round-trip.
+ * </ul>
+ */
+@ApplicationScoped
+public class PayloadRenderer {
+
+    /**
+     * @param templates field id → template, as stored on the binding
+     * @param schema the channel's contract; {@link PayloadSchema#empty()} sends everything as text
+     * @param context {@code {task, content, review, session}}
+     * @throws PayloadRenderException listing every field that could not be produced
+     */
+    public Map<String, Object> render(
+            Map<String, String> templates, PayloadSchema schema, Map<String, Object> context) {
+        Map<String, String> safeTemplates = templates == null ? Map.of() : templates;
+        List<String> problems = new ArrayList<>();
+        Map<String, Object> payload = new LinkedHashMap<>();
+
+        for (String fieldId : fieldOrder(safeTemplates, schema)) {
+            PayloadSchema.Field field = schema.field(fieldId);
+            boolean required = field != null && field.required();
+            String template = safeTemplates.get(fieldId);
+
+            if (template == null || template.isBlank()) {
+                if (required) {
+                    problems.add("'" + fieldId + "' is required but has no mapping");
+                }
+                continue;
+            }
+
+            String rendered;
+            try {
+                rendered = PayloadTemplate.render(template, context);
+            } catch (TemplateSyntaxException e) {
+                // Save-time validation should have caught this; a stored binding can still be
+                // older than the validator, so fail loudly instead of sending the raw template.
+                problems.add("'" + fieldId + "' has an invalid template: " + e.getMessage());
+                continue;
+            }
+
+            if (rendered.isEmpty()) {
+                if (required) {
+                    problems.add("'" + fieldId + "' is required but its mapping produced no value");
+                }
+                continue;
+            }
+
+            PayloadSchema.FieldType type = field == null ? PayloadSchema.FieldType.STRING : field.type();
+            try {
+                payload.put(fieldId, coerce(template, rendered, type, context));
+            } catch (IllegalArgumentException e) {
+                problems.add("'" + fieldId + "' expects " + type.name().toLowerCase()
+                        + " but produced " + excerpt(rendered));
+            }
+        }
+
+        if (!problems.isEmpty()) {
+            throw new PayloadRenderException(problems);
+        }
+        return payload;
+    }
+
+    /**
+     * Checks a mapping before it is stored: templates parse, read known variables, and cover
+     * every required field.
+     *
+     * @return every problem found; empty when the mapping is storable
+     */
+    public List<String> validate(
+            Map<String, String> templates, PayloadSchema schema, Set<String> allowedRoots) {
+        Map<String, String> safeTemplates = templates == null ? Map.of() : templates;
+        List<String> problems = new ArrayList<>();
+
+        for (PayloadSchema.Field field : schema.requiredFields()) {
+            String template = safeTemplates.get(field.id());
+            if (template == null || template.isBlank()) {
+                problems.add("'" + field.id() + "' is required but has no mapping");
+            }
+        }
+        safeTemplates.forEach((fieldId, template) -> {
+            if (template == null || template.isBlank()) {
+                return;
+            }
+            try {
+                PayloadTemplate.validate(template, allowedRoots);
+            } catch (TemplateSyntaxException e) {
+                problems.add("'" + fieldId + "': " + e.getMessage());
+            }
+        });
+        return problems;
+    }
+
+    /**
+     * Declared fields first, in contract order, then any mapped field the contract does not
+     * declare — an operator may legitimately send an extra key a stale schema omits.
+     */
+    private static Set<String> fieldOrder(Map<String, String> templates, PayloadSchema schema) {
+        Set<String> order = new LinkedHashSet<>();
+        schema.fields().forEach(field -> order.add(field.id()));
+        order.addAll(templates.keySet());
+        return order;
+    }
+
+    private static Object coerce(
+            String template, String rendered, PayloadSchema.FieldType type, Map<String, Object> context) {
+        if (type == PayloadSchema.FieldType.STRING) {
+            return rendered;
+        }
+        // A lone variable already holds a typed value; prefer it over re-parsing its text.
+        if (PayloadTemplate.isSingleVariable(template)) {
+            Object raw = PayloadTemplate.resolve(
+                    PayloadTemplate.parse(template).get(0).text(), context);
+            if (raw instanceof Boolean && type == PayloadSchema.FieldType.BOOLEAN) {
+                return raw;
+            }
+            if (raw instanceof Number number) {
+                return type == PayloadSchema.FieldType.INTEGER ? number.longValue() : raw;
+            }
+        }
+        String text = rendered.trim();
+        return switch (type) {
+            case BOOLEAN -> toBoolean(text);
+            case INTEGER -> Long.valueOf(text);
+            case NUMBER -> new BigDecimal(text);
+            case STRING -> rendered;
+        };
+    }
+
+    /**
+     * Accepts only the forms a partner would recognize. Being lenient here (treating any
+     * non-empty string as true, say) would turn a mapping mistake into a wrong verdict.
+     */
+    private static Boolean toBoolean(String text) {
+        return switch (text.toLowerCase()) {
+            case "true", "1" -> Boolean.TRUE;
+            case "false", "0" -> Boolean.FALSE;
+            default -> throw new IllegalArgumentException(text);
+        };
+    }
+
+    /** Values are business data, not secrets, but an error line is no place for a whole document. */
+    private static String excerpt(String value) {
+        String text = value.strip();
+        return "'" + (text.length() <= 60 ? text : text.substring(0, 60) + "…") + "'";
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
@@ -1,0 +1,107 @@
+package com.microboxlabs.miot.integrations.template;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The channel's data contract, read from {@code integration_operations.request_schema}.
+ *
+ * <p>That column has existed since the schema was created and, until now, nothing ever read
+ * it. This is its first reader: it tells the renderer which fields exist, what JSON type each
+ * must leave as, and which ones may not be omitted — and it is the same list the settings UI
+ * renders as mapping rows.
+ *
+ * <p>Interpreted as a JSON-Schema subset:
+ *
+ * <pre>{@code
+ * { "type": "object",
+ *   "properties": { "aprobado": { "type": "boolean", "title": "Approved" } },
+ *   "required": ["aprobado"] }
+ * }</pre>
+ *
+ * <p>Anything richer (nested objects, arrays, {@code oneOf}, validation keywords) is ignored
+ * rather than rejected — an operator may have pasted a fuller schema, and the parts we do
+ * understand are still the parts we act on. A property with no usable {@code type}, including
+ * {@code string} with {@code "format": "date-time"}, is treated as {@link FieldType#STRING}
+ * and passed through verbatim.
+ */
+public record PayloadSchema(List<Field> fields) {
+
+    /** The JSON types a channel field can be sent as. */
+    public enum FieldType {
+        STRING,
+        BOOLEAN,
+        INTEGER,
+        NUMBER
+    }
+
+    public record Field(String id, FieldType type, boolean required) {
+    }
+
+    private static final PayloadSchema EMPTY = new PayloadSchema(List.of());
+
+    /** A schema declaring nothing — every mapped field is then sent as a string. */
+    public static PayloadSchema empty() {
+        return EMPTY;
+    }
+
+    /** Property order is preserved, so the UI lists fields the way the contract declares them. */
+    public static PayloadSchema of(Map<String, Object> requestSchema) {
+        if (requestSchema == null || requestSchema.isEmpty()) {
+            return EMPTY;
+        }
+        Object rawProperties = requestSchema.get("properties");
+        if (!(rawProperties instanceof Map<?, ?> properties) || properties.isEmpty()) {
+            return EMPTY;
+        }
+        Set<String> required = requiredNames(requestSchema.get("required"));
+
+        List<Field> fields = new ArrayList<>(properties.size());
+        properties.forEach((name, definition) -> {
+            String id = String.valueOf(name);
+            fields.add(new Field(id, typeOf(definition), required.contains(id)));
+        });
+        return new PayloadSchema(List.copyOf(fields));
+    }
+
+    public Field field(String id) {
+        return fields.stream().filter(field -> field.id().equals(id)).findFirst().orElse(null);
+    }
+
+    public List<Field> requiredFields() {
+        return fields.stream().filter(Field::required).toList();
+    }
+
+    private static Set<String> requiredNames(Object raw) {
+        if (!(raw instanceof Iterable<?> items)) {
+            return Set.of();
+        }
+        Set<String> names = new LinkedHashSet<>();
+        for (Object item : items) {
+            if (item != null) {
+                names.add(String.valueOf(item));
+            }
+        }
+        return names;
+    }
+
+    private static FieldType typeOf(Object definition) {
+        if (!(definition instanceof Map<?, ?> map)) {
+            return FieldType.STRING;
+        }
+        Object type = map.get("type");
+        if (type == null) {
+            return FieldType.STRING;
+        }
+        return switch (String.valueOf(type).toLowerCase()) {
+            case "boolean" -> FieldType.BOOLEAN;
+            case "integer" -> FieldType.INTEGER;
+            case "number" -> FieldType.NUMBER;
+            // "string" and anything unrecognized (including date-time formats) pass through.
+            default -> FieldType.STRING;
+        };
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadTemplate.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadTemplate.java
@@ -1,0 +1,178 @@
+package com.microboxlabs.miot.integrations.template;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The payload template language: literal text interleaved with {@code {{dotted.path}}}
+ * variables, resolved against a context of {@code {task, content, review, session}}.
+ *
+ * <p><b>Deliberately a strict subset of Handlebars.</b> The settings UI previews templates
+ * with the real engine, so anything this cannot reproduce identically — blocks
+ * ({@code {{#if}}}, {@code {{#each}}}), helpers ({@code {{formatDate x}}}), partials,
+ * comments, unescaped stashes — is <b>rejected at save time</b> rather than rendered
+ * differently in production. That is the whole point: preview and runtime cannot drift,
+ * because a template they would disagree about is never stored.
+ *
+ * <p>Escaping is intentionally absent. Values go into a JSON body built by Jackson, which
+ * does its own escaping; HTML-escaping them here would corrupt the payload.
+ *
+ * <p>If helpers are wanted later, add a real Handlebars dependency and relax
+ * {@link #validate} — do not let the two sides diverge in the meantime.
+ */
+public final class PayloadTemplate {
+
+    /** The context objects a template may read. */
+    public static final Set<String> DEFAULT_ROOTS = Set.of("task", "content", "review", "session");
+
+    private PayloadTemplate() {
+    }
+
+    /** One piece of a parsed template: either literal text or a variable path. */
+    record Node(String text, boolean variable) {
+    }
+
+    /**
+     * Checks the template renders identically here and in the UI's engine, and that every
+     * variable it reads exists.
+     *
+     * @param allowedRoots the context objects in scope; typically {@link #DEFAULT_ROOTS}
+     * @return every path the template references, for callers that want to report them
+     * @throws TemplateSyntaxException naming the construct or root at fault
+     */
+    public static Set<String> validate(String template, Set<String> allowedRoots) {
+        Set<String> paths = new LinkedHashSet<>();
+        for (Node node : parse(template)) {
+            if (!node.variable()) {
+                continue;
+            }
+            String path = node.text();
+            String root = path.contains(".") ? path.substring(0, path.indexOf('.')) : path;
+            if (!allowedRoots.contains(root)) {
+                throw new TemplateSyntaxException("Unknown variable '" + path + "': '" + root
+                        + "' is not one of " + new java.util.TreeSet<>(allowedRoots));
+            }
+            if (!path.contains(".")) {
+                // {{task}} would stringify a whole object into the payload; almost certainly
+                // a half-typed path rather than an intent.
+                throw new TemplateSyntaxException(
+                        "Variable '" + path + "' is a whole object; use one of its fields, e.g. '"
+                                + path + ".someField'");
+            }
+            paths.add(path);
+        }
+        return paths;
+    }
+
+    /**
+     * Substitutes each variable with its context value. A path that resolves to nothing
+     * becomes the empty string — a missing optional value is normal, and
+     * {@code PayloadRenderer} decides whether an empty result may be sent.
+     */
+    public static String render(String template, Map<String, Object> context) {
+        StringBuilder out = new StringBuilder();
+        for (Node node : parse(template)) {
+            out.append(node.variable() ? resolveToString(node.text(), context) : node.text());
+        }
+        return out.toString();
+    }
+
+    /**
+     * Whether the template is exactly one variable and nothing else, so the caller can use
+     * the context value's own type instead of its string form.
+     */
+    public static boolean isSingleVariable(String template) {
+        List<Node> nodes = parse(template);
+        return nodes.size() == 1 && nodes.get(0).variable();
+    }
+
+    /** The raw context value a single-variable template points at, or null. */
+    public static Object resolve(String path, Map<String, Object> context) {
+        Object current = context;
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    private static String resolveToString(String path, Map<String, Object> context) {
+        Object value = resolve(path, context);
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    /**
+     * Splits a template into literal and variable nodes, rejecting every construct outside
+     * the supported subset.
+     */
+    static List<Node> parse(String template) {
+        List<Node> nodes = new ArrayList<>();
+        if (template == null || template.isEmpty()) {
+            return nodes;
+        }
+        int cursor = 0;
+        while (cursor < template.length()) {
+            int open = template.indexOf("{{", cursor);
+            if (open < 0) {
+                nodes.add(new Node(template.substring(cursor), false));
+                break;
+            }
+            if (open > cursor) {
+                nodes.add(new Node(template.substring(cursor, open), false));
+            }
+            // {{{raw}}} skips escaping in Handlebars. We never escape, so accepting it would
+            // quietly mean something different from what the preview showed.
+            if (template.startsWith("{{{", open)) {
+                throw new TemplateSyntaxException(
+                        "Unescaped '{{{ }}}' is not supported; use '{{ }}'");
+            }
+            int close = template.indexOf("}}", open + 2);
+            if (close < 0) {
+                throw new TemplateSyntaxException(
+                        "Unclosed '{{' — every variable must end with '}}'");
+            }
+            nodes.add(new Node(requirePath(template.substring(open + 2, close)), true));
+            cursor = close + 2;
+        }
+        return nodes;
+    }
+
+    /** @throws TemplateSyntaxException when the stash is a block, helper, partial or comment */
+    private static String requirePath(String rawInner) {
+        String inner = rawInner.trim();
+        if (inner.isEmpty()) {
+            throw new TemplateSyntaxException("Empty '{{}}' is not a variable");
+        }
+        char first = inner.charAt(0);
+        // # block, / close, ^ inverted, > partial, ! comment, & unescaped, = delimiters
+        if ("#/^>!&=".indexOf(first) >= 0) {
+            throw new TemplateSyntaxException("'{{" + inner + "}}' is not supported — this field "
+                    + "takes plain variables like '{{task.serviceCode}}', not blocks, partials or comments");
+        }
+        for (int i = 0; i < inner.length(); i++) {
+            if (Character.isWhitespace(inner.charAt(i))) {
+                throw new TemplateSyntaxException("'{{" + inner + "}}' looks like a helper call; "
+                        + "only plain variables such as '{{review.verdict}}' are supported");
+            }
+        }
+        if (inner.startsWith(".") || inner.endsWith(".") || inner.contains("..")) {
+            throw new TemplateSyntaxException("'{{" + inner + "}}' is not a valid variable path");
+        }
+        for (int i = 0; i < inner.length(); i++) {
+            char c = inner.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '.') {
+                throw new TemplateSyntaxException(
+                        "'{{" + inner + "}}' contains an unsupported character '" + c + "'");
+            }
+        }
+        return inner;
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/TemplateSyntaxException.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/TemplateSyntaxException.java
@@ -1,0 +1,17 @@
+package com.microboxlabs.miot.integrations.template;
+
+/**
+ * A payload template uses syntax this renderer cannot faithfully reproduce, or refers to
+ * a variable root that does not exist.
+ *
+ * <p>Raised at <b>save</b> time, not dispatch time. The settings UI previews templates with
+ * a full Handlebars engine; this renderer implements only variable substitution. Refusing
+ * the difference when the binding is stored is what keeps the preview honest — a template
+ * that would render differently in production never reaches storage.
+ */
+public class TemplateSyntaxException extends RuntimeException {
+
+    public TemplateSyntaxException(String message) {
+        super(message);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/CredentialAuthProvidersTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/CredentialAuthProvidersTest.java
@@ -1,0 +1,124 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyCredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.apikey.ApiKeyStrategy;
+import com.microboxlabs.miot.integrations.auth.basic.BasicAuthStrategy;
+import com.microboxlabs.miot.integrations.auth.basic.BasicCredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.bearer.BearerCredentialAuthProvider;
+import com.microboxlabs.miot.integrations.auth.bearer.BearerTokenStrategy;
+import com.microboxlabs.miot.integrations.auth.customheaders.CustomHeadersCredentialAuthProvider;
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** The credential-shape contract each provider expects, and how it fails when it isn't met. */
+class CredentialAuthProvidersTest {
+
+    private static CredentialAuthContext context(
+            AuthType authType, Map<String, Object> publicConfig, Map<String, Object> secret) {
+        return new CredentialAuthContext(authType, null, publicConfig, secret);
+    }
+
+    @Test
+    void bearerSendsTheStoredTokenAsAnAuthorizationHeader() {
+        var provider = new BearerCredentialAuthProvider(new BearerTokenStrategy());
+
+        ResolvedAuth auth = provider.resolve(
+                context(AuthType.BEARER_TOKEN, Map.of(), Map.of("token", "abc-123")));
+
+        assertEquals("Bearer abc-123", auth.headers().get("Authorization"));
+        assertTrue(auth.queryParams().isEmpty());
+    }
+
+    @Test
+    void bearerNamesTheMissingKeyRatherThanFailingAsANull() {
+        var provider = new BearerCredentialAuthProvider(new BearerTokenStrategy());
+
+        AuthResolutionException failure = assertThrows(AuthResolutionException.class,
+                () -> provider.resolve(context(AuthType.BEARER_TOKEN, Map.of(), Map.of())));
+
+        assertTrue(failure.getMessage().contains("token"), failure.getMessage());
+    }
+
+    @Test
+    void basicEncodesTheNonSecretUsernameWithTheSecretPassword() {
+        var provider = new BasicCredentialAuthProvider(new BasicAuthStrategy());
+
+        ResolvedAuth auth = provider.resolve(context(
+                AuthType.BASIC, Map.of("username", "svc-user"), Map.of("password", "s3cret")));
+
+        String expected = Base64.getEncoder().encodeToString("svc-user:s3cret".getBytes());
+        assertEquals("Basic " + expected, auth.headers().get("Authorization"));
+    }
+
+    @Test
+    void apiKeyPlacementFollowsTheAuthTypeNotTheConfig() {
+        var provider = new ApiKeyCredentialAuthProvider(new ApiKeyStrategy());
+        Map<String, Object> publicConfig = Map.of("name", "X-Api-Key");
+        Map<String, Object> secret = Map.of("value", "key-789");
+
+        ResolvedAuth header = provider.resolve(context(AuthType.API_KEY_HEADER, publicConfig, secret));
+        assertEquals("key-789", header.headers().get("X-Api-Key"));
+        assertTrue(header.queryParams().isEmpty());
+
+        ResolvedAuth query = provider.resolve(context(AuthType.API_KEY_QUERY, publicConfig, secret));
+        assertEquals("key-789", query.queryParams().get("X-Api-Key"));
+        assertTrue(query.headers().isEmpty());
+    }
+
+    @Test
+    void customHeadersCopiesEveryStoredHeader() {
+        var provider = new CustomHeadersCredentialAuthProvider();
+
+        ResolvedAuth auth = provider.resolve(context(AuthType.CUSTOM_HEADERS, Map.of(),
+                Map.of("headers", Map.of("X-Tenant", "acme", "X-Signature", "sig-1"))));
+
+        assertEquals("acme", auth.headers().get("X-Tenant"));
+        assertEquals("sig-1", auth.headers().get("X-Signature"));
+    }
+
+    @Test
+    void customHeadersRefusesAValueThatCouldInjectAnotherHeader() {
+        var provider = new CustomHeadersCredentialAuthProvider();
+
+        AuthResolutionException failure = assertThrows(AuthResolutionException.class,
+                () -> provider.resolve(context(AuthType.CUSTOM_HEADERS, Map.of(),
+                        Map.of("headers", Map.of("X-Evil", "ok\r\nX-Injected: yes")))));
+
+        assertTrue(failure.getMessage().contains("X-Evil"), failure.getMessage());
+    }
+
+    @Test
+    void customHeadersRequiresANonEmptyHeaderMap() {
+        var provider = new CustomHeadersCredentialAuthProvider();
+
+        assertThrows(AuthResolutionException.class,
+                () -> provider.resolve(context(AuthType.CUSTOM_HEADERS, Map.of(), Map.of())));
+        assertThrows(AuthResolutionException.class,
+                () -> provider.resolve(context(AuthType.CUSTOM_HEADERS, Map.of(),
+                        Map.of("headers", Map.of()))));
+    }
+
+    @Test
+    void noAuthResolvesToNothingAtAll() {
+        ResolvedAuth auth = new NoAuthProvider().resolve(context(AuthType.NONE, Map.of(), Map.of()));
+
+        assertTrue(auth.headers().isEmpty());
+        assertTrue(auth.queryParams().isEmpty());
+    }
+
+    @Test
+    void theSecretHalfNeverAppearsInAContextsToString() {
+        String rendered = context(AuthType.BEARER_TOKEN, Map.of("clientId", "public-id"),
+                Map.of("token", "super-secret-value")).toString();
+
+        assertFalse(rendered.contains("super-secret-value"), rendered);
+        assertTrue(rendered.contains("redacted"), rendered);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/CredentialAuthRegistryTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/auth/CredentialAuthRegistryTest.java
@@ -1,0 +1,79 @@
+package com.microboxlabs.miot.integrations.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.AuthType;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CredentialAuthRegistryTest {
+
+    /** A provider that reports which auth types it claims and tags the header it produced. */
+    private record StubProvider(String id, Set<AuthType> types) implements CredentialAuthProvider {
+        @Override
+        public Set<AuthType> supportedTypes() {
+            return types;
+        }
+
+        @Override
+        public ResolvedAuth resolve(CredentialAuthContext context) {
+            return ResolvedAuth.headers(Map.of("X-Handled-By", id), null);
+        }
+    }
+
+    private static CredentialAuthContext context(AuthType authType) {
+        return new CredentialAuthContext(authType, null, Map.of(), Map.of());
+    }
+
+    @Test
+    void dispatchesToTheProviderThatClaimsTheAuthType() {
+        var registry = new CredentialAuthRegistry(List.of(
+                new StubProvider("bearer", Set.of(AuthType.BEARER_TOKEN)),
+                new StubProvider("basic", Set.of(AuthType.BASIC))));
+
+        assertEquals("bearer",
+                registry.resolve(context(AuthType.BEARER_TOKEN)).headers().get("X-Handled-By"));
+        assertEquals("basic",
+                registry.resolve(context(AuthType.BASIC)).headers().get("X-Handled-By"));
+    }
+
+    @Test
+    void oneProviderCanClaimSeveralAuthTypes() {
+        var registry = new CredentialAuthRegistry(List.of(
+                new StubProvider("apikey", Set.of(AuthType.API_KEY_HEADER, AuthType.API_KEY_QUERY))));
+
+        assertEquals("apikey",
+                registry.resolve(context(AuthType.API_KEY_HEADER)).headers().get("X-Handled-By"));
+        assertEquals("apikey",
+                registry.resolve(context(AuthType.API_KEY_QUERY)).headers().get("X-Handled-By"));
+    }
+
+    @Test
+    void twoProvidersClaimingTheSameTypeFailFast() {
+        List<CredentialAuthProvider> clashing = List.of(
+                new StubProvider("first", Set.of(AuthType.BEARER_TOKEN)),
+                new StubProvider("second", Set.of(AuthType.BEARER_TOKEN)));
+
+        // A last-one-wins registry would silently authenticate with the wrong provider,
+        // so the ambiguity has to surface at startup rather than at 3am.
+        IllegalStateException failure =
+                assertThrows(IllegalStateException.class, () -> CredentialAuthRegistry.index(clashing));
+
+        assertTrue(failure.getMessage().contains("BEARER_TOKEN"), failure.getMessage());
+    }
+
+    @Test
+    void anUnhandledAuthTypeIsRefusedRatherThanSentUnauthenticated() {
+        var registry = new CredentialAuthRegistry(List.of(
+                new StubProvider("bearer", Set.of(AuthType.BEARER_TOKEN))));
+
+        AuthResolutionException failure = assertThrows(AuthResolutionException.class,
+                () -> registry.resolve(context(AuthType.OAUTH2_CLIENT_CREDENTIALS)));
+
+        assertTrue(failure.getMessage().contains("OAUTH2_CLIENT_CREDENTIALS"), failure.getMessage());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvokerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvokerTest.java
@@ -1,0 +1,115 @@
+package com.microboxlabs.miot.integrations.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * URL assembly and response classification — the two pieces of the invoker that decide
+ * where a call goes and what its answer means. The HTTP send itself needs a live socket
+ * (no mocking framework in this module) and is covered by the connection test path.
+ */
+class IntegrationOperationInvokerTest {
+
+    @Test
+    void joinsBaseUrlAndPathWithExactlyOneSlash() {
+        assertEquals(URI.create("https://api.example.com/v1/photos"),
+                IntegrationOperationInvoker.buildUrl(
+                        URI.create("https://api.example.com"), "/v1/photos", Map.of()));
+
+        // A trailing slash on the base and a leading one on the path must not double up.
+        assertEquals(URI.create("https://api.example.com/v1/photos"),
+                IntegrationOperationInvoker.buildUrl(
+                        URI.create("https://api.example.com/"), "/v1/photos", Map.of()));
+
+        // ...nor may both be missing one.
+        assertEquals(URI.create("https://api.example.com/v1/photos"),
+                IntegrationOperationInvoker.buildUrl(
+                        URI.create("https://api.example.com"), "v1/photos", Map.of()));
+    }
+
+    @Test
+    void keepsABasePathPrefix() {
+        assertEquals(URI.create("https://api.example.com/api/v1/photos"),
+                IntegrationOperationInvoker.buildUrl(
+                        URI.create("https://api.example.com/api"), "/v1/photos", Map.of()));
+    }
+
+    @Test
+    void appendsAuthQueryParamsAfterAnExistingQueryString() {
+        URI url = IntegrationOperationInvoker.buildUrl(
+                URI.create("https://api.example.com"), "/photos?state=new", Map.of("api_key", "k1"));
+
+        assertEquals("https://api.example.com/photos?state=new&api_key=k1", url.toString());
+    }
+
+    @Test
+    void startsTheQueryStringWhenThePathHasNone() {
+        URI url = IntegrationOperationInvoker.buildUrl(
+                URI.create("https://api.example.com"), "/photos", Map.of("api_key", "k1"));
+
+        assertEquals("https://api.example.com/photos?api_key=k1", url.toString());
+    }
+
+    @Test
+    void encodesQueryParamNamesAndValues() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("api key", "a+b c&d");
+
+        URI url = IntegrationOperationInvoker.buildUrl(
+                URI.create("https://api.example.com"), "/photos", params);
+
+        assertEquals("https://api.example.com/photos?api+key=a%2Bb+c%26d", url.toString());
+    }
+
+    @Test
+    void toleratesAnEmptyPath() {
+        assertEquals(URI.create("https://api.example.com"),
+                IntegrationOperationInvoker.buildUrl(URI.create("https://api.example.com"), "", Map.of()));
+    }
+
+    @Test
+    void refusesAConnectionWithNoBaseUrl() {
+        assertThrows(OperationInvocationException.class,
+                () -> IntegrationOperationInvoker.buildUrl(null, "/photos", Map.of()));
+    }
+
+    @Test
+    void classifies2xxAsSuccessful() {
+        assertTrue(new OperationInvocationResult(200, "{}").successful());
+        assertTrue(new OperationInvocationResult(204, "").successful());
+        assertFalse(new OperationInvocationResult(400, "{}").successful());
+    }
+
+    @Test
+    void onlyServerFaultsAndBackpressureAreRetryable() {
+        assertTrue(new OperationInvocationResult(500, "").retryable());
+        assertTrue(new OperationInvocationResult(503, "").retryable());
+        // 4xx by number, but both explicitly mean "later", not "never".
+        assertTrue(new OperationInvocationResult(408, "").retryable());
+        assertTrue(new OperationInvocationResult(429, "").retryable());
+
+        // A malformed or rejected request fails identically however often it is resent.
+        assertFalse(new OperationInvocationResult(400, "").retryable());
+        assertFalse(new OperationInvocationResult(401, "").retryable());
+        assertFalse(new OperationInvocationResult(404, "").retryable());
+        assertFalse(new OperationInvocationResult(422, "").retryable());
+    }
+
+    @Test
+    void summaryCarriesTheProvidersReasonButIsCapped() {
+        assertEquals("HTTP 404", new OperationInvocationResult(404, "   ").summary());
+        assertEquals("HTTP 422: GUID no existe",
+                new OperationInvocationResult(422, "GUID no existe").summary());
+
+        String summary = new OperationInvocationResult(500, "x".repeat(500)).summary();
+        assertTrue(summary.endsWith("…"), summary);
+        assertTrue(summary.length() < 350, "summary should be capped, was " + summary.length());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java
@@ -1,0 +1,192 @@
+package com.microboxlabs.miot.integrations.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PayloadRendererTest {
+
+    private final PayloadRenderer renderer = new PayloadRenderer();
+
+    private static final Map<String, Object> CONTEXT = Map.of(
+            "task", Map.of("serviceCode", "SRV-1"),
+            "content", Map.of("mediaId", "19f8-a8ad"),
+            "review", Map.of("verdict", false, "comment", "", "score", 7),
+            "session", Map.of("user", "revisor.demo"));
+
+    /** The partner contract as it would be stored in integration_operations.request_schema. */
+    private static PayloadSchema schema() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("guidMultimedia", Map.of("type", "string"));
+        properties.put("aprobado", Map.of("type", "boolean"));
+        properties.put("mensaje", Map.of("type", "string"));
+        properties.put("intentos", Map.of("type", "integer"));
+        return PayloadSchema.of(Map.of(
+                "type", "object",
+                "properties", properties,
+                "required", List.of("guidMultimedia", "aprobado")));
+    }
+
+    @Test
+    void buildsThePayloadFromTheMappedTemplates() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "{{content.mediaId}}",
+                "aprobado", "{{review.verdict}}"), schema(), CONTEXT);
+
+        assertEquals("19f8-a8ad", payload.get("guidMultimedia"));
+        assertEquals(Boolean.FALSE, payload.get("aprobado"));
+    }
+
+    @Test
+    void aBooleanFieldLeavesAsJsonBooleanNotAString() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "{{content.mediaId}}",
+                "aprobado", "{{review.verdict}}"), schema(), CONTEXT);
+
+        assertTrue(payload.get("aprobado") instanceof Boolean,
+                "aprobado was " + payload.get("aprobado").getClass());
+    }
+
+    @Test
+    void coercesTextFormsOfBooleansToo() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "x", "aprobado", "true"), schema(), CONTEXT);
+        assertEquals(Boolean.TRUE, payload.get("aprobado"));
+
+        payload = renderer.render(Map.of("guidMultimedia", "x", "aprobado", "0"), schema(), CONTEXT);
+        assertEquals(Boolean.FALSE, payload.get("aprobado"));
+    }
+
+    @Test
+    void refusesAValueThatIsNotRecognizablyBoolean() {
+        // Treating any non-empty string as true would turn a mapping slip into a wrong verdict.
+        PayloadRenderException failure = assertThrows(PayloadRenderException.class,
+                () -> renderer.render(Map.of(
+                        "guidMultimedia", "x", "aprobado", "quizás"), schema(), CONTEXT));
+
+        assertTrue(failure.getMessage().contains("aprobado"), failure.getMessage());
+        assertTrue(failure.getMessage().contains("boolean"), failure.getMessage());
+    }
+
+    @Test
+    void coercesIntegersAndKeepsNumericTypesFromContext() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "x", "aprobado", "true", "intentos", "{{review.score}}"),
+                schema(), CONTEXT);
+
+        assertEquals(7L, payload.get("intentos"));
+    }
+
+    @Test
+    void anEmptyOptionalFieldIsOmittedRatherThanSentBlank() {
+        // review.comment is "" — most partners treat an absent key and "" differently.
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "{{content.mediaId}}",
+                "aprobado", "{{review.verdict}}",
+                "mensaje", "{{review.comment}}"), schema(), CONTEXT);
+
+        assertFalse(payload.containsKey("mensaje"), "empty optional field should be omitted");
+    }
+
+    @Test
+    void anEmptyRequiredFieldIsAnErrorNotABlankWrite() {
+        PayloadRenderException failure = assertThrows(PayloadRenderException.class,
+                () -> renderer.render(Map.of(
+                        "guidMultimedia", "{{task.missing}}",
+                        "aprobado", "{{review.verdict}}"), schema(), CONTEXT));
+
+        assertTrue(failure.getMessage().contains("guidMultimedia"), failure.getMessage());
+    }
+
+    @Test
+    void anUnmappedRequiredFieldIsAnError() {
+        PayloadRenderException failure = assertThrows(PayloadRenderException.class,
+                () -> renderer.render(Map.of("aprobado", "{{review.verdict}}"), schema(), CONTEXT));
+
+        assertTrue(failure.getMessage().contains("guidMultimedia"), failure.getMessage());
+    }
+
+    @Test
+    void reportsEveryProblemAtOnce() {
+        PayloadRenderException failure = assertThrows(PayloadRenderException.class,
+                () -> renderer.render(Map.of("aprobado", "nope"), schema(), CONTEXT));
+
+        // Both the missing required field and the bad boolean, in one pass.
+        assertEquals(2, failure.problems().size(), failure.getMessage());
+    }
+
+    @Test
+    void anUndeclaredMappedFieldIsSentAsText() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "guidMultimedia", "x", "aprobado", "true",
+                "extraCampo", "{{session.user}}"), schema(), CONTEXT);
+
+        assertEquals("revisor.demo", payload.get("extraCampo"));
+    }
+
+    @Test
+    void withoutASchemaEverythingIsSentAsText() {
+        Map<String, Object> payload = renderer.render(
+                Map.of("anything", "{{review.verdict}}"), PayloadSchema.empty(), CONTEXT);
+
+        assertEquals("false", payload.get("anything"));
+    }
+
+    @Test
+    void declaredFieldsKeepContractOrder() {
+        Map<String, Object> payload = renderer.render(Map.of(
+                "mensaje", "hola", "aprobado", "true", "guidMultimedia", "x"), schema(), CONTEXT);
+
+        assertEquals(List.of("guidMultimedia", "aprobado", "mensaje"),
+                List.copyOf(payload.keySet()));
+    }
+
+    /* ---- save-time validation ---- */
+
+    @Test
+    void validateAcceptsACompleteMapping() {
+        List<String> problems = renderer.validate(Map.of(
+                "guidMultimedia", "{{content.mediaId}}",
+                "aprobado", "{{review.verdict}}"), schema(), PayloadTemplate.DEFAULT_ROOTS);
+
+        assertTrue(problems.isEmpty(), problems.toString());
+    }
+
+    @Test
+    void validateFlagsMissingRequiredFieldsAndBadSyntax() {
+        List<String> problems = renderer.validate(Map.of(
+                "aprobado", "{{#if review.verdict}}si{{/if}}"), schema(), PayloadTemplate.DEFAULT_ROOTS);
+
+        assertEquals(2, problems.size(), problems.toString());
+        assertTrue(problems.toString().contains("guidMultimedia"), problems.toString());
+        assertTrue(problems.toString().contains("aprobado"), problems.toString());
+    }
+
+    @Test
+    void validateFlagsAnUnknownVariableRoot() {
+        List<String> problems = renderer.validate(Map.of(
+                "guidMultimedia", "{{invoice.total}}",
+                "aprobado", "true"), schema(), PayloadTemplate.DEFAULT_ROOTS);
+
+        assertEquals(1, problems.size(), problems.toString());
+        assertTrue(problems.get(0).contains("invoice"), problems.toString());
+    }
+
+    @Test
+    void numberFieldsKeepDecimalPrecision() {
+        PayloadSchema numeric = PayloadSchema.of(Map.of(
+                "type", "object",
+                "properties", Map.of("monto", Map.of("type", "number"))));
+
+        Map<String, Object> payload = renderer.render(Map.of("monto", "10.50"), numeric, CONTEXT);
+
+        assertEquals(new BigDecimal("10.50"), payload.get("monto"));
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadTemplateTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadTemplateTest.java
@@ -1,0 +1,138 @@
+package com.microboxlabs.miot.integrations.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PayloadTemplateTest {
+
+    private static final Map<String, Object> CONTEXT = Map.of(
+            "task", Map.of("serviceCode", "SRV-1", "priority", "UR"),
+            "content", Map.of("mediaId", "19f8-a8ad"),
+            "review", Map.of("verdict", false, "comment", "Falta señalética"),
+            "session", Map.of("user", "revisor.demo"));
+
+    @Test
+    void substitutesAVariableWithItsContextValue() {
+        assertEquals("19f8-a8ad", PayloadTemplate.render("{{content.mediaId}}", CONTEXT));
+    }
+
+    @Test
+    void interpolatesVariablesInsideLiteralText() {
+        assertEquals("svc SRV-1 / UR",
+                PayloadTemplate.render("svc {{task.serviceCode}} / {{task.priority}}", CONTEXT));
+    }
+
+    @Test
+    void toleratesWhitespaceAroundThePath() {
+        assertEquals("SRV-1", PayloadTemplate.render("{{  task.serviceCode  }}", CONTEXT));
+    }
+
+    @Test
+    void aMissingVariableRendersEmptyRatherThanLeakingTheTemplate() {
+        assertEquals("", PayloadTemplate.render("{{task.doesNotExist}}", CONTEXT));
+        assertEquals("a-b", PayloadTemplate.render("a{{task.nope}}-b", CONTEXT));
+    }
+
+    @Test
+    void rendersNonStringValuesViaTheirTextForm() {
+        assertEquals("false", PayloadTemplate.render("{{review.verdict}}", CONTEXT));
+    }
+
+    @Test
+    void anEmptyTemplateRendersEmpty() {
+        assertEquals("", PayloadTemplate.render("", CONTEXT));
+        assertEquals("", PayloadTemplate.render(null, CONTEXT));
+    }
+
+    @Test
+    void literalTextWithoutVariablesPassesThrough() {
+        assertEquals("plain text", PayloadTemplate.render("plain text", CONTEXT));
+    }
+
+    /* ---- the parity guarantee: anything the UI's Handlebars would treat differently ---- */
+
+    @Test
+    void rejectsBlockHelpers() {
+        assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{#if review.verdict}}si{{/if}}",
+                        PayloadTemplate.DEFAULT_ROOTS));
+    }
+
+    @Test
+    void rejectsHelperCalls() {
+        TemplateSyntaxException failure = assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{formatDate review.reviewedAt}}",
+                        PayloadTemplate.DEFAULT_ROOTS));
+        assertTrue(failure.getMessage().contains("helper"), failure.getMessage());
+    }
+
+    @Test
+    void rejectsPartialsCommentsAndUnescapedStashes() {
+        for (String template : new String[] {"{{> part}}", "{{! note}}", "{{&raw}}", "{{^inv}}x{{/inv}}"}) {
+            assertThrows(TemplateSyntaxException.class,
+                    () -> PayloadTemplate.validate(template, PayloadTemplate.DEFAULT_ROOTS),
+                    "should reject " + template);
+        }
+        assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{{task.serviceCode}}}", PayloadTemplate.DEFAULT_ROOTS));
+    }
+
+    @Test
+    void rejectsAnUnclosedVariable() {
+        assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{task.serviceCode", PayloadTemplate.DEFAULT_ROOTS));
+    }
+
+    @Test
+    void rejectsAnUnknownVariableRoot() {
+        TemplateSyntaxException failure = assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{invoice.total}}", PayloadTemplate.DEFAULT_ROOTS));
+        assertTrue(failure.getMessage().contains("invoice"), failure.getMessage());
+    }
+
+    @Test
+    void rejectsAWholeObjectReference() {
+        // {{task}} would stringify a Map into the payload — a half-typed path, not an intent.
+        assertThrows(TemplateSyntaxException.class,
+                () -> PayloadTemplate.validate("{{task}}", PayloadTemplate.DEFAULT_ROOTS));
+    }
+
+    @Test
+    void rejectsMalformedPaths() {
+        for (String bad : new String[] {"{{.task}}", "{{task.}}", "{{task..code}}", "{{}}"}) {
+            assertThrows(TemplateSyntaxException.class,
+                    () -> PayloadTemplate.validate(bad, PayloadTemplate.DEFAULT_ROOTS),
+                    "should reject " + bad);
+        }
+    }
+
+    @Test
+    void acceptsAndReportsTheVariablesItReads() {
+        Set<String> paths = PayloadTemplate.validate(
+                "{{task.serviceCode}} {{review.comment}}", PayloadTemplate.DEFAULT_ROOTS);
+
+        assertEquals(Set.of("task.serviceCode", "review.comment"), paths);
+    }
+
+    @Test
+    void recognizesASingleVariableTemplate() {
+        assertTrue(PayloadTemplate.isSingleVariable("{{review.verdict}}"));
+        assertTrue(PayloadTemplate.isSingleVariable("  {{review.verdict}}  ".trim()));
+        assertFalse(PayloadTemplate.isSingleVariable("x {{review.verdict}}"));
+        assertFalse(PayloadTemplate.isSingleVariable("{{a.b}}{{c.d}}"));
+    }
+
+    @Test
+    void resolveReturnsTheRawTypedValue() {
+        assertEquals(Boolean.FALSE, PayloadTemplate.resolve("review.verdict", CONTEXT));
+        assertEquals("SRV-1", PayloadTemplate.resolve("task.serviceCode", CONTEXT));
+        assertEquals(null, PayloadTemplate.resolve("task.missing", CONTEXT));
+        assertEquals(null, PayloadTemplate.resolve("task.serviceCode.deeper", CONTEXT));
+    }
+}


### PR DESCRIPTION
Plan only — no implementation. Backend for the column **review process**: when a service in a reviewed column is approved/rejected, push the verdict to an external system via a stored credential and an operator-defined field mapping.

Doc: `quarkus-srv/miot-integrations/docs/review-channel-dispatch.md`

## The finding that shaped it

The module already has every noun — credential profiles, integration connections, **operation contracts**, the `async_jobs` ledger, and the generic `ModulithJobWorker`/`ModulithJobHandler` dispatch.

It's missing the **verb**: nothing anywhere executes an `integration_operation`. The catalog is write-only and `request_schema` has no reader (verified — its only consumers are the domain/service/repo/api/dto). Every outbound call today is a bespoke hardcoded client (`CalendarBookingsClient`, `MetaWhatsAppClient`), each re-implementing URL joining, auth and error mapping. `GenericConnectionTester.supports()` returns `false` and its "test" makes no call.

So this is mostly **finishing the connection framework**, plus a thin review-specific binding. Phases 1–2 are reusable infrastructure with value independent of the review process.

## Mapping to the UI

The drawer's **channel** = a `(connection, operation)` pair. Its **field contract** = `integration_operations.request_schema` — an existing, already-writable column that finally gets its first reader, instead of a parallel concept.

## Phases (each independently shippable)

1. **Operation invoker** — `AuthStrategyRegistry` (`AuthType`→strategy; 4 strategies exist with no registry), `ResolvedConnection` carrying `authType`, `resolve(tenant, connectionId)`, tenant-safe operation lookup, and `IntegrationOperationInvoker`. *Bonus: `GenericConnectionTester` can become a real probe.*
2. **Payload rendering** — `{{dotted.path}}` renderer + type coercion off `request_schema` (a `boolean` field must leave as JSON `true`, not `"true"`) + `TemplateValidator`.
3. **Binding schema + CRUD** — migration `V0.6.11` (0.6.10 is head), `review_channel_bindings`, owner-gated REST incl. `/dispatch-targets` (channel-picker feed) and `/preview`.
4. **Verdict intake + job handler** — `POST /review-verdicts` → trigger filter → enqueue → `ReviewVerdictDispatchHandler` (`job_type=review_verdict_dispatch`). No `async_jobs` migration needed.
5. **Frontend swap** — separate PR in `apps/app`.

## Decisions

- **Reuse `ProviderType.CUSTOM_HTTP`** — avoids a provider CHECK-constraint migration and its rolling-deploy hazard.
- **Intake as REST, not a direct ECM enqueue** — keeps binding lookup and trigger filtering configurable without an ECM deploy.
- **Snapshot the context at enqueue** — a retry must send what was reviewed, not the task's current state.
- **Dedupe on `(binding, media, verdict)`** — a re-delivered verdict is a no-op via the existing partial unique index.

## Risks called out

- **Template parity** — the drawer previews with real Handlebars; a substitution-subset backend would diverge silently. Mitigation: validate and reject unsupported constructs *on save*, so a template that can't round-trip never reaches storage.
- **Rolling deploys** — Phase 3 is a new table only; any later column needs `NOT NULL` **with a default** (the `V0.6.9`→`V0.6.10` repair).
- **Cross-tenant leak** — `integration_operations` has no `tenant_code`; every query must go through a tenant-checked connection load.
- **Partner 4xx** — park on validation errors, but `429`/`408` must stay retryable.

## Open questions (in the doc)

Lane identity (display title vs stable stage id), who `session.*` is at dispatch time, the verdict source of truth, and whether `max_attempts` is per-binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for invoking configured integration operations over HTTP.
  * Added authentication options including API keys, Basic, Bearer, OAuth2, custom headers, and unauthenticated requests.
  * Added payload templates with variable substitution, schema-based validation, type conversion, and clear validation errors.
  * Added operation result handling with success and retryable status classification.
* **Documentation**
  * Added design documentation for review-channel dispatch, including payload mapping, retries, activation, and phased delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->