### PR TITLE
fix(task-forms): stop re-asking for motives the review already recorded

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-review-context.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/bento-review-context.tsx
@@ -4,7 +4,10 @@ import { createContext, useContext, useMemo, useState, type ReactNode } from "re
 import type { ObservationEntry } from "./components/side-data/multimedia-manager.tsx/viewer/observations/observation.types";
 
 export type { ObservationEntry };
-export type RejectedItem = { fileName: string; observations: ObservationEntry[] };
+// `contentType` is the item's `mintral:contentType`. It travels with the verdict so a
+// consumer can tell *which kind* of document was rejected without re-reading the node —
+// the confirm modal turns it into the rejection codes the backend expects.
+export type RejectedItem = { fileName: string; contentType?: string; observations: ObservationEntry[] };
 export type ApprovedItem = { fileName: string; observations: ObservationEntry[] };
 type BentoReviewState = { pending: number; rejected: number; rejectedItems: RejectedItem[]; approvedItems: ApprovedItem[] };
 

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -522,7 +522,8 @@ export default function FileImages({
         const observations = lastRejection?.kind === "state_change"
           ? lastRejection.observations
           : [];
-        return { fileName, observations };
+        const contentType = file?.file?.entry?.properties?.["mintral:contentType"];
+        return { fileName, contentType, observations };
       });
   }, [allIds, reviewableIds, reviewStatuses, images, documents, committedTimeline]);
 

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/review-rejection-reasons.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/review-rejection-reasons.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { rejectionReasonsFrom } from "./review-rejection-reasons";
+import type { RejectedItem } from "../task-bento-form/bento-review-context";
+
+const item = (contentType?: string): RejectedItem => ({
+  fileName: `${contentType ?? "unknown"}.jpg`,
+  contentType,
+  observations: [],
+});
+
+describe("rejectionReasonsFrom", () => {
+  it("maps each reviewed content type to the code the backend expects", () => {
+    expect(
+      rejectionReasonsFrom([
+        item("PICKUP_GUIDE_IMAGE"),
+        item("PICKUP_LEFT_IMAGE"),
+        item("PICKUP_RIGHT_IMAGE"),
+        item("PICKUP_FRONT_IMAGE"),
+        item("PICKUP_REAR_IMAGE"),
+      ])
+    ).toEqual([
+      "REJECTED_GUIDE",
+      "REJECTED_LEFT_SIDE",
+      "REJECTED_RIGHT_SIDE",
+      "REJECTED_FRONT",
+      "REJECTED_BACK",
+    ]);
+  });
+
+  it("reports a content type once however many of its documents were rejected", () => {
+    expect(
+      rejectionReasonsFrom([item("PICKUP_LEFT_IMAGE"), item("PICKUP_LEFT_IMAGE")])
+    ).toEqual(["REJECTED_LEFT_SIDE"]);
+  });
+
+  it("emits nothing for content the backend excludes from this rejection", () => {
+    // POD and load proofs are reviewable, but the mission-control rejection ignores them —
+    // a code here would claim a rejection that is never acted on.
+    expect(
+      rejectionReasonsFrom([item("PROOF_OF_DELIVERY"), item("PROOF_OF_LOAD_FLOOR")])
+    ).toEqual([]);
+  });
+
+  it("skips an item whose content type is missing rather than guessing", () => {
+    expect(rejectionReasonsFrom([item(undefined), item("PICKUP_FRONT_IMAGE")])).toEqual([
+      "REJECTED_FRONT",
+    ]);
+  });
+
+  it("returns nothing when no document was rejected", () => {
+    expect(rejectionReasonsFrom([])).toEqual([]);
+  });
+});

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/review-rejection-reasons.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/review-rejection-reasons.ts
@@ -1,0 +1,41 @@
+import type { RejectedItem } from "../task-bento-form/bento-review-context";
+
+/**
+ * Rejection codes derived from a per-document review verdict.
+ *
+ * Moving a service back to the earlier stage used to ask the operator to pick the
+ * rejected documents from a list, even though they had just rejected them one by one in
+ * the gallery. The list is the same information asked twice, and the two can disagree —
+ * so the codes are now read off the verdict instead.
+ *
+ * The codes themselves still matter downstream: the backend maps them to the document
+ * types it reports to the client system, and skips the notification when none survive.
+ * Deriving them keeps that payload intact while the modal only shows the summary.
+ */
+const CONTENT_TYPE_TO_REASON: Readonly<Record<string, string>> = {
+  PICKUP_GUIDE_IMAGE: "REJECTED_GUIDE",
+  PICKUP_LEFT_IMAGE: "REJECTED_LEFT_SIDE",
+  PICKUP_RIGHT_IMAGE: "REJECTED_RIGHT_SIDE",
+  PICKUP_FRONT_IMAGE: "REJECTED_FRONT",
+  PICKUP_REAR_IMAGE: "REJECTED_BACK",
+};
+
+/**
+ * The rejection codes for a set of reviewed items, deduplicated and in the order the
+ * documents were reviewed.
+ *
+ * Content types absent from the map — the delivery and load proofs — yield nothing on
+ * purpose: the backend excludes them from this rejection anyway, so emitting a code for
+ * them would claim a rejection it will not act on. An item whose type never loaded is
+ * skipped for the same reason; guessing from the file name would be worse than silence.
+ */
+export function rejectionReasonsFrom(items: readonly RejectedItem[]): string[] {
+  const reasons = new Set<string>();
+  for (const item of items) {
+    const reason = item.contentType
+      ? CONTENT_TYPE_TO_REASON[item.contentType]
+      : undefined;
+    if (reason) reasons.add(reason);
+  }
+  return [...reasons];
+}

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.test.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import TaskConfirmModal from "./task-confirm-modal";
+import {
+  OUTCOME_PREPARE_SERVICE_V2,
+  TYPE_WFSHIP2_MISSION_CONTROL_TASK,
+} from "../../services/form.service";
+import type { RejectedItem } from "../task-bento-form/bento-review-context";
+
+const { taskNextAction, push } = vi.hoisted(() => ({
+  taskNextAction: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock("../../services/client-form.service", () => ({ taskNextAction }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+}));
+
+vi.mock("@/features/common/providers/client-api.provider", () => ({
+  useLiveETA: () => ({ eta: undefined }),
+}));
+
+const dict = {
+  modal: {
+    title: "Estás moviendo la tarea",
+    subtitle: "No podrás deshacerlo",
+    title2: "Posibles motivos:",
+    reason: "Motivo",
+    confirm: "Confirmar mover a {outcome}",
+    selectOptions: "Seleccionar opciones",
+  },
+  outcome: {
+    continueModalApprovedCount_one: "1 documento aprobado",
+    continueModalApprovedCount: "{count} documentos aprobados",
+    goBackModalRejectedCount_one: "1 documento rechazado",
+    goBackModalRejectedCount: "{count} documentos rechazados",
+    goBackModalNoMotives: "Sin observaciones",
+  },
+};
+
+const rejected = (contentType: string): RejectedItem => ({
+  fileName: `${contentType}.jpg`,
+  contentType,
+  observations: [],
+});
+
+function renderModal(rejectedItems: RejectedItem[]) {
+  return render(
+    <TaskConfirmModal
+      openModal
+      setOpenModal={vi.fn()}
+      commentsFieldEnabled
+      taskId="2984416"
+      taskType={TYPE_WFSHIP2_MISSION_CONTROL_TASK}
+      outcome={OUTCOME_PREPARE_SERVICE_V2}
+      outcomeLabel="Controlar Servicio"
+      dict={dict}
+      approvedItems={[]}
+      rejectedItems={rejectedItems}
+    />
+  );
+}
+
+/** Reads the FormData the modal submitted, as a plain object. */
+function submittedPayload() {
+  const formData = taskNextAction.mock.calls[0][1] as FormData;
+  return Object.fromEntries(formData.entries());
+}
+
+describe("TaskConfirmModal, sending a service back for control", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskNextAction.mockResolvedValue({ success: true });
+  });
+
+  it("asks for nothing the review already answered", async () => {
+    renderModal([rejected("PICKUP_LEFT_IMAGE")]);
+
+    expect(screen.queryByText("Posibles motivos:")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText("1 documento rechazado")).toBeInTheDocument();
+  });
+
+  it("derives the rejection codes from the reviewed documents", async () => {
+    renderModal([rejected("PICKUP_LEFT_IMAGE"), rejected("PICKUP_RIGHT_IMAGE")]);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Confirmar mover a Controlar Servicio" })
+    );
+
+    await waitFor(() => expect(taskNextAction).toHaveBeenCalled());
+    const payload = submittedPayload();
+    expect(JSON.parse(payload.reasons as string)).toEqual([
+      "REJECTED_LEFT_SIDE",
+      "REJECTED_RIGHT_SIDE",
+    ]);
+    expect(payload.isMultiReason).toBe("true");
+  });
+
+  it("still asks for a motive when no document was rejected", () => {
+    // Nothing in the review explains the move, so the operator has to say why —
+    // dropping the inputs here would leave the transition with no reason at all.
+    renderModal([]);
+
+    expect(screen.getByText("Posibles motivos:")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+});

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-confirm-modal/task-confirm-modal.tsx
@@ -35,6 +35,7 @@ import {
   TYPE_WFDELIVERY_RECEIVE_DELIVERY_TASK,
   OUTCOME_TO_CONFIRM_DELIVERY_V2,
   OUTCOME_TO_CLOSE_MONITORING_V2,
+  OUTCOME_PREPARE_SERVICE_V2,
 } from "../../services/form.service";
 import { useState, useMemo, useEffect } from "react";
 import {
@@ -52,6 +53,7 @@ import {
   ShippingCoordinatorProcessTaskV2,
 } from "../../services/form.service.types";
 import { ReviewedItemCard } from "../task-actions/review-items";
+import { rejectionReasonsFrom } from "./review-rejection-reasons";
 import { SidebarSection } from "../task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/sidebar-section";
 import { HiCheckCircle, HiDocumentText } from "react-icons/hi2";
 
@@ -97,6 +99,22 @@ export default function TaskConfirmModal({
   }, [taskType, outcome]);
 
   const hasReviewItems = approvedItems.length > 0 || rejectedItems.length > 0;
+
+  // Sending a service back for control is a rejection the reviewer has already made,
+  // document by document. Re-asking for the motives here duplicates that verdict and lets
+  // the two disagree, so when the review carries the rejection the modal shows only its
+  // summary and derives the codes the backend needs from it.
+  const reviewCarriesRejection =
+    taskType === TYPE_WFSHIP2_MISSION_CONTROL_TASK &&
+    outcome === OUTCOME_PREPARE_SERVICE_V2 &&
+    rejectedItems.length > 0;
+
+  const derivedReasons = useMemo(
+    () => (reviewCarriesRejection ? rejectionReasonsFrom(rejectedItems) : []),
+    [reviewCarriesRejection, rejectedItems]
+  );
+
+  const hideMotiveInputs = suppressMotiveInputs || reviewCarriesRejection;
 
   // Use consolidated state management for select/reason fields
   const {
@@ -160,7 +178,7 @@ export default function TaskConfirmModal({
         outcome: outcome!,
         comments,
         taskType: taskType ?? "",
-        selectedValues,
+        selectedValues: reviewCarriesRejection ? derivedReasons : selectedValues,
         selectConfig,
         extraData,
         customFormValues: formValues,
@@ -245,7 +263,7 @@ export default function TaskConfirmModal({
         </ModalHeader>
         <ModalBody>
           <div className="flex flex-col gap-4">
-            {selectConfig && !suppressMotiveInputs && (
+            {selectConfig && !hideMotiveInputs && (
               <div className="flex flex-col gap-2">
                 <Label>
                   {(dict.modal as I18nRecord).title2 as string}
@@ -290,7 +308,7 @@ export default function TaskConfirmModal({
               </div>
             )}
 
-            {commentsFieldEnabled && !suppressMotiveInputs && (
+            {commentsFieldEnabled && !hideMotiveInputs && (
               <div className="flex flex-col gap-y-2">
                 <Label htmlFor="comments">{tr("modal.reason", dict)}:</Label>
                 <Textarea
@@ -304,8 +322,8 @@ export default function TaskConfirmModal({
               </div>
             )}
 
-            {((!commentsFieldEnabled && !suppressMotiveInputs && !taskFormConfig?.customFormConfig) ||
-              suppressMotiveInputs) &&
+            {((!commentsFieldEnabled && !hideMotiveInputs && !taskFormConfig?.customFormConfig) ||
+              hideMotiveInputs) &&
               !hasReviewItems && (
                 <div className="flex items-center justify-center py-4">
                   <KanbanMove />


### PR DESCRIPTION
Moving a service back for control ("Controlar Servicio") opened the confirm modal with the old reject form — a multi-select of rejected documents plus a required free-text motive — even though the reviewer had just rejected each document with its own reasons. The same answer, asked twice, with no guarantee the two agree.

The modal now shows only the review summary for that transition.

## Why it isn't just "delete the inputs"

Those motive codes are load-bearing. `HandleKaumonNotification.extractDocumentTypesForMissionControl` maps `REJECTED_LEFT_SIDE`/`REJECTED_FRONT`/… to the document types it reports to the client system, and **skips the notification entirely when the list comes back empty** — silently, with only a log warning. The integration is enabled in both dev and prod, and this outcome (`Preparar Servicio`) is the only one that triggers it.

So the codes are now derived from the verdict rather than dropped:

| `mintral:contentType` | code |
|---|---|
| `PICKUP_GUIDE_IMAGE` | `REJECTED_GUIDE` |
| `PICKUP_LEFT_IMAGE` | `REJECTED_LEFT_SIDE` |
| `PICKUP_RIGHT_IMAGE` | `REJECTED_RIGHT_SIDE` |
| `PICKUP_FRONT_IMAGE` | `REJECTED_FRONT` |
| `PICKUP_REAR_IMAGE` | `REJECTED_BACK` |

The delivery and load proofs are deliberately absent — the backend excludes them from this rejection anyway, so a code for them would claim something it never acts on. The wire payload keeps its shape (`reasons` + `isMultiReason`); only its source changes.

The free-text motive is no longer collected, so the forum post composes from the reasons alone (`"Documentos rechazados"` + bullet list). The per-document observations the reviewer wrote are already stored on their own nodes.

## Scope

Only mission-control → `Preparar Servicio`, and only when at least one document was rejected. A move with nothing rejected still asks for a motive — nothing in the review would explain it.

## Verification

- 8 new tests: the derivation table, dedup, excluded types, missing type, and the modal itself — that it hides both inputs, submits `["REJECTED_LEFT_SIDE","REJECTED_RIGHT_SIDE"]` for two rejected side images, and still renders the inputs when nothing was rejected.
- Full app suite green (979 passed), `tsc --noEmit` clean.
- Checked in the browser against coordinador-dev on a service with 2 approved / 2 rejected images: modal renders summary-only. Modal was closed without confirming — no dev task was moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)