### PR TITLE
ci(quarkus): don't let a SonarCloud failure block the modulith image publish

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -91,9 +91,15 @@ jobs:
         working-directory: quarkus-srv
 
       - name: SonarCloud Scan
+        # Analysis only — it must never gate the Docker Image publish. On 2026-07-24 the
+        # 'sonar' goal prefix stopped resolving ("No plugin found for prefix 'sonar'") and
+        # failed this job, which skipped `docker-jvm` and stranded every modulith deploy.
+        # continue-on-error keeps a Sonar hiccup from blocking releases; the fully-qualified
+        # goal removes the reliance on prefix resolution that broke.
+        continue-on-error: true
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: >
-          ./mvnw sonar:sonar
+          ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.projectKey=microboxlabs_modulariot-quarkus
           -Dsonar.organization=microboxlabs
           -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## Why the M2M fix (#999) is merged but not deployed

The modulith image (`ghcr.io/microboxlabs/miot-srv`) is published by the **Docker Image** job in `quarkus.yml`, which is `needs: build-jvm`. `build-jvm` runs `./mvnw clean verify` (passes — including the new Testcontainers boot test) and then the **SonarCloud Scan** step: `./mvnw sonar:sonar`.

On 2026-07-24 the `sonar` goal prefix stopped resolving:
```
[ERROR] No plugin found for prefix 'sonar' in the current project -> NoPluginFoundForPrefixException
[INFO] BUILD FAILURE
```
That failed `build-jvm` → **skipped `docker-jvm`** → no new `miot-srv` image → the nightly deploys stale `miot-srv:latest`. Net effect: **#999 (the `/events` M2M auth fix) is merged and green on tests, but the running modulith never got an image with it** (confirmed against the live pod: its `@M2MAuth` startup list lacks `OrgIntegrationEventsResource`).

This has been failing since ~15:22 on commits *before* #999 (`4e6f0fc`, `d1fff75`), and `git log` shows no workflow/pom change caused it — the prefix was resolving via something external that broke.

## Fix

Two changes to the **SonarCloud Scan** step:
- **`continue-on-error: true`** — code analysis must never gate a release. A Sonar/plugin hiccup should not strand modulith deploys.
- **Fully-qualified goal** `org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` — removes the reliance on `sonar` prefix resolution that broke, so analysis keeps working too.

Nothing else in the pipeline changes; `docker-jvm` still `needs: build-jvm`, which now succeeds.

## Recovery path

`.github/workflows/quarkus.yml` is in the workflow's own `push` paths, so **merging this re-triggers Quarkus CI on trunk**. Trunk already contains #999, so `docker-jvm` rebuilds `miot-srv` from current trunk (with the M2M fix) and publishes `:latest`. A nightly / dev deploy then picks it up. Confirm the new image has it:
```
kubectl logs deploy/dev-mintral-miot-modulith -n default | grep "Discovered @M2MAuth.*events"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarCloud analysis execution in the build workflow.
  * Build jobs now continue even when SonarCloud reports issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->