### PR TITLE
fix(ci): restrict harness summary token

### DIFF
--- a/.github/workflows/harness.yaml
+++ b/.github/workflows/harness.yaml
@@ -361,6 +361,7 @@ jobs:
   summary:
     name: Build Summary
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - lint-and-test
       - image-evals-pre-publish


### PR DESCRIPTION
## Summary

Explicitly disable `GITHUB_TOKEN` permissions for the Harness CI summary job.

## Root cause

The summary job had no explicit permissions block, so GitHub could grant its token broader default permissions than the job needs. The job only writes to `$GITHUB_STEP_SUMMARY` and makes no authenticated GitHub API calls.

## Impact

The summary job now runs with no token permissions, following least privilege.

## Validation

- Ruby YAML parser accepted `.github/workflows/harness.yaml`
- `git diff --check`
- `actionlint` is not installed locally