### PR TITLE
feat(integrations): operator-defined templates → connection instances (P1 backend)

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationTemplatesResource.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgIntegrationTemplatesResource.java
@@ -1,0 +1,159 @@
+package com.microboxlabs.miot.integrations.api;
+
+import com.microboxlabs.miot.core.auth.OrganizationContext;
+import com.microboxlabs.miot.core.auth.TenantContext;
+import com.microboxlabs.miot.core.permission.OrganizationRoleService;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.dto.UpdateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.service.IntegrationTemplateService;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Integration templates: the operator-defined types connections are created from. Mirrors
+ * {@link OrgIntegrationConnectionsResource} — org-scoped, owner-gated, and returning
+ * {@link Uni} so the request stays on the Vert.x event loop while the blocking service call is
+ * offloaded to the worker pool.
+ */
+@Path("/api/v1/orgs/{organizationId}/integrations/templates")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Integration Templates", description = "Reusable integration types (contracts) instances are created from")
+@SecurityRequirement(name = "oidc")
+@Authenticated
+@IfBuildProperty(name = "miot.component.integrations.enabled", stringValue = "true")
+public class OrgIntegrationTemplatesResource {
+
+    private final TenantContext tenantContext;
+    private final OrganizationContext organizationContext;
+    private final OrganizationRoleService roleService;
+    private final IntegrationTemplateService service;
+
+    @Inject
+    public OrgIntegrationTemplatesResource(
+            TenantContext tenantContext,
+            OrganizationContext organizationContext,
+            OrganizationRoleService roleService,
+            IntegrationTemplateService service) {
+        this.tenantContext = tenantContext;
+        this.organizationContext = organizationContext;
+        this.roleService = roleService;
+        this.service = service;
+    }
+
+    @GET
+    @Operation(summary = "List integration templates")
+    public Uni<Response> listTemplates(@PathParam("organizationId") String organizationId) {
+        String tenant = tenantCode(organizationId);
+        return ownerWork(organizationId,
+                () -> Response.ok(service.listTemplates(tenant)).build());
+    }
+
+    @POST
+    @Operation(summary = "Create an integration template")
+    public Uni<Response> createTemplate(
+            @PathParam("organizationId") String organizationId,
+            CreateIntegrationTemplateRequest req) {
+        String tenant = tenantCode(organizationId);
+        return ownerWork(organizationId, () -> Response.status(Response.Status.CREATED)
+                .entity(service.createTemplate(tenant, req))
+                .build());
+    }
+
+    @GET
+    @Path("/{templateId}")
+    @Operation(summary = "Get an integration template")
+    public Uni<Response> getTemplate(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("templateId") String templateId) {
+        String tenant = tenantCode(organizationId);
+        return ownerWork(organizationId, () -> {
+            var template = service.getTemplate(tenant, templateId);
+            return template == null
+                    ? Response.status(Response.Status.NOT_FOUND).build()
+                    : Response.ok(template).build();
+        });
+    }
+
+    @PATCH
+    @Path("/{templateId}")
+    @Operation(summary = "Update an integration template (partial)")
+    public Uni<Response> updateTemplate(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("templateId") String templateId,
+            UpdateIntegrationTemplateRequest req) {
+        String tenant = tenantCode(organizationId);
+        return ownerWork(organizationId, () -> {
+            var template = service.updateTemplate(tenant, templateId, req);
+            return template == null
+                    ? Response.status(Response.Status.NOT_FOUND).build()
+                    : Response.ok(template).build();
+        });
+    }
+
+    @DELETE
+    @Path("/{templateId}")
+    @Operation(summary = "Delete an integration template (refused while instances exist)")
+    public Uni<Response> deleteTemplate(
+            @PathParam("organizationId") String organizationId,
+            @PathParam("templateId") String templateId) {
+        String tenant = tenantCode(organizationId);
+        return ownerWork(organizationId, () -> {
+            try {
+                return service.deleteTemplate(tenant, templateId)
+                        ? Response.noContent().build()
+                        : Response.status(Response.Status.NOT_FOUND).build();
+            } catch (IllegalStateException e) {
+                // A template still backing connections cannot be removed without orphaning them.
+                return Response.status(Response.Status.CONFLICT)
+                        .type(MediaType.APPLICATION_JSON)
+                        .entity(Map.of("error", e.getMessage()))
+                        .build();
+            }
+        });
+    }
+
+    /**
+     * Runs a blocking supplier on the worker pool so this non-blocking endpoint keeps the
+     * request on the event loop (required by the reactive org filter).
+     */
+    private static <T> Uni<T> onWorker(Supplier<T> work) {
+        return Uni.createFrom().item(work).runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    private <T> Uni<T> ownerWork(String organizationId, Supplier<T> work) {
+        return roleService.requireOwner(organizationId)
+                .flatMap(ignored -> onWorker(work));
+    }
+
+    private String tenantCode(String organizationId) {
+        if (!Objects.equals(organizationId, organizationContext.getOrganizationId())) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(Map.of("error", "Organization context does not match request path"))
+                    .build());
+        }
+        return tenantContext.getTenantCode() != null ? tenantContext.getTenantCode() : tenantContext.getClientId();
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationConnection.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationConnection.java
@@ -14,5 +14,23 @@ public record IntegrationConnection(
         ConnectionStatus status,
         OffsetDateTime lastTestedAt,
         Boolean lastTestResult,
-        Map<String, Object> metadata) {
+        Map<String, Object> metadata,
+        /** The template this connection is an instance of, or {@code null} for an ad-hoc connection. */
+        String templateId) {
+
+    /** Back-compat: connections not created from a template carry no {@code templateId}. */
+    public IntegrationConnection(
+            String id,
+            String tenantCode,
+            String name,
+            ProviderType providerType,
+            URI baseUrl,
+            String credentialProfileId,
+            ConnectionStatus status,
+            OffsetDateTime lastTestedAt,
+            Boolean lastTestResult,
+            Map<String, Object> metadata) {
+        this(id, tenantCode, name, providerType, baseUrl, credentialProfileId,
+                status, lastTestedAt, lastTestResult, metadata, null);
+    }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationTemplate.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationTemplate.java
@@ -1,0 +1,22 @@
+package com.microboxlabs.miot.integrations.domain;
+
+import java.util.Map;
+
+/**
+ * An operator-defined integration type: the reusable contract a family of connections
+ * shares. Like an n8n node type, it owns the payload shape — the operation to call
+ * ({@code operationName}, {@code method}, {@code path}) and its {@code requestSchema} /
+ * {@code responseSchema} — while each connection instance supplies its own base URL and
+ * credential.
+ */
+public record IntegrationTemplate(
+        String id,
+        String tenantCode,
+        String name,
+        ProviderType providerType,
+        String operationName,
+        String method,
+        String path,
+        Map<String, Object> requestSchema,
+        Map<String, Object> responseSchema) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationConnectionRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationConnectionRequest.java
@@ -4,10 +4,17 @@ import com.microboxlabs.miot.integrations.domain.ProviderType;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * Creates a connection. When {@code templateId} is set, the connection is an <em>instance</em>
+ * of that template: its {@code providerType} and its operation (method/path/schema) come from
+ * the template, and {@code providerType} in this request is ignored. Without a template it is
+ * an ad-hoc connection, exactly as before.
+ */
 public record CreateIntegrationConnectionRequest(
         String name,
         ProviderType providerType,
         URI baseUrl,
         String credentialProfileId,
-        Map<String, Object> metadata) {
+        Map<String, Object> metadata,
+        String templateId) {
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationTemplateRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/CreateIntegrationTemplateRequest.java
@@ -1,0 +1,19 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import java.util.Map;
+
+/**
+ * Defines an integration type: the contract every connection created from it will share.
+ * {@code operationName}/{@code method}/{@code path}/{@code requestSchema} are copied onto
+ * each instance's operation; {@code providerType} is the kind those instances take.
+ */
+public record CreateIntegrationTemplateRequest(
+        String name,
+        ProviderType providerType,
+        String operationName,
+        String method,
+        String path,
+        Map<String, Object> requestSchema,
+        Map<String, Object> responseSchema) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/UpdateIntegrationTemplateRequest.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/UpdateIntegrationTemplateRequest.java
@@ -1,0 +1,21 @@
+package com.microboxlabs.miot.integrations.dto;
+
+import java.util.Map;
+
+/**
+ * Partial update for an integration template. Every field is optional — a {@code null}
+ * field leaves the stored value unchanged. {@code providerType} is intentionally absent:
+ * a template's kind is fixed once instances exist against it.
+ *
+ * <p>Edits apply to connections created <em>after</em> the change; existing instances keep
+ * the contract they were provisioned with (their operation is a copy). Retro-propagation to
+ * live instances is a separate, opt-in operation.
+ */
+public record UpdateIntegrationTemplateRequest(
+        String name,
+        String operationName,
+        String method,
+        String path,
+        Map<String, Object> requestSchema,
+        Map<String, Object> responseSchema) {
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
@@ -24,17 +24,21 @@ public class IntegrationConnectionRepository {
 
     private static final Logger LOG = Logger.getLogger(IntegrationConnectionRepository.class);
 
-    private static final String SELECT_BY_TENANT = """
-            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                   status, last_tested_at, last_test_result, metadata
+    // Shared read/return column list, so template_id is threaded through every query that
+    // feeds mapRow without repeating (and mis-indenting) it.
+    private static final String COLUMNS = """
+            id, tenant_code, name, provider_type, base_url, credential_profile_id,
+            status, last_tested_at, last_test_result, metadata, template_id""";
+
+    private static final String SELECT_BY_TENANT = "SELECT " + COLUMNS + """
+
             FROM miot_integrations.integration_connections
             WHERE tenant_code = $1 AND active
             ORDER BY name
             """;
 
-    private static final String SELECT_BY_TENANT_AND_ID = """
-            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                   status, last_tested_at, last_test_result, metadata
+    private static final String SELECT_BY_TENANT_AND_ID = "SELECT " + COLUMNS + """
+
             FROM miot_integrations.integration_connections
             WHERE tenant_code = $1 AND id = $2 AND active
             """;
@@ -42,9 +46,8 @@ public class IntegrationConnectionRepository {
     // Best connection of a provider for a tenant: prefer ACTIVE, then a passing test,
     // then the most recently tested. Lets a caller send through whichever connection the
     // operator most recently validated.
-    private static final String SELECT_ACTIVE_BY_PROVIDER = """
-            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                   status, last_tested_at, last_test_result, metadata
+    private static final String SELECT_ACTIVE_BY_PROVIDER = "SELECT " + COLUMNS + """
+
             FROM miot_integrations.integration_connections
             WHERE tenant_code = $1 AND provider_type = $2 AND active
             ORDER BY (status = 'ACTIVE') DESC,
@@ -60,9 +63,8 @@ public class IntegrationConnectionRepository {
     // at most one such row, but we deliberately fetch LIMIT 2: the read path fails closed in
     // findActiveWhatsAppByPhoneNumberId if the invariant is ever violated, so inbound is never
     // silently routed to an arbitrary tenant (a cross-tenant leak).
-    private static final String SELECT_ACTIVE_WHATSAPP_BY_PHONE_NUMBER_ID = """
-            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                   status, last_tested_at, last_test_result, metadata
+    private static final String SELECT_ACTIVE_WHATSAPP_BY_PHONE_NUMBER_ID = "SELECT " + COLUMNS + """
+
             FROM miot_integrations.integration_connections
             WHERE provider_type = 'WHATSAPP'
               AND active
@@ -73,30 +75,35 @@ public class IntegrationConnectionRepository {
     // Reverse index for the credentials screen: which connections reference these
     // profiles. Takes the whole id set at once so listing N credentials stays one query
     // instead of N.
-    private static final String SELECT_BY_CREDENTIAL_PROFILES = """
-            SELECT id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                   status, last_tested_at, last_test_result, metadata
+    private static final String SELECT_BY_CREDENTIAL_PROFILES = "SELECT " + COLUMNS + """
+
             FROM miot_integrations.integration_connections
             WHERE tenant_code = $1 AND credential_profile_id = ANY($2) AND active
+            ORDER BY name
+            """;
+
+    // Instances of a template, for the "used by" panel and the template delete guard.
+    private static final String SELECT_BY_TEMPLATE = "SELECT " + COLUMNS + """
+
+            FROM miot_integrations.integration_connections
+            WHERE tenant_code = $1 AND template_id = $2 AND active
             ORDER BY name
             """;
 
     private static final String INSERT = """
             INSERT INTO miot_integrations.integration_connections (
                 id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                status, last_tested_at, last_test_result, metadata
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            RETURNING id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                      status, last_tested_at, last_test_result, metadata
-            """;
+                status, last_tested_at, last_test_result, metadata, template_id
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING
+            """ + COLUMNS;
 
     private static final String UPDATE_TEST_RESULT = """
             UPDATE miot_integrations.integration_connections
             SET status = $3, last_tested_at = $4, last_test_result = $5, updated_at = $4
             WHERE tenant_code = $1 AND id = $2 AND active
-            RETURNING id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                      status, last_tested_at, last_test_result, metadata
-            """;
+            RETURNING
+            """ + COLUMNS;
 
     // Partial update: a null parameter leaves the column unchanged (explicit ::casts so the
     // NULL binds keep their type in the prepared statement). metadata is replaced wholesale.
@@ -107,9 +114,8 @@ public class IntegrationConnectionRepository {
                 metadata = COALESCE($5::jsonb, metadata),
                 updated_at = now()
             WHERE tenant_code = $1 AND id = $2 AND active
-            RETURNING id, tenant_code, name, provider_type, base_url, credential_profile_id,
-                      status, last_tested_at, last_test_result, metadata
-            """;
+            RETURNING
+            """ + COLUMNS;
 
     private final Instance<Pool> clientInstance;
 
@@ -138,7 +144,8 @@ public class IntegrationConnectionRepository {
                 .addString(connection.status().name())
                 .addOffsetDateTime(connection.lastTestedAt())
                 .addBoolean(connection.lastTestResult())
-                .addJsonObject(toJson(connection.metadata()));
+                .addJsonObject(toJson(connection.metadata()))
+                .addUUID(toUuid(connection.templateId()));
         return mapRow(client().preparedQuery(INSERT)
                 .execute(params)
                 .await().indefinitely()
@@ -224,6 +231,24 @@ public class IntegrationConnectionRepository {
                 .toList();
     }
 
+    /**
+     * Connections that are instances of {@code templateId}. Blank or non-UUID ids
+     * short-circuit before the pool, so they never reach the DB (and are safe with a null
+     * pool in unit tests).
+     */
+    public List<IntegrationConnection> listByTemplate(String tenantCode, String templateId) {
+        UUID id = parseUuidOrNull(templateId);
+        if (id == null) {
+            return List.of();
+        }
+        return client().preparedQuery(SELECT_BY_TEMPLATE)
+                .execute(Tuple.of(tenantCode, id))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
     public IntegrationConnection update(
             String tenantCode,
             String connectionId,
@@ -265,6 +290,7 @@ public class IntegrationConnectionRepository {
 
     private IntegrationConnection mapRow(Row row) {
         UUID credentialProfileId = row.getUUID("credential_profile_id");
+        UUID templateId = row.getUUID("template_id");
         return new IntegrationConnection(
                 row.getUUID("id").toString(),
                 row.getString("tenant_code"),
@@ -275,7 +301,8 @@ public class IntegrationConnectionRepository {
                 ConnectionStatus.valueOf(row.getString("status")),
                 row.getOffsetDateTime("last_tested_at"),
                 row.getBoolean("last_test_result"),
-                toMap(row.getJsonObject("metadata")));
+                toMap(row.getJsonObject("metadata")),
+                templateId == null ? null : templateId.toString());
     }
 
     private UUID toUuid(String value) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationTemplateRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationTemplateRepository.java
@@ -1,0 +1,185 @@
+package com.microboxlabs.miot.integrations.persistence;
+
+import com.microboxlabs.miot.integrations.domain.IntegrationTemplate;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.sqlclient.Pool;
+import io.vertx.mutiny.sqlclient.Row;
+import io.vertx.mutiny.sqlclient.Tuple;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class IntegrationTemplateRepository {
+
+    private static final String COLUMNS = """
+            id, tenant_code, name, provider_type, operation_name, method, path,
+            request_schema, response_schema""";
+
+    private static final String SELECT_BY_TENANT = "SELECT " + COLUMNS + """
+             FROM miot_integrations.integration_templates
+            WHERE tenant_code = $1 AND active
+            ORDER BY name
+            """;
+
+    private static final String SELECT_BY_TENANT_AND_ID = "SELECT " + COLUMNS + """
+             FROM miot_integrations.integration_templates
+            WHERE tenant_code = $1 AND id = $2 AND active
+            """;
+
+    private static final String INSERT = """
+            INSERT INTO miot_integrations.integration_templates (
+                id, tenant_code, name, provider_type, operation_name, method, path,
+                request_schema, response_schema
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING
+            """ + COLUMNS;
+
+    // Partial update: a null parameter leaves the column unchanged (explicit ::casts so the
+    // NULL binds keep their type). provider_type is intentionally immutable — a template's
+    // kind is fixed once instances exist against it.
+    private static final String UPDATE = """
+            UPDATE miot_integrations.integration_templates
+            SET name           = COALESCE($3::text, name),
+                operation_name = COALESCE($4::text, operation_name),
+                method         = COALESCE($5::text, method),
+                path           = COALESCE($6::text, path),
+                request_schema = COALESCE($7::jsonb, request_schema),
+                response_schema = COALESCE($8::jsonb, response_schema),
+                updated_at     = now()
+            WHERE tenant_code = $1 AND id = $2 AND active
+            RETURNING
+            """ + COLUMNS;
+
+    private static final String SOFT_DELETE = """
+            UPDATE miot_integrations.integration_templates
+            SET active = false, updated_at = now()
+            WHERE tenant_code = $1 AND id = $2 AND active
+            """;
+
+    private final Instance<Pool> clientInstance;
+
+    // Protected so tests can subclass it with a null pool, as the sibling repositories allow.
+    protected IntegrationTemplateRepository(Instance<Pool> clientInstance) {
+        this.clientInstance = clientInstance;
+    }
+
+    public List<IntegrationTemplate> listByTenant(String tenantCode) {
+        return client().preparedQuery(SELECT_BY_TENANT)
+                .execute(Tuple.of(tenantCode))
+                .await().indefinitely()
+                .stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    /** @return the template, or {@code null} when the id is unknown, inactive, or another tenant's. */
+    public IntegrationTemplate findByTenantAndId(String tenantCode, String templateId) {
+        UUID id = parseUuidOrNull(templateId);
+        if (id == null) {
+            return null;
+        }
+        var rows = client().preparedQuery(SELECT_BY_TENANT_AND_ID)
+                .execute(Tuple.of(tenantCode, id))
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    public IntegrationTemplate create(IntegrationTemplate template) {
+        Tuple params = Tuple.tuple()
+                .addUUID(UUID.fromString(template.id()))
+                .addString(template.tenantCode())
+                .addString(template.name())
+                .addString(template.providerType().name())
+                .addString(template.operationName())
+                .addString(template.method())
+                .addString(template.path())
+                .addJsonObject(toJson(template.requestSchema()))
+                .addJsonObject(toJson(template.responseSchema()));
+        return mapRow(client().preparedQuery(INSERT)
+                .execute(params)
+                .await().indefinitely()
+                .iterator().next());
+    }
+
+    /**
+     * Partial update. {@code null} fields leave their columns unchanged.
+     *
+     * @return the updated template, or {@code null} when the id is unknown or inactive
+     */
+    public IntegrationTemplate update(
+            String tenantCode,
+            String templateId,
+            String name,
+            String operationName,
+            String method,
+            String path,
+            Map<String, Object> requestSchema,
+            Map<String, Object> responseSchema) {
+        Tuple params = Tuple.tuple()
+                .addString(tenantCode)
+                .addUUID(UUID.fromString(templateId))
+                .addString(name)
+                .addString(operationName)
+                .addString(method)
+                .addString(path)
+                .addValue(requestSchema == null ? null : new JsonObject(requestSchema))
+                .addValue(responseSchema == null ? null : new JsonObject(responseSchema));
+        var rows = client().preparedQuery(UPDATE)
+                .execute(params)
+                .await().indefinitely();
+        return rows.iterator().hasNext() ? mapRow(rows.iterator().next()) : null;
+    }
+
+    /** @return {@code true} when a row was deactivated, {@code false} when nothing matched. */
+    public boolean softDelete(String tenantCode, String templateId) {
+        UUID id = parseUuidOrNull(templateId);
+        if (id == null) {
+            return false;
+        }
+        return client().preparedQuery(SOFT_DELETE)
+                .execute(Tuple.of(tenantCode, id))
+                .await().indefinitely()
+                .rowCount() > 0;
+    }
+
+    private Pool client() {
+        return clientInstance.get();
+    }
+
+    private static UUID parseUuidOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private IntegrationTemplate mapRow(Row row) {
+        return new IntegrationTemplate(
+                row.getUUID("id").toString(),
+                row.getString("tenant_code"),
+                row.getString("name"),
+                ProviderType.valueOf(row.getString("provider_type")),
+                row.getString("operation_name"),
+                row.getString("method"),
+                row.getString("path"),
+                toMap(row.getJsonObject("request_schema")),
+                toMap(row.getJsonObject("response_schema")));
+    }
+
+    private JsonObject toJson(Map<String, Object> value) {
+        return new JsonObject(value == null ? Map.of() : value);
+    }
+
+    private Map<String, Object> toMap(JsonObject value) {
+        return value == null ? Map.of() : new LinkedHashMap<>(value.getMap());
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionService.java
@@ -4,6 +4,8 @@ import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
 import com.microboxlabs.miot.integrations.domain.CredentialProfile;
 import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
 import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import com.microboxlabs.miot.integrations.domain.IntegrationTemplate;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
 import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest;
@@ -12,6 +14,7 @@ import com.microboxlabs.miot.integrations.dto.UpdateIntegrationConnectionRequest
 import com.microboxlabs.miot.integrations.persistence.CredentialProfileRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationTemplateRepository;
 import com.microboxlabs.miot.integrations.tester.ConnectionTesterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +31,7 @@ public class IntegrationConnectionService {
     private final CredentialProfileService credentialProfileService;
     private final IntegrationConnectionRepository connectionRepository;
     private final IntegrationOperationRepository operationRepository;
+    private final IntegrationTemplateRepository templateRepository;
     private final ConnectionTesterRegistry testerRegistry;
 
     @Inject
@@ -36,11 +40,13 @@ public class IntegrationConnectionService {
             CredentialProfileService credentialProfileService,
             IntegrationConnectionRepository connectionRepository,
             IntegrationOperationRepository operationRepository,
+            IntegrationTemplateRepository templateRepository,
             ConnectionTesterRegistry testerRegistry) {
         this.credentialProfileRepository = credentialProfileRepository;
         this.credentialProfileService = credentialProfileService;
         this.connectionRepository = connectionRepository;
         this.operationRepository = operationRepository;
+        this.templateRepository = templateRepository;
         this.testerRegistry = testerRegistry;
     }
 
@@ -48,19 +54,57 @@ public class IntegrationConnectionService {
         return connectionRepository.listByTenant(tenantCode);
     }
 
+    /**
+     * Creates a connection. When {@code templateId} is set, the connection is an instance of
+     * that template: its provider type comes from the template, and the template's contract is
+     * copied onto a freshly-provisioned operation so the dispatch path (connection + operation)
+     * needs no template awareness. Without a template it is an ad-hoc connection.
+     */
     public IntegrationConnection createConnection(String tenantCode, CreateIntegrationConnectionRequest req) {
+        IntegrationTemplate template = req.templateId() == null
+                ? null
+                : templateRepository.findByTenantAndId(tenantCode, req.templateId());
+        if (req.templateId() != null && template == null) {
+            throw new IllegalArgumentException("Unknown integration template: " + req.templateId());
+        }
+
+        ProviderType providerType = template != null ? template.providerType() : req.providerType();
         IntegrationConnection connection = new IntegrationConnection(
                 UUID.randomUUID().toString(),
                 tenantCode,
                 req.name(),
-                req.providerType(),
+                providerType,
                 req.baseUrl(),
                 req.credentialProfileId(),
                 ConnectionStatus.DRAFT,
                 null,
                 null,
-                safeMap(req.metadata()));
-        return connectionRepository.create(connection);
+                safeMap(req.metadata()),
+                template != null ? template.id() : null);
+        IntegrationConnection created = connectionRepository.create(connection);
+
+        if (template != null) {
+            provisionTemplateOperation(created.id(), template);
+        }
+        return created;
+    }
+
+    /**
+     * Copies a template's contract onto a new instance as its operation. The instance keeps its
+     * own copy (so dispatch stays connection-scoped and the UI can hold it read-only), which is
+     * why a later template edit reaches only connections created after it.
+     */
+    private void provisionTemplateOperation(String connectionId, IntegrationTemplate template) {
+        IntegrationOperation operation = new IntegrationOperation(
+                UUID.randomUUID().toString(),
+                connectionId,
+                template.operationName(),
+                template.method(),
+                template.path(),
+                safeMap(template.requestSchema()),
+                safeMap(template.responseSchema()),
+                false);
+        operationRepository.create(operation);
     }
 
     public IntegrationConnection getConnection(String tenantCode, String connectionId) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationTemplateService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationTemplateService.java
@@ -1,0 +1,104 @@
+package com.microboxlabs.miot.integrations.service;
+
+import com.microboxlabs.miot.integrations.domain.IntegrationTemplate;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.dto.UpdateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationTemplateRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * CRUD for integration templates — the operator-defined types instances are created from.
+ * A template owns the payload contract; {@link IntegrationConnectionService} copies it onto
+ * each instance's operation at creation time.
+ */
+@ApplicationScoped
+public class IntegrationTemplateService {
+
+    private final IntegrationTemplateRepository templateRepository;
+    private final IntegrationConnectionRepository connectionRepository;
+
+    @Inject
+    public IntegrationTemplateService(
+            IntegrationTemplateRepository templateRepository,
+            IntegrationConnectionRepository connectionRepository) {
+        this.templateRepository = templateRepository;
+        this.connectionRepository = connectionRepository;
+    }
+
+    public List<IntegrationTemplate> listTemplates(String tenantCode) {
+        return templateRepository.listByTenant(tenantCode);
+    }
+
+    public IntegrationTemplate getTemplate(String tenantCode, String templateId) {
+        return templateRepository.findByTenantAndId(tenantCode, templateId);
+    }
+
+    public IntegrationTemplate createTemplate(String tenantCode, CreateIntegrationTemplateRequest req) {
+        // The operation name shown against every instance defaults to the template's name.
+        String operationName = blankToNull(req.operationName()) == null ? req.name() : req.operationName();
+        IntegrationTemplate template = new IntegrationTemplate(
+                UUID.randomUUID().toString(),
+                tenantCode,
+                req.name(),
+                req.providerType(),
+                operationName,
+                normalizeMethod(req.method()),
+                req.path(),
+                safeMap(req.requestSchema()),
+                safeMap(req.responseSchema()));
+        return templateRepository.create(template);
+    }
+
+    /** @return the updated template, or {@code null} when it does not exist. */
+    public IntegrationTemplate updateTemplate(
+            String tenantCode, String templateId, UpdateIntegrationTemplateRequest req) {
+        return templateRepository.update(
+                tenantCode,
+                templateId,
+                blankToNull(req.name()),
+                blankToNull(req.operationName()),
+                normalizeMethodOrNull(req.method()),
+                blankToNull(req.path()),
+                req.requestSchema(),
+                req.responseSchema());
+    }
+
+    /**
+     * Soft-deletes a template. Refuses (throws {@link IllegalStateException}) while any
+     * connection is still an instance of it, so a type is never pulled out from under its
+     * instances.
+     *
+     * @return {@code false} when the template did not exist
+     */
+    public boolean deleteTemplate(String tenantCode, String templateId) {
+        int instances = connectionRepository.listByTemplate(tenantCode, templateId).size();
+        if (instances > 0) {
+            throw new IllegalStateException(
+                    "Cannot delete a template with " + instances + " connection(s) still using it");
+        }
+        return templateRepository.softDelete(tenantCode, templateId);
+    }
+
+    private static String normalizeMethod(String method) {
+        return method == null ? null : method.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private static String normalizeMethodOrNull(String method) {
+        return blankToNull(method) == null ? null : normalizeMethod(method);
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    private Map<String, Object> safeMap(Map<String, Object> map) {
+        return map == null ? Map.of() : new LinkedHashMap<>(map);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.12__add_integration_templates.sql
+++ b/quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.12__add_integration_templates.sql
@@ -1,0 +1,56 @@
+-- Integration templates: an operator-defined "type" (like an n8n node type) that owns the
+-- payload contract — method, path and request/response schema — for a family of connections.
+--
+-- A connection is an *instance* of a template: it supplies its own base URL and credential,
+-- and on creation copies the template's contract into its own operation. That copy keeps the
+-- dispatch path (connection + operation) untouched while guaranteeing every instance of a
+-- template is forced through the same review-process field mapping. The instance's operation
+-- is template-owned (read-only in the UI) so it cannot drift from the contract.
+CREATE TABLE miot_integrations.integration_templates (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       BIGINT REFERENCES miot_core.tenants(id),
+    tenant_code     VARCHAR(128) NOT NULL,
+    name            VARCHAR(160) NOT NULL,
+    provider_type   VARCHAR(64)  NOT NULL,
+    operation_name  VARCHAR(160) NOT NULL,
+    method          VARCHAR(16)  NOT NULL,
+    path            TEXT         NOT NULL,
+    request_schema  JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    response_schema JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    active          BOOLEAN      NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- Mirrors the connections' provider_type set (extended through V0.6.6); a template's
+    -- kind is the kind its instances take.
+    CONSTRAINT chk_integration_templates_provider_type CHECK (
+        provider_type IN (
+            'POSTGREST',
+            'ALERCE_TMS',
+            'N8N',
+            'AUTH0',
+            'ECM',
+            'CUSTOM_HTTP',
+            'WHATSAPP',
+            'GPS_WEBHOOK'
+        )
+    ),
+    CONSTRAINT chk_integration_templates_method CHECK (
+        method IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')
+    )
+);
+
+CREATE INDEX idx_integration_templates_tenant_code
+    ON miot_integrations.integration_templates(tenant_code);
+CREATE UNIQUE INDEX idx_integration_templates_tenant_name_active
+    ON miot_integrations.integration_templates(tenant_code, lower(name))
+    WHERE active;
+
+-- A connection may be an instance of a template. Nullable: ad-hoc connections (and every
+-- connection created before templates existed) have none, and behave exactly as before.
+ALTER TABLE miot_integrations.integration_connections
+    ADD COLUMN template_id UUID REFERENCES miot_integrations.integration_templates(id);
+
+-- Backs "which connections are instances of this template?" — the delete guard and the
+-- instances list.
+CREATE INDEX idx_integration_connections_template
+    ON miot_integrations.integration_connections(template_id) WHERE active;

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationConnectionServiceTest.java
@@ -24,6 +24,6 @@ class IntegrationConnectionServiceTest {
     }
 
     private IntegrationConnectionService serviceWithoutDependencies() {
-        return new IntegrationConnectionService(null, null, null, null, null);
+        return new IntegrationConnectionService(null, null, null, null, null, null);
     }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationTemplateServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationTemplateServiceTest.java
@@ -1,0 +1,252 @@
+package com.microboxlabs.miot.integrations.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
+import com.microboxlabs.miot.integrations.domain.IntegrationTemplate;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationConnectionRequest;
+import com.microboxlabs.miot.integrations.dto.CreateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.dto.UpdateIntegrationTemplateRequest;
+import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import com.microboxlabs.miot.integrations.persistence.IntegrationTemplateRepository;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class IntegrationTemplateServiceTest {
+
+    private static final String TENANT = "tenant-1";
+
+    private final FakeTemplates templates = new FakeTemplates();
+    private final FakeConnections connections = new FakeConnections();
+
+    private IntegrationTemplateService service() {
+        return new IntegrationTemplateService(templates, connections);
+    }
+
+    private static CreateIntegrationTemplateRequest createRequest(String name, String method) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of("guidMultimedia", Map.of("type", "string")));
+        return new CreateIntegrationTemplateRequest(
+                name, ProviderType.CUSTOM_HTTP, "", method, "/v1/estado", schema, Map.of());
+    }
+
+    @Test
+    void createDefaultsOperationNameToTemplateNameAndUppercasesMethod() {
+        IntegrationTemplate created = service().createTemplate(TENANT, createRequest("Dev Mentor", "post"));
+
+        assertEquals("Dev Mentor", created.name());
+        // Blank operationName falls back to the template name.
+        assertEquals("Dev Mentor", created.operationName());
+        // Method is normalised to the case the CHECK constraint accepts.
+        assertEquals("POST", created.method());
+        assertEquals(ProviderType.CUSTOM_HTTP, created.providerType());
+        assertEquals(created, templates.store.get(created.id()));
+    }
+
+    @Test
+    void updateLeavesNullFieldsUnchanged() {
+        IntegrationTemplate created = service().createTemplate(TENANT, createRequest("Dev Mentor", "POST"));
+
+        IntegrationTemplate updated = service().updateTemplate(
+                TENANT, created.id(),
+                new UpdateIntegrationTemplateRequest(null, null, null, "/v2/estado", null, null));
+
+        assertEquals("Dev Mentor", updated.name());
+        assertEquals("/v2/estado", updated.path());
+        assertEquals("POST", updated.method());
+    }
+
+    @Test
+    void updateMissingTemplateReturnsNull() {
+        assertNull(service().updateTemplate(
+                TENANT, "no-such-id",
+                new UpdateIntegrationTemplateRequest("x", null, null, null, null, null)));
+    }
+
+    @Test
+    void deleteSucceedsWhenNoInstances() {
+        IntegrationTemplate created = service().createTemplate(TENANT, createRequest("Dev Mentor", "POST"));
+
+        assertTrue(service().deleteTemplate(TENANT, created.id()));
+        assertFalse(templates.store.containsKey(created.id()));
+    }
+
+    @Test
+    void deleteRefusedWhileInstancesExist() {
+        IntegrationTemplate created = service().createTemplate(TENANT, createRequest("Dev Mentor", "POST"));
+        connections.instances = List.of(instanceOf(created.id()));
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class, () -> service().deleteTemplate(TENANT, created.id()));
+        assertTrue(error.getMessage().contains("1 connection"));
+        // The template survives the refused delete.
+        assertTrue(templates.store.containsKey(created.id()));
+    }
+
+    @Test
+    void deleteMissingTemplateReturnsFalse() {
+        assertFalse(service().deleteTemplate(TENANT, "no-such-id"));
+    }
+
+    /* ---- create-instance-from-template (IntegrationConnectionService) ---- */
+
+    @Test
+    void creatingAConnectionFromATemplateProvisionsItsOperation() {
+        IntegrationTemplate template = service().createTemplate(TENANT, createRequest("Dev Mentor", "POST"));
+        FakeOperations operations = new FakeOperations();
+        IntegrationConnectionService connectionService = new IntegrationConnectionService(
+                null, null, connections, operations, templates, null);
+
+        IntegrationConnection created = connectionService.createConnection(
+                TENANT,
+                new CreateIntegrationConnectionRequest(
+                        "Dev Mentor QA", null, URI.create("https://qa.example.com"),
+                        "cred-qa", Map.of(), template.id()));
+
+        // The instance records its template and inherits the template's provider type.
+        assertEquals(template.id(), created.templateId());
+        assertEquals(ProviderType.CUSTOM_HTTP, created.providerType());
+        // Exactly one operation was provisioned, copying the template's contract.
+        assertEquals(1, operations.created.size());
+        IntegrationOperation op = operations.created.get(0);
+        assertEquals(created.id(), op.connectionId());
+        assertEquals("Dev Mentor", op.name());
+        assertEquals("POST", op.method());
+        assertEquals("/v1/estado", op.path());
+        assertEquals(template.requestSchema(), op.requestSchema());
+    }
+
+    @Test
+    void creatingAConnectionFromAnUnknownTemplateFails() {
+        FakeOperations operations = new FakeOperations();
+        IntegrationConnectionService connectionService = new IntegrationConnectionService(
+                null, null, connections, operations, templates, null);
+
+        assertThrows(IllegalArgumentException.class, () -> connectionService.createConnection(
+                TENANT,
+                new CreateIntegrationConnectionRequest(
+                        "Ghost", null, URI.create("https://x"), null, Map.of(), "no-such-template")));
+        assertTrue(operations.created.isEmpty());
+    }
+
+    @Test
+    void creatingAnAdHocConnectionProvisionsNoOperation() {
+        FakeOperations operations = new FakeOperations();
+        IntegrationConnectionService connectionService = new IntegrationConnectionService(
+                null, null, connections, operations, templates, null);
+
+        IntegrationConnection created = connectionService.createConnection(
+                TENANT,
+                new CreateIntegrationConnectionRequest(
+                        "Ad hoc", ProviderType.N8N, URI.create("https://x"), null, Map.of(), null));
+
+        assertNull(created.templateId());
+        assertEquals(ProviderType.N8N, created.providerType());
+        assertTrue(operations.created.isEmpty());
+    }
+
+    private static IntegrationConnection instanceOf(String templateId) {
+        return new IntegrationConnection(
+                "conn-1", TENANT, "Dev Mentor QA", ProviderType.CUSTOM_HTTP,
+                URI.create("https://qa.example.com"), "cred-qa",
+                com.microboxlabs.miot.integrations.domain.ConnectionStatus.DRAFT,
+                null, null, Map.of(), templateId);
+    }
+
+    /* ---- fakes ---- */
+
+    private static final class FakeTemplates extends IntegrationTemplateRepository {
+        private final Map<String, IntegrationTemplate> store = new LinkedHashMap<>();
+
+        private FakeTemplates() {
+            super(null);
+        }
+
+        @Override
+        public List<IntegrationTemplate> listByTenant(String tenantCode) {
+            return new ArrayList<>(store.values());
+        }
+
+        @Override
+        public IntegrationTemplate findByTenantAndId(String tenantCode, String templateId) {
+            return store.get(templateId);
+        }
+
+        @Override
+        public IntegrationTemplate create(IntegrationTemplate template) {
+            store.put(template.id(), template);
+            return template;
+        }
+
+        @Override
+        public IntegrationTemplate update(
+                String tenantCode, String templateId, String name, String operationName,
+                String method, String path, Map<String, Object> requestSchema,
+                Map<String, Object> responseSchema) {
+            IntegrationTemplate existing = store.get(templateId);
+            if (existing == null) {
+                return null;
+            }
+            IntegrationTemplate updated = new IntegrationTemplate(
+                    existing.id(), existing.tenantCode(),
+                    name != null ? name : existing.name(),
+                    existing.providerType(),
+                    operationName != null ? operationName : existing.operationName(),
+                    method != null ? method : existing.method(),
+                    path != null ? path : existing.path(),
+                    requestSchema != null ? requestSchema : existing.requestSchema(),
+                    responseSchema != null ? responseSchema : existing.responseSchema());
+            store.put(templateId, updated);
+            return updated;
+        }
+
+        @Override
+        public boolean softDelete(String tenantCode, String templateId) {
+            return store.remove(templateId) != null;
+        }
+    }
+
+    private static final class FakeConnections extends IntegrationConnectionRepository {
+        private List<IntegrationConnection> instances = List.of();
+
+        private FakeConnections() {
+            super(null);
+        }
+
+        @Override
+        public List<IntegrationConnection> listByTemplate(String tenantCode, String templateId) {
+            return instances;
+        }
+
+        @Override
+        public IntegrationConnection create(IntegrationConnection connection) {
+            return connection;
+        }
+    }
+
+    private static final class FakeOperations extends IntegrationOperationRepository {
+        private final List<IntegrationOperation> created = new ArrayList<>();
+
+        private FakeOperations() {
+            super(null);
+        }
+
+        @Override
+        public IntegrationOperation create(IntegrationOperation operation) {
+            created.add(operation);
+            return operation;
+        }
+    }
+}


### PR DESCRIPTION
**Phase 1 of the integration-templates work.** Adds the *type → instance* layer the review-channel config was missing, so an operator can define one **Dev-Mentor** template and stand up many connections against it, each with its own credential + host, all forced through the same review mapping. Backend only; FE admin is P2.

## The model

- **Template** = an operator-defined type (like an n8n node type) that owns the **contract**: `provider_type`, `operation_name`, `method`, `path`, `request_schema` / `response_schema`.
- **Connection** = an **instance** of a template: its own `base_url` + `credential` + `name`, plus a nullable `template_id`.
- **Copy-on-create**: creating a connection with `templateId` provisions its operation by *copying* the template's contract. Dispatch stays connection+operation-scoped, so **dispatch / dispatch-targets / bindings / rendering are untouched** — instances just show up as attachable channels. The copy is instance-owned, so a later template edit reaches only new instances (retro-propagation is a deliberate later add).

## Changes

| Area | |
|---|---|
| Migration | `V0.6.12`: `integration_templates` + `integration_connections.template_id` (nullable, FK, partial index) |
| Domain | new `IntegrationTemplate`; `IntegrationConnection` gains `templateId` via a **back-compat secondary ctor** so the 5 existing call sites are untouched |
| Persistence | new `IntegrationTemplateRepository`; connection repo threads `template_id` through a shared `COLUMNS` list + adds `listByTemplate` |
| Service | new `IntegrationTemplateService` (CRUD; delete refuses while instances exist); `IntegrationConnectionService.createConnection` provisions the operation from the template |
| API | new owner-gated `OrgIntegrationTemplatesResource` (CRUD), mirroring the connections resource (Uni + worker offload + org-context check) |

Ad-hoc connections (no `templateId`) behave exactly as before.

## Verification

- **344 module tests pass**, 9 new: template CRUD, the delete guard, and create-from-template provisioning (op copied, `providerType` inherited, ad-hoc creates no op).
- Boot/Flyway verified — the app starts and runs `V0.6.12` cleanly (the suite's one flaky failure was a port clash with a local `kubectl port-forward` on 8081, green on a free test port).

## Next (P2)

FE **Integraciones** admin page: define templates, create instances (pick template → name + base URL + credential → test). The review drawer already consumes instances via `/dispatch-targets`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-scoped integration templates with create, view, edit, list, and delete capabilities.
  * Connections can now be created from templates, automatically inheriting the template’s provider and operation details.
  * Added support for request and response schemas in integration templates.

* **Bug Fixes**
  * Prevented deletion of templates that are still used by active connections.
  * Added validation for organization access and template references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->