### PR TITLE
[app] Resolve Sonar findings from PR #1006

### DIFF
--- a/turbo-repo/apps/app/src/features/integration-config/components/connection-form-modal.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/connection-form-modal.tsx
@@ -110,16 +110,21 @@ export function ConnectionFormModal({
 
           <div className="flex flex-col gap-1">
             <Label className="text-xs">{tr("connection.form.template", dict)}</Label>
-            {editing ? (
-              <span className="text-sm text-gray-700 dark:text-gray-200">
-                {templates.find((t) => t.id === connection.templateId)?.name ??
-                  tr("connection.form.noTemplate", dict)}
-              </span>
-            ) : templates.length === 0 ? (
-              <Alert color="gray" icon={HiInformationCircle}>
-                <span className="text-xs">{tr("connection.form.needTemplate", dict)}</span>
-              </Alert>
-            ) : (
+            <FormFieldState
+              editing={editing}
+              empty={templates.length === 0}
+              editingContent={
+                <span className="text-sm text-gray-700 dark:text-gray-200">
+                  {templates.find((t) => t.id === connection?.templateId)?.name ??
+                    tr("connection.form.noTemplate", dict)}
+                </span>
+              }
+              emptyContent={
+                <Alert color="gray" icon={HiInformationCircle}>
+                  <span className="text-xs">{tr("connection.form.needTemplate", dict)}</span>
+                </Alert>
+              }
+            >
               <Select
                 sizing="sm"
                 value={templateId}
@@ -131,7 +136,7 @@ export function ConnectionFormModal({
                   </option>
                 ))}
               </Select>
-            )}
+            </FormFieldState>
           </div>
 
           <div className="flex flex-col gap-1">
@@ -157,18 +162,23 @@ export function ConnectionFormModal({
 
           <div className="flex flex-col gap-1">
             <Label className="text-xs">{tr("connection.form.credential", dict)}</Label>
-            {editing ? (
-              <span className="text-sm text-gray-700 dark:text-gray-200">
-                {credentialName ?? tr("connection.form.noCredential", dict)}
-                <span className="ml-2 text-[11px] text-gray-400">
-                  {tr("connection.form.credentialFixed", dict)}
+            <FormFieldState
+              editing={editing}
+              empty={credentials.length === 0}
+              editingContent={
+                <span className="text-sm text-gray-700 dark:text-gray-200">
+                  {credentialName ?? tr("connection.form.noCredential", dict)}
+                  <span className="ml-2 text-[11px] text-gray-400">
+                    {tr("connection.form.credentialFixed", dict)}
+                  </span>
                 </span>
-              </span>
-            ) : credentials.length === 0 ? (
-              <p className="text-[11px] text-gray-500 dark:text-gray-400">
-                {tr("connection.form.noCredentials", dict)}
-              </p>
-            ) : (
+              }
+              emptyContent={
+                <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                  {tr("connection.form.noCredentials", dict)}
+                </p>
+              }
+            >
               <Select
                 sizing="sm"
                 value={credentialId}
@@ -181,7 +191,7 @@ export function ConnectionFormModal({
                   </option>
                 ))}
               </Select>
-            )}
+            </FormFieldState>
           </div>
 
           <div className="flex justify-end gap-2 pt-2">
@@ -196,4 +206,24 @@ export function ConnectionFormModal({
       </ModalBody>
     </Modal>
   );
+}
+
+interface FormFieldStateProps {
+  readonly editing: boolean;
+  readonly empty: boolean;
+  readonly editingContent: React.ReactNode;
+  readonly emptyContent: React.ReactNode;
+  readonly children: React.ReactNode;
+}
+
+function FormFieldState({
+  editing,
+  empty,
+  editingContent,
+  emptyContent,
+  children,
+}: Readonly<FormFieldStateProps>) {
+  if (editing) return editingContent;
+  if (empty) return emptyContent;
+  return children;
 }

--- a/turbo-repo/apps/app/src/features/integration-config/components/integration-config-page-content.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/integration-config-page-content.tsx
@@ -110,11 +110,11 @@ export function IntegrationConfigPageContent({ dict }: Readonly<{ dict: I18nReco
             </Button>
           }
         />
-        {isLoading ? (
-          <Loading />
-        ) : templates.length === 0 ? (
-          <EmptyNotice text={tr("templates.empty", dict)} />
-        ) : (
+        <ContentState
+          isLoading={isLoading}
+          isEmpty={templates.length === 0}
+          emptyText={tr("templates.empty", dict)}
+        >
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
             {templates.map((template) => (
               <div
@@ -176,7 +176,7 @@ export function IntegrationConfigPageContent({ dict }: Readonly<{ dict: I18nReco
               </div>
             ))}
           </div>
-        )}
+        </ContentState>
       </section>
 
       {/* Connections — the instances */}
@@ -197,11 +197,11 @@ export function IntegrationConfigPageContent({ dict }: Readonly<{ dict: I18nReco
             </Button>
           }
         />
-        {isLoading ? (
-          <Loading />
-        ) : connections.length === 0 ? (
-          <EmptyNotice text={tr("connections.empty", dict)} />
-        ) : (
+        <ContentState
+          isLoading={isLoading}
+          isEmpty={connections.length === 0}
+          emptyText={tr("connections.empty", dict)}
+        >
           <div className="flex flex-col gap-2">
             {connections.map((connection) => (
               <div
@@ -247,7 +247,7 @@ export function IntegrationConfigPageContent({ dict }: Readonly<{ dict: I18nReco
               </div>
             ))}
           </div>
-        )}
+        </ContentState>
       </section>
 
       <TemplateFormModal
@@ -349,6 +349,22 @@ function Loading() {
       <Spinner />
     </div>
   );
+}
+
+function ContentState({
+  isLoading,
+  isEmpty,
+  emptyText,
+  children,
+}: Readonly<{
+  isLoading: boolean;
+  isEmpty: boolean;
+  emptyText: string;
+  children: React.ReactNode;
+}>) {
+  if (isLoading) return <Loading />;
+  if (isEmpty) return <EmptyNotice text={emptyText} />;
+  return children;
 }
 
 function EmptyNotice({ text }: Readonly<{ text: string }>) {

--- a/turbo-repo/apps/app/src/features/integration-config/components/template-form-modal.tsx
+++ b/turbo-repo/apps/app/src/features/integration-config/components/template-form-modal.tsx
@@ -189,25 +189,11 @@ export function TemplateFormModal({
               placeholder={SCHEMA_PLACEHOLDER}
               color={schemaBroken ? "failure" : "gray"}
             />
-            {schemaBroken ? (
-              <p className="text-[11px] text-red-600 dark:text-red-400">
-                {tr("template.form.schemaInvalid", dict)}
-              </p>
-            ) : leaves.length > 0 ? (
-              <div className="flex flex-wrap gap-1">
-                <span className="text-[11px] text-gray-500 dark:text-gray-400">
-                  {tr("template.form.fieldsDetected", dict)}:
-                </span>
-                {leaves.map((leaf) => (
-                  <code
-                    key={leaf}
-                    className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-                  >
-                    {leaf}
-                  </code>
-                ))}
-              </div>
-            ) : null}
+            <SchemaFeedback
+              schemaBroken={schemaBroken}
+              leaves={leaves}
+              dict={dict}
+            />
           </div>
 
           <div className="flex justify-end gap-2 pt-2">
@@ -221,6 +207,40 @@ export function TemplateFormModal({
         </div>
       </ModalBody>
     </Modal>
+  );
+}
+
+function SchemaFeedback({
+  schemaBroken,
+  leaves,
+  dict,
+}: Readonly<{
+  schemaBroken: boolean;
+  leaves: readonly string[];
+  dict: I18nRecord;
+}>) {
+  if (schemaBroken) {
+    return (
+      <p className="text-[11px] text-red-600 dark:text-red-400">
+        {tr("template.form.schemaInvalid", dict)}
+      </p>
+    );
+  }
+  if (leaves.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      <span className="text-[11px] text-gray-500 dark:text-gray-400">
+        {tr("template.form.fieldsDetected", dict)}:
+      </span>
+      {leaves.map((leaf) => (
+        <code
+          key={leaf}
+          className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+        >
+          {leaf}
+        </code>
+      ))}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- extract small render-state helpers for five nested conditional render expressions
- preserve the existing loading, empty, editing, and selection states
- address all `typescript:S3358` findings reported against merged PR #1006

## Why

SonarCloud reported five nested-ternary code smells in the integration configuration UI introduced by PR #1006. This follow-up keeps the behavior unchanged while making each state transition explicit with sequential conditions.

## Validation

- focused ESLint on all three changed components
- `vitest run src/features/integration-config/integration-config.types.test.ts` (7 tests passed)
- TypeScript AST check confirms no directly nested conditional expressions remain in the changed files
- `git diff --check`

The app-wide `check-types` command remains blocked locally by pre-existing unresolved internal workspace packages (`miot-calendar-*`, `miot-resource-*`, and `miot-harness-*`); no reported type error points to the changed files.