### PR TITLE
feat(shipping): validate and autocomplete review mapping templates

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
@@ -1,5 +1,5 @@
 import type { IconType } from "react-icons";
-import { HiChatAlt2, HiMail } from "react-icons/hi";
+import { HiClipboardList, HiPhotograph, HiUser } from "react-icons/hi";
 
 /**
  * Review-process integration — the mockup model.
@@ -50,59 +50,50 @@ export interface VariableGroup {
 }
 
 /**
- * The four objects a mapping can pull from. Samples are deliberately generic —
- * this is a public repo, so no real client, tenant or contact data appears.
+ * The objects a mapping can pull from — the context the producer actually sends.
+ *
+ * `content.*` is **one reviewed item**: an array contract renders the mapped fields
+ * once per element, binding `content` to each in turn, so `{{content.mediaId}}` means
+ * "this item's media id". That is why the verdict lives here rather than under a
+ * `review` object — a single task completion can carry several media with different
+ * outcomes.
+ *
+ * `review` remains a legal root server-side (so a hand-written `{{review.x}}` is not
+ * rejected), but nothing populates it today, which is why it is not offered here.
+ *
+ * Samples are deliberately generic — this is a public repo, so no real client, tenant
+ * or contact data appears.
  */
 export const VARIABLE_GROUPS: readonly VariableGroup[] = [
   {
     id: "task",
     labelKey: "variables.groups.task",
-    icon: HiChatAlt2,
+    icon: HiClipboardList,
     variables: [
-      { path: "task.mintral_serviceCode", labelKey: "variables.task.serviceCode", sample: "SRV-1649906" },
-      { path: "task.mintral_priorityCode", labelKey: "variables.task.priority", sample: "UR" },
-      { path: "task.client", labelKey: "variables.task.client", sample: "Cliente Demo" },
-      { path: "task.mintral_clientRut", labelKey: "variables.task.clientRut", sample: "11.111.111-1" },
-      { path: "task.origin", labelKey: "variables.task.origin", sample: "SCL" },
-      { path: "task.destination", labelKey: "variables.task.destination", sample: "ANF" },
-      { path: "task.mintral_driver1Name", labelKey: "variables.task.driver", sample: "Conductor Demo" },
-      { path: "task.mintral_truckLicensePlate", labelKey: "variables.task.truckPlate", sample: "AA-BB-11" },
-      { path: "task.expectedDepartureDate", labelKey: "variables.task.departureDate", sample: "2026-07-16" },
+      { path: "task.serviceCode", labelKey: "variables.task.serviceCode", sample: "1649906" },
+      { path: "task.formKey", labelKey: "variables.task.formKey", sample: "wfship2:missionControlTask" },
+      { path: "task.outcome", labelKey: "variables.task.outcome", sample: "monitorTripInCourse" },
     ],
   },
   {
     id: "content",
     labelKey: "variables.groups.content",
-    icon: HiMail,
+    icon: HiPhotograph,
     variables: [
-      { path: "content.integrationMediaId", labelKey: "variables.content.mediaId", sample: "19f8f3a89a1-a8ad5969-48944a06" },
-      { path: "content.integrationSource", labelKey: "variables.content.source", sample: "app_operaciones" },
-      { path: "content.integrationReasonCode", labelKey: "variables.content.reasonCode", sample: "Service_Ready_To_Depart_Onsite" },
-      { path: "content.integratedAt", labelKey: "variables.content.integratedAt", sample: "2026-07-16T12:00:00Z" },
-      { path: "content.fileName", labelKey: "variables.content.fileName", sample: "onsite_frontal.jpeg" },
-      { path: "content.mimeType", labelKey: "variables.content.mimeType", sample: "image/jpeg" },
-    ],
-  },
-  {
-    id: "review",
-    labelKey: "variables.groups.review",
-    icon: HiChatAlt2,
-    variables: [
-      { path: "review.verdict", labelKey: "variables.review.verdict", sample: "false" },
-      { path: "review.decision", labelKey: "variables.review.decision", sample: "rechazado" },
-      { path: "review.comment", labelKey: "variables.review.comment", sample: "Falta señalética en la carga" },
-      { path: "review.reviewer", labelKey: "variables.review.reviewer", sample: "revisor.demo" },
-      { path: "review.reviewedAt", labelKey: "variables.review.reviewedAt", sample: "2026-07-16T14:30:00Z" },
+      { path: "content.mediaId", labelKey: "variables.content.mediaId", sample: "19f8f3a89a1-a8ad5969" },
+      { path: "content.verdict", labelKey: "variables.content.verdict", sample: "false" },
+      { path: "content.reviewStatus", labelKey: "variables.content.reviewStatus", sample: "REJECTED" },
+      { path: "content.comment", labelKey: "variables.content.comment", sample: "Falta señalética en la carga" },
+      { path: "content.contentType", labelKey: "variables.content.contentType", sample: "PICKUP_FRONT_IMAGE" },
+      { path: "content.reviewedBy", labelKey: "variables.content.reviewedBy", sample: "revisor.demo" },
     ],
   },
   {
     id: "session",
     labelKey: "variables.groups.session",
-    icon: HiMail,
+    icon: HiUser,
     variables: [
-      { path: "session.user", labelKey: "variables.session.user", sample: "usuario.demo" },
-      { path: "session.email", labelKey: "variables.session.email", sample: "usuario.demo@example.com" },
-      { path: "session.fullName", labelKey: "variables.session.fullName", sample: "Usuario Demo" },
+      { path: "session.reviewer", labelKey: "variables.session.reviewer", sample: "revisor.demo" },
     ],
   },
 ];

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Alert, Button, TextInput } from "flowbite-react";
-import { HiInformationCircle, HiPlus, HiArrowRight } from "react-icons/hi";
+import { useMemo } from "react";
+import { Alert } from "flowbite-react";
+import { HiInformationCircle, HiArrowRight, HiExclamationCircle } from "react-icons/hi";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { Section } from "./review-config-tab";
@@ -10,9 +10,9 @@ import {
   buildSampleContext,
   renderTemplate,
   VARIABLE_GROUPS,
-  type TemplateVariable,
-  type VariableGroup,
 } from "./review-integration.types";
+import { checkTemplate } from "./review-template-validation";
+import { ReviewTemplateInput } from "./review-template-input";
 import type { DispatchTarget, DispatchTargetField } from "./review-binding.types";
 
 const SAMPLE_CONTEXT = buildSampleContext();
@@ -52,7 +52,8 @@ export function ReviewMappingTab({
               >
                 <Icon className="h-3 w-3" />
                 {trDynamic(group.labelKey, dict)}
-                <code className="font-mono opacity-70">{`{{${group.id}}}`}</code>
+                {/* `.*` because a bare {{task}} is a whole object, which the server rejects. */}
+                <code className="font-mono opacity-70">{`{{${group.id}.*}}`}</code>
               </span>
             );
           })}
@@ -87,28 +88,20 @@ function MappingField({
   onChange: (value: string) => void;
   dict: I18nRecord;
 }>) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [paletteOpen, setPaletteOpen] = useState(false);
-
-  const missing = field.required && !template.trim();
+  const check = useMemo(() => checkTemplate(template), [template]);
   const preview = useMemo(
     () => renderTemplate(template, SAMPLE_CONTEXT),
     [template]
   );
 
-  function insertToken(path: string) {
-    const token = `{{${path}}}`;
-    const input = inputRef.current;
-    const start = input?.selectionStart ?? template.length;
-    const end = input?.selectionEnd ?? template.length;
-    const next = template.slice(0, start) + token + template.slice(end);
-    onChange(next);
-    setPaletteOpen(false);
-    requestAnimationFrame(() => {
-      input?.focus();
-      const caret = start + token.length;
-      input?.setSelectionRange(caret, caret);
-    });
+  const missing = field.required && !template.trim();
+  const broken = check.status === "invalid";
+
+  let color: "gray" | "success" | "failure" = "gray";
+  if (missing || broken) {
+    color = "failure";
+  } else if (check.status === "valid") {
+    color = "success";
   }
 
   return (
@@ -133,147 +126,45 @@ function MappingField({
         </span>
       </div>
 
-      <div className="relative flex items-start gap-2">
-        <div className="min-w-0 flex-1">
-          <TextInput
-            ref={inputRef}
-            sizing="sm"
-            value={template}
-            onChange={(e) => onChange(e.target.value)}
-            placeholder={tr("mapping.templatePlaceholder", dict)}
-            color={missing ? "failure" : "gray"}
-            className="font-mono [&_input]:text-xs"
-            autoComplete="off"
-          />
-        </div>
-        <Button
-          type="button"
-          color="light"
-          size="xs"
-          onClick={() => setPaletteOpen((open) => !open)}
-          aria-expanded={paletteOpen}
-        >
-          <HiPlus className="mr-1 h-3 w-3" />
-          {tr("mapping.insertVariable", dict)}
-        </Button>
-        {paletteOpen && (
-          <VariablePalette
-            onInsert={insertToken}
-            onClose={() => setPaletteOpen(false)}
-            dict={dict}
-          />
-        )}
-      </div>
+      <ReviewTemplateInput
+        value={template}
+        onChange={onChange}
+        placeholder={tr("mapping.templatePlaceholder", dict)}
+        color={color}
+      />
 
-      {/* Live preview against sample data. */}
-      <div className="mt-1.5 flex items-center gap-1.5 text-xs">
-        <HiArrowRight className="h-3 w-3 shrink-0 text-gray-400" />
-        {template.trim() ? (
-          <code className="min-w-0 truncate font-mono text-gray-600 dark:text-gray-300">
-            {preview || tr("mapping.previewEmpty", dict)}
-          </code>
-        ) : (
-          <span className="text-gray-400">
-            {missing
-              ? tr("mapping.previewRequired", dict)
-              : tr("mapping.previewUnset", dict)}
+      {/* Why the server would refuse this template, in its own terms. */}
+      {check.problem && (
+        <p className="mt-1.5 flex items-start gap-1.5 text-[11px] text-red-600 dark:text-red-400">
+          <HiExclamationCircle className="mt-px h-3 w-3 shrink-0" />
+          <span>
+            {trDynamic(
+              `mapping.errors.${check.problem.code}`,
+              dict,
+              check.problem.params
+            )}
           </span>
-        )}
-      </div>
+        </p>
+      )}
+
+      {/* Live preview against sample data — withheld while the template is broken,
+          since rendering a template that cannot be stored only misleads. */}
+      {!broken && (
+        <div className="mt-1.5 flex items-center gap-1.5 text-xs">
+          <HiArrowRight className="h-3 w-3 shrink-0 text-gray-400" />
+          {template.trim() ? (
+            <code className="min-w-0 truncate font-mono text-gray-600 dark:text-gray-300">
+              {preview || tr("mapping.previewEmpty", dict)}
+            </code>
+          ) : (
+            <span className="text-gray-400">
+              {missing
+                ? tr("mapping.previewRequired", dict)
+                : tr("mapping.previewUnset", dict)}
+            </span>
+          )}
+        </div>
+      )}
     </div>
-  );
-}
-
-function VariablePalette({
-  onInsert,
-  onClose,
-  dict,
-}: Readonly<{
-  onInsert: (path: string) => void;
-  onClose: () => void;
-  dict: I18nRecord;
-}>) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function onPointerDown(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
-    }
-    document.addEventListener("mousedown", onPointerDown);
-    return () => document.removeEventListener("mousedown", onPointerDown);
-  }, [onClose]);
-
-  return (
-    <div
-      ref={ref}
-      className="absolute right-0 top-9 z-50 max-h-72 w-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-1 shadow-xl dark:border-gray-600 dark:bg-gray-800"
-    >
-      {VARIABLE_GROUPS.map((group) => (
-        <VariableGroupSection
-          key={group.id}
-          group={group}
-          onInsert={onInsert}
-          dict={dict}
-        />
-      ))}
-    </div>
-  );
-}
-
-function VariableGroupSection({
-  group,
-  onInsert,
-  dict,
-}: Readonly<{
-  group: VariableGroup;
-  onInsert: (path: string) => void;
-  dict: I18nRecord;
-}>) {
-  const Icon = group.icon;
-  return (
-    <div className="mb-1">
-      <div className="flex items-center gap-1.5 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
-        <Icon className="h-3 w-3" />
-        {trDynamic(group.labelKey, dict)}
-      </div>
-      {group.variables.map((variable) => (
-        <VariableRow
-          key={variable.path}
-          variable={variable}
-          onInsert={onInsert}
-          dict={dict}
-        />
-      ))}
-    </div>
-  );
-}
-
-function VariableRow({
-  variable,
-  onInsert,
-  dict,
-}: Readonly<{
-  variable: TemplateVariable;
-  onInsert: (path: string) => void;
-  dict: I18nRecord;
-}>) {
-  return (
-    <button
-      type="button"
-      onClick={() => onInsert(variable.path)}
-      className="flex w-full flex-col items-start gap-0.5 rounded px-2 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
-    >
-      <span className="flex w-full items-center justify-between gap-2">
-        <span className="truncate text-xs text-gray-700 dark:text-gray-200">
-          {trDynamic(variable.labelKey, dict)}
-        </span>
-        <code className="shrink-0 font-mono text-[10px] text-primary-600 dark:text-primary-300">
-          {`{{${variable.path}}}`}
-        </code>
-      </span>
-      <span className="truncate text-[10px] text-gray-400">
-        {variable.sample}
-      </span>
-    </button>
   );
 }

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-input.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-input.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { TextInput } from "flowbite-react";
+import {
+  useHbAutocomplete,
+  type HbDropdownItem,
+  type HbNamespace,
+} from "@/features/dashboard/dashlets/common/use-hb-autocomplete";
+import { DropdownList } from "@/features/dashboard/dashlets/common/dropdown-list";
+import { VARIABLE_GROUPS } from "./review-integration.types";
+
+/**
+ * The mapping template field: a text input that autocompletes the context objects.
+ *
+ * Typing `{{` lists the objects (task, content, session); picking one drills into its
+ * fields; typing `{{content.me` filters directly. The autocomplete machinery is the
+ * dashboard's — the same behaviour operators already know from dashlet settings —
+ * rather than a second implementation that would drift from it.
+ *
+ * Validation is deliberately *not* the dashboard's `getHandlebarsStatus`: that compiles
+ * with the real Handlebars engine and would accept `{{#if}}`, which this field's server
+ * rejects. The caller passes `color` from `checkTemplate`, which mirrors the server.
+ */
+
+/** Each context object and the fields it offers, from the single variable catalog. */
+const NAMESPACES: HbNamespace[] = VARIABLE_GROUPS.map((group) => ({
+  prefix: group.id,
+  suggestions: group.variables.map((variable) =>
+    variable.path.slice(group.id.length + 1)
+  ),
+}));
+
+interface ReviewTemplateInputProps {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly placeholder?: string;
+  readonly color?: "gray" | "success" | "failure";
+}
+
+export function ReviewTemplateInput({
+  value,
+  onChange,
+  placeholder,
+  color = "gray",
+}: Readonly<ReviewTemplateInputProps>) {
+  const ac = useHbAutocomplete({ value, onChange, namespaces: NAMESPACES });
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+
+  // The drawer scrolls and clips; a portal keeps the list out of its overflow.
+  useEffect(() => {
+    if (!ac.isOpen || !ac.inputRef.current) return;
+    const rect = ac.inputRef.current.getBoundingClientRect();
+    setPosition({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  }, [ac.isOpen, ac.filtered, ac.inputRef]);
+
+  return (
+    <div ref={ac.containerRef} className="relative">
+      <TextInput
+        ref={ac.inputRef as React.RefObject<HTMLInputElement>}
+        value={value}
+        onChange={ac.handleChange}
+        onClick={ac.handleClick}
+        onKeyDown={ac.handleKeyDownCombined}
+        placeholder={placeholder}
+        sizing="sm"
+        color={color}
+        className="font-mono [&_input]:text-xs"
+        autoComplete="off"
+      />
+      {ac.isOpen &&
+        createPortal(
+          <div
+            style={{
+              position: "fixed",
+              top: position.top,
+              left: position.left,
+              minWidth: position.width,
+              zIndex: 9999,
+            }}
+          >
+            <DropdownList
+              items={ac.filtered}
+              selectedIndex={ac.selectedIndex}
+              onSelect={ac.handleSelect}
+              onHover={ac.setSelectedIndex}
+              dropdownRef={ac.dropdownRef}
+              getKey={(item: HbDropdownItem) =>
+                item.kind === "namespace"
+                  ? `ns:${item.prefix}`
+                  : `${item.prefix}.${item.key}`
+              }
+              renderItem={(item: HbDropdownItem) =>
+                item.kind === "namespace" ? (
+                  <span className="font-mono text-xs">
+                    {"{{"}
+                    <span className="font-semibold">{item.prefix}</span>
+                    {".*}}"}
+                    <span className="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                      {item.count}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="font-mono text-xs">
+                    {`{{${item.prefix}.`}
+                    <span className="font-semibold">{item.key}</span>
+                    {"}}"}
+                  </span>
+                )
+              }
+            />
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { checkTemplate } from "./review-template-validation";
+
+/**
+ * Each case mirrors a rule in the server's PayloadTemplate. If one of these starts
+ * failing because the server relaxed, relax both together — the point of this
+ * validator is that the drawer never shows green for a template that cannot be saved.
+ */
+describe("checkTemplate", () => {
+  it("treats literal text with no variables as neutral", () => {
+    expect(checkTemplate("just text").status).toBe("none");
+    expect(checkTemplate("").status).toBe("none");
+  });
+
+  it("accepts a plain dotted path and reports what it reads", () => {
+    const check = checkTemplate("{{content.mediaId}}");
+    expect(check.status).toBe("valid");
+    expect(check.paths).toEqual(["content.mediaId"]);
+  });
+
+  it("tolerates padding inside the braces, as the server does", () => {
+    expect(checkTemplate("{{  content.mediaId  }}").status).toBe("valid");
+  });
+
+  it("accepts literals interleaved with several variables", () => {
+    const check = checkTemplate("svc {{task.serviceCode}} / {{content.verdict}}");
+    expect(check.status).toBe("valid");
+    expect(check.paths).toEqual(["task.serviceCode", "content.verdict"]);
+  });
+
+  it("rejects blocks, partials and comments", () => {
+    // The dashboard's Handlebars-backed validator calls this valid; the server does not.
+    expect(checkTemplate("{{#if content.verdict}}x{{/if}}").problem?.code).toBe("notPlain");
+    expect(checkTemplate("{{> partial}}").problem?.code).toBe("notPlain");
+    expect(checkTemplate("{{! comment}}").problem?.code).toBe("notPlain");
+  });
+
+  it("rejects a helper call", () => {
+    expect(checkTemplate("{{formatDate content.mediaId}}").problem?.code).toBe("helperCall");
+  });
+
+  it("rejects the unescaped triple-stash", () => {
+    expect(checkTemplate("{{{content.mediaId}}}").problem?.code).toBe("unescaped");
+  });
+
+  it("rejects an unclosed or empty stash", () => {
+    expect(checkTemplate("{{content.mediaId").problem?.code).toBe("unclosed");
+    expect(checkTemplate("{{}}").problem?.code).toBe("empty");
+  });
+
+  it("rejects an unknown root and names the allowed ones", () => {
+    const check = checkTemplate("{{nope.field}}");
+    expect(check.problem?.code).toBe("unknownRoot");
+    expect(check.problem?.params?.root).toBe("nope");
+    expect(check.problem?.params?.roots).toContain("content");
+  });
+
+  it("rejects a bare root — a whole object would stringify into the payload", () => {
+    const check = checkTemplate("{{task}}");
+    expect(check.problem?.code).toBe("wholeObject");
+    expect(check.problem?.params?.path).toBe("task");
+  });
+
+  it("rejects malformed paths and unsupported characters", () => {
+    expect(checkTemplate("{{content..mediaId}}").problem?.code).toBe("badPath");
+    expect(checkTemplate("{{.mediaId}}").problem?.code).toBe("badPath");
+    expect(checkTemplate("{{content.}}").problem?.code).toBe("badPath");
+    const dashed = checkTemplate("{{content.media-id}}");
+    expect(dashed.problem?.code).toBe("badChar");
+    expect(dashed.problem?.params?.char).toBe("-");
+  });
+
+  it("still allows review.* — the server accepts the root even though nothing fills it", () => {
+    expect(checkTemplate("{{review.verdict}}").status).toBe("valid");
+  });
+});

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
@@ -1,0 +1,123 @@
+/**
+ * Validates a mapping template against the exact subset the server accepts.
+ *
+ * This deliberately does **not** use the Handlebars engine the dashboard inputs use.
+ * `Handlebars.compile("{{#if x}}")` succeeds, so a generic validator would paint a
+ * template green that `PayloadTemplate.validate` then refuses to store — the same
+ * preview-stronger-than-the-server divergence the renderer already avoids. The rules
+ * below mirror `PayloadTemplate.parse`/`validate` one for one; if that relaxes (real
+ * helpers, say), relax this in the same change.
+ */
+
+/** The context objects a template may read — mirrors `PayloadTemplate.DEFAULT_ROOTS`. */
+export const ALLOWED_ROOTS: readonly string[] = ["task", "content", "review", "session"];
+
+/** Stashes that open a block, partial, comment or delimiter change. */
+const NON_VARIABLE_PREFIXES = "#/^>!&=";
+
+export type TemplateStatus = "valid" | "invalid" | "none";
+
+/** A problem, as a code plus its substitutions, so the UI can translate it. */
+export interface TemplateProblem {
+  readonly code:
+    | "unescaped"
+    | "unclosed"
+    | "empty"
+    | "notPlain"
+    | "helperCall"
+    | "badPath"
+    | "badChar"
+    | "unknownRoot"
+    | "wholeObject";
+  readonly params?: Readonly<Record<string, string>>;
+}
+
+export interface TemplateCheck {
+  readonly status: TemplateStatus;
+  /** The first problem found; absent when the template is usable. */
+  readonly problem?: TemplateProblem;
+  /** Every variable path the template reads, in order. */
+  readonly paths: readonly string[];
+}
+
+const OK = (paths: string[]): TemplateCheck => ({
+  status: paths.length > 0 ? "valid" : "none",
+  paths,
+});
+
+const FAIL = (
+  code: TemplateProblem["code"],
+  params?: Record<string, string>
+): TemplateCheck => ({ status: "invalid", problem: { code, params }, paths: [] });
+
+/**
+ * @param allowedRoots the context objects in scope; defaults to {@link ALLOWED_ROOTS}
+ * @returns `none` for a template with no variables (plain literal text is legal), and
+ *          the first reason the server would reject it otherwise
+ */
+export function checkTemplate(
+  template: string,
+  allowedRoots: readonly string[] = ALLOWED_ROOTS
+): TemplateCheck {
+  if (!template) return OK([]);
+
+  const paths: string[] = [];
+  let cursor = 0;
+
+  while (cursor < template.length) {
+    const open = template.indexOf("{{", cursor);
+    if (open < 0) break;
+
+    // `{{{raw}}}` skips escaping in Handlebars. The server never escapes, so accepting
+    // it here would quietly mean something other than what was previewed.
+    if (template.startsWith("{{{", open)) return FAIL("unescaped");
+
+    const close = template.indexOf("}}", open + 2);
+    if (close < 0) return FAIL("unclosed");
+
+    const problem = checkStash(template.slice(open + 2, close), allowedRoots, paths);
+    if (problem) return problem;
+
+    cursor = close + 2;
+  }
+
+  return OK(paths);
+}
+
+/** Validates one `{{…}}` stash, pushing its path when usable. */
+function checkStash(
+  raw: string,
+  allowedRoots: readonly string[],
+  paths: string[]
+): TemplateCheck | null {
+  const inner = raw.trim();
+  if (!inner) return FAIL("empty");
+
+  if (NON_VARIABLE_PREFIXES.includes(inner[0])) {
+    return FAIL("notPlain", { expression: inner });
+  }
+  // Whitespace survives the trim only between tokens — i.e. a helper call.
+  if (/\s/.test(inner)) return FAIL("helperCall", { expression: inner });
+
+  if (inner.startsWith(".") || inner.endsWith(".") || inner.includes("..")) {
+    return FAIL("badPath", { expression: inner });
+  }
+  const badChar = /[^A-Za-z0-9_.]/.exec(inner);
+  if (badChar) return FAIL("badChar", { expression: inner, char: badChar[0] });
+
+  const dot = inner.indexOf(".");
+  const root = dot < 0 ? inner : inner.slice(0, dot);
+  if (!allowedRoots.includes(root)) {
+    return FAIL("unknownRoot", {
+      path: inner,
+      root,
+      roots: [...allowedRoots].sort((a, b) => a.localeCompare(b)).join(", "),
+    });
+  }
+  // `{{task}}` would stringify a whole object into the payload — almost always a
+  // half-typed path rather than an intent.
+  if (dot < 0) return FAIL("wholeObject", { path: inner });
+
+  paths.push(inner);
+  return null;
+}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -37,7 +37,7 @@
       },
       "mapping": {
         "title": "Data mapping",
-        "help": "Use Handlebars templates to build each channel field from the available objects.",
+        "help": "Map each channel field to a variable. Type {{ to autocomplete.",
         "noChannel": "Select a channel in the Review tab to configure the mapping.",
         "required": "Required",
         "optional": "Optional",
@@ -50,6 +50,17 @@
           "string": "text",
           "boolean": "boolean",
           "datetime": "date/time"
+        },
+        "errors": {
+          "unescaped": "Unescaped '{{{ }}}' is not supported — use '{{ }}'.",
+          "unclosed": "Unclosed '{{' — every variable must end with '}}'.",
+          "empty": "Empty '{{}}' is not a variable.",
+          "notPlain": "'{expression}' is not supported. This field takes plain variables such as task.serviceCode — not blocks, partials or comments.",
+          "helperCall": "'{expression}' looks like a helper call. Only plain variables such as content.verdict are supported.",
+          "badPath": "'{expression}' is not a valid variable path.",
+          "badChar": "'{expression}' contains an unsupported character: '{char}'.",
+          "unknownRoot": "'{path}' is unknown: '{root}' is not one of {roots}.",
+          "wholeObject": "'{path}' is a whole object — use one of its fields (e.g. .mediaId)."
         }
       },
       "job": {
@@ -84,7 +95,9 @@
           "destination": "Destination",
           "driver": "Driver",
           "truckPlate": "Truck plate",
-          "departureDate": "Departure date"
+          "departureDate": "Departure date",
+          "formKey": "Task form key",
+          "outcome": "Task outcome"
         },
         "content": {
           "mediaId": "Media ID",
@@ -92,7 +105,12 @@
           "reasonCode": "Reason code",
           "integratedAt": "Integrated at",
           "fileName": "File name",
-          "mimeType": "MIME type"
+          "mimeType": "MIME type",
+          "verdict": "Verdict (boolean)",
+          "reviewStatus": "Review status",
+          "comment": "Review comment",
+          "contentType": "Content type",
+          "reviewedBy": "Reviewed by"
         },
         "review": {
           "verdict": "Verdict (boolean)",
@@ -104,7 +122,8 @@
         "session": {
           "user": "Session user",
           "email": "User email",
-          "fullName": "Full name"
+          "fullName": "Full name",
+          "reviewer": "Reviewer"
         }
       }
     },

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -37,7 +37,7 @@
       },
       "mapping": {
         "title": "Mapeo de datos",
-        "help": "Usa plantillas Handlebars para construir cada campo del canal a partir de los objetos disponibles.",
+        "help": "Asocia cada campo del canal a una variable. Escribe {{ para autocompletar.",
         "noChannel": "Selecciona un canal en la pestaña Revisión para configurar el mapeo.",
         "required": "Requerido",
         "optional": "Opcional",
@@ -50,6 +50,17 @@
           "string": "texto",
           "boolean": "booleano",
           "datetime": "fecha/hora"
+        },
+        "errors": {
+          "unescaped": "No se admite '{{{ }}}'. Usa '{{ }}'.",
+          "unclosed": "Falta cerrar la variable con '}}'.",
+          "empty": "'{{}}' está vacío: indica una variable.",
+          "notPlain": "'{expression}' no está permitido. Este campo acepta solo variables simples como task.serviceCode, no bloques, parciales ni comentarios.",
+          "helperCall": "'{expression}' parece una llamada a un helper. Solo se admiten variables simples como content.verdict.",
+          "badPath": "'{expression}' no es una ruta de variable válida.",
+          "badChar": "'{expression}' contiene un carácter no admitido: '{char}'.",
+          "unknownRoot": "'{path}' no existe: '{root}' no es uno de {roots}.",
+          "wholeObject": "'{path}' es un objeto completo: usa uno de sus campos (por ejemplo, .mediaId)."
         }
       },
       "job": {
@@ -84,7 +95,9 @@
           "destination": "Destino",
           "driver": "Conductor",
           "truckPlate": "Patente camión",
-          "departureDate": "Fecha de salida"
+          "departureDate": "Fecha de salida",
+          "formKey": "Clave de tarea (formKey)",
+          "outcome": "Resultado de la tarea"
         },
         "content": {
           "mediaId": "ID multimedia",
@@ -92,7 +105,12 @@
           "reasonCode": "Código de motivo",
           "integratedAt": "Fecha de integración",
           "fileName": "Nombre de archivo",
-          "mimeType": "Tipo de archivo"
+          "mimeType": "Tipo de archivo",
+          "verdict": "Veredicto (booleano)",
+          "reviewStatus": "Estado de revisión",
+          "comment": "Comentario de revisión",
+          "contentType": "Tipo de contenido",
+          "reviewedBy": "Revisado por"
         },
         "review": {
           "verdict": "Veredicto (booleano)",
@@ -104,7 +122,8 @@
         "session": {
           "user": "Usuario de sesión",
           "email": "Correo del usuario",
-          "fullName": "Nombre completo"
+          "fullName": "Nombre completo",
+          "reviewer": "Revisor"
         }
       }
     },


### PR DESCRIPTION
## What

The mapping field accepted anything and only flagged *"required but empty"* — so a template the server refuses to store looked fine right up until save. This adds **syntax validation** and **autocomplete over the context objects**.

## Validation that matches the server

`checkTemplate()` mirrors `PayloadTemplate` one-for-one: plain `{{dotted.path}}` only — no blocks, helpers, partials, comments or `{{{raw}}}`; known roots; no bare root (`{{task}}` stringifies a whole object). The input turns green/red live and shows the reason in the operator's language.

**It deliberately does not reuse the dashboard's `getHandlebarsStatus`.** That calls `Handlebars.compile`, which *succeeds* on `{{#if x}}` — so it would paint green a template the server rejects. That preview-stronger-than-the-server divergence is exactly what this feature exists to prevent (same reason the preview renderer isn't Handlebars either).

## Autocomplete

Reuses the dashboard's `useHbAutocomplete` + `DropdownList`, so it behaves like dashlet settings rather than being a second implementation:

- `{{` → lists the objects (task, content, session) with field counts
- pick one → drills into its fields
- `{{content.me` → filters directly

## Variable catalog now matches reality

The catalog held **mockup-era** fields (`content.integrationMediaId`, `review.verdict`, `session.user`). The ECM producer actually emits `task.serviceCode/formKey/outcome`, `content.mediaId/verdict/reviewStatus/comment/contentType/reviewedBy`, `session.reviewer` — so autocomplete would have suggested paths that resolve to nothing. Now aligned.

`content.*` is **one reviewed item** (an array contract renders once per element), which is why the verdict lives there and not under `review`. `review` stays a legal root server-side, so a hand-written `{{review.x}}` is not flagged — it's just not suggested.

## Removed the per-field "insert variable" palette

The autocomplete covers the same job. Keeping both meant two dropdowns competing for the caret and ref plumbing for no gain. The header chips still list the objects (now shown as `{{task.*}}`, since a bare `{{task}}` is invalid). Happy to restore it if you'd rather keep click-to-browse.

## Verification

- **33 tests pass** (`vitest run src/features/shipping/components/lane/`), incl. a new suite pinning every server rule.
- `check-types`: 161 **pre-existing** failures in this worktree from unbuilt `@microboxlabs/miot-*` workspace packages — **none in these files**.
- i18n added to `es`/`en` (9 error messages + new variable labels).

## ⚠️ Separate bug this surfaced

The "only on rejection" trigger stores `matchCondition = {"review.verdict": false}`, but the producer emits **no `review` root** (the verdict is per-item at `content[].verdict`). So `on_reject` bindings would never match. Fixing it needs a semantic decision — with several media per task, does "rejected" mean *any* item rejected? — so I left it alone rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)