### PR TITLE
fix(security): use cryptographic randomness

### DIFF
--- a/turbo-repo/apps/web-admin/app/components/PasswordGenerator.tsx
+++ b/turbo-repo/apps/web-admin/app/components/PasswordGenerator.tsx
@@ -8,28 +8,53 @@ interface PasswordGeneratorProps {
   disabled?: boolean;
 }
 
+function getSecureRandomIndex(maxExclusive: number): number {
+  const maxUint32 = 0x1_0000_0000;
+  const limit = maxUint32 - (maxUint32 % maxExclusive);
+  const randomValue = new Uint32Array(1);
+
+  do {
+    crypto.getRandomValues(randomValue);
+  } while (randomValue[0] >= limit);
+
+  return randomValue[0] % maxExclusive;
+}
+
+function shuffleSecurely(characters: string[]): string {
+  for (let index = characters.length - 1; index > 0; index -= 1) {
+    const swapIndex = getSecureRandomIndex(index + 1);
+    [characters[index], characters[swapIndex]] = [
+      characters[swapIndex],
+      characters[index],
+    ];
+  }
+
+  return characters.join("");
+}
+
 function generateSecurePassword(length: number = 32): string {
-  const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
-  let password = "";
-  
+  const charset =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
+  const password: string[] = [];
+
   // Ensure at least one character from each category
   const lowercase = "abcdefghijklmnopqrstuvwxyz";
   const uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const numbers = "0123456789";
   const symbols = "!@#$%^&*";
-  
-  password += lowercase[Math.floor(Math.random() * lowercase.length)];
-  password += uppercase[Math.floor(Math.random() * uppercase.length)];
-  password += numbers[Math.floor(Math.random() * numbers.length)];
-  password += symbols[Math.floor(Math.random() * symbols.length)];
-  
+
+  password.push(lowercase[getSecureRandomIndex(lowercase.length)]);
+  password.push(uppercase[getSecureRandomIndex(uppercase.length)]);
+  password.push(numbers[getSecureRandomIndex(numbers.length)]);
+  password.push(symbols[getSecureRandomIndex(symbols.length)]);
+
   // Fill the rest with random characters
   for (let i = password.length; i < length; i++) {
-    password += charset[Math.floor(Math.random() * charset.length)];
+    password.push(charset[getSecureRandomIndex(charset.length)]);
   }
-  
-  // Shuffle the password to avoid predictable patterns
-  return password.split('').sort(() => Math.random() - 0.5).join('');
+
+  // Shuffle the password to avoid predictable category positions.
+  return shuffleSecurely(password);
 }
 
 export function PasswordGenerator({ onGenerate, disabled = false }: PasswordGeneratorProps) {

--- a/turbo-repo/packages/ui/src/connect-stream-modal.tsx
+++ b/turbo-repo/packages/ui/src/connect-stream-modal.tsx
@@ -39,6 +39,15 @@ const ICON_MAP = {
   Terminal,
 };
 
+function createDevelopmentApiKey(): string {
+  const randomBytes = crypto.getRandomValues(new Uint8Array(16));
+  const suffix = Array.from(randomBytes, (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+
+  return `miot_key_${suffix}`;
+}
+
 export function ConnectStreamModal({ 
   isOpen, 
   onClose, 
@@ -69,12 +78,12 @@ export function ConnectStreamModal({
         setApiKey(data.apiKey);
       } else {
         // Development fallback
-        setApiKey("miot_key_" + Math.random().toString(36).substring(2, 22));
+        setApiKey(createDevelopmentApiKey());
       }
     } catch (error) {
       console.error("Failed to fetch credentials:", error);
       // Fallback for development
-      setApiKey("miot_key_" + Math.random().toString(36).substr(2, 20));
+      setApiKey(createDevelopmentApiKey());
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

Replace `Math.random()` in the CodeQL-flagged password generator and development API-key fallback.

- generate password characters with `crypto.getRandomValues()` and rejection sampling
- use a cryptographically secure Fisher–Yates shuffle to prevent predictable category positions
- create the development fallback key from 128 bits of browser cryptographic randomness

## Root cause

The password generator and a value labeled as an API key relied on `Math.random()`, which is not suitable for credentials or security-sensitive values.

## Validation

- `npm run --workspace=@modulariot/ui lint` — passed
- verified no `Math.random()` remains in either flagged file
- `git diff --check`
- web-admin type checking remains blocked by pre-existing Bun, Prisma client, and chart formatter errors outside these files