### PR TITLE
feat(review): record and render review rounds from the reviewer UI (P3)

### DIFF
--- a/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
+++ b/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
@@ -1,0 +1,91 @@
+import "server-only";
+import { auth } from "@/auth";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getReviewRounds,
+  recordReviewRound,
+} from "@/features/common/providers/alfresco-api/alfresco-api.provider";
+import { logError } from "@/lib/logger";
+
+const ROUTE = "/app/api/review/rounds";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const contentNodeRef = new URL(req.url).searchParams.get("contentNodeRef");
+  if (!contentNodeRef) {
+    return NextResponse.json(
+      { error: "contentNodeRef is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    return NextResponse.json(await getReviewRounds(session, contentNodeRef));
+  } catch (e: unknown) {
+    logError(e as Error, { route: `GET ${ROUTE}`, contentNodeRef });
+    if ((e as { status?: number })?.status === 401) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json(
+      { error: "Failed to fetch review rounds" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: {
+    contentNodeRef?: string;
+    verdict?: "APPROVED" | "REJECTED";
+    reasons?: string[];
+    comment?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { contentNodeRef, verdict } = body;
+  if (!contentNodeRef) {
+    return NextResponse.json(
+      { error: "contentNodeRef is required" },
+      { status: 400 }
+    );
+  }
+  // PENDING is not a decision — returning content to review is the absence of a round.
+  if (verdict !== "APPROVED" && verdict !== "REJECTED") {
+    return NextResponse.json(
+      { error: "verdict must be APPROVED or REJECTED" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const round = await recordReviewRound(session, {
+      contentNodeRef,
+      verdict,
+      reasons: body.reasons,
+      comment: body.comment,
+    });
+    return NextResponse.json(round, { status: 201 });
+  } catch (e: unknown) {
+    logError(e as Error, { route: `POST ${ROUTE}`, contentNodeRef, verdict });
+    if ((e as { status?: number })?.status === 401) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json(
+      { error: "Failed to record review decision" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -37,6 +37,7 @@ import type {
   MessageTemplatesResponse,
   StatisticsMode,
   StatisticsTasksResponse,
+  ReviewRoundResponse,
 } from "./alfresco-api.types";
 import fetcher from "../fetcher";
 import type { FetcherError } from "../fetcher.types";
@@ -2265,4 +2266,40 @@ export async function searchGroups(
     displayName: group.displayName || group.shortName,
     kind: "group" as const,
   }));
+}
+
+/**
+ * One review decision on one content node: the verdict, its reason codes and the single
+ * comment that goes with it, recorded together.
+ *
+ * <p>The ECM assigns the sequence number, reads the judged version off the node and takes
+ * the reviewer from the authenticated session, so none of those are sent.
+ */
+export async function recordReviewRound(
+  session: Session,
+  data: {
+    contentNodeRef: string;
+    verdict: "APPROVED" | "REJECTED";
+    reasons?: string[];
+    comment?: string;
+  }
+): Promise<ReviewRoundResponse> {
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/review/round`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  return fetcher<ReviewRoundResponse>(url, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+/** A content node's review decisions, oldest first. Empty for content reviewed before rounds. */
+export async function getReviewRounds(
+  session: Session,
+  contentNodeRef: string
+): Promise<{ rounds: ReviewRoundResponse[] }> {
+  const params = new URLSearchParams({ contentNodeRef });
+  const baseUrl = `${process.env.ECM_API_URL}/alfresco/s/mintral/review/rounds?${params.toString()}`;
+  const { url, headers } = prepareAlfrescoAuth(baseUrl, session);
+  return fetcher<{ rounds: ReviewRoundResponse[] }>(url, { method: "GET", headers });
 }

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
@@ -581,3 +581,19 @@ export type LegacyPeopleSearchResponse = {
     organization?: string;
   }>;
 };
+
+/**
+ * One recorded review decision, as the ECM returns it.
+ *
+ * `version` and `round` are null for content reviewed before rounds existed; `reasons` is
+ * empty for an approval.
+ */
+export type ReviewRoundResponse = {
+  seq: number;
+  verdict: "APPROVED" | "REJECTED";
+  version: string | null;
+  reasons: string[];
+  comment: string | null;
+  reviewedBy: string | null;
+  decidedAt: string | null;
+};

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -37,6 +37,7 @@ import {
 import { SendableFile } from "@/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/clasification-form";
 import type {
   ForumDiscussionResponse,
+  ReviewRoundResponse,
   UserSiteResponse,
 } from "./alfresco-api/alfresco-api.types";
 import { LoadSearchResponse } from "@/types/load.types";
@@ -2267,4 +2268,35 @@ export async function updateServiceCategory(
   });
   if (!response.ok)
     throw new Error(`updateServiceCategory: ${response.status}`);
+}
+
+/**
+ * Records one review decision: verdict, reason codes and the single comment that goes with
+ * them, in one request.
+ *
+ * Replaces the pair of writes this used to take — the reviewable aspect and a forum topic,
+ * issued independently — where one failing left the other committed with nothing to repair
+ * it. The ECM assigns the sequence, reads the judged version off the node, and takes the
+ * reviewer from the session.
+ */
+export async function recordReviewRound(data: {
+  contentNodeRef: string;
+  verdict: "APPROVED" | "REJECTED";
+  reasons?: string[];
+  comment?: string;
+}): Promise<ReviewRoundResponse> {
+  return fetcher("/app/api/review/rounds", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+/** A content node's review decisions, oldest first. Empty for content reviewed before rounds. */
+export async function getReviewRounds(
+  contentNodeRef: string
+): Promise<{ rounds: ReviewRoundResponse[] }> {
+  return fetcher(
+    `/app/api/review/rounds?contentNodeRef=${encodeURIComponent(contentNodeRef)}`
+  );
 }

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -12,13 +12,12 @@ import {
   useOptimisticFileUpload,
   putBentoMultimedia,
   deleteBentoMultimedia,
-  updateBentoReviewState,
-  createContentForumTopic,
+  recordReviewRound,
   replyContentForumPost,
   deleteContentForumPost,
   deleteContentForumTopic,
 } from "@/features/common/providers/client-api.provider";
-import { TaskResponse, ForumDiscussionResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
+import { TaskResponse, ForumDiscussionResponse, ReviewRoundResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
 
@@ -209,6 +208,38 @@ function buildObservationEntry(obs: FlatPost): ObservationEntry {
       createdBy: r.author,
     })),
   };
+}
+
+/**
+ * A content node's review rounds as timeline entries, oldest first.
+ *
+ * Each round is one decision, so it becomes one state-change entry carrying a single
+ * observation: its reason codes and the one comment the reviewer wrote. That is the whole
+ * difference from the forum shape, where the codes and the verdict were separate topics and
+ * a reply became another post concatenated into the text.
+ */
+export function roundsToTimeline(rounds: ReviewRoundResponse[]): TimelineEntry[] {
+  return rounds.map((round) => {
+    const decidedAt = round.decidedAt ? new Date(round.decidedAt) : new Date();
+    const reviewer = round.reviewedBy ?? undefined;
+    const hasDetail = round.reasons.length > 0 || !!round.comment;
+    return {
+      kind: "state_change" as const,
+      id: `round-${round.seq}`,
+      status: round.verdict === "APPROVED" ? ("approved" as const) : ("rejected" as const),
+      committedAt: decidedAt,
+      committedBy: reviewer,
+      observations: hasDetail
+        ? [{
+            id: `round-${round.seq}-detail`,
+            types: round.reasons as ObservationType[],
+            description: round.comment ?? "",
+            createdAt: decidedAt,
+            createdBy: reviewer,
+          }]
+        : [],
+    };
+  });
 }
 
 function buildNodeTimeline(data: ForumDiscussionResponse, refMap: Map<string, { topicRef: string; postRef: string }>): TimelineEntry[] {
@@ -614,14 +645,27 @@ export default function FileImages({
   const currentUserName = session?.user?.name ?? session?.user?.email ?? undefined;
 
 
+  /**
+   * Records one decision as a review round: the verdict together with the reasons and the
+   * comment the reviewer staged for this file.
+   *
+   * This used to be two independent writes — the reviewable aspect and a forum topic —
+   * issued under Promise.allSettled. When one failed the UI rolled back its own state and
+   * left the other committed on the server, with nothing to repair the disagreement. One
+   * request, one transaction, so there is no half-state to reconcile.
+   */
   const handleStatusChange = useCallback(async (id: string, status: ReviewStatus) => {
+    if (status === "pending") {
+      // Returning content to review is the absence of a decision, not a decision that says
+      // it is undecided, so it records no round.
+      return;
+    }
     const now = new Date();
-    const ALFRESCO_STATE_MAP: Record<string, "APPROVED" | "REJECTED" | "PENDING"> = { approved: "APPROVED", rejected: "REJECTED", pending: "PENDING" };
-    const alfrescoState = ALFRESCO_STATE_MAP[status] ?? "PENDING";
+    const staged = draftObservations.get(id) ?? [];
+    const reasons = [...new Set(staged.flatMap((obs) => obs.types ?? []))];
+    const comment = staged.map((obs) => obs.description).filter(Boolean).join("\n\n");
 
-    // Capture full-map snapshots inside the updaters before writing optimistic values.
-    // Restored verbatim on any API failure so prior state (including previously committed
-    // decisions) is never lost.
+    // Snapshots for rollback, captured before the optimistic write.
     let snapStatuses: Map<string, ReviewStatus> | undefined;
     let snapTimestamps: Map<string, Date> | undefined;
     let snapUsers: Map<string, string> | undefined;
@@ -642,12 +686,14 @@ export default function FileImages({
     });
     setCommittedTimeline((prev) => { snapTimeline = prev; return prev; });
 
-    const [updateResult, forumResult] = await Promise.allSettled([
-      updateBentoReviewState(id, alfrescoState, currentUserName, now.toISOString()),
-      createContentForumTopic(toNodeRef(id), alfrescoState, alfrescoState),
-    ]);
-
-    if (updateResult.status === "rejected" || forumResult.status === "rejected") {
+    try {
+      await recordReviewRound({
+        contentNodeRef: toNodeRef(id),
+        verdict: status === "approved" ? "APPROVED" : "REJECTED",
+        reasons,
+        comment: comment || undefined,
+      });
+    } catch {
       toast.error(tr("bento.multimedia.review_state_update_error", dictionary));
       if (snapStatuses) setReviewStatuses(() => snapStatuses!);
       if (snapTimestamps) setReviewStatusTimestamps(() => snapTimestamps!);
@@ -656,43 +702,39 @@ export default function FileImages({
       return;
     }
 
+    // The staged observations are now part of the recorded round, so they stop being staged.
+    setDraftObservations((prev) => {
+      const next = new Map(prev); next.delete(id); return next;
+    });
     setCommittedTimeline((prev) => {
       const next = new Map(prev);
       const existing = prev.get(id) ?? [];
-      next.set(id, buildCommittedEntry(existing, status, id, now, currentUserName, []));
+      next.set(id, buildCommittedEntry(existing, status, id, now, currentUserName, staged));
       return next;
     });
-  }, [currentUserName, dictionary]);
+  }, [currentUserName, dictionary, draftObservations]);
 
+  /**
+   * Stages an observation against a file. Nothing is written until the reviewer decides:
+   * a reason with no verdict is what the old forum stored as an unrelated topic, which is
+   * why it could never say which reasons belonged to which decision.
+   */
   const handleAddObservation = useCallback((fileId: string, types: ObservationType[], description: string) => {
     const entry: ObservationEntry = { id: crypto.randomUUID(), types, description, createdAt: new Date(), createdBy: currentUserName };
-    // Always add to committedTimeline immediately (visible right away)
-    setCommittedTimeline((prev) => {
+    setDraftObservations((prev) => {
       const next = new Map(prev);
-      next.set(fileId, [...(prev.get(fileId) ?? []), { kind: "observation" as const, ...entry }]);
+      next.set(fileId, [...(prev.get(fileId) ?? []), entry]);
       return next;
     });
-    // Always persist immediately — store types as comma-separated prefix: [type1,type2] description
-    createContentForumTopic(toNodeRef(fileId), types.join(","), description).catch(() => {});
   }, [currentUserName]);
 
   const handleRemoveDraftObservation = useCallback((fileId: string, obsId: string) => {
-    // Remove from committedTimeline (observations are always added there now)
-    setCommittedTimeline((prev) => {
+    setDraftObservations((prev) => {
       const next = new Map(prev);
       next.set(fileId, (prev.get(fileId) ?? []).filter((e) => e.id !== obsId));
       return next;
     });
-    // If the obsId is a backend ref (not a local temp id), delete the post
-    if (!obsId.startsWith("obs-")) {
-      const refs = forumRefMap.get(obsId);
-      if (refs) {
-        deleteContentForumPost(refs.topicRef, refs.postRef).catch(() => {});
-      } else {
-        deleteContentForumTopic(toNodeRef(obsId)).catch(() => {});
-      }
-    }
-  }, [forumRefMap]);
+  }, []);
 
   const handleRemoveCommittedObservation = useCallback((fileId: string, obsId: string) => {
     setCommittedTimeline((prev) => {
@@ -823,27 +865,35 @@ export default function FileImages({
     }
   }, [documentsData, files]);
 
-  // Hydrate committedTimeline from per-node forum discussions
+  // Hydrate committedTimeline: review rounds where a node has them, its forum discussion
+  // otherwise. Rounds win — the forum kept observations and state changes as unrelated
+  // topics, so it cannot say which reasons belonged to which decision. The forum read stays
+  // for content decided before rounds existed, which is not backfilled.
   const [discussionsLoaded, setDiscussionsLoaded] = useState(false);
   useEffect(() => {
     if (allIds.length === 0 || discussionsLoaded) return;
     let cancelled = false;
-    async function fetchDiscussions() {
+    async function fetchHistories() {
       const results = await Promise.allSettled(
         allIds.map(async (nodeId) => {
-          const res = await fetch(`/app/api/forum/content?contentNodeRef=${encodeURIComponent(toNodeRef(nodeId))}`);
-          if (!res.ok) return { nodeId, data: null };
-          const data = (await res.json()) as ForumDiscussionResponse;
-          return { nodeId, data };
+          const nodeRef = encodeURIComponent(toNodeRef(nodeId));
+          const roundsRes = await fetch(`/app/api/review/rounds?contentNodeRef=${nodeRef}`);
+          if (roundsRes.ok) {
+            const { rounds } = (await roundsRes.json()) as { rounds: ReviewRoundResponse[] };
+            if (rounds?.length) return { nodeId, rounds, data: null };
+          }
+          const res = await fetch(`/app/api/forum/content?contentNodeRef=${nodeRef}`);
+          if (!res.ok) return { nodeId, rounds: null, data: null };
+          return { nodeId, rounds: null, data: (await res.json()) as ForumDiscussionResponse };
         })
       );
       if (cancelled) return;
       const timeline = new Map<string, TimelineEntry[]>();
       const refMap = new Map<string, { topicRef: string; postRef: string }>();
       for (const result of results) {
-        if (result.status !== "fulfilled" || !result.value.data) continue;
-        const { nodeId, data } = result.value;
-        const entries = buildNodeTimeline(data, refMap);
+        if (result.status !== "fulfilled") continue;
+        const { nodeId, rounds, data } = result.value;
+        const entries = rounds ? roundsToTimeline(rounds) : data ? buildNodeTimeline(data, refMap) : [];
         if (entries.length > 0) timeline.set(nodeId, entries);
       }
       setForumRefMap((prev) => new Map([...prev, ...refMap]));
@@ -856,7 +906,7 @@ export default function FileImages({
       });
       setDiscussionsLoaded(true);
     }
-    fetchDiscussions();
+    fetchHistories();
     return () => { cancelled = true; };
   }, [allIds, discussionsLoaded]);
 

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/rounds-to-timeline.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/rounds-to-timeline.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { roundsToTimeline } from "./file-images";
+import type { ReviewRoundResponse } from "@/features/common/providers/alfresco-api/alfresco-api.types";
+
+const round = (over: Partial<ReviewRoundResponse> = {}): ReviewRoundResponse => ({
+  seq: 1,
+  verdict: "REJECTED",
+  version: "1.0",
+  reasons: ["poor_image_quality"],
+  comment: "No se ve la imagen",
+  reviewedBy: "reviewer",
+  decidedAt: "2026-07-27T11:10:15Z",
+  ...over,
+});
+
+describe("roundsToTimeline", () => {
+  it("turns one round into one state change carrying its reasons and comment", () => {
+    const [entry] = roundsToTimeline([round()]);
+
+    expect(entry.kind).toBe("state_change");
+    expect(entry).toMatchObject({ status: "rejected", committedBy: "reviewer" });
+    if (entry.kind !== "state_change") throw new Error("expected a state change");
+    expect(entry.observations).toHaveLength(1);
+    expect(entry.observations[0].types).toEqual(["poor_image_quality"]);
+    expect(entry.observations[0].description).toBe("No se ve la imagen");
+  });
+
+  it("keeps each round's reasons to itself", () => {
+    // The defect the round model exists to fix: read out of the forum, the second
+    // rejection carried the first one's codes too, because nothing recorded which
+    // observation belonged to which decision.
+    const entries = roundsToTimeline([
+      round({ seq: 1, reasons: ["bad_lighting"], comment: "Muy oscura" }),
+      round({ seq: 2, reasons: ["wrong_document"], comment: "No corresponde" }),
+    ]);
+
+    expect(entries).toHaveLength(2);
+    const [first, second] = entries;
+    if (first.kind !== "state_change" || second.kind !== "state_change") {
+      throw new Error("expected state changes");
+    }
+    expect(first.observations[0].types).toEqual(["bad_lighting"]);
+    expect(second.observations[0].types).toEqual(["wrong_document"]);
+  });
+
+  it("gives an approval with nothing to say no observation", () => {
+    const [entry] = roundsToTimeline([
+      round({ verdict: "APPROVED", reasons: [], comment: null }),
+    ]);
+
+    if (entry.kind !== "state_change") throw new Error("expected a state change");
+    expect(entry.status).toBe("approved");
+    expect(entry.observations).toEqual([]);
+  });
+
+  it("parses the decision time and reuses it for the observation", () => {
+    const [entry] = roundsToTimeline([round()]);
+
+    if (entry.kind !== "state_change") throw new Error("expected a state change");
+    expect(entry.committedAt.toISOString()).toBe("2026-07-27T11:10:15.000Z");
+    expect(entry.observations[0].createdAt).toEqual(entry.committedAt);
+  });
+
+  it("gives each round a distinct id so React does not reuse a row", () => {
+    const entries = roundsToTimeline([round({ seq: 1 }), round({ seq: 2 })]);
+
+    expect(new Set(entries.map((e) => e.id)).size).toBe(2);
+  });
+
+  it("renders content with no rounds as an empty timeline", () => {
+    expect(roundsToTimeline([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
P3 of the review-rounds plan. Companion to ecm-coordinator #349 (merged) and **#350 (must merge first — see below)**.

## ⚠️ Ordering

**Do not merge this before ecm-coordinator #350.** P1's `record()` stops the UI writing forum topics; a pre-P2 emitter still reads the forum for reasons, so shipping this first would send every rejection out with **no reasons at all**.

## The write

`handleStatusChange` fired `updateBentoReviewState` and `createContentForumTopic` under `Promise.allSettled`. When one failed it rolled back the local state and left the other committed on the server, with nothing to repair the disagreement. It now calls the round webscript once — one request, one transaction, no half-state.

**Observations stop persisting on their own.** They stage against the file and are consumed by the decision that follows. A reason with no verdict is precisely what the forum stored as an unrelated topic, and precisely why it could never say which observations justified which decision. Cancelling the review discards them, which is the honest outcome for something never decided.

**Returning content to review records nothing** — that's the absence of a decision, not a decision saying it's undecided.

## The read

The sidebar timeline builds from rounds where a node has them, forum otherwise. The fallback is not optional here: with no backfill (decision 3), every document decided before this still has only forum topics, and dropping that path would blank their history.

## Also added

`GET /mintral/review/rounds` on the ECM side (pushed to #350) — P1 and P2 only gave us a way to *write* a round, and the UI has to render the history.

## Verification

- Typecheck clean; 992 tests pass, 1 skipped (6 added for the round→timeline conversion).
- **Not yet exercised against a live repository** — see the note below.

## Still open

Two things from the original UX list are *not* in here, deliberately:

- **Replies** still exist on the observation card. Decision 2 says drop them from the review path; the reasons they fed no longer reach the wire, so the correctness half is done, but the affordance is still on screen. Removing it touches the non-reviewable-document case too, which deserves its own change.
- The reject flow still allows several staged observations per decision, whose comments are joined with a blank line. One comment per decision is the model; collapsing the form to a single reasons+comment entry is a UI change worth doing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added review-round tracking for multimedia decisions, including approval or rejection, reasons, comments, timestamps, and reviewer details.
  * Review history is now displayed in the timeline, with separate entries for each decision.
* **Improvements**
  * Observations remain as drafts until a review decision is submitted, reducing unintended saves.
  * Review-round history takes precedence when available, with existing discussion history retained as a fallback.
* **Bug Fixes**
  * Improved timeline consistency and preservation of staged observations when review submissions succeed or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->