### PR TITLE
feat(integrations): render nested object/array payload bodies

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
@@ -4,7 +4,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,21 +11,28 @@ import java.util.Set;
 /**
  * Builds a channel's outbound JSON body from the binding's field templates.
  *
- * <p>Per field: render the template, coerce the result to the type the channel's
- * {@link PayloadSchema} declares, and decide whether an empty result may be sent. Every
- * problem is collected before throwing, so an operator sees a whole broken mapping at once
+ * <p>Per scalar field: render the template, coerce the result to the type the channel's
+ * {@link PayloadSchema} declares, and decide whether an empty result may be sent. A structural
+ * field (an object, or an array over a context collection) expands into a nested node instead.
+ * Every problem is collected before throwing, so an operator sees a whole broken mapping at once
  * rather than one fault per attempt.
  *
- * <p>Two rules worth knowing:
+ * <p>Rules worth knowing:
  *
  * <ul>
  *   <li><b>An empty optional field is omitted, not sent blank.</b> Most partners treat an
  *       absent key and {@code ""} differently, and "no reviewer comment" means the former.
  *       An empty <i>required</i> field is an error — silently writing a blank into a
- *       required slot is worse than failing.
+ *       required slot is worse than failing. A structural field whose expansion is empty is
+ *       treated the same: omitted when optional, kept when required.
  *   <li><b>A template that is exactly one variable keeps the context value's own type.</b>
  *       {@code {{review.verdict}}} over a real boolean sends JSON {@code false}, not
  *       {@code "false"}, without depending on a string round-trip.
+ *   <li><b>Nested mapping rows are keyed by their dotted path.</b> An {@code array} field
+ *       {@code fotos} whose element declares {@code guidMultimedia} looks up the template
+ *       {@code fotos.guidMultimedia}, so a leaf name reused at two depths ({@code aprobada}
+ *       on the envelope and on each foto) never collides. Only the top level accepts an
+ *       undeclared mapped key as a passthrough.
  * </ul>
  */
 @ApplicationScoped
@@ -40,52 +46,7 @@ public class PayloadRenderer {
      */
     public Map<String, Object> render(
             Map<String, String> templates, PayloadSchema schema, Map<String, Object> context) {
-        Map<String, String> safeTemplates = templates == null ? Map.of() : templates;
-        List<String> problems = new ArrayList<>();
-        Map<String, Object> payload = new LinkedHashMap<>();
-
-        for (String fieldId : fieldOrder(safeTemplates, schema)) {
-            PayloadSchema.Field field = schema.field(fieldId);
-            boolean required = field != null && field.required();
-            String template = safeTemplates.get(fieldId);
-
-            if (template == null || template.isBlank()) {
-                if (required) {
-                    problems.add("'" + fieldId + "' is required but has no mapping");
-                }
-                continue;
-            }
-
-            String rendered;
-            try {
-                rendered = PayloadTemplate.render(template, context);
-            } catch (TemplateSyntaxException e) {
-                // Save-time validation should have caught this; a stored binding can still be
-                // older than the validator, so fail loudly instead of sending the raw template.
-                problems.add("'" + fieldId + "' has an invalid template: " + e.getMessage());
-                continue;
-            }
-
-            if (rendered.isEmpty()) {
-                if (required) {
-                    problems.add("'" + fieldId + "' is required but its mapping produced no value");
-                }
-                continue;
-            }
-
-            PayloadSchema.FieldType type = field == null ? PayloadSchema.FieldType.STRING : field.type();
-            try {
-                payload.put(fieldId, coerce(template, rendered, type, context));
-            } catch (IllegalArgumentException e) {
-                problems.add("'" + fieldId + "' expects " + type.name().toLowerCase()
-                        + " but produced " + excerpt(rendered));
-            }
-        }
-
-        if (!problems.isEmpty()) {
-            throw new PayloadRenderException(problems);
-        }
-        return payload;
+        return renderObject(safeTemplates(templates), schema, safeContext(context), "");
     }
 
     /**
@@ -95,7 +56,8 @@ public class PayloadRenderer {
      * collection it names ({@link PayloadSchema#itemsFrom()}, e.g. {@code content}), binding
      * that name to each element in turn — so {@code {{content.mediaId}}} means "this element's
      * media id". Shared roots ({@code task}, {@code session}) stay visible to every element.
-     * The object case is unchanged: it delegates to {@link #render}.
+     * The object case delegates to {@link #render}, which now also expands nested object and
+     * array fields.
      *
      * @throws PayloadRenderException listing every element/field that could not be produced
      */
@@ -104,62 +66,29 @@ public class PayloadRenderer {
         if (!schema.array()) {
             return render(templates, schema, context);
         }
-        Map<String, Object> safeContext = context == null ? Map.of() : context;
-        Object collection = safeContext.get(schema.itemsFrom());
-        if (collection == null) {
-            // Nothing to report is a valid empty array, not a fault. In practice the producer
-            // skips emitting at all in this case; rendering stays total regardless.
-            return List.of();
-        }
-        if (!(collection instanceof List<?> elements)) {
-            throw new PayloadRenderException(List.of(
-                    "context '" + schema.itemsFrom() + "' must be an array to render an array body"));
-        }
-
-        PayloadSchema itemSchema = schema.itemSchema();
-        List<Object> rendered = new ArrayList<>(elements.size());
-        List<String> problems = new ArrayList<>();
-        for (int i = 0; i < elements.size(); i++) {
-            if (!(elements.get(i) instanceof Map<?, ?> element)) {
-                problems.add(schema.itemsFrom() + "[" + i + "] is not an object");
-                continue;
-            }
-            Map<String, Object> itemContext = new LinkedHashMap<>(safeContext);
-            @SuppressWarnings("unchecked")
-            Map<String, Object> asMap = (Map<String, Object>) element;
-            itemContext.put(schema.itemsFrom(), asMap);
-            try {
-                rendered.add(render(templates, itemSchema, itemContext));
-            } catch (PayloadRenderException e) {
-                int index = i;
-                e.problems().forEach(problem ->
-                        problems.add(schema.itemsFrom() + "[" + index + "]: " + problem));
-            }
-        }
-        if (!problems.isEmpty()) {
-            throw new PayloadRenderException(problems);
-        }
-        return rendered;
+        return renderElements(
+                safeTemplates(templates), schema.itemsFrom(), schema.itemSchema(), safeContext(context), "");
     }
 
     /**
      * Checks a mapping before it is stored: templates parse, read known variables, and cover
-     * every required field.
+     * every required field. Required coverage follows nested structure by the dotted path the
+     * renderer looks a nested field up under.
      *
      * @return every problem found; empty when the mapping is storable
      */
     public List<String> validate(
             Map<String, String> templates, PayloadSchema schema, Set<String> allowedRoots) {
-        Map<String, String> safeTemplates = templates == null ? Map.of() : templates;
+        Map<String, String> mappings = safeTemplates(templates);
         List<String> problems = new ArrayList<>();
 
-        for (PayloadSchema.Field field : schema.requiredFields()) {
-            String template = safeTemplates.get(field.id());
+        for (String requiredPath : requiredLeafPaths(schema, "")) {
+            String template = mappings.get(requiredPath);
             if (template == null || template.isBlank()) {
-                problems.add("'" + field.id() + "' is required but has no mapping");
+                problems.add("'" + requiredPath + "' is required but has no mapping");
             }
         }
-        safeTemplates.forEach((fieldId, template) -> {
+        mappings.forEach((fieldId, template) -> {
             if (template == null || template.isBlank()) {
                 return;
             }
@@ -172,15 +101,186 @@ public class PayloadRenderer {
         return problems;
     }
 
+    /* ---------------------------------------------------------------------- */
+
     /**
-     * Declared fields first, in contract order, then any mapped field the contract does not
-     * declare — an operator may legitimately send an extra key a stale schema omits.
+     * Renders one object level. Scalar fields come from their templates; an {@code array} field
+     * expands into a list over its context collection and an {@code object} field into a nested
+     * map, each keyed for template lookup by {@code prefix + fieldId}. Only the top level (empty
+     * prefix) also emits undeclared, undotted mapped keys as string passthroughs.
      */
-    private static Set<String> fieldOrder(Map<String, String> templates, PayloadSchema schema) {
-        Set<String> order = new LinkedHashSet<>();
-        schema.fields().forEach(field -> order.add(field.id()));
-        order.addAll(templates.keySet());
-        return order;
+    private Map<String, Object> renderObject(
+            Map<String, String> templates, PayloadSchema schema, Map<String, Object> context, String prefix) {
+        List<String> problems = new ArrayList<>();
+        Map<String, Object> payload = new LinkedHashMap<>();
+
+        for (PayloadSchema.Field field : schema.fields()) {
+            String path = prefix + field.id();
+            switch (field.type()) {
+                case ARRAY -> {
+                    try {
+                        List<Object> value =
+                                renderElements(templates, field.itemsFrom(), field.child(), context, path + ".");
+                        if (!value.isEmpty() || field.required()) {
+                            payload.put(field.id(), value);
+                        }
+                    } catch (PayloadRenderException e) {
+                        problems.addAll(e.problems());
+                    }
+                }
+                case OBJECT -> {
+                    try {
+                        Map<String, Object> value = renderObject(templates, field.child(), context, path + ".");
+                        if (!value.isEmpty() || field.required()) {
+                            payload.put(field.id(), value);
+                        }
+                    } catch (PayloadRenderException e) {
+                        problems.addAll(e.problems());
+                    }
+                }
+                default -> renderScalar(payload, problems, field, field.id(), path, templates, context);
+            }
+        }
+
+        if (prefix.isEmpty()) {
+            for (String key : templates.keySet()) {
+                if (!key.contains(".") && schema.field(key) == null) {
+                    renderScalar(payload, problems, null, key, key, templates, context);
+                }
+            }
+        }
+
+        if (!problems.isEmpty()) {
+            throw new PayloadRenderException(problems);
+        }
+        return payload;
+    }
+
+    /**
+     * Renders an array node: one object per element of the {@code itemsFrom} context collection,
+     * with that element bound under the collection's own name so an item template
+     * ({@code {{content.mediaId}}}) reads this element. Used for a top-level array body and for a
+     * nested array field alike.
+     */
+    private List<Object> renderElements(Map<String, String> templates, String itemsFrom,
+            PayloadSchema itemSchema, Map<String, Object> context, String prefix) {
+        Object collection = resolveCollection(context, itemsFrom);
+        if (collection == null) {
+            // Nothing to report is a valid empty array, not a fault. In practice the producer
+            // skips emitting at all in this case; rendering stays total regardless.
+            return List.of();
+        }
+        if (!(collection instanceof List<?> elements)) {
+            throw new PayloadRenderException(List.of(
+                    "context '" + itemsFrom + "' must be an array to render an array body"));
+        }
+
+        String bindName = lastSegment(itemsFrom);
+        List<Object> rendered = new ArrayList<>(elements.size());
+        List<String> problems = new ArrayList<>();
+        for (int i = 0; i < elements.size(); i++) {
+            if (!(elements.get(i) instanceof Map<?, ?> element)) {
+                problems.add(itemsFrom + "[" + i + "] is not an object");
+                continue;
+            }
+            Map<String, Object> itemContext = new LinkedHashMap<>(context);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> asMap = (Map<String, Object>) element;
+            itemContext.put(bindName, asMap);
+            try {
+                rendered.add(renderObject(templates, itemSchema, itemContext, prefix));
+            } catch (PayloadRenderException e) {
+                int index = i;
+                e.problems().forEach(problem -> problems.add(itemsFrom + "[" + index + "]: " + problem));
+            }
+        }
+        if (!problems.isEmpty()) {
+            throw new PayloadRenderException(problems);
+        }
+        return rendered;
+    }
+
+    /**
+     * Renders one scalar field into {@code payload} under {@code jsonKey}, looking its template
+     * up by {@code templateKey} (the dotted path) and reporting problems against that same key.
+     * A null {@code field} is an undeclared passthrough, sent as text.
+     */
+    private void renderScalar(Map<String, Object> payload, List<String> problems,
+            PayloadSchema.Field field, String jsonKey, String templateKey,
+            Map<String, String> templates, Map<String, Object> context) {
+        boolean required = field != null && field.required();
+        String template = templates.get(templateKey);
+
+        if (template == null || template.isBlank()) {
+            if (required) {
+                problems.add("'" + templateKey + "' is required but has no mapping");
+            }
+            return;
+        }
+
+        String rendered;
+        try {
+            rendered = PayloadTemplate.render(template, context);
+        } catch (TemplateSyntaxException e) {
+            // Save-time validation should have caught this; a stored binding can still be
+            // older than the validator, so fail loudly instead of sending the raw template.
+            problems.add("'" + templateKey + "' has an invalid template: " + e.getMessage());
+            return;
+        }
+
+        if (rendered.isEmpty()) {
+            if (required) {
+                problems.add("'" + templateKey + "' is required but its mapping produced no value");
+            }
+            return;
+        }
+
+        PayloadSchema.FieldType type = field == null ? PayloadSchema.FieldType.STRING : field.type();
+        try {
+            payload.put(jsonKey, coerce(template, rendered, type, context));
+        } catch (IllegalArgumentException e) {
+            problems.add("'" + templateKey + "' expects " + type.name().toLowerCase()
+                    + " but produced " + excerpt(rendered));
+        }
+    }
+
+    /** The required scalar leaves of a schema, as the dotted paths they are mapped under. */
+    private static List<String> requiredLeafPaths(PayloadSchema schema, String prefix) {
+        List<String> paths = new ArrayList<>();
+        for (PayloadSchema.Field field : schema.fields()) {
+            String path = prefix + field.id();
+            if (field.structural()) {
+                if (field.child() != null) {
+                    paths.addAll(requiredLeafPaths(field.child(), path + "."));
+                }
+            } else if (field.required()) {
+                paths.add(path);
+            }
+        }
+        return paths;
+    }
+
+    /** Resolves a (possibly dotted) context path to the collection an array field iterates. */
+    private static Object resolveCollection(Map<String, Object> context, String itemsFrom) {
+        if (itemsFrom == null || itemsFrom.isBlank()) {
+            return null;
+        }
+        Object current = context;
+        for (String segment : itemsFrom.split("\\.")) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    private static String lastSegment(String itemsFrom) {
+        int dot = itemsFrom.lastIndexOf('.');
+        return dot < 0 ? itemsFrom : itemsFrom.substring(dot + 1);
     }
 
     private static Object coerce(
@@ -204,7 +304,8 @@ public class PayloadRenderer {
             case BOOLEAN -> toBoolean(text);
             case INTEGER -> Long.valueOf(text);
             case NUMBER -> new BigDecimal(text);
-            case STRING -> rendered;
+            // STRING is handled above; OBJECT/ARRAY never reach coerce (they expand structurally).
+            default -> rendered;
         };
     }
 
@@ -224,5 +325,13 @@ public class PayloadRenderer {
     private static String excerpt(String value) {
         String text = value.strip();
         return "'" + (text.length() <= 60 ? text : text.substring(0, 60) + "…") + "'";
+    }
+
+    private static Map<String, String> safeTemplates(Map<String, String> templates) {
+        return templates == null ? Map.of() : templates;
+    }
+
+    private static Map<String, Object> safeContext(Map<String, Object> context) {
+        return context == null ? Map.of() : context;
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
@@ -34,16 +34,38 @@ import java.util.Set;
  *              "required": ["guidMultimedia"] } }
  * }</pre>
  *
- * <p>The declared {@link #fields()} are the same either way — the mapping rows an operator
- * fills in — so the settings UI and save-time validation treat an array contract exactly
- * like an object one. Only the renderer cares about the difference: it renders those fields
- * once per element of {@link #itemsFrom()} instead of once total.
+ * <p><b>Nested fields.</b> A partner that wants an <i>object</i> wrapping that array — a
+ * {@code Command} envelope carrying {@code serviceCode} and a {@code fotos} list — declares a
+ * property whose own {@code type} is {@code object} or {@code array}. An {@code array} property
+ * iterates its own {@code itemsFrom} collection (default {@code content}) and renders {@code items}
+ * once per element; an {@code object} property renders its {@code properties} against the same
+ * context. Nesting composes to any depth, so an element of {@code fotos} may itself declare a
+ * {@code mensaje} array. A nested field's mapping rows are keyed by their dotted path
+ * ({@code fotos.guidMultimedia}), which keeps a reused leaf name ({@code aprobada} on both the
+ * envelope and each foto) unambiguous.
  *
- * <p>Anything richer (nested objects, {@code oneOf}, validation keywords) is ignored rather
- * than rejected — an operator may have pasted a fuller schema, and the parts we do understand
- * are still the parts we act on. A property with no usable {@code type}, including
- * {@code string} with {@code "format": "date-time"}, is treated as {@link FieldType#STRING}
- * and passed through verbatim.
+ * <pre>{@code
+ * { "type": "object",
+ *   "properties": {
+ *     "serviceCode": { "type": "string" },
+ *     "fotos": { "type": "array", "itemsFrom": "content",
+ *                "items": { "type": "object",
+ *                           "properties": { "guidMultimedia": { "type": "string" } } } } },
+ *   "required": ["serviceCode", "fotos"] }
+ * }</pre>
+ *
+ * <p>The declared {@link #fields()} are the mapping rows an operator fills in — so the settings
+ * UI and save-time validation treat an array contract exactly like an object one. Only the
+ * renderer cares about the difference: it renders those fields once per element of
+ * {@link #itemsFrom()} instead of once total, and a structural field expands into a nested
+ * object or array rather than a scalar.
+ *
+ * <p>Validation keywords ({@code oneOf}, {@code minLength}, …) are ignored rather than rejected —
+ * an operator may have pasted a fuller schema, and the parts we do understand are still the parts
+ * we act on. A property with no usable {@code type}, including {@code string} with
+ * {@code "format": "date-time"}, is treated as {@link FieldType#STRING} and passed through
+ * verbatim; an {@code object}/{@code array} property that declares no usable sub-fields degrades
+ * to the same string passthrough rather than an empty nested node.
  */
 public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom) {
 
@@ -52,10 +74,27 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
         STRING,
         BOOLEAN,
         INTEGER,
-        NUMBER
+        NUMBER,
+        OBJECT,
+        ARRAY
     }
 
-    public record Field(String id, FieldType type, boolean required) {
+    /**
+     * One declared field. A scalar leaf ({@code child == null}) is produced from its mapped
+     * template. A structural field carries a nested contract: {@link FieldType#OBJECT} renders
+     * {@code child} against the same context, {@link FieldType#ARRAY} renders {@code child} once
+     * per element of the context collection named by {@code itemsFrom}.
+     */
+    public record Field(String id, FieldType type, boolean required, PayloadSchema child, String itemsFrom) {
+
+        /** A scalar leaf — the shape every existing caller assumes. */
+        public Field(String id, FieldType type, boolean required) {
+            this(id, type, required, null, null);
+        }
+
+        public boolean structural() {
+            return type == FieldType.OBJECT || type == FieldType.ARRAY;
+        }
     }
 
     /** The context collection an array schema iterates when {@code itemsFrom} is absent. */
@@ -79,9 +118,7 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
             return EMPTY;
         }
         if (isArray(requestSchema)) {
-            Object rawItems = requestSchema.get("items");
-            Map<?, ?> items = rawItems instanceof Map<?, ?> map ? map : Map.of();
-            List<Field> fields = fieldsOf(items);
+            List<Field> fields = itemFieldsOf(requestSchema);
             return fields.isEmpty() ? EMPTY : new PayloadSchema(fields, true, itemsFrom(requestSchema));
         }
         List<Field> fields = fieldsOf(requestSchema);
@@ -103,16 +140,23 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
 
     /* ---------------------------------------------------------------------- */
 
-    private static boolean isArray(Map<String, Object> requestSchema) {
-        return "array".equalsIgnoreCase(String.valueOf(requestSchema.get("type")));
+    private static boolean isArray(Map<?, ?> schema) {
+        return "array".equalsIgnoreCase(String.valueOf(schema.get("type")));
     }
 
-    private static String itemsFrom(Map<String, Object> requestSchema) {
-        Object raw = requestSchema.get("itemsFrom");
+    private static String itemsFrom(Map<?, ?> schema) {
+        Object raw = schema.get("itemsFrom");
         if (raw == null || String.valueOf(raw).isBlank()) {
             return DEFAULT_ITEMS_FROM;
         }
         return String.valueOf(raw).trim();
+    }
+
+    /** The element (object) fields of an array schema, read from its {@code items}. */
+    private static List<Field> itemFieldsOf(Map<?, ?> arraySchema) {
+        Object rawItems = arraySchema.get("items");
+        Map<?, ?> items = rawItems instanceof Map<?, ?> map ? map : Map.of();
+        return fieldsOf(items);
     }
 
     /** Reads {@code properties}/{@code required} of an object schema map into fields. */
@@ -125,9 +169,32 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
         List<Field> fields = new ArrayList<>(properties.size());
         properties.forEach((name, definition) -> {
             String id = String.valueOf(name);
-            fields.add(new Field(id, typeOf(definition), required.contains(id)));
+            fields.add(fieldOf(id, definition, required.contains(id)));
         });
         return List.copyOf(fields);
+    }
+
+    /** One field, structural (object/array) when it declares a usable nested contract. */
+    private static Field fieldOf(String id, Object definition, boolean required) {
+        if (!(definition instanceof Map<?, ?> def)) {
+            return new Field(id, FieldType.STRING, required);
+        }
+        String type = def.get("type") == null ? "" : String.valueOf(def.get("type")).toLowerCase();
+        if ("array".equals(type)) {
+            List<Field> items = itemFieldsOf(def);
+            // An array of scalars is not a mapping surface we render element fields for; keep the
+            // node rather than reject, degrading to a string passthrough as any unknown type does.
+            return items.isEmpty()
+                    ? new Field(id, FieldType.STRING, required)
+                    : new Field(id, FieldType.ARRAY, required, new PayloadSchema(items), itemsFrom(def));
+        }
+        if ("object".equals(type) || (type.isEmpty() && def.get("properties") instanceof Map<?, ?>)) {
+            List<Field> childFields = fieldsOf(def);
+            return childFields.isEmpty()
+                    ? new Field(id, FieldType.STRING, required)
+                    : new Field(id, FieldType.OBJECT, required, new PayloadSchema(childFields), null);
+        }
+        return new Field(id, scalarType(type), required);
     }
 
     private static Set<String> requiredNames(Object raw) {
@@ -143,15 +210,8 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
         return names;
     }
 
-    private static FieldType typeOf(Object definition) {
-        if (!(definition instanceof Map<?, ?> map)) {
-            return FieldType.STRING;
-        }
-        Object type = map.get("type");
-        if (type == null) {
-            return FieldType.STRING;
-        }
-        return switch (String.valueOf(type).toLowerCase()) {
+    private static FieldType scalarType(String type) {
+        return switch (type) {
             case "boolean" -> FieldType.BOOLEAN;
             case "integer" -> FieldType.INTEGER;
             case "number" -> FieldType.NUMBER;

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadNestedRenderingTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadNestedRenderingTest.java
@@ -1,0 +1,142 @@
+package com.microboxlabs.miot.integrations.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Nested bodies: the Dev-Mentor {@code ActualizarEstadoFoto} contract is an object envelope
+ * ({@code serviceCode}, an overall {@code aprobada}, {@code username}) wrapping a {@code fotos}
+ * array, and each foto may carry its own {@code mensaje} array of reason objects. This proves the
+ * renderer builds that whole shape from one flat template map keyed by dotted path — including the
+ * deepest {@code mensaje} nesting, so once the producer supplies per-photo reasons no further
+ * renderer work is needed.
+ */
+class PayloadNestedRenderingTest {
+
+    private final PayloadRenderer renderer = new PayloadRenderer();
+
+    /** The request_schema as it would be stored for the Dev-Mentor operation. */
+    private static PayloadSchema devMentorSchema() {
+        Map<String, Object> reasonProps = new LinkedHashMap<>();
+        reasonProps.put("codigo", Map.of("type", "string"));
+        reasonProps.put("nombre", Map.of("type", "string"));
+        Map<String, Object> mensaje = Map.of(
+                "type", "array",
+                "itemsFrom", "content.reasons",
+                "items", Map.of("type", "object", "properties", reasonProps,
+                        "required", List.of("codigo", "nombre")));
+
+        Map<String, Object> fotoProps = new LinkedHashMap<>();
+        fotoProps.put("guidMultimedia", Map.of("type", "string"));
+        fotoProps.put("aprobada", Map.of("type", "boolean"));
+        fotoProps.put("mensaje", mensaje);
+        Map<String, Object> fotos = Map.of(
+                "type", "array",
+                "itemsFrom", "content",
+                "items", Map.of("type", "object", "properties", fotoProps,
+                        "required", List.of("guidMultimedia", "aprobada")));
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("serviceCode", Map.of("type", "string"));
+        envelope.put("aprobada", Map.of("type", "boolean"));
+        envelope.put("username", Map.of("type", "string"));
+        envelope.put("fotos", fotos);
+        return PayloadSchema.of(Map.of(
+                "type", "object",
+                "properties", envelope,
+                "required", List.of("serviceCode", "aprobada", "username", "fotos")));
+    }
+
+    private static final Map<String, String> TEMPLATES = Map.ofEntries(
+            Map.entry("serviceCode", "{{task.serviceCode}}"),
+            Map.entry("aprobada", "{{task.approved}}"),
+            Map.entry("username", "{{session.reviewer}}"),
+            Map.entry("fotos.guidMultimedia", "{{content.mediaId}}"),
+            Map.entry("fotos.aprobada", "{{content.verdict}}"),
+            Map.entry("fotos.mensaje.codigo", "{{reasons.codigo}}"),
+            Map.entry("fotos.mensaje.nombre", "{{reasons.nombre}}"));
+
+    @Test
+    void schemaParsesTheEnvelopeAndItsNestedArrayAndObjectFields() {
+        PayloadSchema schema = devMentorSchema();
+        assertFalse(schema.array(), "the envelope is an object, not a top-level array");
+
+        PayloadSchema.Field fotos = schema.field("fotos");
+        assertEquals(PayloadSchema.FieldType.ARRAY, fotos.type());
+        assertEquals("content", fotos.itemsFrom());
+
+        PayloadSchema.Field mensaje = fotos.child().field("mensaje");
+        assertEquals(PayloadSchema.FieldType.ARRAY, mensaje.type());
+        assertEquals("content.reasons", mensaje.itemsFrom());
+        assertEquals(List.of("codigo", "nombre"),
+                mensaje.child().fields().stream().map(PayloadSchema.Field::id).toList());
+    }
+
+    @Test
+    void buildsTheFullEnvelopeWithFotosAndPerPhotoReasons() {
+        Object body = renderer.renderBody(TEMPLATES, devMentorSchema(), context());
+
+        Map<?, ?> envelope = assertInstanceOf(Map.class, body);
+        assertEquals("1656793", envelope.get("serviceCode"));
+        assertEquals(Boolean.FALSE, envelope.get("aprobada"), "overall verdict, from the envelope template");
+        assertEquals("mdavid@sitrans.cl", envelope.get("username"));
+
+        List<?> fotos = assertInstanceOf(List.class, envelope.get("fotos"));
+        assertEquals(2, fotos.size());
+
+        // Approved photo: its per-photo verdict wins over the reused leaf name, and with no
+        // reasons the optional mensaje array is omitted, not sent empty.
+        Map<?, ?> approved = (Map<?, ?>) fotos.get(0);
+        assertEquals("g1", approved.get("guidMultimedia"));
+        assertEquals(Boolean.TRUE, approved.get("aprobada"));
+        assertFalse(approved.containsKey("mensaje"), "no reasons → no mensaje key");
+
+        // Rejected photo: mensaje is an array of {codigo, nombre} reason objects.
+        Map<?, ?> rejected = (Map<?, ?>) fotos.get(1);
+        assertEquals("g2", rejected.get("guidMultimedia"));
+        assertEquals(Boolean.FALSE, rejected.get("aprobada"));
+        List<?> mensaje = assertInstanceOf(List.class, rejected.get("mensaje"));
+        assertEquals(1, mensaje.size());
+        Map<?, ?> reason = (Map<?, ?>) mensaje.get(0);
+        assertEquals("wrong_format", reason.get("codigo"));
+        assertEquals("Formato incorrecto", reason.get("nombre"));
+    }
+
+    @Test
+    void reusedLeafNameDoesNotCollideAcrossDepths() {
+        // Both the envelope and each foto declare "aprobada"; the dotted template keys keep them
+        // apart — the envelope's overall verdict must not be overwritten by a photo's.
+        Object body = renderer.renderBody(TEMPLATES, devMentorSchema(), context());
+        Map<?, ?> envelope = (Map<?, ?>) body;
+
+        assertEquals(Boolean.FALSE, envelope.get("aprobada"));
+        List<?> fotos = (List<?>) envelope.get("fotos");
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) fotos.get(0)).get("aprobada"));
+        assertTrue(((Map<?, ?>) fotos.get(1)).get("aprobada") == Boolean.FALSE);
+    }
+
+    private static Map<String, Object> context() {
+        Map<String, Object> approvedPhoto = new LinkedHashMap<>();
+        approvedPhoto.put("mediaId", "g1");
+        approvedPhoto.put("verdict", true);
+
+        Map<String, Object> rejectedPhoto = new LinkedHashMap<>();
+        rejectedPhoto.put("mediaId", "g2");
+        rejectedPhoto.put("verdict", false);
+        rejectedPhoto.put("reasons", List.of(
+                Map.of("codigo", "wrong_format", "nombre", "Formato incorrecto")));
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("task", Map.of("serviceCode", "1656793", "approved", false));
+        context.put("session", Map.of("reviewer", "mdavid@sitrans.cl"));
+        context.put("content", List.of(approvedPhoto, rejectedPhoto));
+        return context;
+    }
+}


### PR DESCRIPTION
## Why

The review-verdict dispatch reaches Dev-Mentor now (auth + endpoint fixed), but the partner returns **400**: its `ActualizarEstadoFoto` `Command` is an **object envelope** wrapping an array —

```json
{ "serviceCode":"…", "aprobada":false, "username":"…",
  "fotos":[ {"guidMultimedia":"…","aprobada":false,"mensaje":[{"codigo":"…","nombre":"…"}]} ] }
```

— while the renderer could only emit a *flat object* or a *bare top-level array*. Its deserializer rejects the array at byte 1. The `request_schema` DSL doc explicitly punted on nesting.

## What

- **`PayloadSchema`** now parses a property whose own `type` is `object` or `array` into a **structural `Field`** carrying its nested contract: an object field holds its sub-fields; an array field holds the element fields plus the `itemsFrom` collection it iterates (default `content`).
- **`PayloadRenderer`** expands these **recursively, to any depth**: an array field renders one element per context-collection item (a dotted `itemsFrom` like `content.reasons` resolves per element), an object field renders a nested map.
- **Dotted-path template keys** (`fotos.guidMultimedia`) key each nested mapping row, so a leaf name reused at two depths — `aprobada` on the envelope *and* on each foto — never collides. Only the top level still accepts an undeclared key as a string passthrough.
- **Empty optional structural fields are omitted** like empty scalars, so an approved photo with no reasons sends no `mensaje`.

## Tests

`./mvnw -pl miot-integrations test -Dtest='Payload*Test,IntegrationEventDispatchHandlerTest,IntegrationEventBindingServiceTest'` → **63 passing**:
- new `PayloadNestedRenderingTest` builds the whole Dev-Mentor envelope — envelope scalars, `fotos` array, and the **deepest `mensaje` array-of-objects** — from one flat template map, and proves the reused `aprobada` doesn't collide;
- every existing flat-object and top-level-array test still green (nothing about the two original shapes changed).

## Scope / next

This lands the **full renderer capability** for the Dev-Mentor shape, including the `mensaje` nesting. Remaining to green the end-to-end call:
1. store the object `request_schema` + dotted binding templates on the operation (dev config);
2. producer (ECM) emits the envelope's overall `aprobada` and per-photo structured reasons (`codigo`/`nombre`) — the latter sourced from the per-content `fm:discussion` reject-reason posts. With this PR the renderer needs no further change for either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)