### PR TITLE
feat(integrations): nested mapping in the drawer — leaf fields + dynamic-root validation

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -226,7 +226,9 @@ public class IntegrationEventBindingService {
     }
 
     private static List<DispatchTargetResponse.Field> fieldsOf(PayloadSchema schema) {
-        return schema.fields().stream()
+        // Leaf fields (dotted paths) so a nested contract renders one editable mapping row per
+        // value — fotos.guidMultimedia, fotos.mensaje.codigo — never an array/object container.
+        return schema.leafFields().stream()
                 .map(field -> new DispatchTargetResponse.Field(
                         field.id(), field.type().name().toLowerCase(), field.required()))
                 .toList();

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,17 +89,35 @@ public class PayloadRenderer {
                 problems.add("'" + requiredPath + "' is required but has no mapping");
             }
         }
+        // A nested array binds each element under its collection's own name, so a template inside
+        // it legitimately reads a root the caller never declared ({{reasons.code}} within a
+        // content.reasons array). Those roots come from the schema, not the caller, so add them.
+        Set<String> roots = new LinkedHashSet<>(allowedRoots);
+        collectArrayBindNames(schema, roots);
         mappings.forEach((fieldId, template) -> {
             if (template == null || template.isBlank()) {
                 return;
             }
             try {
-                PayloadTemplate.validate(template, allowedRoots);
+                PayloadTemplate.validate(template, roots);
             } catch (TemplateSyntaxException e) {
                 problems.add("'" + fieldId + "': " + e.getMessage());
             }
         });
         return problems;
+    }
+
+    /** The extra template roots a schema's array fields introduce — each element is bound under
+     *  the last segment of its {@code itemsFrom} ({@code content.reasons} → {@code reasons}). */
+    private static void collectArrayBindNames(PayloadSchema schema, Set<String> roots) {
+        for (PayloadSchema.Field field : schema.fields()) {
+            if (field.type() == PayloadSchema.FieldType.ARRAY && field.itemsFrom() != null) {
+                roots.add(lastSegment(field.itemsFrom()));
+            }
+            if (field.child() != null) {
+                collectArrayBindNames(field.child(), roots);
+            }
+        }
     }
 
     /* ---------------------------------------------------------------------- */

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
@@ -138,6 +138,31 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
         return fields.stream().filter(Field::required).toList();
     }
 
+    /**
+     * Every scalar leaf as a field whose id is its dotted path — the mapping rows an operator
+     * actually fills in. A structural field contributes its leaves ({@code fotos.guidMultimedia},
+     * {@code fotos.mensaje.codigo}), not itself: an array/object is a container, not a value to
+     * template. Used by the settings UI so it renders one editable row per leaf.
+     */
+    public List<Field> leafFields() {
+        List<Field> leaves = new ArrayList<>();
+        collectLeaves("", fields, leaves);
+        return List.copyOf(leaves);
+    }
+
+    private static void collectLeaves(String prefix, List<Field> fields, List<Field> out) {
+        for (Field field : fields) {
+            String id = prefix + field.id();
+            if (field.structural()) {
+                if (field.child() != null) {
+                    collectLeaves(id + ".", field.child().fields(), out);
+                }
+            } else {
+                out.add(new Field(id, field.type(), field.required()));
+            }
+        }
+    }
+
     /* ---------------------------------------------------------------------- */
 
     private static boolean isArray(Map<?, ?> schema) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadNestedRenderingTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadNestedRenderingTest.java
@@ -122,6 +122,36 @@ class PayloadNestedRenderingTest {
         assertTrue(((Map<?, ?>) fotos.get(1)).get("aprobada") == Boolean.FALSE);
     }
 
+    @Test
+    void leafFieldsAreTheDottedScalarMappingRowsTheUiRenders() {
+        List<PayloadSchema.Field> leaves = devMentorSchema().leafFields();
+
+        // One editable row per value, in contract order — never the fotos/mensaje containers.
+        assertEquals(
+                List.of("serviceCode", "aprobada", "username",
+                        "fotos.guidMultimedia", "fotos.aprobada",
+                        "fotos.mensaje.codigo", "fotos.mensaje.nombre"),
+                leaves.stream().map(PayloadSchema.Field::id).toList());
+        // Every leaf is scalar (no ARRAY/OBJECT leaks to the type label the UI shows).
+        assertTrue(leaves.stream().noneMatch(PayloadSchema.Field::structural));
+        assertEquals(PayloadSchema.FieldType.BOOLEAN, leaf(leaves, "fotos.aprobada").type());
+        assertTrue(leaf(leaves, "fotos.mensaje.codigo").required());
+    }
+
+    @Test
+    void validateAcceptsTheDynamicPerElementArrayRoot() {
+        // {{reasons.code}} reads a root bound only while rendering the content.reasons array — it
+        // is derived from the schema, so save-time validation must accept it, not flag it.
+        List<String> problems =
+                renderer.validate(TEMPLATES, devMentorSchema(), PayloadTemplate.DEFAULT_ROOTS);
+
+        assertTrue(problems.isEmpty(), problems.toString());
+    }
+
+    private static PayloadSchema.Field leaf(List<PayloadSchema.Field> leaves, String id) {
+        return leaves.stream().filter(field -> field.id().equals(id)).findFirst().orElseThrow();
+    }
+
     private static Map<String, Object> context() {
         Map<String, Object> approvedPhoto = new LinkedHashMap<>();
         approvedPhoto.put("mediaId", "g1");


### PR DESCRIPTION
Follow-up to #1002 (nested payload bodies). #1002 taught the renderer to build an object-with-nested-array body at runtime; this makes the **settings drawer** able to configure and save that same nested mapping. (The commit was pushed onto #1002's branch after it merged, so it never landed — hence this fresh PR.)

## Problem (from the drawer)

With a nested contract the drawer showed only top-level fields: `fotos` rendered as a single required **scalar** row (labelled with the raw i18n key `mapping.types.array`), and the real rows — `fotos.guidMultimedia`, `fotos.mensaje.codigo` — were never offered. Save-time validation also rejected `fotos.mensaje.codigo = {{reasons.code}}` as an unknown root, because `reasons` is bound only while rendering the `content.reasons` array.

## Fix (backend-only, no FE change)

- **`PayloadSchema.leafFields()`** flattens the contract to its scalar leaves as dotted-path fields (`fotos.mensaje.codigo`, type `string`). The dispatch-targets field list now uses it, so the drawer renders one editable row per value — never an array/object container, and no dotted key is dropped on save.
- **`PayloadRenderer.validate()`** augments the allowed roots with each array field's element bind name (`content.reasons → reasons`), so a template that legitimately reads a per-element root validates instead of being flagged.

The FE already renders `target.fields` generically (one row per `field.id`), so leaf ids flow through with correct `texto`/`booleano` labels and no `mapping.types.array`.

## Tests

`./mvnw -pl miot-integrations test -Dtest='Payload*Test,IntegrationEventBindingServiceTest,IntegrationEventDispatchHandlerTest'` → **65 passing**, incl. two new: leaf-field flattening to the exact dotted rows, and `validate()` accepting `{{reasons.code}}`. Flat-object and top-level-array contracts unchanged.

Runtime dispatch never validates, so this only affects the settings UI. Completes the Dev-Mentor nested-mapping chain alongside merged #1002 (renderer) and ecm-coordinator #346 (per-photo reasons + overall verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)