### PR TITLE
feat(app): integrations admin — templates & connections (P2)

### DIFF
--- a/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
+++ b/miot-harness/src/miot_harness/context_skills/defaults/skills/miot-search/SKILL.md
@@ -117,6 +117,7 @@ value you have confirmed; never emit a literal placeholder.
 | `/where-is-my-load` | where is my load, dónde está mi carga, expedición, expedition | Load/expedition tracking | `expeditionCode` or `expeditionNumber` (one at a time) |
 | `/notifications` | notifications, notificaciones | User notifications | — |
 | `/integrations/jobs` | integration jobs, trabajos de integración, job console, consola de trabajos | Asynchronous integration job activity and status | — |
+| `/integrations/connections` | integration connections, conexiones de integración, integration templates, plantillas de integración, integration types | Integration templates (types) and the connections created from them | — |
 | `/users/settings` | settings, configuración, ajustes | User settings; organizations at `/users/settings/organizations`, data sources at `/users/settings/data-sources` | — |
 | `/users/settings/credentials` | credentials, credenciales, API credentials, credenciales API | Reusable organization credentials for data sources, integrations, and jobs | — |
 | `/admin/console/logs` | admin logs, logs, registros (admins only) | Operational logs | — |

--- a/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/connections/page.tsx
+++ b/turbo-repo/apps/app/src/app/[lang]/(secured)/integrations/connections/page.tsx
@@ -1,0 +1,19 @@
+import { getDictionary } from "@/features/i18n/i18n.service";
+import { I18nRecord, ParamsWithLang } from "@/features/i18n/i18n.service.types";
+import { RouteGuard } from "@/features/auth/components/route-guard";
+import { IntegrationConfigPageContent } from "@/features/integration-config/components/integration-config-page-content";
+
+export default async function IntegrationConnectionsPage({ params }: ParamsWithLang) {
+  const { lang } = await params;
+  const [, dictionary] = await getDictionary(lang);
+  const dict = (dictionary.pages as I18nRecord)?.integrationConnections as I18nRecord;
+
+  return (
+    <RouteGuard path="/integrations/connections" fallbackPath={`/${lang}/shipping`}>
+      {/* LayoutContent is overflow-hidden — pages own their scroll (same wrapper as jobs). */}
+      <div className="flex h-full w-full flex-col overflow-y-auto bg-white dark:bg-gray-900">
+        <IntegrationConfigPageContent dict={dict ?? {}} />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/templates/[templateId]/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/templates/[templateId]/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+import { requireOrganizationOwner } from "@/app/api/utils/organization-owner";
+
+/**
+ * GET/PATCH/DELETE /api/admin/orgs/[orgId]/integrations/templates/[templateId]
+ *
+ * Proxies to Quarkus `.../integrations/templates/{templateId}`. DELETE answers 409
+ * (forwarded verbatim) while connections are still instances of the template.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string; templateId: string }> }
+) {
+  const { orgId, templateId } = await params;
+  const denied = await requireOrganizationOwner(orgId);
+  if (denied) return denied;
+  return forwardToQuarkus(templatePath(orgId, templateId));
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string; templateId: string }> }
+) {
+  const { orgId, templateId } = await params;
+  const denied = await requireOrganizationOwner(orgId);
+  if (denied) return denied;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(templatePath(orgId, templateId), {
+    method: "PATCH",
+    body,
+  });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string; templateId: string }> }
+) {
+  const { orgId, templateId } = await params;
+  const denied = await requireOrganizationOwner(orgId);
+  if (denied) return denied;
+  return forwardToQuarkus(templatePath(orgId, templateId), { method: "DELETE" });
+}
+
+function templatePath(orgId: string, templateId: string): string {
+  return `/api/v1/orgs/${encodeURIComponent(orgId)}/integrations/templates/${encodeURIComponent(templateId)}`;
+}

--- a/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/templates/route.ts
+++ b/turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/templates/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { forwardToQuarkus } from "@/app/api/utils/quarkus-proxy";
+import { requireOrganizationOwner } from "@/app/api/utils/organization-owner";
+
+/**
+ * GET  /api/admin/orgs/[orgId]/integrations/templates — list templates
+ * POST /api/admin/orgs/[orgId]/integrations/templates — create a template
+ *
+ * Proxies to Quarkus `GET/POST /api/v1/orgs/{orgId}/integrations/templates`
+ * (miot-integrations). A template is an operator-defined integration type; every
+ * route requires organization-owner access and Quarkus enforces it again.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  const { orgId } = await params;
+  const denied = await requireOrganizationOwner(orgId);
+  if (denied) return denied;
+  const safe = encodeURIComponent(orgId);
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/templates`);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  const { orgId } = await params;
+  const denied = await requireOrganizationOwner(orgId);
+  if (denied) return denied;
+  const safe = encodeURIComponent(orgId);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  return forwardToQuarkus(`/api/v1/orgs/${safe}/integrations/templates`, {
+    method: "POST",
+    body,
+  });
+}

--- a/turbo-repo/apps/app/src/features/auth/config/route-permissions.ts
+++ b/turbo-repo/apps/app/src/features/auth/config/route-permissions.ts
@@ -64,6 +64,10 @@ export const ROUTE_PERMISSIONS = {
   // enforces org membership per request.
   "/integrations/jobs": [],
 
+  // Integrations config (templates + connections) — any authenticated member;
+  // the backend owner-gates every mutation per request.
+  "/integrations/connections": [],
+
   // Admin console routes
   "/admin/console/message-templates": ADMIN_ROLES,
 } as const;

--- a/turbo-repo/apps/app/src/features/integration-config/components/connection-form-modal.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/connection-form-modal.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Label,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  Select,
+  TextInput,
+} from "flowbite-react";
+import { HiInformationCircle } from "react-icons/hi";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import type { CredentialListItem } from "@/features/credentials/credential.types";
+import type {
+  CreateConnectionRequest,
+  IntegrationConnection,
+  IntegrationTemplate,
+  UpdateConnectionRequest,
+} from "../integration-config.types";
+
+interface ConnectionFormModalProps {
+  readonly show: boolean;
+  /** The instance being edited, or undefined to create a new one. */
+  readonly connection: IntegrationConnection | undefined;
+  readonly templates: readonly IntegrationTemplate[];
+  readonly credentials: readonly CredentialListItem[];
+  readonly onClose: () => void;
+  readonly onSave: (
+    create: CreateConnectionRequest | null,
+    id?: string,
+    patch?: UpdateConnectionRequest
+  ) => Promise<unknown>;
+  readonly saving: boolean;
+  readonly dict: I18nRecord;
+}
+
+export function ConnectionFormModal({
+  show,
+  connection,
+  templates,
+  credentials,
+  onClose,
+  onSave,
+  saving,
+  dict,
+}: Readonly<ConnectionFormModalProps>) {
+  const editing = connection !== undefined;
+  const [templateId, setTemplateId] = useState("");
+  const [name, setName] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [credentialId, setCredentialId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!show) return;
+    setError(null);
+    setTemplateId(connection?.templateId ?? templates[0]?.id ?? "");
+    setName(connection?.name ?? "");
+    setBaseUrl(connection?.baseUrl ?? "");
+    setCredentialId(connection?.credentialProfileId ?? "");
+  }, [show, connection, templates]);
+
+  const canSave =
+    name.trim() !== "" &&
+    baseUrl.trim() !== "" &&
+    (editing || templateId !== "") &&
+    !saving;
+
+  async function handleSave() {
+    try {
+      if (editing) {
+        await onSave(null, connection.id, {
+          name: name.trim(),
+          baseUrl: baseUrl.trim(),
+        });
+      } else {
+        await onSave({
+          name: name.trim(),
+          baseUrl: baseUrl.trim(),
+          credentialProfileId: credentialId || null,
+          templateId,
+        });
+      }
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : tr("common.saveFailed", dict));
+    }
+  }
+
+  const credentialName = credentials.find((c) => c.id === credentialId)?.name;
+
+  return (
+    <Modal show={show} onClose={onClose} size="lg">
+      <ModalHeader>
+        {editing
+          ? tr("connection.form.editTitle", dict)
+          : tr("connection.form.createTitle", dict)}
+      </ModalHeader>
+      <ModalBody>
+        <div className="flex flex-col gap-4">
+          {error && (
+            <Alert color="failure" icon={HiInformationCircle}>
+              <span className="text-xs">{error}</span>
+            </Alert>
+          )}
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">{tr("connection.form.template", dict)}</Label>
+            {editing ? (
+              <span className="text-sm text-gray-700 dark:text-gray-200">
+                {templates.find((t) => t.id === connection.templateId)?.name ??
+                  tr("connection.form.noTemplate", dict)}
+              </span>
+            ) : templates.length === 0 ? (
+              <Alert color="gray" icon={HiInformationCircle}>
+                <span className="text-xs">{tr("connection.form.needTemplate", dict)}</span>
+              </Alert>
+            ) : (
+              <Select
+                sizing="sm"
+                value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)}
+              >
+                {templates.map((template) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name} · {template.method} {template.path}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">{tr("connection.form.name", dict)}</Label>
+            <TextInput
+              sizing="sm"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={tr("connection.form.namePlaceholder", dict)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">{tr("connection.form.baseUrl", dict)}</Label>
+            <TextInput
+              sizing="sm"
+              className="font-mono [&_input]:text-xs"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.partner.example.com"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">{tr("connection.form.credential", dict)}</Label>
+            {editing ? (
+              <span className="text-sm text-gray-700 dark:text-gray-200">
+                {credentialName ?? tr("connection.form.noCredential", dict)}
+                <span className="ml-2 text-[11px] text-gray-400">
+                  {tr("connection.form.credentialFixed", dict)}
+                </span>
+              </span>
+            ) : credentials.length === 0 ? (
+              <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                {tr("connection.form.noCredentials", dict)}
+              </p>
+            ) : (
+              <Select
+                sizing="sm"
+                value={credentialId}
+                onChange={(e) => setCredentialId(e.target.value)}
+              >
+                <option value="">{tr("connection.form.noCredential", dict)}</option>
+                {credentials.map((credential) => (
+                  <option key={credential.id} value={credential.id}>
+                    {credential.name} · {credential.environment}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button color="gray" size="sm" onClick={onClose}>
+              {tr("common.cancel", dict)}
+            </Button>
+            <Button color="blue" size="sm" onClick={handleSave} disabled={!canSave}>
+              {saving ? tr("common.saving", dict) : tr("common.save", dict)}
+            </Button>
+          </div>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-config/components/integration-config-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/integration-config-page-content.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useState } from "react";
+import { Alert, Badge, Button, Spinner } from "flowbite-react";
+import {
+  HiOutlineTemplate,
+  HiOutlineLink,
+  HiPlus,
+  HiPencil,
+  HiTrash,
+  HiPlay,
+  HiInformationCircle,
+} from "react-icons/hi";
+import { toast } from "sonner";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import { useOrgScopes } from "@/features/layout/components/secured-navbar/org-switcher/use-org-scopes";
+import { useIntegrationConfig } from "../use-integration-config";
+import type {
+  IntegrationConnection,
+  IntegrationTemplate,
+} from "../integration-config.types";
+import { TemplateFormModal } from "./template-form-modal";
+import { ConnectionFormModal } from "./connection-form-modal";
+
+export function IntegrationConfigPageContent({ dict }: Readonly<{ dict: I18nRecord }>) {
+  const { activeOrg } = useOrgScopes();
+  const orgSlug = activeOrg?.slug ?? null;
+  const {
+    templates,
+    connections,
+    credentials,
+    isLoading,
+    error,
+    saving,
+    saveTemplate,
+    removeTemplate,
+    saveConnection,
+    testInstance,
+  } = useIntegrationConfig(orgSlug);
+
+  const [templateModal, setTemplateModal] = useState<{
+    open: boolean;
+    template?: IntegrationTemplate;
+  }>({ open: false });
+  const [connectionModal, setConnectionModal] = useState<{
+    open: boolean;
+    connection?: IntegrationConnection;
+  }>({ open: false });
+  const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
+  const [testing, setTesting] = useState<string | null>(null);
+
+  const instanceCount = (templateId: string) =>
+    connections.filter((c) => c.templateId === templateId).length;
+
+  async function handleDeleteTemplate(id: string) {
+    try {
+      await removeTemplate(id);
+      toast.success(tr("toast.templateDeleted", dict));
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : tr("toast.actionFailed", dict));
+    } finally {
+      setConfirmingDelete(null);
+    }
+  }
+
+  async function handleTest(id: string) {
+    setTesting(id);
+    try {
+      const result = await testInstance(id);
+      if (result.success) {
+        toast.success(tr("toast.testOk", dict));
+      } else {
+        toast.error(result.message ?? tr("toast.testFailed", dict));
+      }
+    } catch (cause) {
+      toast.error(cause instanceof Error ? cause.message : tr("toast.testFailed", dict));
+    } finally {
+      setTesting(null);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-6">
+      <header>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          {tr("page.title", dict)}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {tr("page.subtitle", dict)}
+        </p>
+      </header>
+
+      {error && (
+        <Alert color="failure" icon={HiInformationCircle}>
+          <span className="text-xs">{error.message}</span>
+        </Alert>
+      )}
+
+      {/* Templates — the types */}
+      <section className="flex flex-col gap-3">
+        <SectionHeader
+          icon={<HiOutlineTemplate className="h-5 w-5 text-primary-500" />}
+          title={tr("templates.title", dict)}
+          help={tr("templates.help", dict)}
+          action={
+            <Button size="xs" color="blue" onClick={() => setTemplateModal({ open: true })}>
+              <HiPlus className="mr-1 h-3.5 w-3.5" />
+              {tr("templates.new", dict)}
+            </Button>
+          }
+        />
+        {isLoading ? (
+          <Loading />
+        ) : templates.length === 0 ? (
+          <EmptyNotice text={tr("templates.empty", dict)} />
+        ) : (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {templates.map((template) => (
+              <div
+                key={template.id}
+                className="flex flex-col gap-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {template.name}
+                      </span>
+                      <Badge color="gray">{template.providerType}</Badge>
+                    </div>
+                    <code className="mt-1 block truncate font-mono text-[11px] text-gray-500 dark:text-gray-400">
+                      {template.method} {template.path}
+                    </code>
+                    <span className="text-[11px] text-gray-400">
+                      {tr("templates.instanceCount", dict, {
+                        count: String(instanceCount(template.id)),
+                      })}
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 gap-1">
+                    <IconButton
+                      label={tr("common.edit", dict)}
+                      onClick={() => setTemplateModal({ open: true, template })}
+                    >
+                      <HiPencil className="h-4 w-4" />
+                    </IconButton>
+                    <IconButton
+                      label={tr("common.delete", dict)}
+                      danger
+                      onClick={() => setConfirmingDelete(template.id)}
+                    >
+                      <HiTrash className="h-4 w-4" />
+                    </IconButton>
+                  </div>
+                </div>
+                {confirmingDelete === template.id && (
+                  <div className="flex items-center justify-between gap-2 rounded bg-red-50 px-2 py-1 dark:bg-red-900/20">
+                    <span className="text-[11px] text-red-700 dark:text-red-300">
+                      {tr("templates.confirmDelete", dict)}
+                    </span>
+                    <div className="flex gap-1">
+                      <Button size="xs" color="gray" onClick={() => setConfirmingDelete(null)}>
+                        {tr("common.cancel", dict)}
+                      </Button>
+                      <Button
+                        size="xs"
+                        color="failure"
+                        onClick={() => handleDeleteTemplate(template.id)}
+                      >
+                        {tr("common.delete", dict)}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Connections — the instances */}
+      <section className="flex flex-col gap-3">
+        <SectionHeader
+          icon={<HiOutlineLink className="h-5 w-5 text-primary-500" />}
+          title={tr("connections.title", dict)}
+          help={tr("connections.help", dict)}
+          action={
+            <Button
+              size="xs"
+              color="blue"
+              disabled={templates.length === 0}
+              onClick={() => setConnectionModal({ open: true })}
+            >
+              <HiPlus className="mr-1 h-3.5 w-3.5" />
+              {tr("connections.new", dict)}
+            </Button>
+          }
+        />
+        {isLoading ? (
+          <Loading />
+        ) : connections.length === 0 ? (
+          <EmptyNotice text={tr("connections.empty", dict)} />
+        ) : (
+          <div className="flex flex-col gap-2">
+            {connections.map((connection) => (
+              <div
+                key={connection.id}
+                className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {connection.name}
+                    </span>
+                    <StatusBadge connection={connection} dict={dict} />
+                    {connection.templateId && (
+                      <span className="text-[11px] text-gray-400">
+                        {templates.find((t) => t.id === connection.templateId)?.name ??
+                          connection.providerType}
+                      </span>
+                    )}
+                  </div>
+                  <code className="mt-0.5 block truncate font-mono text-[11px] text-gray-500 dark:text-gray-400">
+                    {connection.baseUrl}
+                  </code>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <IconButton
+                    label={tr("connections.test", dict)}
+                    onClick={() => handleTest(connection.id)}
+                    disabled={testing === connection.id}
+                  >
+                    {testing === connection.id ? (
+                      <Spinner size="sm" />
+                    ) : (
+                      <HiPlay className="h-4 w-4" />
+                    )}
+                  </IconButton>
+                  <IconButton
+                    label={tr("common.edit", dict)}
+                    onClick={() => setConnectionModal({ open: true, connection })}
+                  >
+                    <HiPencil className="h-4 w-4" />
+                  </IconButton>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <TemplateFormModal
+        show={templateModal.open}
+        template={templateModal.template}
+        onClose={() => setTemplateModal({ open: false })}
+        onSave={saveTemplate}
+        saving={saving}
+        dict={dict}
+      />
+      <ConnectionFormModal
+        show={connectionModal.open}
+        connection={connectionModal.connection}
+        templates={templates}
+        credentials={credentials}
+        onClose={() => setConnectionModal({ open: false })}
+        onSave={saveConnection}
+        saving={saving}
+        dict={dict}
+      />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+function SectionHeader({
+  icon,
+  title,
+  help,
+  action,
+}: Readonly<{
+  icon: React.ReactNode;
+  title: string;
+  help: string;
+  action: React.ReactNode;
+}>) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex items-start gap-2">
+        {icon}
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{help}</p>
+        </div>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+function StatusBadge({
+  connection,
+  dict,
+}: Readonly<{ connection: IntegrationConnection; dict: I18nRecord }>) {
+  if (connection.status === "ACTIVE" || connection.lastTestResult === true) {
+    return <Badge color="success">{tr("status.active", dict)}</Badge>;
+  }
+  if (connection.status === "TEST_FAILED" || connection.lastTestResult === false) {
+    return <Badge color="failure">{tr("status.failed", dict)}</Badge>;
+  }
+  return <Badge color="gray">{tr("status.draft", dict)}</Badge>;
+}
+
+function IconButton({
+  label,
+  onClick,
+  danger,
+  disabled,
+  children,
+}: Readonly<{
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}>) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded p-1.5 text-gray-400 disabled:opacity-50 ${
+        danger
+          ? "hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+          : "hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Loading() {
+  return (
+    <div className="flex justify-center py-6">
+      <Spinner />
+    </div>
+  );
+}
+
+function EmptyNotice({ text }: Readonly<{ text: string }>) {
+  return (
+    <Alert color="gray" icon={HiInformationCircle}>
+      <span className="text-xs">{text}</span>
+    </Alert>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-config/components/template-form-modal.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/template-form-modal.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Button,
+  Label,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  Select,
+  Textarea,
+  TextInput,
+} from "flowbite-react";
+import { HiInformationCircle } from "react-icons/hi";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { tr } from "@/features/i18n/tr.service";
+import {
+  HTTP_METHODS,
+  PROVIDER_TYPES,
+  parseJsonObject,
+  schemaLeafPaths,
+  type CreateTemplateRequest,
+  type IntegrationTemplate,
+} from "../integration-config.types";
+
+interface TemplateFormModalProps {
+  readonly show: boolean;
+  readonly template: IntegrationTemplate | undefined;
+  readonly onClose: () => void;
+  readonly onSave: (body: CreateTemplateRequest, id?: string) => Promise<unknown>;
+  readonly saving: boolean;
+  readonly dict: I18nRecord;
+}
+
+const SCHEMA_PLACEHOLDER = `{
+  "type": "object",
+  "properties": {
+    "serviceCode": { "type": "string" },
+    "aprobada": { "type": "boolean" }
+  },
+  "required": ["serviceCode"]
+}`;
+
+export function TemplateFormModal({
+  show,
+  template,
+  onClose,
+  onSave,
+  saving,
+  dict,
+}: Readonly<TemplateFormModalProps>) {
+  const editing = template !== undefined;
+  const [name, setName] = useState("");
+  const [providerType, setProviderType] = useState(PROVIDER_TYPES[0]);
+  const [operationName, setOperationName] = useState("");
+  const [method, setMethod] = useState(HTTP_METHODS[0]);
+  const [path, setPath] = useState("");
+  const [requestSchemaText, setRequestSchemaText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!show) return;
+    setError(null);
+    setName(template?.name ?? "");
+    setProviderType(template?.providerType ?? PROVIDER_TYPES[0]);
+    setOperationName(template?.operationName ?? "");
+    setMethod(template?.method ?? HTTP_METHODS[0]);
+    setPath(template?.path ?? "");
+    setRequestSchemaText(
+      template?.requestSchema && Object.keys(template.requestSchema).length > 0
+        ? JSON.stringify(template.requestSchema, null, 2)
+        : ""
+    );
+  }, [show, template]);
+
+  const schemaCheck = useMemo(() => parseJsonObject(requestSchemaText), [requestSchemaText]);
+  const leaves = useMemo(
+    () => ("value" in schemaCheck ? schemaLeafPaths(schemaCheck.value) : []),
+    [schemaCheck]
+  );
+  const schemaBroken = "error" in schemaCheck;
+
+  const canSave =
+    name.trim() !== "" && path.trim() !== "" && !schemaBroken && !saving;
+
+  async function handleSave() {
+    if ("error" in schemaCheck) {
+      setError(tr("template.form.schemaInvalid", dict));
+      return;
+    }
+    try {
+      await onSave(
+        {
+          name: name.trim(),
+          providerType,
+          operationName: operationName.trim(),
+          method,
+          path: path.trim(),
+          requestSchema: schemaCheck.value,
+          responseSchema: {},
+        },
+        template?.id
+      );
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : tr("common.saveFailed", dict));
+    }
+  }
+
+  return (
+    <Modal show={show} onClose={onClose} size="2xl">
+      <ModalHeader>
+        {editing ? tr("template.form.editTitle", dict) : tr("template.form.createTitle", dict)}
+      </ModalHeader>
+      <ModalBody>
+        <div className="flex flex-col gap-4">
+          {error && (
+            <Alert color="failure" icon={HiInformationCircle}>
+              <span className="text-xs">{error}</span>
+            </Alert>
+          )}
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Field label={tr("template.form.name", dict)}>
+              <TextInput
+                sizing="sm"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={tr("template.form.namePlaceholder", dict)}
+              />
+            </Field>
+            <Field label={tr("template.form.providerType", dict)}>
+              <Select
+                sizing="sm"
+                value={providerType}
+                disabled={editing}
+                onChange={(e) => setProviderType(e.target.value)}
+              >
+                {PROVIDER_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-[8rem_1fr]">
+            <Field label={tr("template.form.method", dict)}>
+              <Select sizing="sm" value={method} onChange={(e) => setMethod(e.target.value)}>
+                {HTTP_METHODS.map((verb) => (
+                  <option key={verb} value={verb}>
+                    {verb}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+            <Field label={tr("template.form.path", dict)}>
+              <TextInput
+                sizing="sm"
+                className="font-mono [&_input]:text-xs"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                placeholder="/api/v1/resource"
+              />
+            </Field>
+          </div>
+
+          <Field label={tr("template.form.operationName", dict)}>
+            <TextInput
+              sizing="sm"
+              value={operationName}
+              onChange={(e) => setOperationName(e.target.value)}
+              placeholder={tr("template.form.operationNamePlaceholder", dict)}
+            />
+          </Field>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs">{tr("template.form.requestSchema", dict)}</Label>
+            <p className="text-[11px] text-gray-500 dark:text-gray-400">
+              {tr("template.form.requestSchemaHelp", dict)}
+            </p>
+            <Textarea
+              rows={9}
+              className="font-mono text-xs"
+              value={requestSchemaText}
+              onChange={(e) => setRequestSchemaText(e.target.value)}
+              placeholder={SCHEMA_PLACEHOLDER}
+              color={schemaBroken ? "failure" : "gray"}
+            />
+            {schemaBroken ? (
+              <p className="text-[11px] text-red-600 dark:text-red-400">
+                {tr("template.form.schemaInvalid", dict)}
+              </p>
+            ) : leaves.length > 0 ? (
+              <div className="flex flex-wrap gap-1">
+                <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                  {tr("template.form.fieldsDetected", dict)}:
+                </span>
+                {leaves.map((leaf) => (
+                  <code
+                    key={leaf}
+                    className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                  >
+                    {leaf}
+                  </code>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button color="gray" size="sm" onClick={onClose}>
+              {tr("common.cancel", dict)}
+            </Button>
+            <Button color="blue" size="sm" onClick={handleSave} disabled={!canSave}>
+              {saving ? tr("common.saving", dict) : tr("common.save", dict)}
+            </Button>
+          </div>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: Readonly<{ label: string; children: React.ReactNode }>) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-config/integration-config-data-service.ts
+++ b/turbo-repo/apps/app/src/features/integration-config/integration-config-data-service.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { ApiError } from "@/features/settings-admin/data/settings-admin-data-service";
+import type {
+  ConnectionTestResult,
+  CreateConnectionRequest,
+  CreateTemplateRequest,
+  IntegrationConnection,
+  IntegrationTemplate,
+  UpdateConnectionRequest,
+  UpdateTemplateRequest,
+} from "./integration-config.types";
+
+/**
+ * Client-side wrappers around the Next.js admin proxy routes for integration templates and
+ * connections, which forward to miot-integrations. Throw {@link ApiError} on non-2xx so SWR
+ * surfaces it — including the 409 the API returns when a template still has instances.
+ *
+ * Served under basePath "/app"; fetch() is not auto-prefixed, so the base includes it
+ * explicitly (as every sibling data service does).
+ */
+
+const base = (orgSlug: string) =>
+  `/app/api/admin/orgs/${encodeURIComponent(orgSlug)}/integrations`;
+
+async function readError(res: Response, url: string): Promise<ApiError> {
+  let message: string | undefined;
+  try {
+    const body = (await res.json()) as { error?: string; message?: string };
+    message = body.error ?? body.message;
+  } catch {
+    // non-JSON error body — fall back to the status message
+  }
+  return new ApiError({ status: res.status, url, message });
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!res.ok) throw await readError(res, url);
+  return (await res.json()) as T;
+}
+
+async function sendJson<T>(method: string, url: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+  });
+  if (!res.ok) throw await readError(res, url);
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Templates                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export function fetchTemplates(orgSlug: string): Promise<IntegrationTemplate[]> {
+  return getJson<IntegrationTemplate[]>(`${base(orgSlug)}/templates`);
+}
+
+export function createTemplate(
+  orgSlug: string,
+  body: CreateTemplateRequest
+): Promise<IntegrationTemplate> {
+  return sendJson<IntegrationTemplate>("POST", `${base(orgSlug)}/templates`, body);
+}
+
+export function updateTemplate(
+  orgSlug: string,
+  id: string,
+  body: UpdateTemplateRequest
+): Promise<IntegrationTemplate> {
+  return sendJson<IntegrationTemplate>(
+    "PATCH",
+    `${base(orgSlug)}/templates/${encodeURIComponent(id)}`,
+    body
+  );
+}
+
+export function deleteTemplate(orgSlug: string, id: string): Promise<void> {
+  return sendJson<void>("DELETE", `${base(orgSlug)}/templates/${encodeURIComponent(id)}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Connections (instances)                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function fetchConnections(orgSlug: string): Promise<IntegrationConnection[]> {
+  return getJson<IntegrationConnection[]>(`${base(orgSlug)}/connections`);
+}
+
+export function createConnection(
+  orgSlug: string,
+  body: CreateConnectionRequest
+): Promise<IntegrationConnection> {
+  return sendJson<IntegrationConnection>("POST", `${base(orgSlug)}/connections`, body);
+}
+
+export function updateConnection(
+  orgSlug: string,
+  id: string,
+  body: UpdateConnectionRequest
+): Promise<IntegrationConnection> {
+  return sendJson<IntegrationConnection>(
+    "PATCH",
+    `${base(orgSlug)}/connections/${encodeURIComponent(id)}`,
+    body
+  );
+}
+
+export function testConnection(
+  orgSlug: string,
+  id: string
+): Promise<ConnectionTestResult> {
+  return sendJson<ConnectionTestResult>(
+    "POST",
+    `${base(orgSlug)}/connections/${encodeURIComponent(id)}/test`,
+    {}
+  );
+}

--- a/turbo-repo/apps/app/src/features/integration-config/integration-config.types.test.ts
+++ b/turbo-repo/apps/app/src/features/integration-config/integration-config.types.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { parseJsonObject, schemaLeafPaths } from "./integration-config.types";
+
+describe("parseJsonObject", () => {
+  it("returns the object for valid JSON", () => {
+    const result = parseJsonObject('{"a": 1}');
+    expect(result).toEqual({ value: { a: 1 } });
+  });
+
+  it("treats empty text as an empty object", () => {
+    expect(parseJsonObject("   ")).toEqual({ value: {} });
+  });
+
+  it("rejects a top-level array — the schema must be an object", () => {
+    expect(parseJsonObject("[1,2]")).toEqual({ error: "notObject" });
+  });
+
+  it("reports a parse error for malformed JSON", () => {
+    const result = parseJsonObject("{ not json");
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("schemaLeafPaths", () => {
+  it("lists scalar leaves of a flat object", () => {
+    const schema = {
+      type: "object",
+      properties: { serviceCode: { type: "string" }, aprobada: { type: "boolean" } },
+    };
+    expect(schemaLeafPaths(schema)).toEqual(["serviceCode", "aprobada"]);
+  });
+
+  it("recurses through nested arrays and objects with dotted paths", () => {
+    // The Dev-Mentor-shaped envelope: an object with an array of objects, one of which
+    // itself holds an array of objects.
+    const schema = {
+      type: "object",
+      properties: {
+        serviceCode: { type: "string" },
+        aprobada: { type: "boolean" },
+        fotos: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              guidMultimedia: { type: "string" },
+              aprobada: { type: "boolean" },
+              mensaje: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    codigo: { type: "string" },
+                    nombre: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(schemaLeafPaths(schema)).toEqual([
+      "serviceCode",
+      "aprobada",
+      "fotos.guidMultimedia",
+      "fotos.aprobada",
+      "fotos.mensaje.codigo",
+      "fotos.mensaje.nombre",
+    ]);
+  });
+
+  it("has no leaves for an empty schema", () => {
+    expect(schemaLeafPaths({})).toEqual([]);
+  });
+});

--- a/turbo-repo/apps/app/src/features/integration-config/integration-config.types.ts
+++ b/turbo-repo/apps/app/src/features/integration-config/integration-config.types.ts
@@ -1,0 +1,131 @@
+/**
+ * Integration configuration — the operator-facing layer over miot-integrations.
+ *
+ * An **integration template** is a reusable *type* (like an n8n node type): it owns the
+ * payload contract — method, path and the request schema the review process maps against.
+ * A **connection** is an *instance* of a template: its own base URL and credential. Creating
+ * a connection from a template copies the template's contract onto it, so several instances
+ * of one template all speak the same payload with different endpoints and credentials.
+ */
+
+/** `IntegrationTemplate` as miot-integrations serializes it. */
+export interface IntegrationTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly providerType: string;
+  readonly operationName: string;
+  readonly method: string;
+  readonly path: string;
+  readonly requestSchema: Record<string, unknown>;
+  readonly responseSchema: Record<string, unknown>;
+}
+
+/** `IntegrationConnection` as miot-integrations serializes it — an instance of a template. */
+export interface IntegrationConnection {
+  readonly id: string;
+  readonly name: string;
+  readonly providerType: string;
+  readonly baseUrl: string;
+  readonly credentialProfileId: string | null;
+  readonly status: string;
+  readonly lastTestedAt: string | null;
+  readonly lastTestResult: boolean | null;
+  readonly templateId: string | null;
+  readonly metadata: Record<string, unknown>;
+}
+
+export interface CreateTemplateRequest {
+  readonly name: string;
+  readonly providerType: string;
+  readonly operationName: string;
+  readonly method: string;
+  readonly path: string;
+  readonly requestSchema: Record<string, unknown>;
+  readonly responseSchema: Record<string, unknown>;
+}
+
+export type UpdateTemplateRequest = Partial<Omit<CreateTemplateRequest, "providerType">>;
+
+export interface CreateConnectionRequest {
+  readonly name: string;
+  readonly baseUrl: string;
+  readonly credentialProfileId: string | null;
+  /** Set to create an instance of a template; the operation is provisioned from it. */
+  readonly templateId: string;
+}
+
+export interface UpdateConnectionRequest {
+  readonly name?: string;
+  readonly baseUrl?: string;
+}
+
+export interface ConnectionTestResult {
+  readonly success: boolean;
+  readonly testedAt: string;
+  readonly message: string | null;
+}
+
+/** Provider kinds a template can take, matching the backend enum. CUSTOM_HTTP leads. */
+export const PROVIDER_TYPES: readonly string[] = [
+  "CUSTOM_HTTP",
+  "N8N",
+  "POSTGREST",
+  "ALERCE_TMS",
+  "AUTH0",
+  "ECM",
+];
+
+export const HTTP_METHODS: readonly string[] = ["POST", "PUT", "PATCH", "GET", "DELETE"];
+
+/**
+ * Parses a JSON string into an object, or returns an error message. Used by the schema
+ * editors: the field holds text, the request wants an object.
+ */
+export function parseJsonObject(
+  text: string
+): { value: Record<string, unknown> } | { error: string } {
+  const trimmed = text.trim();
+  if (!trimmed) return { value: {} };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (cause) {
+    return { error: cause instanceof Error ? cause.message : "Invalid JSON" };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { error: "notObject" };
+  }
+  return { value: parsed as Record<string, unknown> };
+}
+
+/**
+ * The dotted leaf paths a JSON-Schema subset declares, for the "fields this template maps"
+ * preview. Mirrors the server's leaf flattening: an object recurses into `properties`, an
+ * array recurses into `items`, and everything else is a leaf.
+ */
+export function schemaLeafPaths(schema: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  walk(schema, "", out);
+  return out;
+}
+
+function walk(node: unknown, prefix: string, out: string[]): void {
+  if (typeof node !== "object" || node === null) return;
+  const schema = node as Record<string, unknown>;
+  const type = schema.type;
+  if (type === "object" && isRecord(schema.properties)) {
+    for (const [key, child] of Object.entries(schema.properties)) {
+      walk(child, prefix ? `${prefix}.${key}` : key, out);
+    }
+    return;
+  }
+  if (type === "array" && isRecord(schema.items)) {
+    walk(schema.items, prefix, out);
+    return;
+  }
+  if (prefix) out.push(prefix);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/turbo-repo/apps/app/src/features/integration-config/use-integration-config.ts
+++ b/turbo-repo/apps/app/src/features/integration-config/use-integration-config.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import { fetchCredentials } from "@/features/credentials/credentials-data-service";
+import type { CredentialListItem } from "@/features/credentials/credential.types";
+import {
+  createConnection,
+  createTemplate,
+  deleteTemplate,
+  fetchConnections,
+  fetchTemplates,
+  testConnection,
+  updateConnection,
+  updateTemplate,
+} from "./integration-config-data-service";
+import type {
+  ConnectionTestResult,
+  CreateConnectionRequest,
+  CreateTemplateRequest,
+  IntegrationConnection,
+  IntegrationTemplate,
+  UpdateConnectionRequest,
+  UpdateTemplateRequest,
+} from "./integration-config.types";
+
+const SWR_OPTS = { revalidateOnFocus: false, dedupingInterval: 5_000 } as const;
+
+/**
+ * Templates, connections and credentials for the integrations admin page, plus the
+ * mutations that keep them in step. Mutations revalidate rather than patching locally, so
+ * server-owned fields (a connection's status, its last test result) come back from the
+ * source that decided them.
+ */
+export function useIntegrationConfig(orgSlug: string | null) {
+  const templates = useSWR<IntegrationTemplate[], Error>(
+    orgSlug ? ["int-templates", orgSlug] : null,
+    () => fetchTemplates(orgSlug as string),
+    SWR_OPTS
+  );
+  const connections = useSWR<IntegrationConnection[], Error>(
+    orgSlug ? ["int-connections", orgSlug] : null,
+    () => fetchConnections(orgSlug as string),
+    SWR_OPTS
+  );
+  const credentials = useSWR<readonly CredentialListItem[], Error>(
+    orgSlug ? ["int-credentials", orgSlug] : null,
+    () => fetchCredentials(orgSlug as string),
+    SWR_OPTS
+  );
+
+  const [saving, setSaving] = useState(false);
+
+  const withSaving = useCallback(async <T>(work: () => Promise<T>): Promise<T> => {
+    setSaving(true);
+    try {
+      return await work();
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const saveTemplate = useCallback(
+    (body: CreateTemplateRequest, id?: string) =>
+      withSaving(async () => {
+        const saved = id
+          ? await updateTemplate(orgSlug as string, id, body as UpdateTemplateRequest)
+          : await createTemplate(orgSlug as string, body);
+        await templates.mutate();
+        return saved;
+      }),
+    [orgSlug, templates, withSaving]
+  );
+
+  const removeTemplate = useCallback(
+    (id: string) =>
+      withSaving(async () => {
+        await deleteTemplate(orgSlug as string, id);
+        await templates.mutate();
+      }),
+    [orgSlug, templates, withSaving]
+  );
+
+  const saveConnection = useCallback(
+    (create: CreateConnectionRequest | null, id?: string, patch?: UpdateConnectionRequest) =>
+      withSaving(async () => {
+        const saved = id
+          ? await updateConnection(orgSlug as string, id, patch ?? {})
+          : await createConnection(orgSlug as string, create as CreateConnectionRequest);
+        await connections.mutate();
+        return saved;
+      }),
+    [orgSlug, connections, withSaving]
+  );
+
+  const testInstance = useCallback(
+    async (id: string): Promise<ConnectionTestResult> => {
+      const result = await testConnection(orgSlug as string, id);
+      await connections.mutate();
+      return result;
+    },
+    [orgSlug, connections]
+  );
+
+  return {
+    templates: templates.data ?? [],
+    connections: connections.data ?? [],
+    credentials: credentials.data ?? [],
+    isLoading: templates.isLoading || connections.isLoading,
+    error: templates.error ?? connections.error,
+    saving,
+    saveTemplate,
+    removeTemplate,
+    saveConnection,
+    testInstance,
+    refresh: () => {
+      void templates.mutate();
+      void connections.mutate();
+    },
+  };
+}

--- a/turbo-repo/apps/app/src/features/layout/models/pages-config.json
+++ b/turbo-repo/apps/app/src/features/layout/models/pages-config.json
@@ -81,6 +81,20 @@
   {
     "label": "integrations",
     "href": "/integrations/jobs",
+    "items": [
+      {
+        "href": "/integrations/jobs",
+        "label": "integrationJobs",
+        "requiredGroups": [],
+        "blockedGroups": []
+      },
+      {
+        "href": "/integrations/connections",
+        "label": "integrationConnections",
+        "requiredGroups": [],
+        "blockedGroups": []
+      }
+    ],
     "requiredGroups": [],
     "blockedGroups": []
   },

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2028,6 +2028,79 @@
           "deleted": "Successfully deleted"
         }
       }
+    },
+    "integrationConnections": {
+      "page": {
+        "title": "Integrations",
+        "subtitle": "Define integration types and create connections from them."
+      },
+      "templates": {
+        "title": "Templates",
+        "help": "A reusable type: define the data contract (method, path and fields) once.",
+        "new": "New template",
+        "empty": "No templates yet. Create one to start adding connections.",
+        "instanceCount": "{count} connection(s)",
+        "confirmDelete": "Delete this template?"
+      },
+      "connections": {
+        "title": "Connections",
+        "help": "An instance of a template, with its own URL and credential.",
+        "new": "New connection",
+        "empty": "No connections yet.",
+        "test": "Test"
+      },
+      "status": {
+        "active": "Active",
+        "failed": "Failed",
+        "draft": "Draft"
+      },
+      "common": {
+        "edit": "Edit",
+        "delete": "Delete",
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving…",
+        "saveFailed": "Could not save"
+      },
+      "toast": {
+        "templateDeleted": "Template deleted",
+        "actionFailed": "Could not complete the action",
+        "testOk": "Connection tested successfully",
+        "testFailed": "Connection test failed"
+      },
+      "template": {
+        "form": {
+          "createTitle": "New template",
+          "editTitle": "Edit template",
+          "name": "Name",
+          "namePlaceholder": "e.g. Partner API",
+          "providerType": "Provider type",
+          "method": "Method",
+          "path": "Path",
+          "operationName": "Operation name",
+          "operationNamePlaceholder": "e.g. Report verdict",
+          "requestSchema": "Payload schema (JSON Schema)",
+          "requestSchemaHelp": "The fields the review process will map. An object with properties; nested objects and arrays are supported.",
+          "schemaInvalid": "The schema is not a valid JSON object.",
+          "fieldsDetected": "Detected fields"
+        }
+      },
+      "connection": {
+        "form": {
+          "createTitle": "New connection",
+          "editTitle": "Edit connection",
+          "template": "Template",
+          "noTemplate": "No template",
+          "needTemplate": "Create a template first.",
+          "name": "Name",
+          "namePlaceholder": "e.g. Partner API · QA",
+          "baseUrl": "Base URL",
+          "credential": "Credential",
+          "noCredential": "No credential",
+          "noCredentials": "No credentials. Create them in Settings › Credentials.",
+          "credentialFixed": "(not editable here)"
+        }
+      }
     }
   },
   "layout": {
@@ -2086,7 +2159,9 @@
         "subtitle1": "Consolidation",
         "subtitle2": "Document Separation",
         "subtitle3": "Client System Validation",
-        "subtitle4": "GPS Validation"
+        "subtitle4": "GPS Validation",
+        "integrationJobs": "Activity",
+        "integrationConnections": "Connections"
       }
     },
     "calendar": {

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2028,6 +2028,79 @@
           "deleted": "Eliminado exitosamente"
         }
       }
+    },
+    "integrationConnections": {
+      "page": {
+        "title": "Integraciones",
+        "subtitle": "Define tipos de integración y crea conexiones a partir de ellos."
+      },
+      "templates": {
+        "title": "Plantillas",
+        "help": "Un tipo reutilizable: define el contrato de datos (método, ruta y campos) una sola vez.",
+        "new": "Nueva plantilla",
+        "empty": "Aún no hay plantillas. Crea una para poder añadir conexiones.",
+        "instanceCount": "{count} conexión(es)",
+        "confirmDelete": "¿Eliminar esta plantilla?"
+      },
+      "connections": {
+        "title": "Conexiones",
+        "help": "Una instancia de una plantilla, con su propia URL y credencial.",
+        "new": "Nueva conexión",
+        "empty": "Aún no hay conexiones.",
+        "test": "Probar"
+      },
+      "status": {
+        "active": "Activa",
+        "failed": "Falló",
+        "draft": "Borrador"
+      },
+      "common": {
+        "edit": "Editar",
+        "delete": "Eliminar",
+        "cancel": "Cancelar",
+        "save": "Guardar",
+        "saving": "Guardando…",
+        "saveFailed": "No se pudo guardar"
+      },
+      "toast": {
+        "templateDeleted": "Plantilla eliminada",
+        "actionFailed": "No se pudo completar la acción",
+        "testOk": "Conexión probada correctamente",
+        "testFailed": "La prueba de conexión falló"
+      },
+      "template": {
+        "form": {
+          "createTitle": "Nueva plantilla",
+          "editTitle": "Editar plantilla",
+          "name": "Nombre",
+          "namePlaceholder": "Ej: Partner API",
+          "providerType": "Tipo de proveedor",
+          "method": "Método",
+          "path": "Ruta",
+          "operationName": "Nombre de la operación",
+          "operationNamePlaceholder": "Ej: Reportar veredicto",
+          "requestSchema": "Esquema de la carga (JSON Schema)",
+          "requestSchemaHelp": "Los campos que el proceso de revisión mapeará. Un objeto con propiedades; admite objetos y arreglos anidados.",
+          "schemaInvalid": "El esquema no es un objeto JSON válido.",
+          "fieldsDetected": "Campos detectados"
+        }
+      },
+      "connection": {
+        "form": {
+          "createTitle": "Nueva conexión",
+          "editTitle": "Editar conexión",
+          "template": "Plantilla",
+          "noTemplate": "Sin plantilla",
+          "needTemplate": "Crea una plantilla primero.",
+          "name": "Nombre",
+          "namePlaceholder": "Ej: Partner API · QA",
+          "baseUrl": "URL base",
+          "credential": "Credencial",
+          "noCredential": "Sin credencial",
+          "noCredentials": "No hay credenciales. Créalas en Ajustes › Credenciales.",
+          "credentialFixed": "(no editable aquí)"
+        }
+      }
     }
   },
   "layout": {
@@ -2086,7 +2159,9 @@
         "collaboratorsManagement": "Colaboradores",
         "searchPlaceholder": "Buscar...",
         "createDashboard": "Nuevo dashboard",
-        "closePanel": "Cerrar panel"
+        "closePanel": "Cerrar panel",
+        "integrationJobs": "Actividad",
+        "integrationConnections": "Conexiones"
       }
     },
     "calendar": {


### PR DESCRIPTION
**Phase 2 of the integration-templates work** — the frontend for the type→instance model [#1004](https://github.com/microboxlabs/modulariot/pull/1004) added. FE-only.

## What it delivers

A new **Integraciones · Conexiones** page (under the integrations nav, owner-gated by the backend like the jobs console) that finally lets an operator do in-app what previously needed SQL:

- **Plantillas (types)** — create / edit / delete a template: name, provider type, method, path, and a **JSON-Schema payload editor** with a live *detected fields* preview. Delete surfaces the API's 409 when instances still exist.
- **Conexiones (instances)** — create an instance **from a template** (name + base URL + credential picker, reusing the existing credentials feature), edit its base URL, and **test** it.

This closes the loop on the original ask: *one Dev-Mentor template, many connections with different credentials/hosts* — all configurable from the UI, no code per partner.

## Structure

| | |
|---|---|
| Page | `/integrations/connections` (mirrors the jobs page shell + `RouteGuard`) |
| Feature | `features/integration-config/`: types (+ pure JSON-schema helpers), data service over the admin proxy, SWR hook, 3 components |
| Proxy routes | `integrations/templates` (GET/POST) + `templates/[templateId]` (GET/PATCH/DELETE) |
| Nav | `integrations` becomes a group — **Actividad** (jobs) + **Conexiones** — plus route permission + es/en i18n |

## Verification

- `check-types` clean in the new files (161 total is the unchanged pre-existing baseline from unbuilt workspace packages).
- eslint clean; **7 unit tests** for the schema helpers (`parseJsonObject`, `schemaLeafPaths` incl. the nested Dev-Mentor-shaped envelope).
- End-to-end (create/test against a live partner) needs **#1004 deployed** — the page calls those endpoints. UI renders/compiles now.

## Deliberate follow-ups (P3)

- **Instance delete** and **credential swap on edit** — no backend op yet (`UpdateIntegrationConnectionRequest` covers name/baseUrl/token, not a credential swap or a connection soft-delete). Small backend additions.
- **Schema builder** — the template payload is a JSON-Schema textarea today (with a fields preview); a field-row builder for the flat/common case is a friendlier polish.
- New credentials are picked from the existing **Ajustes › Credenciales** page; no inline credential creation here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Integrations Connections page for managing integration templates and connections.
  * Create, edit, delete, and test integration connections and templates.
  * Added forms for provider details, request schemas, URLs, and credentials.
  * Added connection status indicators, validation, loading states, and success/error notifications.
  * Added localized English and Spanish labels and navigation entries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->