### PR TITLE
fix(task): stop reading a reject-to-earlier-stage as a forward move

### DIFF
--- a/turbo-repo/apps/app/src/app/api/task/end/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.test.ts
@@ -9,6 +9,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const authMock = vi.fn();
 const endTaskMock = vi.fn();
 const updateTaskMock = vi.fn();
+const getChildrenNodesMock = vi.fn();
+const listContentTopicsMock = vi.fn();
 
 vi.mock("@/auth", () => ({
   auth: (...args: unknown[]) => authMock(...args),
@@ -17,6 +19,8 @@ vi.mock("@/auth", () => ({
 vi.mock("@/features/common/providers/alfresco-api/alfresco-api.provider", () => ({
   endTask: (...args: unknown[]) => endTaskMock(...args),
   updateTask: (...args: unknown[]) => updateTaskMock(...args),
+  getChildrenNodes: (...args: unknown[]) => getChildrenNodesMock(...args),
+  listContentTopics: (...args: unknown[]) => listContentTopicsMock(...args),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -98,5 +102,122 @@ describe("POST /api/task/end — P3 processVariables routing", () => {
     );
     // The 4th arg is omitted for the legacy path — provider's default GET.
     expect(endTaskMock.mock.calls[0]).toHaveLength(3);
+  });
+});
+
+/**
+ * The rejected-documents gate exists to stop the workflow advancing over unresolved
+ * reviews. "Preparar Servicio" is an advance out of Presentar Conductor but a rejection
+ * when sent back from Iniciar Viaje, so classifying by label alone blocked the very move
+ * a rejection needs.
+ */
+describe("POST /api/task/end — document-review gating is direction-aware", () => {
+  const BPM_PACKAGE = "workspace://SpacesStore/83c596eb-159a-4037-8596-eb159ab0377a";
+
+  function reviewable(id: string, reviewStatus: string) {
+    return {
+      entry: {
+        id,
+        aspectNames: ["mintral:reviewableAspect"],
+        properties: { "mintral:reviewStatus": reviewStatus },
+      },
+    };
+  }
+
+  function docs(...entries: ReturnType<typeof reviewable>[]) {
+    return { list: { entries } };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({ user: { email: "u@example.com" } });
+    endTaskMock.mockResolvedValue({});
+    updateTaskMock.mockResolvedValue(undefined);
+    // Every rejected document carries an observation, so REJECTED_WITHOUT_OBSERVATIONS
+    // never fires and the direction logic is what these tests actually exercise.
+    listContentTopicsMock.mockResolvedValue({
+      topics: [{ title: "Prueba de integración" }],
+    });
+  });
+
+  async function post(body: Record<string, unknown>) {
+    const { POST } = await loadRoute();
+    return POST(makePostRequest({ taskId: "2983101", bpm_package: BPM_PACKAGE, ...body }));
+  }
+
+  it("allows rejecting back to Preparar Servicio from Iniciar Viaje with rejected documents", async () => {
+    getChildrenNodesMock.mockResolvedValue(
+      docs(reviewable("a", "APPROVED"), reviewable("b", "REJECTED"))
+    );
+
+    const response = await post({
+      transitionId: "Preparar Servicio",
+      reasonId: "wfship2:missionControlTask",
+    });
+
+    expect(response.status).toBe(200);
+    expect(endTaskMock).toHaveBeenCalled();
+  });
+
+  it("still blocks advancing to Preparar Servicio from Presentar Conductor with rejected documents", async () => {
+    getChildrenNodesMock.mockResolvedValue(docs(reviewable("b", "REJECTED")));
+
+    const response = await post({
+      transitionId: "Preparar Servicio",
+      reasonId: "wfship2:presentDriverTask",
+    });
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "REJECTED_DOCUMENTS" },
+    });
+    expect(endTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("still blocks a genuine advance out of Iniciar Viaje with rejected documents", async () => {
+    getChildrenNodesMock.mockResolvedValue(docs(reviewable("b", "REJECTED")));
+
+    const response = await post({
+      transitionId: "Monitorear viaje en curso",
+      reasonId: "wfship2:missionControlTask",
+    });
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "REJECTED_DOCUMENTS" },
+    });
+  });
+
+  it("does not block a return when documents are still pending review", async () => {
+    getChildrenNodesMock.mockResolvedValue(docs(reviewable("a", "PENDING")));
+
+    const response = await post({
+      transitionId: "Preparar Servicio",
+      reasonId: "wfship2:missionControlTask",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("still blocks an advance when documents are pending review", async () => {
+    getChildrenNodesMock.mockResolvedValue(docs(reviewable("a", "PENDING")));
+
+    const response = await post({
+      transitionId: "Monitorear viaje en curso",
+      reasonId: "wfship2:missionControlTask",
+    });
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNREVIEWED_DOCUMENTS" },
+    });
+  });
+
+  it("falls back to the label when the source stage is unknown", async () => {
+    getChildrenNodesMock.mockResolvedValue(docs(reviewable("b", "REJECTED")));
+
+    const response = await post({ transitionId: "Preparar Servicio" });
+
+    expect(response.status).toBe(422);
   });
 });

--- a/turbo-repo/apps/app/src/app/api/task/end/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.ts
@@ -19,9 +19,12 @@ import {
 } from "@/app/api/utils/api-error-handler";
 import type { Session } from "next-auth";
 
-// All transition IDs that advance the workflow forward.
+// All transition IDs that can advance the workflow forward.
 // Backward/previous transitions (secondary options) are not in this set,
 // so they remain allowed even when documents are rejected.
+//
+// A label alone is not enough, though: the same target can be an advance from one
+// stage and a return from another. See RETURN_TRANSITIONS_BY_SOURCE.
 const FORWARD_TRANSITION_IDS = new Set([
   "Presentar Conductor",
   "Preparar Servicio",
@@ -38,12 +41,64 @@ const FORWARD_TRANSITION_IDS = new Set([
   "Asignar Conductor/Transporte",
 ]);
 
+/**
+ * Transitions that send a task *back* to an earlier stage, keyed by the stage they are
+ * issued from.
+ *
+ * The same label means different things depending on where it is issued: "Preparar
+ * Servicio" advances a trip out of "Presentar Conductor", but is a **rejection** when
+ * the control tower sends one back from "Iniciar Viaje". Classifying by label alone
+ * made that rejection read as an advance, so the rejected-documents guard blocked the
+ * one move rejected documents are supposed to permit.
+ *
+ * Mirrors each `End*Task`'s own backward transitions in ecm-coordinator.
+ */
+const RETURN_TRANSITIONS_BY_SOURCE: Record<string, ReadonlySet<string>> = {
+  "wfship2:missionControlTask": new Set([
+    "Preparar Servicio",
+    "Presentar Conductor",
+    "Asignar Conductor/Transporte",
+    "Separar Documentos",
+    "Planificar Servicio",
+  ]),
+  "wfship2:prepareServiceTask": new Set([
+    "Presentar Conductor",
+    "Asignar Conductor/Transporte",
+    "Separar Documentos",
+    "Planificar Servicio",
+  ]),
+  "wfship2:presentDriverTask": new Set([
+    "Asignar Conductor/Transporte",
+    "Separar Documentos",
+    "Planificar Servicio",
+  ]),
+};
+
+/**
+ * Whether this transition advances the workflow *from the stage it was issued in*.
+ *
+ * @param sourceTaskType the form key of the task being completed, sent as `reasonId`
+ *        (e.g. `wfship2:missionControlTask`). Without it a label is ambiguous, so an
+ *        unknown source falls back to the label — the previous behaviour.
+ */
+function isForwardTransition(
+  transitionId: string | undefined,
+  sourceTaskType: string | undefined
+): boolean {
+  if (!transitionId || !FORWARD_TRANSITION_IDS.has(transitionId)) return false;
+  const returns = sourceTaskType
+    ? RETURN_TRANSITIONS_BY_SOURCE[sourceTaskType]
+    : undefined;
+  return !returns?.has(transitionId);
+}
+
 type ReviewViolation = { code: string; message: string };
 
 async function checkDocumentReview(
   session: Session,
   bpmPackage: string,
-  transitionId: string | undefined
+  transitionId: string | undefined,
+  sourceTaskType: string | undefined
 ): Promise<ReviewViolation | null> {
   const packageNodeId = bpmPackage.split("/").pop();
   if (!packageNodeId) return null;
@@ -61,12 +116,16 @@ async function checkDocumentReview(
 
     if (reviewable.length === 0) return null;
 
+    // Both gates below exist to stop the workflow *advancing* over unresolved reviews.
+    // Sending a trip back is how an operator resolves them, so a return is never blocked.
+    const isAdvancing = isForwardTransition(transitionId, sourceTaskType);
+
     const hasPending = reviewable.some((e) => {
       const s = e.entry.properties?.["mintral:reviewStatus"];
       return !s || s === "PENDING";
     });
 
-    if (hasPending) {
+    if (hasPending && isAdvancing) {
       return {
         code: "UNREVIEWED_DOCUMENTS",
         message: "Cannot advance: some documents are still pending review.",
@@ -77,7 +136,7 @@ async function checkDocumentReview(
       (e) => e.entry.properties?.["mintral:reviewStatus"] === "REJECTED"
     );
 
-    if (rejectedEntries.length > 0 && transitionId && FORWARD_TRANSITION_IDS.has(transitionId)) {
+    if (rejectedEntries.length > 0 && isAdvancing) {
       return {
         code: "REJECTED_DOCUMENTS",
         message: "Cannot advance: some documents have been rejected.",
@@ -331,7 +390,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (json.bpm_package) {
-      const violation = await checkDocumentReview(session, json.bpm_package, json.transitionId);
+      const violation = await checkDocumentReview(
+        session,
+        json.bpm_package,
+        json.transitionId,
+        json.reasonId
+      );
       if (violation) {
         return NextResponse.json({ success: false, error: violation }, { status: 422 });
       }


### PR DESCRIPTION
## The bug

Rejecting a trip from **Iniciar Viaje** back to **Preparar Servicio** was refused:

```
POST /app/api/task/end
{"taskId":"2983101","transitionId":"Preparar Servicio","reasonId":"wfship2:missionControlTask", ...}
→ 422 {"code":"REJECTED_DOCUMENTS","message":"Cannot advance: some documents have been rejected."}
```

So the one move that rejected documents are *supposed* to permit was the one blocked. The bento form correctly offered "Confirmar mover a Controlar Servicio"; this route refused it.

## Why

`checkDocumentReview` classified a transition by its **label alone**, and `"Preparar Servicio"` is legitimately in `FORWARD_TRANSITION_IDS` — because it *is* an advance out of *Presentar Conductor*. Issued from `missionControlTask` the same label is a **return**. Same label, opposite direction.

The file's own comment already stated the intended rule — *"Backward/previous transitions … remain allowed even when documents are rejected"* — only the data contradicted it.

## The fix

Direction is now resolved from **the stage the transition is issued in**, using the task form key already sent as `reasonId`:

```ts
const RETURN_TRANSITIONS_BY_SOURCE: Record<string, ReadonlySet<string>> = {
  "wfship2:missionControlTask": new Set(["Preparar Servicio", "Presentar Conductor", ...]),
  "wfship2:prepareServiceTask":  new Set(["Presentar Conductor", ...]),
  "wfship2:presentDriverTask":   new Set(["Asignar Conductor/Transporte", ...]),
};
```

This mirrors each `End*Task`'s own backward transitions in ecm-coordinator (the backend already permits these — `EndMissionControlTask` lists `VAL_PREPARE_SERVICE`, so nothing changes there). An unknown source falls back to the label, i.e. exactly the previous behaviour.

**Also fixed:** the pending-review gate (`UNREVIEWED_DOCUMENTS`) had the identical flaw and would have blocked the same reject on the next attempt, so it is gated the same way. `REJECTED_WITHOUT_OBSERVATIONS` stays **ungated** — it must apply to the rejection itself, and does (the screenshot's rejected docs each carry an observation).

## Verification

`route.test.ts` — **8 pass** (2 existing + 6 new), covering both directions of the ambiguous label:

| case | expected |
|---|---|
| `Preparar Servicio` from `missionControlTask`, rejected docs | **allowed** (was 422) |
| `Preparar Servicio` from `presentDriverTask`, rejected docs | still 422 |
| `Monitorear viaje en curso` from `missionControlTask`, rejected docs | still 422 |
| return with pending docs | allowed |
| advance with pending docs | still 422 `UNREVIEWED_DOCUMENTS` |
| unknown source stage | falls back to label |

`check-types`: no errors in the changed files. (The suite reports 161 pre-existing errors in this fresh worktree — 62 unresolved `@microboxlabs/*` workspace modules whose `dist` isn't built, plus the implicit-any cascade from them. None are in `api/task/end`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)