### PR TITLE
feat(integrations): render an array body for array-typed operation contracts

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dispatch/ChannelDispatcher.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dispatch/ChannelDispatcher.java
@@ -2,7 +2,6 @@ package com.microboxlabs.miot.integrations.dispatch;
 
 import com.microboxlabs.miot.integrations.domain.IntegrationEventBinding;
 import com.microboxlabs.miot.integrations.domain.ProviderType;
-import java.util.Map;
 
 /**
  * Delivers a rendered payload to one kind of channel.
@@ -39,10 +38,11 @@ public interface ChannelDispatcher {
     /**
      * Delivers the payload.
      *
-     * @param payload the rendered body, already coerced to the channel's declared types
+     * @param payload the rendered body, already coerced to the channel's declared types — a
+     *        {@code Map} for an object contract, a {@code List} for an array one
      * @throws com.microboxlabs.miot.integrations.service.OperationInvocationException when the
      *         call could not be completed at all
      */
     DispatchOutcome dispatch(
-            String tenantClientId, IntegrationEventBinding binding, Map<String, Object> payload);
+            String tenantClientId, IntegrationEventBinding binding, Object payload);
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dispatch/HttpOperationDispatcher.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dispatch/HttpOperationDispatcher.java
@@ -6,7 +6,6 @@ import com.microboxlabs.miot.integrations.service.IntegrationOperationInvoker;
 import com.microboxlabs.miot.integrations.service.OperationInvocationResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.util.Map;
 
 /**
  * The default channel: call the binding's operation over HTTP.
@@ -36,7 +35,7 @@ public class HttpOperationDispatcher implements ChannelDispatcher {
 
     @Override
     public DispatchOutcome dispatch(
-            String tenantClientId, IntegrationEventBinding binding, Map<String, Object> payload) {
+            String tenantClientId, IntegrationEventBinding binding, Object payload) {
         OperationInvocationResult result = invoker.invoke(
                 tenantClientId, binding.connectionId(), binding.operationId(), payload);
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/BindingPreviewResponse.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/BindingPreviewResponse.java
@@ -12,12 +12,12 @@ import java.util.Map;
  */
 public record BindingPreviewResponse(
         boolean valid,
-        /** The rendered body when {@code valid}; empty otherwise. */
-        Map<String, Object> payload,
+        /** The rendered body when {@code valid} — an object, or an array for an array contract; empty otherwise. */
+        Object payload,
         /** Every reason the mapping is not sendable; empty when {@code valid}. */
         List<String> problems) {
 
-    public static BindingPreviewResponse ok(Map<String, Object> payload) {
+    public static BindingPreviewResponse ok(Object payload) {
         return new BindingPreviewResponse(true, payload, List.of());
     }
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
@@ -79,7 +79,7 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
                     "Connection " + binding.connectionId() + " no longer exists");
         }
 
-        Map<String, Object> body = render(binding, contractFor(binding), contextOf(payload));
+        Object body = renderBody(binding, contractFor(binding), contextOf(payload));
         ChannelDispatcher dispatcher = dispatchers.dispatcherFor(connection.providerType());
 
         DispatchOutcome outcome = dispatcher.dispatch(tenantClientId, binding, body);
@@ -102,10 +102,10 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
         return operation == null ? PayloadSchema.empty() : PayloadSchema.of(operation.requestSchema());
     }
 
-    private Map<String, Object> render(
+    private Object renderBody(
             IntegrationEventBinding binding, PayloadSchema contract, Map<String, Object> context) {
         try {
-            return renderer.render(binding.fieldTemplates(), contract, context);
+            return renderer.renderBody(binding.fieldTemplates(), contract, context);
         } catch (PayloadRenderException e) {
             // The same binding and the same snapshot will fail identically forever.
             throw new NonRetryableJobException("Payload could not be built: " + e.getMessage());

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -174,7 +174,7 @@ public class IntegrationEventBindingService {
             return BindingPreviewResponse.invalid(problems);
         }
         try {
-            return BindingPreviewResponse.ok(renderer.render(
+            return BindingPreviewResponse.ok(renderer.renderBody(
                     request.fieldTemplates(), contract, context == null ? Map.of() : context));
         } catch (PayloadRenderException e) {
             return BindingPreviewResponse.invalid(e.problems());

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
@@ -85,13 +85,14 @@ public class IntegrationOperationInvoker {
     }
 
     /**
-     * @param body sent as a JSON object on POST/PUT/PATCH; ignored for other methods
+     * @param body sent as a JSON body on POST/PUT/PATCH ({@code Map} → object, {@code List} →
+     *        array); ignored for other methods
      * @throws OperationInvocationException when the operation is unknown to the connection,
      *         the credential is unusable, the URL is not a public HTTP(S) one, or the call
      *         never completed
      */
     public OperationInvocationResult invoke(
-            String tenantCode, String connectionId, String operationId, Map<String, Object> body) {
+            String tenantCode, String connectionId, String operationId, Object body) {
         ResolvedConnection connection = connectionResolver.resolve(tenantCode, connectionId);
         IntegrationOperation operation =
                 operationRepository.findByConnectionAndId(connectionId, operationId);
@@ -116,7 +117,7 @@ public class IntegrationOperationInvoker {
     }
 
     private OperationInvocationResult execute(
-            ResolvedConnection connection, IntegrationOperation operation, Map<String, Object> body) {
+            ResolvedConnection connection, IntegrationOperation operation, Object body) {
         ResolvedAuth auth = resolveAuth(connection);
         URI url = buildUrl(connection.baseUrl(), operation.path(), auth.queryParams());
         // Resolves the host: a stored base URL is operator input and could point at the
@@ -211,7 +212,7 @@ public class IntegrationOperationInvoker {
         return method;
     }
 
-    private String serialize(Map<String, Object> body) {
+    private String serialize(Object body) {
         try {
             return objectMapper.writeValueAsString(body == null ? Map.of() : body);
         } catch (JsonProcessingException e) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
@@ -89,6 +89,60 @@ public class PayloadRenderer {
     }
 
     /**
+     * The body to send: a JSON object for an object contract, a JSON array for an array one.
+     *
+     * <p>An array contract renders its declared fields once per element of the context
+     * collection it names ({@link PayloadSchema#itemsFrom()}, e.g. {@code content}), binding
+     * that name to each element in turn — so {@code {{content.mediaId}}} means "this element's
+     * media id". Shared roots ({@code task}, {@code session}) stay visible to every element.
+     * The object case is unchanged: it delegates to {@link #render}.
+     *
+     * @throws PayloadRenderException listing every element/field that could not be produced
+     */
+    public Object renderBody(
+            Map<String, String> templates, PayloadSchema schema, Map<String, Object> context) {
+        if (!schema.array()) {
+            return render(templates, schema, context);
+        }
+        Map<String, Object> safeContext = context == null ? Map.of() : context;
+        Object collection = safeContext.get(schema.itemsFrom());
+        if (collection == null) {
+            // Nothing to report is a valid empty array, not a fault. In practice the producer
+            // skips emitting at all in this case; rendering stays total regardless.
+            return List.of();
+        }
+        if (!(collection instanceof List<?> elements)) {
+            throw new PayloadRenderException(List.of(
+                    "context '" + schema.itemsFrom() + "' must be an array to render an array body"));
+        }
+
+        PayloadSchema itemSchema = schema.itemSchema();
+        List<Object> rendered = new ArrayList<>(elements.size());
+        List<String> problems = new ArrayList<>();
+        for (int i = 0; i < elements.size(); i++) {
+            if (!(elements.get(i) instanceof Map<?, ?> element)) {
+                problems.add(schema.itemsFrom() + "[" + i + "] is not an object");
+                continue;
+            }
+            Map<String, Object> itemContext = new LinkedHashMap<>(safeContext);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> asMap = (Map<String, Object>) element;
+            itemContext.put(schema.itemsFrom(), asMap);
+            try {
+                rendered.add(render(templates, itemSchema, itemContext));
+            } catch (PayloadRenderException e) {
+                int index = i;
+                e.problems().forEach(problem ->
+                        problems.add(schema.itemsFrom() + "[" + index + "]: " + problem));
+            }
+        }
+        if (!problems.isEmpty()) {
+            throw new PayloadRenderException(problems);
+        }
+        return rendered;
+    }
+
+    /**
      * Checks a mapping before it is stored: templates parse, read known variables, and cover
      * every required field.
      *

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
@@ -22,13 +22,30 @@ import java.util.Set;
  *   "required": ["aprobado"] }
  * }</pre>
  *
- * <p>Anything richer (nested objects, arrays, {@code oneOf}, validation keywords) is ignored
- * rather than rejected — an operator may have pasted a fuller schema, and the parts we do
- * understand are still the parts we act on. A property with no usable {@code type}, including
+ * <p><b>Array bodies.</b> A partner that wants a JSON array — "here are the N media I
+ * reviewed" — declares {@code "type": "array"} with the per-element contract under
+ * {@code items}, and names the context collection to iterate with {@code itemsFrom}
+ * (default {@code content}):
+ *
+ * <pre>{@code
+ * { "type": "array", "itemsFrom": "content",
+ *   "items": { "type": "object",
+ *              "properties": { "guidMultimedia": { "type": "string" } },
+ *              "required": ["guidMultimedia"] } }
+ * }</pre>
+ *
+ * <p>The declared {@link #fields()} are the same either way — the mapping rows an operator
+ * fills in — so the settings UI and save-time validation treat an array contract exactly
+ * like an object one. Only the renderer cares about the difference: it renders those fields
+ * once per element of {@link #itemsFrom()} instead of once total.
+ *
+ * <p>Anything richer (nested objects, {@code oneOf}, validation keywords) is ignored rather
+ * than rejected — an operator may have pasted a fuller schema, and the parts we do understand
+ * are still the parts we act on. A property with no usable {@code type}, including
  * {@code string} with {@code "format": "date-time"}, is treated as {@link FieldType#STRING}
  * and passed through verbatim.
  */
-public record PayloadSchema(List<Field> fields) {
+public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom) {
 
     /** The JSON types a channel field can be sent as. */
     public enum FieldType {
@@ -41,7 +58,15 @@ public record PayloadSchema(List<Field> fields) {
     public record Field(String id, FieldType type, boolean required) {
     }
 
+    /** The context collection an array schema iterates when {@code itemsFrom} is absent. */
+    private static final String DEFAULT_ITEMS_FROM = "content";
+
     private static final PayloadSchema EMPTY = new PayloadSchema(List.of());
+
+    /** An object contract over {@code fields} — the shape every existing caller assumes. */
+    public PayloadSchema(List<Field> fields) {
+        this(fields, false, null);
+    }
 
     /** A schema declaring nothing — every mapped field is then sent as a string. */
     public static PayloadSchema empty() {
@@ -53,18 +78,19 @@ public record PayloadSchema(List<Field> fields) {
         if (requestSchema == null || requestSchema.isEmpty()) {
             return EMPTY;
         }
-        Object rawProperties = requestSchema.get("properties");
-        if (!(rawProperties instanceof Map<?, ?> properties) || properties.isEmpty()) {
-            return EMPTY;
+        if (isArray(requestSchema)) {
+            Object rawItems = requestSchema.get("items");
+            Map<?, ?> items = rawItems instanceof Map<?, ?> map ? map : Map.of();
+            List<Field> fields = fieldsOf(items);
+            return fields.isEmpty() ? EMPTY : new PayloadSchema(fields, true, itemsFrom(requestSchema));
         }
-        Set<String> required = requiredNames(requestSchema.get("required"));
+        List<Field> fields = fieldsOf(requestSchema);
+        return fields.isEmpty() ? EMPTY : new PayloadSchema(fields);
+    }
 
-        List<Field> fields = new ArrayList<>(properties.size());
-        properties.forEach((name, definition) -> {
-            String id = String.valueOf(name);
-            fields.add(new Field(id, typeOf(definition), required.contains(id)));
-        });
-        return new PayloadSchema(List.copyOf(fields));
+    /** The per-element object contract of an array schema, for rendering one element. */
+    public PayloadSchema itemSchema() {
+        return new PayloadSchema(fields);
     }
 
     public Field field(String id) {
@@ -73,6 +99,35 @@ public record PayloadSchema(List<Field> fields) {
 
     public List<Field> requiredFields() {
         return fields.stream().filter(Field::required).toList();
+    }
+
+    /* ---------------------------------------------------------------------- */
+
+    private static boolean isArray(Map<String, Object> requestSchema) {
+        return "array".equalsIgnoreCase(String.valueOf(requestSchema.get("type")));
+    }
+
+    private static String itemsFrom(Map<String, Object> requestSchema) {
+        Object raw = requestSchema.get("itemsFrom");
+        if (raw == null || String.valueOf(raw).isBlank()) {
+            return DEFAULT_ITEMS_FROM;
+        }
+        return String.valueOf(raw).trim();
+    }
+
+    /** Reads {@code properties}/{@code required} of an object schema map into fields. */
+    private static List<Field> fieldsOf(Map<?, ?> schema) {
+        Object rawProperties = schema.get("properties");
+        if (!(rawProperties instanceof Map<?, ?> properties) || properties.isEmpty()) {
+            return List.of();
+        }
+        Set<String> required = requiredNames(schema.get("required"));
+        List<Field> fields = new ArrayList<>(properties.size());
+        properties.forEach((name, definition) -> {
+            String id = String.valueOf(name);
+            fields.add(new Field(id, typeOf(definition), required.contains(id)));
+        });
+        return List.copyOf(fields);
     }
 
     private static Set<String> requiredNames(Object raw) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
@@ -58,10 +58,10 @@ class IntegrationEventDispatchHandlerTest {
         JobOutcome outcome = handler().handle(payload());
 
         assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
-        assertEquals("19f8-a8ad", dispatcher.lastPayload.get("guidMultimedia"));
+        assertEquals("19f8-a8ad", dispatcher.lastPayloadMap().get("guidMultimedia"));
         // The reviewer, snapshotted at intake — a worker thread has no user to ask.
-        assertEquals("revisor.demo", dispatcher.lastPayload.get("usuarioRevisor"));
-        assertEquals(Boolean.FALSE, dispatcher.lastPayload.get("aprobado"));
+        assertEquals("revisor.demo", dispatcher.lastPayloadMap().get("usuarioRevisor"));
+        assertEquals(Boolean.FALSE, dispatcher.lastPayloadMap().get("aprobado"));
     }
 
     @Test
@@ -194,7 +194,7 @@ class IntegrationEventDispatchHandlerTest {
     }
 
     private static final class RecordingDispatcher implements ChannelDispatcher {
-        private Map<String, Object> lastPayload;
+        private Object lastPayload;
         private DispatchOutcome outcome = DispatchOutcome.succeeded("HTTP 200");
 
         @Override
@@ -204,9 +204,14 @@ class IntegrationEventDispatchHandlerTest {
 
         @Override
         public DispatchOutcome dispatch(
-                String tenantClientId, IntegrationEventBinding binding, Map<String, Object> payload) {
+                String tenantClientId, IntegrationEventBinding binding, Object payload) {
             this.lastPayload = payload;
             return outcome;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> lastPayloadMap() {
+            return (Map<String, Object>) lastPayload;
         }
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
@@ -192,8 +192,9 @@ class IntegrationEventBindingServiceTest {
                         "review", Map.of("verdict", false)));
 
         assertTrue(preview.valid(), preview.problems().toString());
-        assertEquals("19f8-a8ad", preview.payload().get("guidMultimedia"));
-        assertEquals(Boolean.FALSE, preview.payload().get("aprobado"));
+        Map<?, ?> payload = (Map<?, ?>) preview.payload();
+        assertEquals("19f8-a8ad", payload.get("guidMultimedia"));
+        assertEquals(Boolean.FALSE, payload.get("aprobado"));
     }
 
     @Test

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadArrayRenderingTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadArrayRenderingTest.java
@@ -1,0 +1,115 @@
+package com.microboxlabs.miot.integrations.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Array bodies: a review that covers several media reports one element per media, each keyed
+ * by its own {@code mediaId} — the shape the Dev-Mentor callback expects.
+ */
+class PayloadArrayRenderingTest {
+
+    private final PayloadRenderer renderer = new PayloadRenderer();
+
+    /** {@code type: array}, three item fields, two required — as stored in request_schema. */
+    private static PayloadSchema arraySchema() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("guidMultimedia", Map.of("type", "string"));
+        properties.put("aprobado", Map.of("type", "boolean"));
+        properties.put("mensaje", Map.of("type", "string"));
+        return PayloadSchema.of(Map.of(
+                "type", "array",
+                "itemsFrom", "content",
+                "items", Map.of(
+                        "type", "object",
+                        "properties", properties,
+                        "required", List.of("guidMultimedia", "aprobado"))));
+    }
+
+    private static final Map<String, String> TEMPLATES = Map.of(
+            "guidMultimedia", "{{content.mediaId}}",
+            "aprobado", "{{content.verdict}}",
+            "mensaje", "{{content.comment}}",
+            "servicio", "{{task.serviceCode}}");
+
+    private static Map<String, Object> contextWith(List<Map<String, Object>> content) {
+        return Map.of("task", Map.of("serviceCode", "1625094"), "content", content);
+    }
+
+    @Test
+    void detectsAnArrayContractAndItsItemFields() {
+        PayloadSchema schema = arraySchema();
+        assertTrue(schema.array());
+        assertEquals("content", schema.itemsFrom());
+        // The declared fields are the item fields — what the drawer maps and validation checks.
+        assertEquals(List.of("guidMultimedia", "aprobado"),
+                schema.requiredFields().stream().map(PayloadSchema.Field::id).toList());
+    }
+
+    @Test
+    void rendersOneObjectPerContentElement() {
+        Object body = renderer.renderBody(TEMPLATES, arraySchema(), contextWith(List.of(
+                mediaItem("19f8-a8ad", true, ""),
+                mediaItem("77bc-1e20", false, "Foto borrosa"))));
+
+        List<?> array = assertInstanceOf(List.class, body);
+        assertEquals(2, array.size());
+
+        Map<?, ?> first = (Map<?, ?>) array.get(0);
+        assertEquals("19f8-a8ad", first.get("guidMultimedia"));
+        assertEquals(Boolean.TRUE, first.get("aprobado"));
+        assertEquals("1625094", first.get("servicio"));   // a shared root stays visible per element
+        assertFalse(first.containsKey("mensaje"), "an empty optional is omitted, not sent blank");
+
+        Map<?, ?> second = (Map<?, ?>) array.get(1);
+        assertEquals(Boolean.FALSE, second.get("aprobado"));
+        assertEquals("Foto borrosa", second.get("mensaje"));
+    }
+
+    @Test
+    void namesTheOffendingElementWhenARequiredItemFieldIsMissing() {
+        Map<String, Object> noMediaId = new LinkedHashMap<>();
+        noMediaId.put("verdict", true);
+        PayloadRenderException e = assertThrows(PayloadRenderException.class, () ->
+                renderer.renderBody(TEMPLATES, arraySchema(), contextWith(List.of(
+                        mediaItem("ok-1", true, ""), noMediaId))));
+        assertTrue(e.problems().stream().anyMatch(p -> p.contains("content[1]")),
+                "expected the failure to point at content[1], got " + e.problems());
+    }
+
+    @Test
+    void rejectsAContextCollectionThatIsNotAnArray() {
+        Map<String, Object> context = Map.of("content", Map.of("mediaId", "x"));
+        assertThrows(PayloadRenderException.class, () ->
+                renderer.renderBody(TEMPLATES, arraySchema(), context));
+    }
+
+    @Test
+    void anObjectContractStillRendersASingleObject() {
+        PayloadSchema object = PayloadSchema.of(Map.of(
+                "type", "object",
+                "properties", Map.of("guidMultimedia", Map.of("type", "string"))));
+        Object body = renderer.renderBody(
+                Map.of("guidMultimedia", "{{content.mediaId}}"),
+                object,
+                Map.of("content", Map.of("mediaId", "single")));
+        Map<?, ?> map = assertInstanceOf(Map.class, body);
+        assertEquals("single", map.get("guidMultimedia"));
+    }
+
+    private static Map<String, Object> mediaItem(String mediaId, boolean verdict, String comment) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("mediaId", mediaId);
+        item.put("verdict", verdict);
+        item.put("comment", comment);
+        return item;
+    }
+}


### PR DESCRIPTION
## What

Lets a partner receive **an array** — "here are the N media I reviewed" — instead of one object. This is the modulith half of the paired change flagged in ecm-coordinator #344: the producer emits `context.content` as an array; this renders one payload element per item.

## How

- **`PayloadSchema`** now understands an array contract:
  ```json
  { "type": "array", "itemsFrom": "content",
    "items": { "type": "object",
               "properties": { "guidMultimedia": {"type":"string"}, "aprobado": {"type":"boolean"}, "mensaje": {"type":"string"} },
               "required": ["guidMultimedia","aprobado"] } }
  ```
  The declared `fields()` are the **item** fields, so the settings drawer and save-time validation treat it exactly like an object contract — only the renderer cares.
- **`PayloadRenderer.renderBody()`** renders those fields **once per element** of the named context collection (`itemsFrom`, default `content`), binding that name to each element (`{{content.mediaId}}` = *this element's* id) while shared roots (`task`, `session`) stay visible to all. Object contracts are untouched — `renderBody` delegates to the existing `render()`.
- The dispatch body **widens `Map<String,Object>` → `Object`** across the one path that carries it (`ChannelDispatcher` → `HttpOperationDispatcher` → `IntegrationOperationInvoker`); Jackson serializes a `List` as a JSON array. `HttpOperationDispatcher` is the sole dispatcher, so the surface is tiny. Object bodies serialize byte-identically.
- Preview renders arrays too (`BindingPreviewResponse.payload` → `Object`).

## Backward compatibility

Every existing (object) contract behaves identically — same code path, same output. New behavior is gated entirely on `type: array` in a request schema.

## Verification

`mvn test` on the affected classes: **60 pass, 0 failures**, including 5 new `PayloadArrayRenderingTest` cases (per-element render, shared-root visibility, empty-optional omission, `content[i]`-indexed problem reporting, non-array-context rejection, object-contract-still-an-object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering and sending JSON array payloads.
  * Array payloads can render each item independently and report validation errors with item indexes.
  * Preview responses now support both object and array payloads.
  * JSON requests can serialize either objects or arrays.

* **Bug Fixes**
  * Improved validation for invalid or non-list array sources while preserving existing object-payload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->