### PR TITLE
fix(shipping): offer task.approved in the mapping variable list

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
@@ -70,12 +70,21 @@ export interface VariableGroup {
  *
  * `content.*` is **one reviewed item**: an array contract renders the mapped fields
  * once per element, binding `content` to each in turn, so `{{content.mediaId}}` means
- * "this item's media id". That is why the verdict lives here rather than under a
+ * "this item's media id". That is why the per-item verdict lives here rather than under a
  * `review` object — a single task completion can carry several media with different
  * outcomes.
  *
+ * An envelope field sits outside that array and so has no "this item" to read. For those,
+ * `task.approved` carries the rollup across the whole task. The mapping language is plain
+ * substitution — no helpers, no folds — so a whole-task answer has to arrive as a whole-task
+ * field; the producer computes it once and every channel reads the same fact.
+ *
  * `review` remains a legal root server-side (so a hand-written `{{review.x}}` is not
  * rejected), but nothing populates it today, which is why it is not offered here.
+ *
+ * **This list must track what the producer emits.** It drifted once already: ECM began
+ * sending `task.approved` and the drawer went on refusing to autocomplete it, so the one
+ * field that answers "was the whole service approved" looked unavailable.
  *
  * Samples are deliberately generic — this is a public repo, so no real client, tenant
  * or contact data appears.
@@ -89,6 +98,10 @@ export const VARIABLE_GROUPS: readonly VariableGroup[] = [
       { path: "task.serviceCode", labelKey: "variables.task.serviceCode", sample: "1649906" },
       { path: "task.formKey", labelKey: "variables.task.formKey", sample: "wfship2:missionControlTask" },
       { path: "task.outcome", labelKey: "variables.task.outcome", sample: "monitorTripInCourse" },
+      // The rollup across every reviewed item: false as soon as one is rejected. Task-scoped
+      // rather than under `content`, because `content.*` is a single item — an envelope field
+      // needs the whole-task answer, and the producer computes it once so every channel agrees.
+      { path: "task.approved", labelKey: "variables.task.approved", sample: "false" },
     ],
   },
   {

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -120,7 +120,8 @@
           "truckPlate": "Truck plate",
           "departureDate": "Departure date",
           "formKey": "Task form key",
-          "outcome": "Task outcome"
+          "outcome": "Task outcome",
+          "approved": "Overall verdict (approved when no item was rejected)"
         },
         "content": {
           "mediaId": "Media ID",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -120,7 +120,8 @@
           "truckPlate": "Patente camión",
           "departureDate": "Fecha de salida",
           "formKey": "Clave de tarea (formKey)",
-          "outcome": "Resultado de la tarea"
+          "outcome": "Resultado de la tarea",
+          "approved": "Veredicto global (aprobado si ningún archivo fue rechazado)"
         },
         "content": {
           "mediaId": "ID multimedia",


### PR DESCRIPTION
`{{task.approved}}` was missing from the drawer's autocomplete, so the one variable that answers *"was the whole service approved"* looked unavailable.

## What was wrong

ECM's `ReviewVerdictEmitter` emits a task-level rollup:

```java
// Overall verdict for the whole service: rejected if any content was.
.put("approved", allApproved(reviewed))
```

The drawer's `VARIABLE_GROUPS` still listed only `serviceCode`, `formKey`, `outcome`. Typing `{{task.approved}}` by hand validated green and rendered correctly — so the gap read as "this field doesn't exist" rather than "this list is stale". That is the worst version of the bug: the feature works, and the UI says it doesn't.

I checked the whole catalogue against what the emitter actually sends, not just this field. `task.approved` was the only gap — `content.*`, `session.*` and the scoped `reasons.*` all match.

## Why `task` and not `content`

`content.*` is **one reviewed item**; an array contract rebinds `content` to each element in turn. An envelope field sits outside that array, so it has no "this item" to read, and the mapping language is plain substitution — no helpers, no folds. A whole-task answer therefore has to arrive as a whole-task field, computed once by the producer so every channel reads the same fact rather than each re-deriving it.

## Verification

Driven in the browser against a real dev contract: `{{task.approved}}` now appears in the `{{task.` autocomplete and previews as `false`, keeping its boolean type through the single-variable typed path.

61 lane tests, 3 locale-parity tests, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `task.approved` variable for review-process templates and previews.
  * The variable provides the overall task verdict, marked approved when no item is rejected.
* **Documentation**
  * Clarified template variable guidance and consistency requirements.
* **Localization**
  * Added English and Spanish translations for the new task verdict variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->