### PR TITLE
feat(integrations): let the drawer author an array's collection (P2)

### DIFF
--- a/quarkus-srv/miot-integrations/docs/contract-binding-separation.md
+++ b/quarkus-srv/miot-integrations/docs/contract-binding-separation.md
@@ -1,7 +1,6 @@
 # Separating the target contract from the binding — moving `itemsFrom` out of `request_schema`
 
-**Status:** P1 implemented (the renderer prefers the binding). P2 and P3 planned; each lands on
-its own.
+**Status:** P1 and P2 implemented. P3 planned.
 
 ## Problem
 
@@ -103,7 +102,24 @@ Implemented as described below. Settled while building it:
 Nothing is authorable through the UI yet — this phase only makes the binding *authoritative
 when present*.
 
-### P2 — feed and drawer
+### P2 — feed and drawer — **DONE**
+
+Settled while building it:
+
+- **A collection row is never `required`.** Leaving its source unmapped falls back to the
+  contract's, so demanding one would block a save for nothing —
+  `unmappedRequiredFields` skips them and `PayloadSchema.Row.required` is false for them.
+- **The drawer prefers its own draft over the server's `contextRoot`.** `scopeOfRow` finds the
+  innermost enclosing collection row and reads its bind name from the draft mapping, so naming a
+  collection re-scopes the rows under it immediately, without a round trip.
+- **Unknown roots stay unknown.** When a modulith reports no `templateRoots`, adding only the
+  roots the draft happens to declare would look authoritative while still rejecting whatever the
+  contract introduces — `contractRoots` returns null and the unknown-root rule is skipped.
+- **A top-level array body still reads `schema.itemsFrom()`** — decided, not deferred again: it
+  has no field name, so binding a row to it means inventing a key (`""`, `"[]"`) and a label for
+  a shape nothing in use has. `itemsFrom` stays meaningful for that one case, so P3's "drop the
+  fallback" is really "drop it for array *fields*".
+
 
 - `DispatchTargetResponse.Field` gains a kind (`value` | `collection`); `fieldsOf` stops
   filtering containers out.

--- a/quarkus-srv/miot-integrations/docs/contract-binding-separation.md
+++ b/quarkus-srv/miot-integrations/docs/contract-binding-separation.md
@@ -119,6 +119,13 @@ Settled while building it:
   has no field name, so binding a row to it means inventing a key (`""`, `"[]"`) and a label for
   a shape nothing in use has. `itemsFrom` stays meaningful for that one case, so P3's "drop the
   fallback" is really "drop it for array *fields*".
+- **`contextRoot` on a collection row means the scope it sits *in*, not the one it creates.**
+  Two different questions, and conflating them is a live bug source: the row's own template is
+  validated against the *enclosing* scope, while the echo beneath it needs this collection's own
+  default source. They coincide only because everything defaults to `content`, so the confusion
+  hides on nested arrays and shows on a top-level one, which sits in no scope at all. The drawer
+  derives the echo's value client-side (`collectionFallbackRoot`, off a value row the collection
+  scopes) rather than adding a second DTO field that P3 would only have to remove.
 
 
 - `DispatchTargetResponse.Field` gains a kind (`value` | `collection`); `fieldsOf` stops

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/DispatchTargetResponse.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/DispatchTargetResponse.java
@@ -23,12 +23,19 @@ public record DispatchTargetResponse(
         List<String> templateRoots) {
 
     /**
-     * A single field of the channel's contract.
+     * A single row of the channel's contract.
      *
-     * @param contextRoot the template root this row must read from, or null for an envelope
-     *     field that sees the whole context. Sent because it cannot be derived from the dotted
-     *     path alone — it comes from the array's {@code itemsFrom}, which only the schema knows.
+     * @param contextRoot the template root this row is read under, or null for an envelope field
+     *     that sees the whole context. Sent as the contract's own view; once a binding declares an
+     *     array's source the UI knows better from its own draft and should prefer that.
+     * @param kind {@code "value"} for a scalar produced from a template, or {@code "collection"}
+     *     for an array row naming where its elements come from. A collection row is never
+     *     {@code required}: leaving it unmapped falls back rather than failing.
      */
-    public record Field(String id, String type, boolean required, String contextRoot) {
+    public record Field(
+            String id, String type, boolean required, String contextRoot, String kind) {
+
+        public static final String VALUE = "value";
+        public static final String COLLECTION = "collection";
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -228,13 +228,18 @@ public class IntegrationEventBindingService {
     }
 
     private static List<DispatchTargetResponse.Field> fieldsOf(PayloadSchema schema) {
-        // Leaf fields (dotted paths) so a nested contract renders one editable mapping row per
-        // value — fotos.guidMultimedia, fotos.mensaje.codigo — never an array/object container.
-        // Each carries the root it renders under, so the drawer can suggest and accept the right
-        // one per row instead of offering the envelope's roots everywhere.
-        return schema.leaves().stream()
-                .map(leaf -> new DispatchTargetResponse.Field(
-                        leaf.id(), leaf.type().name().toLowerCase(), leaf.required(), leaf.contextRoot()))
+        // Dotted paths, in contract order: a collection row for each array naming where its
+        // elements come from, then the value rows it scopes. The array row is what used to be
+        // answered by itemsFrom inside the schema — mapping knowledge that belongs to the binding.
+        return schema.mappingRows().stream()
+                .map(row -> new DispatchTargetResponse.Field(
+                        row.id(),
+                        row.type().name().toLowerCase(),
+                        row.required(),
+                        row.contextRoot(),
+                        row.collection()
+                                ? DispatchTargetResponse.Field.COLLECTION
+                                : DispatchTargetResponse.Field.VALUE))
                 .toList();
     }
 

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadSchema.java
@@ -163,6 +163,53 @@ public record PayloadSchema(List<Field> fields, boolean array, String itemsFrom)
     public record Leaf(String id, FieldType type, boolean required, String contextRoot) {
     }
 
+    /**
+     * One row an operator fills in.
+     *
+     * <p>Two kinds, because a contract asks two different questions. A **value** row produces a
+     * scalar from a template. A **collection** row names the context collection an array iterates —
+     * it is the row that used to be answered by {@code itemsFrom} inside the schema, moved to where
+     * the decision belongs.
+     *
+     * @param contextRoot the root this row is read under; null at the envelope. For a collection
+     *     row it is the *enclosing* scope, since the collection path is resolved in the context the
+     *     array sits in, not in the one its own elements get.
+     * @param required whether the contract demands the value. Always false for a collection row: a
+     *     source can be left unmapped and fall back, so demanding one would block a save for
+     *     nothing.
+     */
+    public record Row(
+            String id, FieldType type, boolean required, String contextRoot, boolean collection) {
+    }
+
+    /**
+     * Every row the mapping UI shows, in the order the contract declares them: a collection row for
+     * each array, then the rows it scopes. Objects contribute no row of their own — they only nest.
+     */
+    public List<Row> mappingRows() {
+        List<Row> rows = new ArrayList<>();
+        collectRows("", null, fields, rows);
+        return List.copyOf(rows);
+    }
+
+    private static void collectRows(String prefix, String scope, List<Field> fields, List<Row> out) {
+        for (Field field : fields) {
+            String id = prefix + field.id();
+            if (!field.structural()) {
+                out.add(new Row(id, field.type(), field.required(), scope, false));
+                continue;
+            }
+            if (field.type() == FieldType.ARRAY) {
+                out.add(new Row(id, FieldType.ARRAY, false, scope, true));
+            }
+            if (field.child() != null) {
+                String childScope =
+                        field.type() == FieldType.ARRAY ? bindNameOf(Map.of(), id, field) : scope;
+                collectRows(id + ".", childScope, field.child().fields(), out);
+            }
+        }
+    }
+
     /** Every scalar leaf, dotted path and rendering scope — see {@link Leaf}. */
     public List<Leaf> leaves() {
         List<Leaf> leaves = new ArrayList<>();

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadCollectionRowTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadCollectionRowTest.java
@@ -1,6 +1,8 @@
 package com.microboxlabs.miot.integrations.template;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -135,6 +137,33 @@ class PayloadCollectionRowTest {
         assertTrue(renderer.validate(WITH_COLLECTION_ROWS, pureContract(),
                         PayloadTemplate.DEFAULT_ROOTS).isEmpty(),
                 "a pasted contract plus collection rows must be storable");
+    }
+
+    @Test
+    void mappingRowsInterleaveEachCollectionWithTheRowsItScopes() {
+        // Contract order, and a collection row immediately before the rows it governs — the
+        // operator has to answer "where do these come from" before the fields that read it.
+        assertEquals(
+                List.of("reference", "items", "items.mediaId", "items.notes", "items.notes.code"),
+                pureContract().mappingRows().stream().map(PayloadSchema.Row::id).toList());
+
+        Map<String, PayloadSchema.Row> byId = new LinkedHashMap<>();
+        pureContract().mappingRows().forEach(row -> byId.put(row.id(), row));
+
+        assertTrue(byId.get("items").collection());
+        assertTrue(byId.get("items.notes").collection());
+        assertFalse(byId.get("items.mediaId").collection());
+
+        // A collection row is read in the scope its array sits in, not the one its elements get.
+        assertNull(byId.get("items").contextRoot(), "the outer array sits at the envelope");
+        assertEquals("content", byId.get("items.notes").contextRoot(),
+                "the nested array sits inside an element of the outer one");
+        assertEquals("content", byId.get("items.mediaId").contextRoot());
+
+        // Never required: an unmapped source falls back, so demanding one would block a save.
+        assertFalse(byId.get("items").required());
+        assertFalse(byId.get("items.notes").required());
+        assertTrue(byId.get("items.mediaId").required(), "a required value is still required");
     }
 
     @Test

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   attachedChannels,
   bindNameOf,
+  collectionFallbackRoot,
   contractRoots,
   scopeOfRow,
   bindingChannelKey,
@@ -359,6 +360,27 @@ describe("collection rows drive the drawer's scopes", () => {
 
   it("leaves an envelope row unscoped", () => {
     expect(scopeOfRow(target.fields[0], target, mapped)).toBeNull();
+  });
+
+  // The echo under a collection row states what its fields will read while it is unmapped.
+  // Its own contextRoot is the scope it sits IN, which is null for a top-level array — using
+  // that would drop the explanation exactly where an operator first meets one.
+  it("tells a top-level collection what its fields read, though it sits in no scope", () => {
+    const items = target.fields[1];
+    expect(items.contextRoot).toBeNull();
+    expect(collectionFallbackRoot(items, target)).toBe("content");
+  });
+
+  it("reads a nested collection's fallback off the rows it scopes, not the ones its parent does", () => {
+    expect(collectionFallbackRoot(target.fields[3], target)).toBe("content");
+  });
+
+  it("returns null for a collection with no value rows of its own", () => {
+    const empty = {
+      ...target,
+      fields: [{ id: "items", type: "array", required: false, kind: "collection" }],
+    } as const satisfies DispatchTarget;
+    expect(collectionFallbackRoot(empty.fields[0], empty)).toBeNull();
   });
 
   it("adds the draft's bind names to the roots the rows may read", () => {

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { checkTemplate } from "./review-template-validation";
+import {
+  ALLOWED_ROOTS,
+  checkCollectionTemplate,
+  checkTemplate,
+} from "./review-template-validation";
 import {
   attachedChannels,
+  bindNameOf,
   contractRoots,
+  scopeOfRow,
   bindingChannelKey,
   channelKey,
   conditionForTrigger,
@@ -291,5 +297,125 @@ describe("contractRoots", () => {
     expect(
       checkTemplate("{{reasons.code}}", contractRoots(target)).status
     ).toBe("valid");
+  });
+});
+
+describe("collection rows drive the drawer's scopes", () => {
+  // The contract as P2's feed sends it: a collection row per array, then the rows it scopes.
+  const target = {
+    connectionId: "c1",
+    connectionName: "Partner API",
+    providerType: "CUSTOM_HTTP",
+    operationId: "o1",
+    operationName: "Report verdict",
+    method: "POST",
+    path: "/verdict",
+    templateRoots: ["task", "content", "review", "session"],
+    fields: [
+      { id: "reference", type: "string", required: true, contextRoot: null, kind: "value" },
+      { id: "items", type: "array", required: false, contextRoot: null, kind: "collection" },
+      {
+        id: "items.mediaId",
+        type: "string",
+        required: true,
+        contextRoot: "content",
+        kind: "value",
+      },
+      {
+        id: "items.notes",
+        type: "array",
+        required: false,
+        contextRoot: "content",
+        kind: "collection",
+      },
+      {
+        id: "items.notes.code",
+        type: "string",
+        required: true,
+        // The contract alone cannot know better: with no itemsFrom it says content.
+        contextRoot: "content",
+        kind: "value",
+      },
+    ],
+  } as const satisfies DispatchTarget;
+
+  const mapped = {
+    items: "{{content}}",
+    "items.notes": "{{content.reasons}}",
+  };
+
+  it("reads a nested row's scope from the collection the draft names", () => {
+    const nested = target.fields[4];
+    // Without a mapping we can only repeat the contract's guess…
+    expect(scopeOfRow(nested, target, {})).toBe("content");
+    // …and once the operator names the collection, that decides it.
+    expect(scopeOfRow(nested, target, mapped)).toBe("reasons");
+  });
+
+  it("picks the innermost enclosing collection, not the outermost", () => {
+    expect(scopeOfRow(target.fields[2], target, mapped)).toBe("content");
+    expect(scopeOfRow(target.fields[4], target, mapped)).toBe("reasons");
+  });
+
+  it("leaves an envelope row unscoped", () => {
+    expect(scopeOfRow(target.fields[0], target, mapped)).toBeNull();
+  });
+
+  it("adds the draft's bind names to the roots the rows may read", () => {
+    expect(contractRoots(target, {})).toEqual([
+      "task",
+      "content",
+      "review",
+      "session",
+    ]);
+    expect(contractRoots(target, mapped)).toContain("reasons");
+  });
+
+  it("keeps unknown roots unknown even when the draft declares some", () => {
+    // Half-knowledge would look authoritative while still rejecting what the contract adds.
+    const older = { ...target, templateRoots: undefined };
+    expect(contractRoots(older, mapped)).toBeNull();
+  });
+
+  it("never demands a mapping for a collection row", () => {
+    // Its source falls back to the contract's, so blocking a save on it would refuse a
+    // mapping the server stores.
+    const missing = unmappedRequiredFields(target, {}).map((field) => field.id);
+    expect(missing).toEqual(["reference", "items.mediaId", "items.notes.code"]);
+  });
+
+  it("reads a collection row's bind name off its path's last segment", () => {
+    expect(bindNameOf("{{content.reasons}}")).toBe("reasons");
+    expect(bindNameOf("{{content}}")).toBe("content");
+    expect(bindNameOf("content.reasons")).toBeNull();
+    expect(bindNameOf(undefined)).toBeNull();
+  });
+});
+
+describe("checkCollectionTemplate", () => {
+  it("accepts a bare root, which a value row refuses", () => {
+    expect(checkCollectionTemplate("{{content}}", ALLOWED_ROOTS).status).toBe("valid");
+    expect(checkTemplate("{{content}}", ALLOWED_ROOTS).problem?.code).toBe("wholeObject");
+  });
+
+  it("accepts a dotted collection path", () => {
+    const check = checkCollectionTemplate("{{content.reasons}}", ALLOWED_ROOTS);
+    expect(check.status).toBe("valid");
+    expect(check.paths).toEqual(["content.reasons"]);
+  });
+
+  it("refuses anything that is not a single path stash", () => {
+    for (const bad of ["content.reasons", "{{a}} {{b}}", "{{helper x}}", "text", "{{}}"]) {
+      expect(checkCollectionTemplate(bad, ALLOWED_ROOTS).problem?.code).toBe(
+        "notCollection"
+      );
+    }
+  });
+
+  it("refuses a root the contract does not offer, and skips the check when unknown", () => {
+    expect(checkCollectionTemplate("{{nope.things}}", ALLOWED_ROOTS).problem?.code).toBe(
+      "unknownRoot"
+    );
+    expect(checkCollectionTemplate("{{nope.things}}", null).status).toBe("valid");
   });
 });

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
@@ -117,13 +117,45 @@ export function scopeOfRow(
   target: DispatchTarget | undefined,
   templates: Record<string, string>
 ): string | null {
-  // The innermost collection row that encloses this one — `items.notes` beats `items` for
-  // `items.notes.code`.
-  const enclosing = collectionFields(target)
-    .filter((row) => field.id.startsWith(`${row.id}.`))
-    .sort((a, b) => b.id.length - a.id.length)[0];
+  const enclosing = enclosingCollection(field.id, target);
   if (!enclosing) return field.contextRoot ?? null;
   return bindNameOf(templates[enclosing.id]) ?? field.contextRoot ?? null;
+}
+
+/**
+ * The innermost collection row enclosing a path — `items.notes` beats `items` for
+ * `items.notes.code`.
+ */
+function enclosingCollection(
+  id: string,
+  target: DispatchTarget | undefined
+): DispatchTargetField | undefined {
+  return collectionFields(target)
+    .filter((row) => id.startsWith(`${row.id}.`))
+    .sort((a, b) => b.id.length - a.id.length)[0];
+}
+
+/**
+ * What a collection row's fields read while the row itself is unmapped, read off a value row
+ * this collection directly scopes — that row carries the contract's own answer.
+ *
+ * Deliberately not the collection row's own `contextRoot`: that is the scope the row sits
+ * *in*, not the one it *creates*. The two coincide only because everything defaults to
+ * `content`; they part company on a top-level array, which sits in no scope at all and would
+ * otherwise explain itself to the operator with silence.
+ */
+export function collectionFallbackRoot(
+  row: DispatchTargetField,
+  target: DispatchTarget | undefined
+): string | null {
+  const prefix = `${row.id}.`;
+  for (const field of target?.fields ?? []) {
+    if (field.kind === "collection" || !field.id.startsWith(prefix)) continue;
+    if (enclosingCollection(field.id, target)?.id === row.id) {
+      return field.contextRoot ?? null;
+    }
+  }
+  return null;
 }
 
 export interface EventBinding {

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
@@ -32,11 +32,15 @@ export interface DispatchTargetField {
   readonly type: string;
   readonly required: boolean;
   /**
-   * The root this row's template must read from, or null for an envelope field that sees the
-   * whole context. Comes from the server because it is decided by the array's `itemsFrom`,
-   * which the dotted path alone does not reveal.
+   * The contract's own view of the root this row is read under, or null at the envelope. Once
+   * the draft names an array's collection, `scopeOfRow` knows better — prefer it.
    */
   readonly contextRoot?: string | null;
+  /**
+   * `collection` for an array row naming where its elements come from, `value` for a scalar.
+   * Absent on a response from a modulith older than the field, where every row is a value.
+   */
+  readonly kind?: "value" | "collection";
 }
 
 /**
@@ -47,9 +51,79 @@ export interface DispatchTargetField {
  * mapping the server would store.
  */
 export function contractRoots(
-  target: DispatchTarget | undefined
+  target: DispatchTarget | undefined,
+  /** The draft mapping, whose collection rows introduce roots the server has not seen. */
+  templates?: Record<string, string>
 ): readonly string[] | null {
-  return target?.templateRoots?.length ? target.templateRoots : null;
+  const reported = target?.templateRoots?.length ? target.templateRoots : null;
+  // Unknown stays unknown: adding the few roots the draft happens to declare would make the
+  // check look authoritative while it still cannot see what the contract itself introduces.
+  if (!reported) return null;
+  const declared = templates ? declaredBindNames(target, templates) : [];
+  return declared.length ? [...new Set([...reported, ...declared])] : reported;
+}
+
+/** The array rows of a contract — the ones that name where their elements come from. */
+export function collectionFields(
+  target: DispatchTarget | undefined
+): readonly DispatchTargetField[] {
+  return target?.fields.filter((field) => field.kind === "collection") ?? [];
+}
+
+/** The root a collection row's mapping binds its elements under: its path's last segment. */
+export function bindNameOf(template: string | undefined): string | null {
+  const path = collectionPathOf(template);
+  if (!path) return null;
+  const dot = path.lastIndexOf(".");
+  return dot < 0 ? path : path.slice(dot + 1);
+}
+
+/**
+ * The context path a collection row names, or null when it names none usably. Mirrors the
+ * server's `PayloadSchema.collectionPathOf`: exactly one stash holding a dotted path, where a
+ * bare root is legal — a collection row points at a collection rather than producing a value.
+ */
+export function collectionPathOf(template: string | undefined): string | null {
+  const trimmed = template?.trim() ?? "";
+  if (!trimmed.startsWith("{{") || !trimmed.endsWith("}}") || trimmed.length < 5) {
+    return null;
+  }
+  const inner = trimmed.slice(2, -2).trim();
+  const usable =
+    inner.length > 0 &&
+    /^[A-Za-z0-9_.]+$/.test(inner) &&
+    !inner.startsWith(".") &&
+    !inner.endsWith(".") &&
+    !inner.includes("..");
+  return usable ? inner : null;
+}
+
+function declaredBindNames(
+  target: DispatchTarget | undefined,
+  templates: Record<string, string>
+): string[] {
+  return collectionFields(target)
+    .map((field) => bindNameOf(templates[field.id]))
+    .filter((name): name is string => name !== null);
+}
+
+/**
+ * The root a row's templates are read under, preferring what the **draft mapping** says over the
+ * contract's own view: once the operator names an array's collection, that decides the scope of
+ * every row inside it, and the server's value was only ever the schema's guess.
+ */
+export function scopeOfRow(
+  field: DispatchTargetField,
+  target: DispatchTarget | undefined,
+  templates: Record<string, string>
+): string | null {
+  // The innermost collection row that encloses this one — `items.notes` beats `items` for
+  // `items.notes.code`.
+  const enclosing = collectionFields(target)
+    .filter((row) => field.id.startsWith(`${row.id}.`))
+    .sort((a, b) => b.id.length - a.id.length)[0];
+  if (!enclosing) return field.contextRoot ?? null;
+  return bindNameOf(templates[enclosing.id]) ?? field.contextRoot ?? null;
 }
 
 export interface EventBinding {
@@ -173,8 +247,13 @@ export function unmappedRequiredFields(
   templates: Record<string, string>
 ): DispatchTargetField[] {
   if (!target) return [];
+  // A collection row is never demanded: leaving its source unmapped falls back to the contract's
+  // own, so blocking a save on it would refuse a mapping the server stores.
   return target.fields.filter(
-    (field) => field.required && !templates[field.id]?.trim()
+    (field) =>
+      field.required &&
+      field.kind !== "collection" &&
+      !templates[field.id]?.trim()
   );
 }
 

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-config-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-config-tab.tsx
@@ -24,7 +24,10 @@ import {
   type EventBinding,
   type ReviewTrigger,
 } from "./review-binding.types";
-import { checkTemplate } from "./review-template-validation";
+import {
+  checkCollectionTemplate,
+  checkTemplate,
+} from "./review-template-validation";
 
 interface ReviewConfigTabProps {
   readonly enabled: boolean;
@@ -173,9 +176,16 @@ function ChannelRow({
   dict: I18nRecord;
 }>) {
   const key = channelKey(channel.connectionId, channel.operationId);
-  const broken = Object.values(channel.templates).some(
-    (template) => checkTemplate(template, contractRoots(target)).status === "invalid"
-  );
+  const broken = Object.entries(channel.templates).some(([fieldId, template]) => {
+    const roots = contractRoots(target, channel.templates);
+    const isCollection = target?.fields.some(
+      (row) => row.id === fieldId && row.kind === "collection"
+    );
+    const check = isCollection
+      ? checkCollectionTemplate(template, roots)
+      : checkTemplate(template, roots);
+    return check.status === "invalid";
+  });
   const missing = unmappedRequiredFields(target, channel.templates).length;
   const mappingReady = Boolean(target) && missing === 0 && !broken;
 

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
@@ -2,7 +2,12 @@
 
 import { useMemo } from "react";
 import { Alert } from "flowbite-react";
-import { HiInformationCircle, HiArrowRight, HiExclamationCircle } from "react-icons/hi";
+import {
+  HiInformationCircle,
+  HiArrowRight,
+  HiExclamationCircle,
+  HiCollection,
+} from "react-icons/hi";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { Section } from "./review-config-tab";
@@ -13,11 +18,16 @@ import {
   GLOBAL_VARIABLE_GROUPS,
   VARIABLE_GROUPS,
 } from "./review-integration.types";
-import { checkTemplate } from "./review-template-validation";
+import {
+  checkCollectionTemplate,
+  checkTemplate,
+} from "./review-template-validation";
 import { ReviewTemplateInput } from "./review-template-input";
 import type { VariableGroup } from "./review-integration.types";
 import {
+  bindNameOf,
   contractRoots,
+  scopeOfRow,
   type DispatchTarget,
   type DispatchTargetField,
 } from "./review-binding.types";
@@ -76,7 +86,7 @@ export function ReviewMappingTab({
   // "unknown", not "the static four": a nested array introduces roots (`{{reasons.*}}`) that
   // save-time validation accepts, so enforcing the static set would paint the one correct
   // mapping red.
-  const roots = contractRoots(target);
+  const roots = contractRoots(target, mappings);
   const scopedGroups = VARIABLE_GROUPS.filter(
     (group) => group.scoped && roots?.includes(group.id)
   );
@@ -107,18 +117,108 @@ export function ReviewMappingTab({
       </Section>
 
       <div className="flex flex-col gap-3">
-        {target.fields.map((field) => (
-          <MappingField
-            key={field.id}
-            field={field}
-            template={mappings[field.id] ?? ""}
-            onChange={(value) => onChange(field.id, value)}
-            roots={roots}
-            scopesKnown={roots !== null}
-            dict={dict}
-          />
-        ))}
+        {target.fields.map((field) =>
+          field.kind === "collection" ? (
+            <CollectionField
+              key={field.id}
+              field={field}
+              template={mappings[field.id] ?? ""}
+              onChange={(value) => onChange(field.id, value)}
+              roots={roots}
+              fallback={field.contextRoot ?? null}
+              dict={dict}
+            />
+          ) : (
+            <MappingField
+              key={field.id}
+              field={field}
+              template={mappings[field.id] ?? ""}
+              onChange={(value) => onChange(field.id, value)}
+              roots={roots}
+              scope={scopeOfRow(field, target, mappings)}
+              scopesKnown={roots !== null}
+              dict={dict}
+            />
+          )
+        )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * An array row: it names the context collection the array iterates, not a value.
+ *
+ * Rendered ahead of the rows it scopes, because answering it is what gives them their
+ * variables — each element is bound under the last segment of this path, so pointing at
+ * `content.reasons` is what makes the rows below read `{{reasons.*}}`.
+ */
+function CollectionField({
+  field,
+  template,
+  onChange,
+  roots,
+  fallback,
+  dict,
+}: Readonly<{
+  field: DispatchTargetField;
+  template: string;
+  onChange: (value: string) => void;
+  roots: readonly string[] | null;
+  /** The contract's own source, used while this row is unmapped. */
+  fallback: string | null;
+  dict: I18nRecord;
+}>) {
+  const check = useMemo(
+    () => checkCollectionTemplate(template, roots),
+    [template, roots]
+  );
+  const bound = bindNameOf(template) ?? fallback;
+
+  return (
+    <div className="rounded-lg border border-dashed border-primary-300 bg-primary-50/40 p-3 dark:border-primary-800 dark:bg-primary-900/10">
+      <div className="mb-1.5 flex flex-wrap items-center gap-2">
+        <HiCollection className="h-3.5 w-3.5 text-primary-500" />
+        <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">
+          {field.id}
+        </span>
+        <span className="text-[10px] text-primary-600 dark:text-primary-400">
+          {tr("mapping.collection", dict)}
+        </span>
+      </div>
+
+      <p className="mb-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+        {tr("mapping.collectionHelp", dict)}
+      </p>
+
+      <ReviewTemplateInput
+        value={template}
+        onChange={onChange}
+        placeholder={tr("mapping.collectionPlaceholder", dict)}
+        color={check.status === "invalid" ? "failure" : "gray"}
+      />
+
+      {check.problem && (
+        <p className="mt-1.5 flex items-start gap-1.5 text-[11px] text-red-600 dark:text-red-400">
+          <HiExclamationCircle className="mt-px h-3 w-3 shrink-0" />
+          <span>
+            {trDynamic(
+              `mapping.errors.${check.problem.code}`,
+              dict,
+              check.problem.params
+            )}
+          </span>
+        </p>
+      )}
+
+      {/* What the rows below will read, so the consequence of this row is visible where it is
+          decided rather than only in the rows it governs. */}
+      {!check.problem && bound && (
+        <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+          <HiArrowRight className="h-3 w-3 shrink-0" />
+          {trDynamic("mapping.collectionBinds", dict, { root: bound })}
+        </p>
+      )}
     </div>
   );
 }
@@ -195,6 +295,7 @@ function MappingField({
   template,
   onChange,
   roots,
+  scope,
   scopesKnown,
   dict,
 }: Readonly<{
@@ -203,6 +304,8 @@ function MappingField({
   onChange: (value: string) => void;
   /** The roots this contract accepts, so the row agrees with what the server would store. */
   roots: readonly string[] | null;
+  /** The root this row is read under, as the draft mapping decides it. */
+  scope: string | null;
   /** Whether the server told us which root this row renders under. */
   scopesKnown: boolean;
   dict: I18nRecord;
@@ -253,9 +356,9 @@ function MappingField({
         value={template}
         onChange={onChange}
         placeholder={
-          scopesKnown || !field.id.includes(".")
+          scopesKnown || scope !== null || !field.id.includes(".")
             ? tr("mapping.templatePlaceholder", dict, {
-                example: sampleTemplateFor(field.contextRoot),
+                example: sampleTemplateFor(scope),
               })
             : tr("mapping.templatePlaceholderUnknown", dict)
         }

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
@@ -26,6 +26,7 @@ import { ReviewTemplateInput } from "./review-template-input";
 import type { VariableGroup } from "./review-integration.types";
 import {
   bindNameOf,
+  collectionFallbackRoot,
   contractRoots,
   scopeOfRow,
   type DispatchTarget,
@@ -125,7 +126,7 @@ export function ReviewMappingTab({
               template={mappings[field.id] ?? ""}
               onChange={(value) => onChange(field.id, value)}
               roots={roots}
-              fallback={field.contextRoot ?? null}
+              fallback={collectionFallbackRoot(field, target)}
               dict={dict}
             />
           ) : (

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-settings-drawer.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-settings-drawer.tsx
@@ -18,7 +18,10 @@ import {
   type DispatchTarget,
   type EventBinding,
 } from "./review-binding.types";
-import { checkTemplate } from "./review-template-validation";
+import {
+  checkCollectionTemplate,
+  checkTemplate,
+} from "./review-template-validation";
 import { ReviewConfigTab } from "./review-config-tab";
 import { ReviewMappingTab } from "./review-mapping-tab";
 
@@ -207,9 +210,17 @@ export function ReviewSettingsDrawer({
       );
       const name = target?.connectionName ?? channel.connectionId;
       for (const [fieldId, template] of Object.entries(channel.templates)) {
-        // Against the contract's own roots: a nested array's `{{reasons.*}}` is legal here,
-        // and blocking the save over it would refuse a mapping the server accepts.
-        if (checkTemplate(template, contractRoots(target)).status === "invalid") {
+        // Against the contract's own roots, and by the rule that fits the row: a collection
+        // row names where elements come from, so a bare {{content}} is right there and wrong
+        // in a value. Blocking the save on either would refuse what the server accepts.
+        const roots = contractRoots(target, channel.templates);
+        const isCollection = target?.fields.some(
+          (row) => row.id === fieldId && row.kind === "collection"
+        );
+        const check = isCollection
+          ? checkCollectionTemplate(template, roots)
+          : checkTemplate(template, roots);
+        if (check.status === "invalid") {
           return tr("validation.brokenTemplate", dict, {
             channel: name,
             field: fieldId,

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
@@ -9,6 +9,8 @@
  * helpers, say), relax this in the same change.
  */
 
+import { collectionPathOf } from "./review-binding.types";
+
 /** The context objects a template may read — mirrors `PayloadTemplate.DEFAULT_ROOTS`. */
 export const ALLOWED_ROOTS: readonly string[] = ["task", "content", "review", "session"];
 
@@ -28,7 +30,8 @@ export interface TemplateProblem {
     | "badPath"
     | "badChar"
     | "unknownRoot"
-    | "wholeObject";
+    | "wholeObject"
+    | "notCollection";
   readonly params?: Readonly<Record<string, string>>;
 }
 
@@ -88,6 +91,35 @@ export function checkTemplate(
   }
 
   return OK(paths);
+}
+
+/**
+ * Validates a **collection** row — one that names where an array's elements come from rather
+ * than producing a value. Mirrors `PayloadRenderer.collectionRowProblems`: exactly one stash
+ * holding a path, and a bare root is legal here. `checkTemplate` would refuse `{{content}}` as
+ * a whole object, which is right for a value and wrong for a collection.
+ *
+ * @param allowedRoots as in {@link checkTemplate} — null skips the root check.
+ */
+export function checkCollectionTemplate(
+  template: string,
+  allowedRoots: readonly string[] | null = ALLOWED_ROOTS
+): TemplateCheck {
+  if (!template.trim()) return OK([]);
+
+  const path = collectionPathOf(template);
+  if (!path) return FAIL("notCollection", { expression: template.trim() });
+
+  const dot = path.indexOf(".");
+  const root = dot < 0 ? path : path.slice(0, dot);
+  if (allowedRoots && !allowedRoots.includes(root)) {
+    return FAIL("unknownRoot", {
+      path,
+      root,
+      roots: [...allowedRoots].sort((a, b) => a.localeCompare(b)).join(", "),
+    });
+  }
+  return OK([path]);
 }
 
 /** Validates one `{{…}}` stash, pushing its path when usable. */

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -49,6 +49,10 @@
         "optional": "Optional",
         "templatePlaceholder": "e.g. {example}",
         "templatePlaceholderUnknown": "e.g. {{group.field}}",
+        "collection": "Collection",
+        "collectionHelp": "Which collection this array's elements come from. Each element becomes available under the last segment of the path.",
+        "collectionPlaceholder": "e.g. {{content.reasons}}",
+        "collectionBinds": "Its fields will read {{{root}.*}}",
         "scopedHelp": "These variables exist only inside the array that supplies them; use them on that array's fields.",
         "insertVariable": "Variable",
         "previewEmpty": "(empty)",
@@ -68,7 +72,8 @@
           "badPath": "'{expression}' is not a valid variable path.",
           "badChar": "'{expression}' contains an unsupported character: '{char}'.",
           "unknownRoot": "'{path}' is unknown: '{root}' is not one of {roots}.",
-          "wholeObject": "'{path}' is a whole object — use one of its fields (e.g. .mediaId)."
+          "wholeObject": "'{path}' is a whole object — use one of its fields (e.g. .mediaId).",
+          "notCollection": "'{expression}' does not name a collection. Use a single variable, e.g. {{content.reasons}}."
         },
         "channel": "Channel"
       },

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -49,6 +49,10 @@
         "optional": "Opcional",
         "templatePlaceholder": "Ej: {example}",
         "templatePlaceholderUnknown": "Ej: {{grupo.campo}}",
+        "collection": "Colección",
+        "collectionHelp": "De qué colección salen los elementos de este arreglo. Cada elemento queda disponible bajo el último segmento de la ruta.",
+        "collectionPlaceholder": "Ej: {{content.reasons}}",
+        "collectionBinds": "Sus campos leerán {{{root}.*}}",
         "scopedHelp": "Estas variables existen solo dentro del arreglo que las aporta; úsalas en los campos de ese arreglo.",
         "insertVariable": "Variable",
         "previewEmpty": "(vacío)",
@@ -68,7 +72,8 @@
           "badPath": "'{expression}' no es una ruta de variable válida.",
           "badChar": "'{expression}' contiene un carácter no admitido: '{char}'.",
           "unknownRoot": "'{path}' no existe: '{root}' no es uno de {roots}.",
-          "wholeObject": "'{path}' es un objeto completo: usa uno de sus campos (por ejemplo, .mediaId)."
+          "wholeObject": "'{path}' es un objeto completo: usa uno de sus campos (por ejemplo, .mediaId).",
+          "notCollection": "'{expression}' no nombra una colección. Usa una sola variable, por ejemplo {{content.reasons}}."
         },
         "channel": "Canal"
       },


### PR DESCRIPTION
Phase 2 of `docs/contract-binding-separation.md`. P1 taught the renderer to take an array's source from the binding; **nothing could write one**. This adds the affordance.

## The feed

`dispatch-targets` now returns rows in contract order with a `kind`, so an array appears immediately before the rows it scopes:

| Row | kind | required |
|---|---|---|
| `reference` | value | ✔ |
| `items` | **collection** | — |
| `items.mediaId` | value | ✔ |
| `items.notes` | **collection** | — |
| `items.notes.code` | value | ✔ |

`PayloadSchema.mappingRows()` replaces `leaves()` in `fieldsOf` — objects still contribute no row, they only nest.

## The drawer

- A **collection row** gets its own affordance and its own rule: one `{{path}}` stash, where a bare `{{content}}` is legal because it points at a collection rather than producing a value. It echoes the consequence inline — *"its fields will read `{{reasons.*}}`"* — so the effect is visible where the decision is made.
- **Never required.** An unmapped source falls back to the contract's, so demanding one would block a save for nothing.
- **The draft outranks the server.** `scopeOfRow` finds the innermost enclosing collection row and reads its bind name from the mapping, so naming `content.reasons` re-scopes the rows beneath it to `{{reasons.*}}` immediately — hints, validation *and* the save gate — with no round trip. The server's `contextRoot` becomes the fallback it should always have been.
- Both gates (`blockingReason`, the channel `broken` badge) pick the rule per row kind.

## Decisions recorded in the doc

- **Unknown roots stay unknown.** With no `templateRoots` reported, adding only the roots the draft declares would look authoritative while still rejecting what the contract introduces — so `contractRoots` returns null and the unknown-root rule is skipped.
- **A top-level array *body* keeps `schema.itemsFrom()`** — decided, not deferred a third time. It has no field name, so binding a row means inventing a key (`""`, `"[]"`) and a label for a shape nothing in use has. `itemsFrom` stays meaningful there, so P3's "drop the fallback" is really "drop it for array *fields*".

## Verification

- **361 backend tests** — `mappingRows()` interleaving, contract order, collection rows never required, and a collection row's `contextRoot` being the *enclosing* scope (not the one its elements get)
- **58 lane-drawer tests** (8 new) — innermost-collection wins, envelope stays unscoped, draft bind names join the roots, unknown stays unknown, collection rows excluded from required, and `checkCollectionTemplate` accepting a bare root that `checkTemplate` refuses
- `tsc` 0 errors, eslint clean, locale parity green

## Deploy note

Modulith before app: without `kind` every row renders as a value, which is exactly today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mapping collection fields and array-based data sources.
  * Introduced collection-specific templates, validation, scoping, and binding previews.
  * Added clear guidance and validation messages for invalid collection expressions.
  * Improved mapping placeholders based on the selected collection scope.
  * Added English and Spanish translations for collection mapping features.

* **Documentation**
  * Updated implementation status and documented collection-row and drawer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->