### PR TITLE
fix(security): remove OAuth app debug logging

### DIFF
--- a/turbo-repo/apps/web-admin/app/org/[orgId]/settings/oauth/page.tsx
+++ b/turbo-repo/apps/web-admin/app/org/[orgId]/settings/oauth/page.tsx
@@ -112,9 +112,8 @@ export default function OAuthAppsPage() {
     setSuccess("Client ID copied to clipboard!");
   };
 
-  const deleteApp = async (appId: string) => {
+  const deleteApp = async (_appId: string) => {
     // TODO: Implement DELETE /api/org/[orgId]/oauth-apps/[appId] API call
-    console.log("Delete app:", appId);
   };
 
   return (


### PR DESCRIPTION
## Summary

Remove the OAuth application ID from the unfinished delete-action debug log.

## Root cause

The OAuth settings page passed an OAuth app identifier from the application list to `console.log`. CodeQL correctly classified this as clear-text logging of sensitive OAuth data.

## Impact

The placeholder delete button retains its existing no-op behavior, but no longer writes OAuth application data to browser logs.

## Validation

- `git diff --check`
- web-admin type check attempted, but is blocked by pre-existing Bun, Prisma client, and chart formatter errors outside this page
- web-admin lint attempted, but is blocked by an existing Flowbite/Tailwind package-export incompatibility