### PR TITLE
fix(shipping): prefix basePath on review-binding API calls

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-bindings-data-service.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-bindings-data-service.ts
@@ -14,7 +14,10 @@ import type {
  */
 
 function base(orgSlug: string): string {
-  return `/api/admin/orgs/${encodeURIComponent(orgSlug)}/integrations`;
+  // Served under basePath "/app"; fetch() is not auto-prefixed the way <Link>/router
+  // are, so include it explicitly — as every sibling data service does. Without it the
+  // browser hits the origin root and the load balancer 308-redirects the call.
+  return `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/integrations`;
 }
 
 /** Surfaces the API's own message, and keeps the status for the 403 case. */


### PR DESCRIPTION
## What

The review-bindings data service called `/api/admin/orgs/{slug}/integrations/*` **without the `/app` basePath** the app is served under (`next.config.mjs` → `basePath: "/app"`).

Next.js only auto-prefixes the basePath onto `<Link>`, `router`, `next/image`, and assets — **not raw `fetch()`**. So the browser requested the origin root, which is not a Next route, and the front load balancer issued a **308 Permanent Redirect**. Because 308 is permanent, the browser cached it to disk and replayed it without hitting the server (`Status: 308 … from disk cache`).

Net effect: `dispatch-targets` and `bindings` never reached the proxy, so the review-settings drawer showed **"No hay conexiones activas"** even after a connection/binding was configured.

## Fix

Prefix `/app` in the data service's `base()`, exactly as every sibling data service already does (`whatsapp`, `gps-webhooks`, `settings-admin` → `/app/api/admin/...`). One line + a comment so it doesn't regress.

## Note for reviewers / testers

A cached 308 sticks in the browser. After deploy, do a **hard reload / clear cache** for `coordinador-dev.mintral.cl` to drop the stored redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected shipping integration API requests to use the proper application URL path.
  * Improved reliability for operations that retrieve or update shipping lane binding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->