### PR TITLE
feat(integrations): record the full outbound request on every dispatch attempt

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobHttpTrace.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobHttpTrace.java
@@ -25,12 +25,17 @@ import java.util.Map;
  * which is what makes it safe to call unconditionally from a shared HTTP client
  * that also serves non-job traffic.
  *
- * <p><b>What is deliberately not recorded: headers.</b> That is where the
- * bearer tokens live, and this data is rendered in a browser console and kept
- * as long as the job row. Bodies are capped at {@link #MAX_BODY_CHARS} and the
- * list at {@link #MAX_EXCHANGES} so one chatty job cannot bloat the row; both
- * caps announce themselves in the recorded data rather than truncating
- * silently.
+ * <p><b>Request headers are recorded only as the caller hands them over.</b>
+ * Header values are where bearer tokens and API keys live, and this data is
+ * rendered in a browser console and kept as long as the job row — so the trace
+ * stores what it is given verbatim and never guesses which headers are secret.
+ * Only the caller knows a header's provenance (an operator-named API-key header
+ * can be called anything), so the caller masks every credential-bearing value
+ * before passing the map here; see {@code IntegrationOperationInvoker}. The older
+ * {@code record(...)} overload without a header map keeps recording none. Bodies
+ * are capped at {@link #MAX_BODY_CHARS} and the list at {@link #MAX_EXCHANGES} so
+ * one chatty job cannot bloat the row; both caps announce themselves in the
+ * recorded data rather than truncating silently.
  */
 public final class JobHttpTrace {
 
@@ -70,12 +75,25 @@ public final class JobHttpTrace {
      */
     public static void record(String method, String url, Integer status, long durationMs,
                               String requestBody, String responseBody, String error) {
+        record(method, url, status, durationMs, requestBody, responseBody, error, null);
+    }
+
+    /**
+     * As {@link #record(String, String, Integer, long, String, String, String)},
+     * additionally capturing the request headers. Pass them <b>already redacted</b>
+     * — the trace stores header values verbatim (see the class note). A null or
+     * empty map records no {@code requestHeaders} field, exactly like the shorter
+     * overload.
+     */
+    public static void record(String method, String url, Integer status, long durationMs,
+                              String requestBody, String responseBody, String error,
+                              Map<String, String> requestHeaders) {
         Recording recording = ACTIVE.get();
         if (recording == null) {
             return;
         }
         try {
-            recording.add(method, url, status, durationMs, requestBody, responseBody, error);
+            recording.add(method, url, status, durationMs, requestBody, responseBody, error, requestHeaders);
         } catch (RuntimeException e) {
             // Deliberately swallowed: a broken trace is never worth failing a
             // delivery over. The exchange is simply missing from the timeline.
@@ -133,7 +151,8 @@ public final class JobHttpTrace {
         private int dropped;
 
         void add(String method, String url, Integer status, long durationMs,
-                 String requestBody, String responseBody, String error) {
+                 String requestBody, String responseBody, String error,
+                 Map<String, String> requestHeaders) {
             if (exchanges.size() >= MAX_EXCHANGES) {
                 dropped++;
                 return;
@@ -142,6 +161,9 @@ public final class JobHttpTrace {
             entry.put("at", OffsetDateTime.now(ZoneOffset.UTC).toString());
             entry.put("method", method);
             entry.put("url", url);
+            if (requestHeaders != null && !requestHeaders.isEmpty()) {
+                entry.put("requestHeaders", new LinkedHashMap<>(requestHeaders));
+            }
             if (status != null) {
                 entry.put("status", status);
             }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvoker.java
@@ -19,6 +19,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -50,6 +51,9 @@ public class IntegrationOperationInvoker {
 
     /** Methods that carry a request body; anything else is sent without one. */
     private static final Set<String> BODY_METHODS = Set.of("POST", "PUT", "PATCH");
+
+    /** What a credential-bearing value becomes in the recorded request. */
+    private static final String REDACTED = "<redacted>";
 
     private final IntegrationConnectionResolver connectionResolver;
     private final IntegrationOperationRepository operationRepository;
@@ -116,41 +120,58 @@ public class IntegrationOperationInvoker {
         return execute(connection, operation, body);
     }
 
-    private OperationInvocationResult execute(
+    OperationInvocationResult execute(
             ResolvedConnection connection, IntegrationOperation operation, Object body) {
         ResolvedAuth auth = resolveAuth(connection);
-        URI url = buildUrl(connection.baseUrl(), operation.path(), auth.queryParams());
-        // Resolves the host: a stored base URL is operator input and could point at the
-        // cluster's own metadata service or a private address.
-        OutboundUrlGuard.requirePublicHttpUrl(url, "connection base URL");
-
         String method = method(operation);
         String requestBody = BODY_METHODS.contains(method) ? serialize(body) : null;
+        URI url = buildUrl(connection.baseUrl(), operation.path(), auth.queryParams());
 
-        HttpRequest.Builder builder = HttpRequest.newBuilder(url).timeout(timeout);
-        auth.headers().forEach(builder::header);
-        if (requestBody != null) {
-            builder.header("Content-Type", "application/json");
-            builder.method(method, HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8));
-        } else {
-            builder.method(method, HttpRequest.BodyPublishers.noBody());
-        }
-        builder.header("Accept", "application/json");
+        // The request as it will be recorded for the audit trail: the same call, with every
+        // credential masked — auth header values, and any auth query params folded into the
+        // URL. Computed up front so it is recorded on every outcome below, including a failure
+        // that happens before the request leaves the process (the SSRF guard rejecting an
+        // unresolvable or internal host) — the case that previously recorded nothing at all.
+        Map<String, String> recordedHeaders = recordedRequestHeaders(auth.headers(), requestBody != null);
+        String recordedUrl = auth.queryParams().isEmpty()
+                ? url.toString()
+                : buildUrl(connection.baseUrl(), operation.path(), maskValues(auth.queryParams())).toString();
 
         long startedAt = System.nanoTime();
         try {
+            // Resolves the host: a stored base URL is operator input and could point at the
+            // cluster's own metadata service or a private address.
+            OutboundUrlGuard.requirePublicHttpUrl(url, "connection base URL");
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder(url).timeout(timeout);
+            auth.headers().forEach(builder::header);
+            if (requestBody != null) {
+                builder.header("Content-Type", "application/json");
+                builder.method(method, HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8));
+            } else {
+                builder.method(method, HttpRequest.BodyPublishers.noBody());
+            }
+            builder.header("Accept", "application/json");
+
             HttpResponse<String> response =
                     httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
-            trace(method, url, response.statusCode(), startedAt, requestBody, response.body(), null);
+            trace(method, recordedUrl, recordedHeaders, response.statusCode(), startedAt,
+                    requestBody, response.body(), null);
             return new OperationInvocationResult(response.statusCode(), response.body());
         } catch (IOException e) {
-            trace(method, url, null, startedAt, requestBody, null, e.toString());
+            trace(method, recordedUrl, recordedHeaders, null, startedAt, requestBody, null, e.toString());
             throw new OperationInvocationException(
                     "Call to " + operation.name() + " failed: " + e.getMessage(), e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            trace(method, url, null, startedAt, requestBody, null, e.toString());
+            trace(method, recordedUrl, recordedHeaders, null, startedAt, requestBody, null, e.toString());
             throw new OperationInvocationException("Call to " + operation.name() + " was interrupted", e);
+        } catch (RuntimeException e) {
+            // A failure before the request left the process — the SSRF guard rejecting an
+            // unresolvable or internal host. Record the intended request (nothing else would
+            // have) and rethrow unchanged so the worker's outcome classification is untouched.
+            trace(method, recordedUrl, recordedHeaders, null, startedAt, requestBody, null, e.getMessage());
+            throw e;
         }
     }
 
@@ -220,10 +241,36 @@ public class IntegrationOperationInvoker {
         }
     }
 
-    private static void trace(String method, URI url, Integer status, long startedAt,
-                              String requestBody, String responseBody, String error) {
+    private static void trace(String method, String url, Map<String, String> requestHeaders,
+                              Integer status, long startedAt, String requestBody, String responseBody,
+                              String error) {
         long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
-        // Headers are deliberately not passed: that is where the token is.
-        JobHttpTrace.record(method, url.toString(), status, durationMs, requestBody, responseBody, error);
+        // Headers are pre-redacted by recordedRequestHeaders — no secret reaches the trace.
+        JobHttpTrace.record(method, url, status, durationMs, requestBody, responseBody, error, requestHeaders);
+    }
+
+    /**
+     * The request's headers as recorded for the audit trail: the transport headers we add
+     * ({@code Accept}, and {@code Content-Type} when there is a body) in the clear, and every
+     * auth-derived header masked. Its value is a bearer token or API key, and only here — where
+     * the header came from the resolved credential rather than the protocol — is that knowable;
+     * an operator-named API-key header could otherwise pass any name-based filter downstream.
+     */
+    static Map<String, String> recordedRequestHeaders(Map<String, String> authHeaders, boolean hasBody) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        authHeaders.forEach((name, value) -> headers.put(name, REDACTED));
+        if (hasBody) {
+            headers.put("Content-Type", "application/json");
+        }
+        headers.put("Accept", "application/json");
+        return headers;
+    }
+
+    /** Same keys, every value masked — so a URL whose query string carries auth secrets can be
+     *  recorded without leaking them. */
+    static Map<String, String> maskValues(Map<String, String> params) {
+        Map<String, String> masked = new LinkedHashMap<>();
+        params.forEach((name, value) -> masked.put(name, REDACTED));
+        return masked;
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobHttpTraceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobHttpTraceTest.java
@@ -50,6 +50,39 @@ class JobHttpTraceTest {
     }
 
     @Test
+    void recordsRequestHeadersWhenTheOverloadSuppliesThem() {
+        JobHttpTrace.begin();
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Authorization", "<redacted>");
+        headers.put("Content-Type", "application/json");
+        headers.put("Accept", "application/json");
+        JobHttpTrace.record("POST", "https://partner/api/photos", null, 3,
+                "{\"aprobada\":false}", null, "connection base URL host could not be resolved", headers);
+
+        Map<String, Object> entry = JobHttpTrace.end().get(0);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> recorded = (Map<String, Object>) entry.get("requestHeaders");
+        assertEquals("<redacted>", recorded.get("Authorization"), "the caller masks credential values");
+        assertEquals("application/json", recorded.get("Content-Type"));
+        assertEquals("application/json", recorded.get("Accept"));
+        // The whole point: a request that never reached the wire is still fully recorded.
+        assertNull(entry.get("status"), "no send happened, so no status");
+        assertEquals("connection base URL host could not be resolved", entry.get("error"));
+        assertEquals("{\"aprobada\":false}", entry.get("requestBody"));
+    }
+
+    @Test
+    void recordsNoHeadersFieldForTheShorterOverloadOrAnEmptyMap() {
+        JobHttpTrace.begin();
+        JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null);
+        JobHttpTrace.record("GET", "http://calendar/slots", 200, 1, null, "[]", null, Map.of());
+
+        List<Map<String, Object>> exchanges = JobHttpTrace.end();
+        assertFalse(exchanges.get(0).containsKey("requestHeaders"), "shorter overload records none");
+        assertFalse(exchanges.get(1).containsKey("requestHeaders"), "an empty map records none");
+    }
+
+    @Test
     void recordingOutsideAWindowIsANoOp() {
         // The client is shared with non-job traffic; recording must not accumulate
         // anywhere when nobody opened a window.

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvokerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationOperationInvokerTest.java
@@ -2,20 +2,36 @@ package com.microboxlabs.miot.integrations.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import com.microboxlabs.miot.integrations.jobs.JobHttpTrace;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * URL assembly and response classification — the two pieces of the invoker that decide
- * where a call goes and what its answer means. The HTTP send itself needs a live socket
- * (no mocking framework in this module) and is covered by the connection test path.
+ * URL assembly, response classification, and how a request is captured for the audit
+ * trail — the pieces of the invoker that decide where a call goes, what its answer means,
+ * and what gets recorded. The successful HTTP send needs a live socket (no mocking
+ * framework in this module) and is covered by the connection test path; the pre-send
+ * guard failure, which is where a request would otherwise go unrecorded, needs none.
  */
 class IntegrationOperationInvokerTest {
+
+    /** No test may leak a trace window onto a reused thread; the guard-path test opens one. */
+    @AfterEach
+    void closeAnyOpenTraceWindow() {
+        JobHttpTrace.end();
+    }
 
     @Test
     void joinsBaseUrlAndPathWithExactlyOneSlash() {
@@ -111,5 +127,76 @@ class IntegrationOperationInvokerTest {
         String summary = new OperationInvocationResult(500, "x".repeat(500)).summary();
         assertTrue(summary.endsWith("…"), summary);
         assertTrue(summary.length() < 350, "summary should be capped, was " + summary.length());
+    }
+
+    @Test
+    void recordedRequestHeadersMaskAuthButKeepTransportHeaders() {
+        Map<String, String> auth = new LinkedHashMap<>();
+        auth.put("Authorization", "Bearer super-secret-token");
+        auth.put("X-Company-Key", "an-operator-named-api-key");
+
+        Map<String, String> recorded =
+                IntegrationOperationInvoker.recordedRequestHeaders(auth, true);
+
+        // Every credential-bearing header is masked — including one whose name we could
+        // not have guessed — while the transport headers we add stay in the clear.
+        assertEquals("<redacted>", recorded.get("Authorization"));
+        assertEquals("<redacted>", recorded.get("X-Company-Key"));
+        assertEquals("application/json", recorded.get("Content-Type"));
+        assertEquals("application/json", recorded.get("Accept"));
+    }
+
+    @Test
+    void recordedRequestHeadersOmitContentTypeWhenThereIsNoBody() {
+        Map<String, String> recorded =
+                IntegrationOperationInvoker.recordedRequestHeaders(Map.of(), false);
+
+        assertFalse(recorded.containsKey("Content-Type"), "a bodyless request sends no Content-Type");
+        assertEquals("application/json", recorded.get("Accept"));
+    }
+
+    @Test
+    void maskValuesKeepsKeysAndRedactsValues() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("api_key", "k1");
+        params.put("signature", "s1");
+
+        Map<String, String> masked = IntegrationOperationInvoker.maskValues(params);
+
+        assertEquals("<redacted>", masked.get("api_key"));
+        assertEquals("<redacted>", masked.get("signature"));
+    }
+
+    @Test
+    void recordsTheIntendedRequestWhenTheGuardRejectsTheHostBeforeSending() {
+        // The exact production failure: the connection base URL resolves to an address the
+        // SSRF guard refuses, so the request never leaves the process. Before this change the
+        // attempt recorded nothing about the request — only a one-line error. It must now
+        // carry the full (credential-masked) request so the console shows what would have been
+        // sent. A loopback host trips the guard deterministically, with no DNS or socket.
+        IntegrationOperationInvoker invoker = new IntegrationOperationInvoker(
+                null, null, null, HttpClient.newHttpClient(), new ObjectMapper(), Duration.ofSeconds(2));
+        ResolvedConnection connection =
+                new ResolvedConnection("c1", URI.create("http://127.0.0.1"), Map.of(), Map.of());
+        IntegrationOperation operation = new IntegrationOperation(
+                "op1", "c1", "ActualizarEstadoFoto", "POST", "/api/photos", Map.of(), Map.of(), false);
+
+        JobHttpTrace.begin();
+        assertThrows(IllegalArgumentException.class,
+                () -> invoker.execute(connection, operation, Map.of("aprobada", false)));
+        List<Map<String, Object>> exchanges = JobHttpTrace.end();
+
+        assertEquals(1, exchanges.size(), "the failed attempt still records one request");
+        Map<String, Object> entry = exchanges.get(0);
+        assertEquals("POST", entry.get("method"));
+        assertEquals("http://127.0.0.1/api/photos", entry.get("url"));
+        assertEquals("{\"aprobada\":false}", entry.get("requestBody"));
+        assertNull(entry.get("status"), "nothing was sent, so there is no status");
+        assertTrue(((String) entry.get("error")).contains("connection base URL"),
+                "the guard's reason is recorded: " + entry.get("error"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> headers = (Map<String, Object>) entry.get("requestHeaders");
+        assertEquals("application/json", headers.get("Content-Type"));
+        assertEquals("application/json", headers.get("Accept"));
     }
 }


### PR DESCRIPTION
## Why

Debugging a review-verdict dispatch that failed in dev, the async-jobs console showed only a one-line error — nothing about the request. The connection's base URL was a seeded stub (`https://devmentor.example.com`), so `OutboundUrlGuard` (the SSRF guard) rejected the unresolvable host **before the request left the process**, and the HTTP trace only records inside the send try/catch. A successful send already records method + URL + body + response; a pre-send failure recorded the request **not at all**, and headers were never recorded on any path.

## What

- **`IntegrationOperationInvoker.execute`** assembles the recorded request up front and traces it on **every** outcome — success, transport failure (`IOException`/interrupt), and the pre-send guard rejection — so a failed attempt now carries the whole intended request the operator can inspect and replay.
- The recorded request includes **headers**, redacted **by provenance** rather than by name: every auth-derived header value (a bearer token, or an operator-named API-key header that no fixed name filter could catch) and any auth query param folded into the URL become `<redacted>`, while the transport headers we set (`Accept`, and `Content-Type` when there's a body) stay in the clear.
- **`JobHttpTrace`** gains a back-compatible `record(...)` overload that accepts the header map and stores it under `requestHeaders`; the existing 7-arg overload keeps recording none, so `CalendarBookingsClient` is untouched.

No secret ever reaches the trace: masking happens at the invoker, where a header's provenance is known, before the map is handed over.

## Tests

`./mvnw -pl miot-integrations test -Dtest='JobHttpTraceTest,IntegrationOperationInvokerTest,ModulithJobWorkerTest'` → **37 passing**, including:
- an end-to-end invoker test proving a **pre-send guard rejection** (loopback host, no DNS/socket) still records the full request — method, URL, body, redacted headers, guard error, no status;
- provenance redaction masks auth + operator-named API-key headers while keeping `Accept`/`Content-Type`;
- the shorter overload and an empty header map record no `requestHeaders` field.

## Context

Surfaced by the review-channel dispatch chain now working end to end in dev (ECM `review.verdict` → modulith `/events`, HS256 auth verified). The remaining dev failure is purely the stubbed connection base URL — this change makes that class of failure self-explanatory in the console. Fixing the stub (real partner endpoint + credential) is operator config, separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)