### PR TITLE
feat(shipping): attach multiple review channels per column

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/content.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/content.tsx
@@ -47,7 +47,7 @@ export default function PageContent({
   const { activeOrg } = useOrgScopes();
   const {
     targets: reviewTargets,
-    bindingForBoard,
+    bindingsForBoard,
     saving: reviewSaving,
     save: saveReviewBinding,
   } = useReviewBindings(activeOrg?.slug ?? null);
@@ -250,10 +250,10 @@ export default function PageContent({
                   isLoading={isLoading}
                   dict={dictionary.base}
                   reviewDict={reviewDict}
-                  reviewBinding={bindingForBoard(board.title)}
+                  reviewBindings={bindingsForBoard(board.title)}
                   reviewTargets={reviewTargets}
                   reviewSaving={reviewSaving}
-                  onReviewSave={(draft) => saveReviewBinding(board.title, draft)}
+                  onReviewSave={(channels) => saveReviewBinding(board.title, channels)}
                   laneState={getLaneState(board.title)}
                   onLaneUpdate={(patch) => updateLaneState(board.title, patch)}
                   setList={setList}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/lane-column.tsx
@@ -30,8 +30,12 @@ import {
 } from "../../hooks/use-lane-view-state";
 import KanbanCard from "../kanban-card/kanban-card";
 import { TaskCounter } from "../TaskCounter";
-import { ReviewSettingsDrawer, type BindingDraft } from "./review-settings-drawer";
-import type { DispatchTarget, EventBinding } from "./review-binding.types";
+import { ReviewSettingsDrawer } from "./review-settings-drawer";
+import type {
+  ChannelBindingDraft,
+  DispatchTarget,
+  EventBinding,
+} from "./review-binding.types";
 
 interface LaneColumnProps {
   board: KanbanBoard;
@@ -41,11 +45,11 @@ interface LaneColumnProps {
   dict: I18nRecord;
   /** `pages.reviewProcess` subtree — the review-integration config UI. */
   reviewDict: I18nRecord;
-  /** The stored binding for this column, own or inherited. */
-  reviewBinding: EventBinding | undefined;
+  /** Every channel attached to this column, own or inherited. */
+  reviewBindings: readonly EventBinding[];
   reviewTargets: readonly DispatchTarget[];
   reviewSaving: boolean;
-  onReviewSave: (draft: BindingDraft) => void;
+  onReviewSave: (channels: ChannelBindingDraft[]) => void;
   laneState: LaneViewState;
   onLaneUpdate: (patch: Partial<LaneViewState>) => void;
   setList: Dispatch<SetStateAction<KanbanBoard[]>>;
@@ -122,7 +126,7 @@ export function LaneColumn({
   isLoading,
   dict,
   reviewDict,
-  reviewBinding,
+  reviewBindings,
   reviewTargets,
   reviewSaving,
   onReviewSave,
@@ -134,14 +138,15 @@ export function LaneColumn({
   onCardClick,
 }: Readonly<LaneColumnProps>) {
   const [reviewDrawerOpen, setReviewDrawerOpen] = useState(false);
-  const reviewEnabled = reviewBinding?.enabled ?? false;
+  const reviewEnabled = reviewBindings.some((binding) => binding.enabled);
 
-  const handleReviewSave = (draft: BindingDraft) => {
+  const handleReviewSave = (channels: ChannelBindingDraft[]) => {
+    const anyEnabled = channels.some((channel) => channel.enabled);
     // The API owns the outcome, so errors surface from it rather than being guessed.
-    Promise.resolve(onReviewSave(draft))
+    Promise.resolve(onReviewSave(channels))
       .then(() => {
         toast.success(
-          draft.enabled
+          anyEnabled
             ? tr("toast.saved", reviewDict)
             : tr("toast.disabled", reviewDict)
         );
@@ -382,7 +387,7 @@ export function LaneColumn({
         show={reviewDrawerOpen}
         onClose={() => setReviewDrawerOpen(false)}
         laneTitle={title}
-        binding={reviewBinding}
+        bindings={reviewBindings}
         targets={reviewTargets}
         saving={reviewSaving}
         onSave={handleReviewSave}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+  attachedChannels,
+  bindingChannelKey,
+  channelKey,
   conditionForTrigger,
   findTarget,
   REVIEW_EVENT_TYPE,
@@ -9,8 +12,29 @@ import {
   triggerFromCondition,
   unmappedRequiredFields,
   type DispatchTarget,
+  type EventBinding,
 } from "./review-binding.types";
 import { renderTemplate } from "./review-integration.types";
+
+/** A stored binding with sensible defaults, overridable per test. */
+function binding(over: Partial<EventBinding>): EventBinding {
+  return {
+    id: "b-1",
+    ownerOrgSlug: "mintral",
+    inherited: false,
+    eventType: REVIEW_EVENT_TYPE,
+    scopeKind: REVIEW_SCOPE_KIND,
+    scopeKey: "wfship:transportValidationTask",
+    connectionId: "c-1",
+    operationId: "o-1",
+    matchCondition: {},
+    fieldTemplates: {},
+    enabled: true,
+    updatedAt: "2026-07-24T00:00:00Z",
+    updatedBy: "someone",
+    ...over,
+  };
+}
 
 const target: DispatchTarget = {
   connectionId: "c-1",
@@ -122,6 +146,76 @@ describe("target identity", () => {
     expect(findTarget([target], "c-1", "o-1")).toBe(target);
     expect(findTarget([target], "c-1", "other")).toBeUndefined();
     expect(findTarget([target], null, "o-1")).toBeUndefined();
+  });
+});
+
+describe("channel identity", () => {
+  it("keys a channel on connection and operation", () => {
+    expect(channelKey("c-1", "o-1")).toBe("c-1::o-1");
+    // A null operation still yields a stable, distinct key.
+    expect(channelKey("c-1", null)).toBe("c-1::");
+  });
+
+  it("derives a binding's channel key from its ids", () => {
+    expect(bindingChannelKey(binding({ connectionId: "c-9", operationId: "o-9" }))).toBe(
+      "c-9::o-9"
+    );
+  });
+});
+
+describe("attachedChannels", () => {
+  it("folds a channel written across a board's task keys into one entry", () => {
+    // monitoringFinalization aggregates several tasks; the same channel is written to
+    // each, but the drawer must show it once.
+    const [taskA, taskB] = taskKeysForBoard("monitoringFinalization");
+    const channels = attachedChannels(
+      [
+        binding({ id: "a", scopeKey: taskA, connectionId: "c-1", operationId: "o-1" }),
+        binding({ id: "b", scopeKey: taskB, connectionId: "c-1", operationId: "o-1" }),
+      ],
+      "monitoringFinalization"
+    );
+
+    expect(channels).toHaveLength(1);
+    expect(bindingChannelKey(channels[0])).toBe("c-1::o-1");
+  });
+
+  it("keeps two distinct channels on the same column", () => {
+    const channels = attachedChannels(
+      [
+        binding({ id: "a", connectionId: "c-1", operationId: "o-1" }),
+        binding({ id: "b", connectionId: "c-2", operationId: "o-2" }),
+      ],
+      "transportValidation"
+    );
+
+    expect(channels.map(bindingChannelKey).sort()).toEqual(["c-1::o-1", "c-2::o-2"]);
+  });
+
+  it("prefers the org's own binding over an inherited one for the same channel", () => {
+    const channels = attachedChannels(
+      [
+        binding({ id: "inh", inherited: true, ownerOrgSlug: "parent" }),
+        binding({ id: "own", inherited: false }),
+      ],
+      "transportValidation"
+    );
+
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe("own");
+  });
+
+  it("ignores bindings from other events or scopes", () => {
+    const channels = attachedChannels(
+      [
+        binding({ id: "other-event", eventType: "something.else" }),
+        binding({ id: "other-scope", scopeKey: "unrelatedTask" }),
+        binding({ id: "keep" }),
+      ],
+      "transportValidation"
+    );
+
+    expect(channels.map((c) => c.id)).toEqual(["keep"]);
   });
 });
 

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
@@ -55,6 +55,17 @@ export interface UpsertBindingRequest {
   readonly enabled: boolean;
 }
 
+/**
+ * One attached channel as the drawer commits it — an upsert without the event and
+ * scope, which the hook fills in per Activiti task. A column carries a *list* of
+ * these: the backend keys bindings on `connection_id` as part of the natural key
+ * precisely so one event can fan out to several channels.
+ */
+export type ChannelBindingDraft = Omit<
+  UpsertBindingRequest,
+  "eventType" | "scopeKind" | "scopeKey"
+>;
+
 export interface BindingPreview {
   readonly valid: boolean;
   readonly payload: Record<string, unknown>;
@@ -99,6 +110,18 @@ export function taskKeysForBoard(boardKey: string): string[] {
 /** The drawer's friendly two-option trigger, expressed as a match condition. */
 export type ReviewTrigger = "on_reject" | "on_review";
 
+/**
+ * One channel as the drawer edits it: the trigger and mapping kept in their friendly
+ * shapes (a two-option trigger, a field→template map) and turned into a binding's
+ * `matchCondition`/`fieldTemplates` only on save.
+ */
+export interface ChannelDraft {
+  readonly connectionId: string;
+  readonly operationId: string | null;
+  readonly trigger: ReviewTrigger;
+  readonly templates: Record<string, string>;
+}
+
 /** The path the verdict arrives under, and the value that means "rejected". */
 const VERDICT_PATH = "review.verdict";
 
@@ -130,9 +153,29 @@ export function unmappedRequiredFields(
   );
 }
 
+/**
+ * Stable identity for a channel: a connection *and* the operation called on it.
+ * This is the key a column's channels are deduplicated and diffed by — it mirrors
+ * the backend's unique key, which includes `connection_id` so one event can bind to
+ * several channels.
+ */
+export function channelKey(
+  connectionId: string,
+  operationId: string | null
+): string {
+  return `${connectionId}::${operationId ?? ""}`;
+}
+
+/** The channel identity of a stored or drafted binding. */
+export function bindingChannelKey(
+  binding: Pick<EventBinding, "connectionId" | "operationId">
+): string {
+  return channelKey(binding.connectionId, binding.operationId);
+}
+
 /** Stable identity for a channel in the picker: a connection *and* an operation. */
 export function targetKey(target: DispatchTarget): string {
-  return `${target.connectionId}::${target.operationId}`;
+  return channelKey(target.connectionId, target.operationId);
 }
 
 export function findTarget(
@@ -146,4 +189,31 @@ export function findTarget(
       target.connectionId === connectionId &&
       (operationId === null || target.operationId === operationId)
   );
+}
+
+/**
+ * The channels attached to a board column, as one binding each.
+ *
+ * A column may aggregate several Activiti tasks, and a channel attached to it is
+ * written once per task — so the same channel appears under more than one scope key.
+ * This folds those duplicates back to one entry per channel (own binding winning over
+ * one inherited from a parent org), which is what the drawer edits. Ordering is
+ * insertion order, so the list is stable across reopens.
+ */
+export function attachedChannels(
+  bindings: readonly EventBinding[],
+  boardKey: string
+): EventBinding[] {
+  const taskKeys = new Set(taskKeysForBoard(boardKey));
+  const byChannel = new Map<string, EventBinding>();
+  for (const binding of bindings) {
+    if (binding.eventType !== REVIEW_EVENT_TYPE) continue;
+    if (!binding.scopeKey || !taskKeys.has(binding.scopeKey)) continue;
+    const key = bindingChannelKey(binding);
+    const existing = byChannel.get(key);
+    if (!existing || (existing.inherited && !binding.inherited)) {
+      byChannel.set(key, binding);
+    }
+  }
+  return [...byChannel.values()];
 }

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-config-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-config-tab.tsx
@@ -1,28 +1,45 @@
 "use client";
 
-import type { ReactNode } from "react";
-import { Alert, Badge, Select, ToggleSwitch } from "flowbite-react";
-import { HiInformationCircle, HiLightningBolt } from "react-icons/hi";
-import type { I18nRecord } from "@/features/i18n/i18n.service.types";
-import { tr } from "@/features/i18n/tr.service";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Alert, Badge, Button, Select, ToggleSwitch } from "flowbite-react";
 import {
+  HiInformationCircle,
+  HiLightningBolt,
+  HiPlus,
+  HiTrash,
+  HiPencilAlt,
+  HiCheckCircle,
+  HiExclamationCircle,
+} from "react-icons/hi";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr, trDynamic } from "@/features/i18n/tr.service";
+import {
+  channelKey,
+  findTarget,
   targetKey,
+  unmappedRequiredFields,
+  type ChannelDraft,
   type DispatchTarget,
   type EventBinding,
   type ReviewTrigger,
 } from "./review-binding.types";
+import { checkTemplate } from "./review-template-validation";
 
 interface ReviewConfigTabProps {
   readonly enabled: boolean;
   readonly onEnabledChange: (value: boolean) => void;
   /** Channels the org can bind, from `/dispatch-targets`. */
   readonly targets: readonly DispatchTarget[];
-  readonly selected: DispatchTarget | undefined;
-  readonly onSelectTarget: (target: DispatchTarget) => void;
-  readonly trigger: ReviewTrigger;
-  readonly onTriggerChange: (trigger: ReviewTrigger) => void;
-  /** The stored binding, when this column already has one. */
-  readonly stored: EventBinding | undefined;
+  /** The channels currently attached to this column (own, editable). */
+  readonly channels: readonly ChannelDraft[];
+  /** The org's own stored bindings, for the job-registry summary. */
+  readonly stored: readonly EventBinding[];
+  /** Channels defined by a parent org: shown for context, not editable here. */
+  readonly inherited: readonly EventBinding[];
+  readonly onAddChannel: (target: DispatchTarget) => void;
+  readonly onDetachChannel: (channelKey: string) => void;
+  readonly onTriggerChange: (channelKey: string, trigger: ReviewTrigger) => void;
+  readonly onEditMapping: (channelKey: string) => void;
   readonly dict: I18nRecord;
 }
 
@@ -30,21 +47,24 @@ export function ReviewConfigTab({
   enabled,
   onEnabledChange,
   targets,
-  selected,
-  onSelectTarget,
-  trigger,
-  onTriggerChange,
+  channels,
   stored,
+  inherited,
+  onAddChannel,
+  onDetachChannel,
+  onTriggerChange,
+  onEditMapping,
   dict,
 }: Readonly<ReviewConfigTabProps>) {
+  const attached = new Set(
+    channels.map((channel) => channelKey(channel.connectionId, channel.operationId))
+  );
+  const available = targets.filter((target) => !attached.has(targetKey(target)));
+
   return (
     <div className="flex flex-col gap-6">
-      {stored?.inherited && (
-        <Alert color="info" icon={HiInformationCircle}>
-          <span className="text-xs">
-            {tr("config.inherited", dict, { org: stored.ownerOrgSlug })}
-          </span>
-        </Alert>
+      {inherited.length > 0 && (
+        <InheritedChannels inherited={inherited} targets={targets} dict={dict} />
       )}
 
       <div className="flex items-start justify-between gap-4 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
@@ -71,37 +91,40 @@ export function ReviewConfigTab({
                 <span className="text-xs">{tr("channel.empty", dict)}</span>
               </Alert>
             ) : (
-              <div className="grid grid-cols-1 gap-3">
-                {targets.map((target) => (
-                  <TargetCard
-                    key={targetKey(target)}
-                    target={target}
-                    selected={
-                      selected !== undefined && targetKey(selected) === targetKey(target)
-                    }
-                    onSelect={() => onSelectTarget(target)}
-                    dict={dict}
-                  />
-                ))}
+              <div className="flex flex-col gap-3">
+                {channels.length === 0 ? (
+                  <Alert color="gray" icon={HiInformationCircle}>
+                    <span className="text-xs">{tr("channel.none", dict)}</span>
+                  </Alert>
+                ) : (
+                  channels.map((channel) => (
+                    <ChannelRow
+                      key={channelKey(channel.connectionId, channel.operationId)}
+                      channel={channel}
+                      target={findTarget(
+                        targets,
+                        channel.connectionId,
+                        channel.operationId
+                      )}
+                      onTriggerChange={onTriggerChange}
+                      onDetach={onDetachChannel}
+                      onEditMapping={onEditMapping}
+                      dict={dict}
+                    />
+                  ))
+                )}
+
+                <AddChannelMenu
+                  available={available}
+                  allAttached={available.length === 0}
+                  onAdd={onAddChannel}
+                  dict={dict}
+                />
               </div>
             )}
           </Section>
 
-          {selected && (
-            <>
-              <Section title={tr("trigger.title", dict)} help={tr("trigger.help", dict)}>
-                <Select
-                  value={trigger}
-                  onChange={(e) => onTriggerChange(e.target.value as ReviewTrigger)}
-                >
-                  <option value="on_reject">{tr("trigger.onReject", dict)}</option>
-                  <option value="on_review">{tr("trigger.onReview", dict)}</option>
-                </Select>
-              </Section>
-
-              <JobPanel stored={stored} dict={dict} />
-            </>
-          )}
+          {channels.length > 0 && <JobPanel stored={stored} dict={dict} />}
         </>
       )}
     </div>
@@ -129,72 +152,242 @@ export function Section({
 }
 
 /**
- * A channel is a connection *and* the operation to call on it.
- *
- * The credential is deliberately not chosen here, unlike in the mockup: a connection
- * already carries one, so picking the channel picks how it authenticates. Offering a
- * second choice would let the two disagree.
+ * One attached channel: a connection + the operation to call on it, with its own
+ * trigger and a shortcut into its mapping. The credential is not chosen here — a
+ * connection already carries one, so the channel picks how it authenticates.
  */
-function TargetCard({
+function ChannelRow({
+  channel,
   target,
-  selected,
-  onSelect,
+  onTriggerChange,
+  onDetach,
+  onEditMapping,
   dict,
 }: Readonly<{
-  target: DispatchTarget;
-  selected: boolean;
-  onSelect: () => void;
+  channel: ChannelDraft;
+  target: DispatchTarget | undefined;
+  onTriggerChange: (channelKey: string, trigger: ReviewTrigger) => void;
+  onDetach: (channelKey: string) => void;
+  onEditMapping: (channelKey: string) => void;
   dict: I18nRecord;
 }>) {
-  const base = "flex flex-col gap-1 rounded-lg border p-3 text-left transition-all";
-  const state = selected
-    ? "cursor-pointer border-primary-500 ring-2 ring-primary-200 dark:border-primary-400 dark:ring-primary-900"
-    : "cursor-pointer border-gray-200 hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800";
+  const key = channelKey(channel.connectionId, channel.operationId);
+  const broken = Object.values(channel.templates).some(
+    (template) => checkTemplate(template).status === "invalid"
+  );
+  const missing = unmappedRequiredFields(target, channel.templates).length;
+  const mappingReady = Boolean(target) && missing === 0 && !broken;
 
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={selected}
-      className={`${base} ${state}`}
-    >
-      <span className="flex flex-wrap items-center gap-2">
-        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-          {target.connectionName}
-        </span>
-        <Badge color="gray">{target.providerType}</Badge>
-        {selected && <Badge color="indigo">{tr("channel.selected", dict)}</Badge>}
-      </span>
-      <span className="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-        <span>{target.operationName}</span>
-        <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] dark:bg-gray-700">
-          {target.method} {target.path}
-        </code>
-      </span>
-    </button>
+    <div className="flex flex-col gap-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <span className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {target?.connectionName ?? channel.connectionId}
+            </span>
+            {target && <Badge color="gray">{target.providerType}</Badge>}
+          </span>
+          <span className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            {target ? (
+              <>
+                <span>{target.operationName}</span>
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] dark:bg-gray-700">
+                  {target.method} {target.path}
+                </code>
+              </>
+            ) : (
+              <span className="text-amber-600 dark:text-amber-400">
+                {tr("channel.unknown", dict)}
+              </span>
+            )}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onDetach(key)}
+          aria-label={tr("channel.detach", dict)}
+          className="shrink-0 rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+        >
+          <HiTrash className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Select
+          sizing="sm"
+          className="flex-1"
+          value={channel.trigger}
+          onChange={(e) => onTriggerChange(key, e.target.value as ReviewTrigger)}
+        >
+          <option value="on_reject">{tr("trigger.onReject", dict)}</option>
+          <option value="on_review">{tr("trigger.onReview", dict)}</option>
+        </Select>
+        <Button
+          type="button"
+          color={mappingReady ? "light" : "warning"}
+          size="xs"
+          onClick={() => onEditMapping(key)}
+          disabled={!target}
+        >
+          {mappingReady ? (
+            <HiCheckCircle className="mr-1 h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+          ) : (
+            <HiExclamationCircle className="mr-1 h-3.5 w-3.5" />
+          )}
+          {tr("channel.mapping", dict)}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** The "+ add channel" affordance: a menu of channels not already attached. */
+function AddChannelMenu({
+  available,
+  allAttached,
+  onAdd,
+  dict,
+}: Readonly<{
+  available: readonly DispatchTarget[];
+  allAttached: boolean;
+  onAdd: (target: DispatchTarget) => void;
+  dict: I18nRecord;
+}>) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
+  if (allAttached) {
+    return (
+      <p className="text-xs text-gray-400">{tr("channel.allAttached", dict)}</p>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <Button
+        type="button"
+        color="light"
+        size="sm"
+        className="w-full"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+      >
+        <HiPlus className="mr-1 h-4 w-4" />
+        {tr("channel.add", dict)}
+      </Button>
+      {open && (
+        <div className="absolute left-0 right-0 top-11 z-50 max-h-64 overflow-y-auto rounded-lg border border-gray-200 bg-white p-1 shadow-xl dark:border-gray-600 dark:bg-gray-800">
+          {available.map((target) => (
+            <button
+              key={targetKey(target)}
+              type="button"
+              onClick={() => {
+                onAdd(target);
+                setOpen(false);
+              }}
+              className="flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <span className="flex w-full items-center gap-2">
+                <HiPencilAlt className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                <span className="truncate text-xs font-medium text-gray-800 dark:text-gray-100">
+                  {target.connectionName}
+                </span>
+                <Badge color="gray" className="ml-auto">
+                  {target.providerType}
+                </Badge>
+              </span>
+              <code className="ml-5 truncate font-mono text-[10px] text-gray-400">
+                {target.method} {target.path}
+              </code>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Channels inherited from a parent org: live and visible, but not this org's to edit. */
+function InheritedChannels({
+  inherited,
+  targets,
+  dict,
+}: Readonly<{
+  inherited: readonly EventBinding[];
+  targets: readonly DispatchTarget[];
+  dict: I18nRecord;
+}>) {
+  const org = inherited[0]?.ownerOrgSlug ?? "";
+  return (
+    <Alert color="info" icon={HiInformationCircle}>
+      <div className="flex flex-col gap-1">
+        <span className="text-xs">{tr("config.inherited", dict, { org })}</span>
+        <ul className="flex flex-col gap-0.5">
+          {inherited.map((binding) => {
+            const target = findTarget(
+              targets,
+              binding.connectionId,
+              binding.operationId
+            );
+            return (
+              <li
+                key={binding.id}
+                className="text-[11px] text-gray-600 dark:text-gray-300"
+              >
+                • {target?.connectionName ?? binding.connectionId}
+                {target ? (
+                  <code className="ml-1 font-mono opacity-70">
+                    {target.method} {target.path}
+                  </code>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </Alert>
   );
 }
 
 function JobPanel({
   stored,
   dict,
-}: Readonly<{ stored: EventBinding | undefined; dict: I18nRecord }>) {
+}: Readonly<{ stored: readonly EventBinding[]; dict: I18nRecord }>) {
+  const armed = stored.filter((binding) => binding.enabled).length;
+  const latest = stored.reduce<EventBinding | undefined>((newest, binding) => {
+    if (!newest) return binding;
+    return binding.updatedAt > newest.updatedAt ? binding : newest;
+  }, undefined);
+
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
       <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
         <HiLightningBolt className="h-4 w-4 text-primary-500" />
         {tr("job.title", dict)}
       </div>
-      {stored ? (
+      {latest ? (
         <div className="mt-2 flex flex-col gap-1 text-xs text-gray-600 dark:text-gray-400">
           <span>
-            <Badge color={stored.enabled ? "success" : "gray"}>
-              {stored.enabled ? tr("job.armed", dict) : tr("job.paused", dict)}
+            <Badge color={armed > 0 ? "success" : "gray"}>
+              {trDynamic("job.channelSummary", dict, {
+                count: String(stored.length),
+                armed: String(armed),
+              })}
             </Badge>
           </span>
           <span>
-            {tr("job.lastUpdated", dict)}: {new Date(stored.updatedAt).toLocaleString()}
-            {stored.updatedBy ? ` · ${stored.updatedBy}` : ""}
+            {tr("job.lastUpdated", dict)}: {new Date(latest.updatedAt).toLocaleString()}
+            {latest.updatedBy ? ` · ${latest.updatedBy}` : ""}
           </span>
         </div>
       ) : (

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
@@ -17,11 +17,21 @@ import type { DispatchTarget, DispatchTargetField } from "./review-binding.types
 
 const SAMPLE_CONTEXT = buildSampleContext();
 
+/** One entry in the channel switcher: a stable key and its display name. */
+export interface MappingChannelTab {
+  readonly key: string;
+  readonly label: string;
+}
+
 interface ReviewMappingTabProps {
   /** The chosen channel; its operation contract supplies the fields to map. */
   readonly target: DispatchTarget | undefined;
   readonly mappings: Record<string, string>;
   readonly onChange: (fieldId: string, template: string) => void;
+  /** The column's attached channels, for switching which one is being mapped. */
+  readonly channels?: readonly MappingChannelTab[];
+  readonly activeChannelId?: string | null;
+  readonly onSelectChannel?: (channelKey: string) => void;
   readonly dict: I18nRecord;
 }
 
@@ -29,18 +39,35 @@ export function ReviewMappingTab({
   target,
   mappings,
   onChange,
+  channels,
+  activeChannelId,
+  onSelectChannel,
   dict,
 }: Readonly<ReviewMappingTabProps>) {
+  const switcher =
+    channels && channels.length > 1 && onSelectChannel ? (
+      <ChannelSwitcher
+        channels={channels}
+        activeChannelId={activeChannelId ?? null}
+        onSelectChannel={onSelectChannel}
+        dict={dict}
+      />
+    ) : null;
+
   if (!target) {
     return (
-      <Alert color="gray" icon={HiInformationCircle}>
-        <span className="text-xs">{tr("mapping.noChannel", dict)}</span>
-      </Alert>
+      <div className="flex flex-col gap-4">
+        {switcher}
+        <Alert color="gray" icon={HiInformationCircle}>
+          <span className="text-xs">{tr("mapping.noChannel", dict)}</span>
+        </Alert>
+      </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-4">
+      {switcher}
       <Section title={tr("mapping.title", dict)} help={tr("mapping.help", dict)}>
         <div className="flex flex-wrap gap-1.5">
           {VARIABLE_GROUPS.map((group) => {
@@ -70,6 +97,49 @@ export function ReviewMappingTab({
             dict={dict}
           />
         ))}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+/** Pills to switch which attached channel's mapping is on screen. */
+function ChannelSwitcher({
+  channels,
+  activeChannelId,
+  onSelectChannel,
+  dict,
+}: Readonly<{
+  channels: readonly MappingChannelTab[];
+  activeChannelId: string | null;
+  onSelectChannel: (channelKey: string) => void;
+  dict: I18nRecord;
+}>) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+        {tr("mapping.channel", dict)}
+      </span>
+      <div className="flex flex-wrap gap-1.5">
+        {channels.map((channel) => {
+          const active = channel.key === activeChannelId;
+          return (
+            <button
+              key={channel.key}
+              type="button"
+              onClick={() => onSelectChannel(channel.key)}
+              aria-pressed={active}
+              className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                active
+                  ? "bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              }`}
+            >
+              {channel.label}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-settings-drawer.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-settings-drawer.tsx
@@ -7,48 +7,63 @@ import { HiX, HiClipboardCheck } from "react-icons/hi";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 import {
+  channelKey,
   conditionForTrigger,
   findTarget,
   triggerFromCondition,
   unmappedRequiredFields,
+  type ChannelBindingDraft,
+  type ChannelDraft,
   type DispatchTarget,
   type EventBinding,
-  type ReviewTrigger,
-  type UpsertBindingRequest,
 } from "./review-binding.types";
+import { checkTemplate } from "./review-template-validation";
 import { ReviewConfigTab } from "./review-config-tab";
 import { ReviewMappingTab } from "./review-mapping-tab";
 
 type TabId = "config" | "mapping";
-
-/** The half of an upsert the drawer owns; the hook adds event type and scope. */
-export type BindingDraft = Omit<
-  UpsertBindingRequest,
-  "eventType" | "scopeKind" | "scopeKey"
->;
 
 interface ReviewSettingsDrawerProps {
   readonly show: boolean;
   readonly onClose: () => void;
   /** Display title of the column being configured. */
   readonly laneTitle: string;
-  /** The stored binding for this column, own or inherited from a parent org. */
-  readonly binding: EventBinding | undefined;
+  /** Every channel attached to this column, own and inherited from a parent org. */
+  readonly bindings: readonly EventBinding[];
   readonly targets: readonly DispatchTarget[];
-  readonly onSave: (draft: BindingDraft) => void;
+  readonly onSave: (channels: ChannelBindingDraft[]) => void;
   readonly saving?: boolean;
   /** `pages.reviewProcess` subtree. */
   readonly dict: I18nRecord;
 }
 
-function draftKey(draft: BindingDraft): string {
-  return JSON.stringify([
-    draft.enabled,
-    draft.connectionId,
-    draft.operationId,
-    draft.matchCondition,
-    draft.fieldTemplates,
-  ]);
+/** Templates serialized key-order-independently, so a re-keyed map is not "dirty". */
+function stableTemplates(templates: Record<string, string>): [string, string][] {
+  return Object.entries(templates).sort(([a], [b]) => (a < b ? -1 : 1));
+}
+
+/** A signature over the editable set, for the dirty check. */
+function channelsSignature(
+  enabled: boolean,
+  channels: readonly ChannelDraft[]
+): string {
+  const rows = channels
+    .map((channel) => [
+      channelKey(channel.connectionId, channel.operationId),
+      channel.trigger,
+      stableTemplates(channel.templates),
+    ])
+    .sort((a, b) => (String(a[0]) < String(b[0]) ? -1 : 1));
+  return JSON.stringify([enabled, rows]);
+}
+
+function draftFromBinding(binding: EventBinding): ChannelDraft {
+  return {
+    connectionId: binding.connectionId,
+    operationId: binding.operationId,
+    trigger: triggerFromCondition(binding.matchCondition),
+    templates: { ...binding.fieldTemplates },
+  };
 }
 
 /**
@@ -56,103 +71,184 @@ function draftKey(draft: BindingDraft): string {
  * dashlet settings drawer (portal to body, slide-in, tabbed) so it reads the same as
  * the rest of the app.
  *
- * The binding is edited as a draft and committed by Save — unlike the lane's view
- * preferences, which stay inline in the column menu and apply instantly.
+ * A column can fan its verdict out to several channels, so the drawer edits a *list*:
+ * each attached channel carries its own trigger and its own field mapping, and Save
+ * commits the whole set (the hook upserts what is attached and drops what was
+ * detached). The master toggle arms or pauses the column's own channels together;
+ * channels inherited from a parent org are shown for context but not editable here.
  */
 export function ReviewSettingsDrawer({
   show,
   onClose,
   laneTitle,
-  binding,
+  bindings,
   targets,
   onSave,
   saving = false,
   dict,
 }: Readonly<ReviewSettingsDrawerProps>) {
+  const ownBindings = useMemo(
+    () => bindings.filter((binding) => !binding.inherited),
+    [bindings]
+  );
+  const inheritedBindings = useMemo(
+    () => bindings.filter((binding) => binding.inherited),
+    [bindings]
+  );
+
   const [activeTab, setActiveTab] = useState<TabId>("config");
   const [enabled, setEnabled] = useState(false);
-  const [connectionId, setConnectionId] = useState<string | null>(null);
-  const [operationId, setOperationId] = useState<string | null>(null);
-  const [trigger, setTrigger] = useState<ReviewTrigger>("on_reject");
-  const [templates, setTemplates] = useState<Record<string, string>>({});
+  const [channels, setChannels] = useState<ChannelDraft[]>([]);
+  const [activeChannelId, setActiveChannelId] = useState<string | null>(null);
 
-  // Re-seed from the stored binding every time the drawer opens, so a reopened form
+  // Re-seed from the stored bindings every time the drawer opens, so a reopened form
   // never shows another column's draft.
   useEffect(() => {
     if (!show) return;
     setActiveTab("config");
-    setEnabled(binding?.enabled ?? false);
-    setConnectionId(binding?.connectionId ?? null);
-    setOperationId(binding?.operationId ?? null);
-    setTrigger(triggerFromCondition(binding?.matchCondition));
-    setTemplates(binding?.fieldTemplates ?? {});
-  }, [show, binding]);
+    setEnabled(ownBindings.some((binding) => binding.enabled));
+    const seeded = ownBindings.map(draftFromBinding);
+    setChannels(seeded);
+    setActiveChannelId(
+      seeded.length > 0
+        ? channelKey(seeded[0].connectionId, seeded[0].operationId)
+        : null
+    );
+  }, [show, ownBindings]);
 
-  const selected = findTarget(targets, connectionId, operationId);
-
-  function selectTarget(next: DispatchTarget) {
-    setConnectionId(next.connectionId);
-    setOperationId(next.operationId);
-    // Seed a blank row per contract field only when nothing is mapped yet, so an
-    // operator returning to an already-mapped channel keeps their work.
-    setTemplates((prev) => {
-      if (Object.keys(prev).length > 0) return prev;
-      const seeded: Record<string, string> = {};
-      next.fields.forEach((field) => {
-        seeded[field.id] = "";
+  function addChannel(target: DispatchTarget) {
+    const key = channelKey(target.connectionId, target.operationId);
+    setChannels((prev) => {
+      if (prev.some((c) => channelKey(c.connectionId, c.operationId) === key)) {
+        return prev;
+      }
+      const templates: Record<string, string> = {};
+      target.fields.forEach((field) => {
+        templates[field.id] = "";
       });
-      return seeded;
+      // New channels default to "both": the safe superset, and the trigger the
+      // producer actually populates today.
+      return [
+        ...prev,
+        {
+          connectionId: target.connectionId,
+          operationId: target.operationId,
+          trigger: "on_review",
+          templates,
+        },
+      ];
+    });
+    setActiveChannelId(key);
+    setActiveTab("mapping");
+  }
+
+  function detachChannel(key: string) {
+    setChannels((prev) =>
+      prev.filter((c) => channelKey(c.connectionId, c.operationId) !== key)
+    );
+    setActiveChannelId((current) => {
+      if (current !== key) return current;
+      const next = channels.find(
+        (c) => channelKey(c.connectionId, c.operationId) !== key
+      );
+      return next ? channelKey(next.connectionId, next.operationId) : null;
     });
   }
 
-  const draft: BindingDraft = useMemo(
-    () => ({
-      connectionId: connectionId ?? "",
-      operationId,
-      matchCondition: conditionForTrigger(trigger),
-      fieldTemplates: templates,
-      enabled,
-    }),
-    [connectionId, operationId, trigger, templates, enabled]
-  );
-
-  const stored: BindingDraft | null = binding
-    ? {
-        connectionId: binding.connectionId,
-        operationId: binding.operationId,
-        matchCondition: binding.matchCondition as Record<string, unknown>,
-        fieldTemplates: binding.fieldTemplates,
-        enabled: binding.enabled,
-      }
-    : null;
-
-  const dirty = stored === null ? enabled : draftKey(draft) !== draftKey(stored);
-
-  // An inherited binding is shown for context but belongs to the parent org.
-  const readOnly = binding?.inherited ?? false;
-
-  const blockingReason = useMemo(() => {
-    if (!enabled) return null;
-    if (!selected) return tr("validation.channelRequired", dict);
-    const missing = unmappedRequiredFields(selected, templates);
-    if (missing.length > 0) {
-      return tr("validation.unmapped", dict, {
-        fields: missing.map((field) => field.id).join(", "),
-      });
-    }
-    return null;
-  }, [enabled, selected, templates, dict]);
-
-  // Whose binding this is, or whether there is anything to save — one line, because
-  // the two states are mutually exclusive and only one can be shown.
-  let footerNote = "";
-  if (readOnly) {
-    footerNote = tr("drawer.readOnly", dict);
-  } else if (!blockingReason && dirty) {
-    footerNote = tr("drawer.unsaved", dict);
+  function patchChannel(key: string, patch: Partial<ChannelDraft>) {
+    setChannels((prev) =>
+      prev.map((c) =>
+        channelKey(c.connectionId, c.operationId) === key ? { ...c, ...patch } : c
+      )
+    );
   }
 
+  function editMapping(key: string) {
+    setActiveChannelId(key);
+    setActiveTab("mapping");
+  }
+
+  const activeChannel = channels.find(
+    (c) => channelKey(c.connectionId, c.operationId) === activeChannelId
+  );
+  const activeTarget = activeChannel
+    ? findTarget(targets, activeChannel.connectionId, activeChannel.operationId)
+    : undefined;
+
+  const committed: ChannelBindingDraft[] = useMemo(
+    () =>
+      channels.map((channel) => ({
+        connectionId: channel.connectionId,
+        operationId: channel.operationId,
+        matchCondition: conditionForTrigger(channel.trigger),
+        fieldTemplates: channel.templates,
+        enabled,
+      })),
+    [channels, enabled]
+  );
+
+  const dirty = useMemo(() => {
+    const storedChannels = ownBindings.map(draftFromBinding);
+    const storedEnabled = ownBindings.some((binding) => binding.enabled);
+    return (
+      channelsSignature(enabled, channels) !==
+      channelsSignature(storedEnabled, storedChannels)
+    );
+  }, [enabled, channels, ownBindings]);
+
+  const blockingReason = useMemo(() => {
+    // A template the server would refuse can never be stored, armed or not.
+    for (const channel of channels) {
+      const target = findTarget(
+        targets,
+        channel.connectionId,
+        channel.operationId
+      );
+      const name = target?.connectionName ?? channel.connectionId;
+      for (const [fieldId, template] of Object.entries(channel.templates)) {
+        if (checkTemplate(template).status === "invalid") {
+          return tr("validation.brokenTemplate", dict, {
+            channel: name,
+            field: fieldId,
+          });
+        }
+      }
+    }
+    if (!enabled) return null;
+    if (channels.length === 0) return tr("validation.noChannels", dict);
+    for (const channel of channels) {
+      const target = findTarget(
+        targets,
+        channel.connectionId,
+        channel.operationId
+      );
+      const missing = unmappedRequiredFields(target, channel.templates);
+      if (missing.length > 0) {
+        return tr("validation.unmapped", dict, {
+          channel: target?.connectionName ?? channel.connectionId,
+          fields: missing.map((field) => field.id).join(", "),
+        });
+      }
+    }
+    return null;
+  }, [enabled, channels, targets, dict]);
+
+  // Whether there is anything to save, shown when nothing blocks it.
+  const footerNote = !blockingReason && dirty ? tr("drawer.unsaved", dict) : "";
+
   if (typeof document === "undefined") return null;
+
+  const mappingChannels = channels.map((channel) => {
+    const target = findTarget(
+      targets,
+      channel.connectionId,
+      channel.operationId
+    );
+    return {
+      key: channelKey(channel.connectionId, channel.operationId),
+      label: target?.connectionName ?? channel.connectionId,
+    };
+  });
 
   const tabs: readonly { id: TabId; label: string }[] = [
     { id: "config", label: tr("drawer.tabConfig", dict) },
@@ -227,21 +323,33 @@ export function ReviewSettingsDrawer({
               enabled={enabled}
               onEnabledChange={setEnabled}
               targets={targets}
-              selected={selected}
-              onSelectTarget={selectTarget}
-              trigger={trigger}
-              onTriggerChange={setTrigger}
-              stored={binding}
+              channels={channels}
+              stored={ownBindings}
+              inherited={inheritedBindings}
+              onAddChannel={addChannel}
+              onDetachChannel={detachChannel}
+              onTriggerChange={(key, trigger) => patchChannel(key, { trigger })}
+              onEditMapping={editMapping}
               dict={dict}
             />
           )}
           {show && activeTab === "mapping" && (
             <ReviewMappingTab
-              target={enabled ? selected : undefined}
-              mappings={templates}
-              onChange={(fieldId, template) =>
-                setTemplates((prev) => ({ ...prev, [fieldId]: template }))
-              }
+              target={enabled ? activeTarget : undefined}
+              mappings={activeChannel?.templates ?? {}}
+              onChange={(fieldId, template) => {
+                if (!activeChannel) return;
+                const key = channelKey(
+                  activeChannel.connectionId,
+                  activeChannel.operationId
+                );
+                patchChannel(key, {
+                  templates: { ...activeChannel.templates, [fieldId]: template },
+                });
+              }}
+              channels={mappingChannels}
+              activeChannelId={activeChannelId}
+              onSelectChannel={setActiveChannelId}
               dict={dict}
             />
           )}
@@ -262,8 +370,8 @@ export function ReviewSettingsDrawer({
               <Button
                 color="blue"
                 size="sm"
-                onClick={() => onSave(draft)}
-                disabled={readOnly || saving || !dirty || Boolean(blockingReason)}
+                onClick={() => onSave(committed)}
+                disabled={saving || !dirty || Boolean(blockingReason)}
               >
                 {saving ? tr("drawer.saving", dict) : tr("drawer.save", dict)}
               </Button>

--- a/turbo-repo/apps/app/src/features/shipping/hooks/use-review-bindings.ts
+++ b/turbo-repo/apps/app/src/features/shipping/hooks/use-review-bindings.ts
@@ -3,12 +3,15 @@
 import { useCallback, useMemo, useState } from "react";
 import useSWR from "swr";
 import {
+  attachedChannels,
+  bindingChannelKey,
+  channelKey,
   REVIEW_EVENT_TYPE,
   REVIEW_SCOPE_KIND,
   taskKeysForBoard,
+  type ChannelBindingDraft,
   type DispatchTarget,
   type EventBinding,
-  type UpsertBindingRequest,
 } from "../components/lane/review-binding.types";
 import {
   deleteBinding,
@@ -27,9 +30,14 @@ const TARGETS_KEY = "integration-dispatch-targets";
  * patching locally, so server-owned fields — who last changed a binding, whether it
  * is inherited from a parent org — come back from the source that decided them.
  *
+ * A column may fan a verdict out to several channels: the backend keys bindings on
+ * `connection_id` on purpose, so one event legitimately drives many. This hook
+ * therefore exposes the *list* of channels a column carries, and `save` commits the
+ * whole set — upserting what is attached and soft-deleting what was detached.
+ *
  * A column maps to one Activiti task per binding. Where a column aggregates several
- * tasks, saving writes one binding each, so every task fires on its own completion
- * rather than one of them silently going unbound.
+ * tasks, saving writes one binding per channel per task, so every task fires on its
+ * own completion rather than one of them silently going unbound.
  */
 export function useReviewBindings(orgSlug: string | null) {
   const {
@@ -51,81 +59,70 @@ export function useReviewBindings(orgSlug: string | null) {
 
   const [saving, setSaving] = useState(false);
 
-  /** Bindings by the Activiti task they listen to, for quick per-column lookup. */
-  const byTaskKey = useMemo(() => {
-    const index = new Map<string, EventBinding>();
-    for (const binding of bindings ?? []) {
-      if (binding.eventType !== REVIEW_EVENT_TYPE || !binding.scopeKey) continue;
-      // An org's own binding wins over one inherited from its parent.
-      const existing = index.get(binding.scopeKey);
-      if (!existing || (existing.inherited && !binding.inherited)) {
-        index.set(binding.scopeKey, binding);
-      }
-    }
-    return index;
-  }, [bindings]);
+  const allBindings = useMemo(() => bindings ?? [], [bindings]);
 
-  /** The binding governing a board column, own or inherited. */
-  const bindingForBoard = useCallback(
-    (boardKey: string): EventBinding | undefined => {
-      for (const taskKey of taskKeysForBoard(boardKey)) {
-        const found = byTaskKey.get(taskKey);
-        if (found) return found;
-      }
-      return undefined;
-    },
-    [byTaskKey]
+  /** The channels attached to a board column, own or inherited, one entry each. */
+  const bindingsForBoard = useCallback(
+    (boardKey: string): EventBinding[] => attachedChannels(allBindings, boardKey),
+    [allBindings]
   );
 
   /**
-   * Writes one binding per Activiti task behind the column. Sequential rather than
-   * concurrent: they share a unique key per task and a failure part-way should stop
-   * rather than race the rest in.
+   * Commits a column's whole set of channels. For every Activiti task behind the
+   * column it upserts each attached channel and soft-deletes the org's own bindings
+   * that are no longer in the set — so detaching a channel in the drawer removes it
+   * everywhere it was written. Inherited bindings belong to a parent org and are left
+   * untouched.
+   *
+   * Sequential rather than concurrent: writes for one task share a unique key and a
+   * failure part-way should stop rather than race the rest in.
    */
   const save = useCallback(
-    async (boardKey: string, draft: Omit<UpsertBindingRequest, "eventType" | "scopeKind" | "scopeKey">) => {
+    async (boardKey: string, channels: readonly ChannelBindingDraft[]) => {
       if (!orgSlug) throw new Error("No organization is selected");
       setSaving(true);
       try {
+        const desired = new Set(
+          channels.map((channel) =>
+            channelKey(channel.connectionId, channel.operationId)
+          )
+        );
         for (const taskKey of taskKeysForBoard(boardKey)) {
-          await upsertBinding(orgSlug, {
-            ...draft,
-            eventType: REVIEW_EVENT_TYPE,
-            scopeKind: REVIEW_SCOPE_KIND,
-            scopeKey: taskKey,
-          });
+          for (const channel of channels) {
+            await upsertBinding(orgSlug, {
+              ...channel,
+              eventType: REVIEW_EVENT_TYPE,
+              scopeKind: REVIEW_SCOPE_KIND,
+              scopeKey: taskKey,
+            });
+          }
+          const stale = allBindings.filter(
+            (binding) =>
+              !binding.inherited &&
+              binding.eventType === REVIEW_EVENT_TYPE &&
+              binding.scopeKey === taskKey &&
+              !desired.has(bindingChannelKey(binding))
+          );
+          for (const binding of stale) {
+            await deleteBinding(orgSlug, binding.id);
+          }
         }
         await mutate();
       } finally {
         setSaving(false);
       }
     },
-    [orgSlug, mutate]
-  );
-
-  const remove = useCallback(
-    async (bindingId: string) => {
-      if (!orgSlug) throw new Error("No organization is selected");
-      setSaving(true);
-      try {
-        await deleteBinding(orgSlug, bindingId);
-        await mutate();
-      } finally {
-        setSaving(false);
-      }
-    },
-    [orgSlug, mutate]
+    [orgSlug, allBindings, mutate]
   );
 
   return {
-    bindings: bindings ?? [],
+    bindings: allBindings,
     targets: targets ?? [],
-    bindingForBoard,
+    bindingsForBoard,
     isLoading,
     error,
     saving,
     save,
-    remove,
     refresh: mutate,
   };
 }

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -19,7 +19,7 @@
       },
       "config": {
         "enableLabel": "Enable the review process for this column",
-        "enableHelp": "When a service in this column is reviewed, its verdict is sent to the selected channel.",
+        "enableHelp": "When a service in this column is reviewed, its verdict is sent to the configured channels.",
         "disabledNotice": "The review process is disabled for this column.",
         "inherited": "Inherited from organization {org}. Read-only here."
       },
@@ -27,7 +27,13 @@
         "title": "Integration channel",
         "help": "Choose where to send the review verdict.",
         "selected": "Selected",
-        "empty": "No active connections. Create and test them in Settings › Integrations."
+        "empty": "No active connections. Create and test them in Settings › Integrations.",
+        "none": "No channels attached yet. Add one to send the verdict.",
+        "add": "Add channel",
+        "allAttached": "Every available channel is already attached.",
+        "detach": "Remove channel",
+        "mapping": "Mapping",
+        "unknown": "Connection not found"
       },
       "trigger": {
         "title": "When to send",
@@ -61,18 +67,22 @@
           "badChar": "'{expression}' contains an unsupported character: '{char}'.",
           "unknownRoot": "'{path}' is unknown: '{root}' is not one of {roots}.",
           "wholeObject": "'{path}' is a whole object — use one of its fields (e.g. .mediaId)."
-        }
+        },
+        "channel": "Channel"
       },
       "job": {
         "title": "Job registration",
         "willRegister": "Saving registers an integration job in async_jobs.",
         "paused": "Job paused (review disabled)",
         "armed": "Armed",
-        "lastUpdated": "Last updated"
+        "lastUpdated": "Last updated",
+        "channelSummary": "{count} channel(s) · {armed} armed"
       },
       "validation": {
         "channelRequired": "Select a channel.",
-        "unmapped": "Required fields still unmapped: {fields}"
+        "unmapped": "Channel {channel} has required fields left unmapped: {fields}",
+        "noChannels": "Add at least one channel to arm the review.",
+        "brokenTemplate": "Channel {channel} has an invalid template in field {field}."
       },
       "toast": {
         "saved": "Review process saved",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -19,7 +19,7 @@
       },
       "config": {
         "enableLabel": "Activar proceso de revisión en esta columna",
-        "enableHelp": "Cuando un servicio de esta columna sea revisado, su veredicto se enviará al canal seleccionado.",
+        "enableHelp": "Cuando un servicio de esta columna sea revisado, su veredicto se enviará a los canales configurados.",
         "disabledNotice": "El proceso de revisión está desactivado para esta columna.",
         "inherited": "Heredado de la organización {org}. Solo lectura aquí."
       },
@@ -27,7 +27,13 @@
         "title": "Canal de integración",
         "help": "Elige a dónde enviar el veredicto de la revisión.",
         "selected": "Seleccionado",
-        "empty": "No hay conexiones activas. Créalas y pruébalas en Ajustes › Integraciones."
+        "empty": "No hay conexiones activas. Créalas y pruébalas en Ajustes › Integraciones.",
+        "none": "No hay canales adjuntos. Añade uno para enviar el veredicto.",
+        "add": "Añadir canal",
+        "allAttached": "Todos los canales disponibles ya están adjuntos.",
+        "detach": "Quitar canal",
+        "mapping": "Mapeo",
+        "unknown": "Conexión no encontrada"
       },
       "trigger": {
         "title": "Cuándo enviar",
@@ -61,18 +67,22 @@
           "badChar": "'{expression}' contiene un carácter no admitido: '{char}'.",
           "unknownRoot": "'{path}' no existe: '{root}' no es uno de {roots}.",
           "wholeObject": "'{path}' es un objeto completo: usa uno de sus campos (por ejemplo, .mediaId)."
-        }
+        },
+        "channel": "Canal"
       },
       "job": {
         "title": "Registro del trabajo",
         "willRegister": "Al guardar se registrará un trabajo de integración en async_jobs.",
         "paused": "Trabajo en pausa (revisión desactivada)",
         "armed": "Activo",
-        "lastUpdated": "Última modificación"
+        "lastUpdated": "Última modificación",
+        "channelSummary": "{count} canal(es) · {armed} activo(s)"
       },
       "validation": {
         "channelRequired": "Selecciona un canal.",
-        "unmapped": "Faltan campos requeridos por mapear: {fields}"
+        "unmapped": "El canal {channel} tiene campos requeridos sin mapear: {fields}",
+        "noChannels": "Añade al menos un canal para activar la revisión.",
+        "brokenTemplate": "El canal {channel} tiene una plantilla inválida en el campo {field}."
       },
       "toast": {
         "saved": "Proceso de revisión guardado",


### PR DESCRIPTION
## What

Let a reviewed column dispatch its verdict to **several channels**, each with its own trigger and its own field mapping — instead of the single channel the drawer allowed.

## Why this is FE-only

The backend already fans out. `IntegrationEventIntakeService.accept` enqueues **one dispatch job per matching binding**, and the binding's unique key includes `connection_id` on purpose — the migration says so:

> `connection_id is part of the key on purpose: one event may legitimately fan out to several channels.`

The "one integration per column" wall was entirely in the app: the hook collapsed a column's bindings to one (`Map<scopeKey, EventBinding>`) and the drawer was a single-binding editor.

## Change

- **Drawer** (`review-settings-drawer.tsx`) now edits a *list* of channels. The master toggle arms/pauses the column's own channels together; **Save commits the whole set** — upserts what's attached, soft-deletes what was detached, across every Activiti task behind the column.
- **Config tab** (`review-config-tab.tsx`): single-select radio → attached-channel list with a `+ Añadir canal` picker (targets not yet attached), a per-row trigger (`Cuándo enviar`), a per-row **Mapeo** shortcut with a ready/incomplete indicator, and detach. Inherited channels render read-only for context.
- **Mapping tab** (`review-mapping-tab.tsx`): adds a channel switcher when a column has more than one channel; otherwise unchanged (reuses the autocomplete input + server-faithful validation).
- **Hook** (`use-review-bindings.ts`): `bindingForBoard → bindingsForBoard` (folds a channel written across a column's task keys into one entry, own-over-inherited); `save(boardKey, channels[])` does the upsert-and-diff-delete.
- Pure helpers `channelKey` / `bindingChannelKey` / `attachedChannels` extracted into `review-binding.types.ts` and unit-tested.

## Validation model

- A **broken template** (server would reject) blocks Save whether armed or not.
- **Unmapped required fields** block Save only while the column is armed.
- The block message names the offending channel.

## Tests

- 47 shipping tests pass (6 new pinning `channelKey` / `attachedChannels` dedup + own-over-inherited).
- `check-types`: 161 errors, all pre-existing (unbuilt `@microboxlabs/miot-*` workspace packages) — none in touched files.
- eslint clean on all touched files.

## Not in scope (flagged)

- The `on_reject` trigger stores `{"review.verdict": false}`, but the producer emits the verdict per item at `content[].verdict` (no `review` root), so `on_reject` bindings never match — a separate semantic decision. New channels default to `on_review` to avoid silently attaching a never-firing channel.
- Backend has no in-place edit for an operation's path (create-only) and no rendered connection-admin UI — creating/editing the channel *instance* itself is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review settings now support configuring multiple channels per shipping lane.
  * Added channel management controls to add, detach, switch, and edit mappings.
  * Added inherited channel visibility and multi-channel job summaries.
* **Bug Fixes**
  * Improved channel identity, deduplication, and handling of inherited configurations.
  * Added validation for missing channels, invalid templates, and unmapped required fields.
* **Localization**
  * Updated English and Spanish text for multi-channel configuration and validation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->