### PR TITLE
fix(shipping): let a collection row name a collection, not its own elements

### DIFF
--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
@@ -8,6 +8,7 @@ import {
   attachedChannels,
   bindNameOf,
   collectionFallbackRoot,
+  collectionScopeOf,
   contractRoots,
   scopeOfRow,
   bindingChannelKey,
@@ -23,7 +24,10 @@ import {
   type DispatchTarget,
   type EventBinding,
 } from "./review-binding.types";
-import { renderTemplate } from "./review-integration.types";
+import {
+  collectionsInScope,
+  renderTemplate,
+} from "./review-integration.types";
 
 /** A stored binding with sensible defaults, overridable per test. */
 function binding(over: Partial<EventBinding>): EventBinding {
@@ -412,6 +416,36 @@ describe("collection rows drive the drawer's scopes", () => {
     expect(bindNameOf("content.reasons")).toBeNull();
     expect(bindNameOf(undefined)).toBeNull();
   });
+
+  it("writes a collection's source in the scope it sits in, not the one it creates", () => {
+    // The distinction that cost a live integration: `items.notes` is answered from inside
+    // `items`, where the element is bound as `content` — so `content.reasons`. Reading its own
+    // bind name instead gives `reasons`, which points the row at its own elements.
+    expect(collectionScopeOf(target.fields[3], target, mapped)).toBe("content");
+    expect(collectionScopeOf(target.fields[1], target, mapped)).toBeNull();
+  });
+
+  it("falls back to the contract's own root when the enclosing row is unmapped", () => {
+    expect(collectionScopeOf(target.fields[3], target, {})).toBe("content");
+  });
+});
+
+describe("collectionsInScope", () => {
+  it("offers the reviewed items at the envelope and their reasons inside one", () => {
+    expect(collectionsInScope(null).map((c) => c.path)).toEqual(["content"]);
+    expect(collectionsInScope("content").map((c) => c.path)).toEqual([
+      "content.reasons",
+    ]);
+  });
+
+  it("never offers a scope its own bind name", () => {
+    // `reasons` is what an element becomes, so a row scoped by it has no further array to
+    // iterate — offering `{{reasons}}` is what produced an empty array and a dropped field.
+    expect(collectionsInScope("reasons")).toEqual([]);
+    for (const scope of [null, "content", "reasons"]) {
+      expect(collectionsInScope(scope).map((c) => c.path)).not.toContain(scope);
+    }
+  });
 });
 
 describe("checkCollectionTemplate", () => {
@@ -439,5 +473,24 @@ describe("checkCollectionTemplate", () => {
       "unknownRoot"
     );
     expect(checkCollectionTemplate("{{nope.things}}", null).status).toBe("valid");
+  });
+
+  it("refuses an element bind name as a source, whatever the roots say", () => {
+    // The one this rule exists for. `reasons` is a legal root *inside* the array it names —
+    // the rows there read `{{reasons.code}}` — so the root check waves it through, and the
+    // server does too: it resolves to nothing, renders `[]`, and an unrequired empty array is
+    // dropped from the payload rather than reported. Green everywhere, field never sent.
+    for (const roots of [ALLOWED_ROOTS, ["task", "content", "reasons"], null]) {
+      expect(checkCollectionTemplate("{{reasons}}", roots).problem?.code).toBe(
+        "elementRoot"
+      );
+    }
+    expect(checkCollectionTemplate("{{reasons.code}}", null).problem?.code).toBe(
+      "elementRoot"
+    );
+  });
+
+  it("still accepts the path that names where those elements come from", () => {
+    expect(checkCollectionTemplate("{{content.reasons}}", null).status).toBe("valid");
   });
 });

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.test.ts
@@ -432,6 +432,9 @@ describe("collection rows drive the drawer's scopes", () => {
 
 describe("collectionsInScope", () => {
   it("offers the reviewed items at the envelope and their reasons inside one", () => {
+    // An unscoped row arrives as null from collectionScopeOf and as undefined from a contract
+    // that declares no root; both are the envelope.
+    expect(collectionsInScope().map((c) => c.path)).toEqual(["content"]);
     expect(collectionsInScope(null).map((c) => c.path)).toEqual(["content"]);
     expect(collectionsInScope("content").map((c) => c.path)).toEqual([
       "content.reasons",

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-binding.types.ts
@@ -158,6 +158,24 @@ export function collectionFallbackRoot(
   return null;
 }
 
+/**
+ * The scope a collection row's own source is written in: the bind name of the array it sits
+ * inside, or null at the envelope.
+ *
+ * Deliberately not `scopeOfRow`, which answers for a value row. The scope a collection row
+ * sits *in* is not the one it *creates*, and conflating the two is exactly how a row ends up
+ * pointed at its own elements — `{{reasons}}` where `{{content.reasons}}` was meant.
+ */
+export function collectionScopeOf(
+  row: DispatchTargetField,
+  target: DispatchTarget | undefined,
+  templates: Record<string, string>
+): string | null {
+  const enclosing = enclosingCollection(row.id, target);
+  if (!enclosing) return null;
+  return bindNameOf(templates[enclosing.id]) ?? collectionFallbackRoot(enclosing, target);
+}
+
 export interface EventBinding {
   readonly id: string;
   readonly ownerOrgSlug: string;

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-collection-input.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-collection-input.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { TextInput } from "flowbite-react";
+import { DropdownList } from "@/features/dashboard/dashlets/common/dropdown-list";
+import { useDropdown } from "@/features/dashboard/dashlets/common/use-dropdown";
+import type { I18nRecord } from "@/features/i18n/i18n.service.types";
+import { trDynamic } from "@/features/i18n/tr.service";
+import type { CollectionVariable } from "./review-integration.types";
+
+/**
+ * The source field of an array row: which collection its elements come from.
+ *
+ * A picker of whole paths rather than the value rows' `{{namespace.field}}` autocomplete,
+ * because the two rows ask different questions and the value vocabulary answers this one
+ * wrongly. It offers every root a template may read — including the bind name the array
+ * itself creates, so picking it aims the row at its own elements — while a bare `{{content}}`,
+ * the right answer for a top-level array, cannot be typed by that machinery at all.
+ */
+export function ReviewCollectionInput({
+  value,
+  onChange,
+  collections,
+  placeholder,
+  color = "gray",
+  dict,
+}: Readonly<{
+  value: string;
+  onChange: (value: string) => void;
+  /** The arrays reachable from this row's scope. Empty hides the picker, leaving free text. */
+  collections: readonly CollectionVariable[];
+  placeholder?: string;
+  color?: "gray" | "success" | "failure";
+  dict: I18nRecord;
+}>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  // Filtered on the path alone, with the braces the operator is mid-typing ignored, so
+  // `{{cont` and `cont` narrow the same way.
+  const items = useMemo(() => {
+    const typed = value.replace(/[{}]/g, "").trim().toLowerCase();
+    if (!typed) return [...collections];
+    return collections.filter((collection) =>
+      collection.path.toLowerCase().includes(typed)
+    );
+  }, [collections, value]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+  const select = useCallback(
+    (collection: CollectionVariable) => {
+      onChange(`{{${collection.path}}}`);
+      setIsOpen(false);
+      inputRef.current?.focus();
+    },
+    [onChange]
+  );
+
+  const { selectedIndex, setSelectedIndex, handleKeyDown } = useDropdown({
+    items,
+    isOpen: isOpen && items.length > 0,
+    onClose: close,
+    onSelect: select,
+    containerRef,
+    dropdownRef,
+  });
+
+  // The drawer scrolls and clips; a portal keeps the list out of its overflow.
+  useEffect(() => {
+    if (!isOpen || !inputRef.current) return;
+    const rect = inputRef.current.getBoundingClientRect();
+    setPosition({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  }, [isOpen, items]);
+
+  const open = useCallback(() => {
+    if (collections.length === 0) return;
+    setIsOpen(true);
+    setSelectedIndex(0);
+  }, [collections.length, setSelectedIndex]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          open();
+        }}
+        onClick={open}
+        onKeyDown={(e) =>
+          handleKeyDown(e as React.KeyboardEvent<HTMLInputElement>)
+        }
+        placeholder={placeholder}
+        sizing="sm"
+        color={color}
+        className="font-mono [&_input]:text-xs"
+        autoComplete="off"
+      />
+      {isOpen &&
+        items.length > 0 &&
+        createPortal(
+          <div
+            style={{
+              position: "fixed",
+              top: position.top,
+              left: position.left,
+              minWidth: position.width,
+              zIndex: 9999,
+            }}
+          >
+            <DropdownList
+              items={items}
+              selectedIndex={selectedIndex}
+              onSelect={select}
+              onHover={setSelectedIndex}
+              dropdownRef={dropdownRef}
+              getKey={(collection: CollectionVariable) => collection.path}
+              renderItem={(collection: CollectionVariable) => (
+                <span className="flex items-baseline gap-2">
+                  <span className="font-mono text-xs">{`{{${collection.path}}}`}</span>
+                  <span className="truncate text-[11px] text-gray-500 dark:text-gray-400">
+                    {trDynamic(collection.labelKey, dict)}
+                  </span>
+                </span>
+              )}
+            />
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
@@ -153,6 +153,57 @@ export const GLOBAL_VARIABLE_GROUPS: readonly VariableGroup[] = VARIABLE_GROUPS.
 );
 
 /**
+ * Roots that exist only as an array element's bind name.
+ *
+ * Legal in a *value* row inside that array, never legal as the array's source: `reasons` is
+ * what an element becomes, not where it came from.
+ */
+export const ELEMENT_ROOTS: readonly string[] = VARIABLE_GROUPS.filter(
+  (group) => group.scoped
+).map((group) => group.id);
+
+/* -------------------------------------------------------------------------- */
+/* Collections — the arrays a collection row can point at                      */
+/* -------------------------------------------------------------------------- */
+
+export interface CollectionVariable {
+  /** Dotted path to the array, written in the scope it is reachable from. */
+  readonly path: string;
+  /** i18n key under `variables.collections`. */
+  readonly labelKey: string;
+  /** The root its elements are rebound under — what the rows inside it read. */
+  readonly binds: VariableGroupId;
+  /** The bind name of the array this one sits inside, or null at the envelope. */
+  readonly within: VariableGroupId | null;
+}
+
+/**
+ * Where an array's elements can come from.
+ *
+ * A collection row asks a different question from every other row — not "what value goes
+ * here" but "which array does this repeat over" — and the answer is a path in the *enclosing*
+ * scope. A separate catalogue is what keeps the two apart: offered the value vocabulary, an
+ * operator picks `{{reasons}}`, which resolves to nothing, renders an empty array, and is then
+ * dropped from the payload altogether, because an unrequired empty array is omitted rather
+ * than reported. That is a live integration shipping no rejection reasons at all, with every
+ * check on screen green.
+ */
+export const COLLECTION_VARIABLES: readonly CollectionVariable[] = [
+  { path: "content", labelKey: "variables.collections.content", binds: "content", within: null },
+  // Reachable only from inside `content`, where the element is bound under that name — which
+  // is also why it is spelled `content.reasons` rather than `reasons`.
+  { path: "content.reasons", labelKey: "variables.collections.reasons", binds: "reasons", within: "content" },
+];
+
+/** The arrays reachable from a scope, null being the envelope. */
+export function collectionsInScope(
+  scope: string | null | undefined
+): readonly CollectionVariable[] {
+  const within = scope ?? null;
+  return COLLECTION_VARIABLES.filter((collection) => collection.within === within);
+}
+
+/**
  * A worked example for one contract row: the first variable of the root that row renders
  * under, so the hint names a path that actually resolves there. Envelope rows see the whole
  * context, so they get the most common starting point instead.

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-integration.types.ts
@@ -195,12 +195,17 @@ export const COLLECTION_VARIABLES: readonly CollectionVariable[] = [
   { path: "content.reasons", labelKey: "variables.collections.reasons", binds: "reasons", within: "content" },
 ];
 
-/** The arrays reachable from a scope, null being the envelope. */
+/**
+ * The arrays reachable from a scope, null being the envelope.
+ *
+ * The default carries the envelope case: an unscoped row reaches here as `undefined` from a
+ * contract that declares no root, and as `null` from `collectionScopeOf`. Both mean the same
+ * thing, and the parameter default collapses them without a second name for it.
+ */
 export function collectionsInScope(
-  scope: string | null | undefined
+  scope: string | null = null
 ): readonly CollectionVariable[] {
-  const within = scope ?? null;
-  return COLLECTION_VARIABLES.filter((collection) => collection.within === within);
+  return COLLECTION_VARIABLES.filter((collection) => collection.within === scope);
 }
 
 /**

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-mapping-tab.tsx
@@ -13,6 +13,7 @@ import { tr, trDynamic } from "@/features/i18n/tr.service";
 import { Section } from "./review-config-tab";
 import {
   buildSampleContext,
+  collectionsInScope,
   renderTemplate,
   sampleTemplateFor,
   GLOBAL_VARIABLE_GROUPS,
@@ -23,10 +24,16 @@ import {
   checkTemplate,
 } from "./review-template-validation";
 import { ReviewTemplateInput } from "./review-template-input";
-import type { VariableGroup } from "./review-integration.types";
+import { ReviewCollectionInput } from "./review-collection-input";
+import type {
+  CollectionVariable,
+  VariableGroup,
+} from "./review-integration.types";
 import {
   bindNameOf,
   collectionFallbackRoot,
+  collectionPathOf,
+  collectionScopeOf,
   contractRoots,
   scopeOfRow,
   type DispatchTarget,
@@ -127,6 +134,9 @@ export function ReviewMappingTab({
               onChange={(value) => onChange(field.id, value)}
               roots={roots}
               fallback={collectionFallbackRoot(field, target)}
+              collections={collectionsInScope(
+                collectionScopeOf(field, target, mappings)
+              )}
               dict={dict}
             />
           ) : (
@@ -160,6 +170,7 @@ function CollectionField({
   onChange,
   roots,
   fallback,
+  collections,
   dict,
 }: Readonly<{
   field: DispatchTargetField;
@@ -168,6 +179,8 @@ function CollectionField({
   roots: readonly string[] | null;
   /** The contract's own source, used while this row is unmapped. */
   fallback: string | null;
+  /** The arrays this row could point at, given the scope it sits in. */
+  collections: readonly CollectionVariable[];
   dict: I18nRecord;
 }>) {
   const check = useMemo(
@@ -175,6 +188,16 @@ function CollectionField({
     [template, roots]
   );
   const bound = bindNameOf(template) ?? fallback;
+
+  // A path that is syntactically fine and still names no array here. Reported rather than
+  // enforced: the catalogue covers the review event, and a contract may iterate a collection
+  // it does not know about, which is the operator's call and not an error.
+  const path = collectionPathOf(template);
+  const unrecognised =
+    !check.problem &&
+    path !== null &&
+    collections.length > 0 &&
+    !collections.some((collection) => collection.path === path);
 
   return (
     <div className="rounded-lg border border-dashed border-primary-300 bg-primary-50/40 p-3 dark:border-primary-800 dark:bg-primary-900/10">
@@ -192,11 +215,13 @@ function CollectionField({
         {tr("mapping.collectionHelp", dict)}
       </p>
 
-      <ReviewTemplateInput
+      <ReviewCollectionInput
         value={template}
         onChange={onChange}
+        collections={collections}
         placeholder={tr("mapping.collectionPlaceholder", dict)}
         color={check.status === "invalid" ? "failure" : "gray"}
+        dict={dict}
       />
 
       {check.problem && (
@@ -212,9 +237,23 @@ function CollectionField({
         </p>
       )}
 
+      {/* Named a path, but not one holding an array here. Without this the row looks settled
+          and the field it feeds simply never reaches the partner. */}
+      {unrecognised && (
+        <p className="mt-1.5 flex items-start gap-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+          <HiExclamationCircle className="mt-px h-3 w-3 shrink-0" />
+          <span>
+            {trDynamic("mapping.collectionUnknown", dict, {
+              path: path ?? "",
+              options: collections.map((c) => `{{${c.path}}}`).join(", "),
+            })}
+          </span>
+        </p>
+      )}
+
       {/* What the rows below will read, so the consequence of this row is visible where it is
           decided rather than only in the rows it governs. */}
-      {!check.problem && bound && (
+      {!check.problem && !unrecognised && bound && (
         <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
           <HiArrowRight className="h-3 w-3 shrink-0" />
           {trDynamic("mapping.collectionBinds", dict, { root: bound })}

--- a/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
+++ b/turbo-repo/apps/app/src/features/shipping/components/lane/review-template-validation.ts
@@ -10,6 +10,7 @@
  */
 
 import { collectionPathOf } from "./review-binding.types";
+import { ELEMENT_ROOTS } from "./review-integration.types";
 
 /** The context objects a template may read — mirrors `PayloadTemplate.DEFAULT_ROOTS`. */
 export const ALLOWED_ROOTS: readonly string[] = ["task", "content", "review", "session"];
@@ -31,7 +32,8 @@ export interface TemplateProblem {
     | "badChar"
     | "unknownRoot"
     | "wholeObject"
-    | "notCollection";
+    | "notCollection"
+    | "elementRoot";
   readonly params?: Readonly<Record<string, string>>;
 }
 
@@ -112,6 +114,16 @@ export function checkCollectionTemplate(
 
   const dot = path.indexOf(".");
   const root = dot < 0 ? path : path.slice(0, dot);
+
+  // Checked ahead of the root rule, which would wave this through: a row inside an array
+  // legitimately has the element bind name among its roots, so `{{reasons}}` passes as a known
+  // root while naming the elements themselves rather than the array they come from. The server
+  // does not catch it either — it resolves to nothing, renders `[]`, and an empty unrequired
+  // array is omitted, so the field simply vanishes from the payload.
+  if (ELEMENT_ROOTS.includes(root)) {
+    return FAIL("elementRoot", { path, root });
+  }
+
   if (allowedRoots && !allowedRoots.includes(root)) {
     return FAIL("unknownRoot", {
       path,

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -53,6 +53,7 @@
         "collectionHelp": "Which collection this array's elements come from. Each element becomes available under the last segment of the path.",
         "collectionPlaceholder": "e.g. {{content.reasons}}",
         "collectionBinds": "Its fields will read {{{root}.*}}",
+        "collectionUnknown": "'{path}' is not a collection available here. At this point you can use: {options}.",
         "scopedHelp": "These variables exist only inside the array that supplies them; use them on that array's fields.",
         "insertVariable": "Variable",
         "previewEmpty": "(empty)",
@@ -73,7 +74,8 @@
           "badChar": "'{expression}' contains an unsupported character: '{char}'.",
           "unknownRoot": "'{path}' is unknown: '{root}' is not one of {roots}.",
           "wholeObject": "'{path}' is a whole object — use one of its fields (e.g. .mediaId).",
-          "notCollection": "'{expression}' does not name a collection. Use a single variable, e.g. {{content.reasons}}."
+          "notCollection": "'{expression}' does not name a collection. Use a single variable, e.g. {{content.reasons}}.",
+          "elementRoot": "'{path}' is the name the elements are given, not where they come from. Name the collection's path, e.g. {{content.reasons}}."
         },
         "channel": "Channel"
       },
@@ -103,6 +105,10 @@
           "review": "Review",
           "session": "User",
           "reasons": "Rejection reasons"
+        },
+        "collections": {
+          "content": "Reviewed files",
+          "reasons": "This file's rejection reasons"
         },
         "reasons": {
           "code": "Reason code",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -53,6 +53,7 @@
         "collectionHelp": "De qué colección salen los elementos de este arreglo. Cada elemento queda disponible bajo el último segmento de la ruta.",
         "collectionPlaceholder": "Ej: {{content.reasons}}",
         "collectionBinds": "Sus campos leerán {{{root}.*}}",
+        "collectionUnknown": "'{path}' no es una colección disponible en este punto. Aquí puedes usar: {options}.",
         "scopedHelp": "Estas variables existen solo dentro del arreglo que las aporta; úsalas en los campos de ese arreglo.",
         "insertVariable": "Variable",
         "previewEmpty": "(vacío)",
@@ -73,7 +74,8 @@
           "badChar": "'{expression}' contiene un carácter no admitido: '{char}'.",
           "unknownRoot": "'{path}' no existe: '{root}' no es uno de {roots}.",
           "wholeObject": "'{path}' es un objeto completo: usa uno de sus campos (por ejemplo, .mediaId).",
-          "notCollection": "'{expression}' no nombra una colección. Usa una sola variable, por ejemplo {{content.reasons}}."
+          "notCollection": "'{expression}' no nombra una colección. Usa una sola variable, por ejemplo {{content.reasons}}.",
+          "elementRoot": "'{path}' es el nombre que reciben los elementos, no de dónde salen. Indica la ruta de la colección, por ejemplo {{content.reasons}}."
         },
         "channel": "Canal"
       },
@@ -103,6 +105,10 @@
           "review": "Revisión",
           "session": "Usuario",
           "reasons": "Motivos de rechazo"
+        },
+        "collections": {
+          "content": "Archivos revisados",
+          "reasons": "Motivos de rechazo de este archivo"
         },
         "reasons": {
           "code": "Código del motivo",


### PR DESCRIPTION
## What went wrong

A collection row asks **where an array's elements come from**. The drawer answered it with the value rows' vocabulary, which is wrong in two directions at once:

- it offers `{{reasons}}` — the name the elements *get*, not where they come from;
- it cannot express `{{content}}`, a bare root, which is the right answer for a top-level array. That answer was unreachable from the dropdown entirely.

Validation agreed with the wrong one: a row inside an array legitimately has `reasons` among its roots (`{{reasons.code}}` is correct for its leaves), so `checkCollectionTemplate`'s root check passed it.

Nothing downstream caught it either. `resolveCollection` returns null, `renderElements` treats a missing collection as a valid empty array, and `renderObject` omits an unrequired empty array rather than reporting it. So a live binding has been shipping every rejection with **no reasons and no reviewer comment**, the partner answering `200`, while every row on the mapping screen showed green.

## The fix

- **A collection catalogue** (`COLLECTION_VARIABLES`) keyed by the scope each path is written in — `content` at the envelope, `content.reasons` inside it — and `collectionScopeOf`, which answers for a collection row rather than a value row. The scope a row *sits in* is not the one it *creates*; conflating them is the whole bug.
- **`ReviewCollectionInput`**: a picker of whole paths for that one field, so the right answer is one click and the wrong one is not on the menu.
- **`checkCollectionTemplate` refuses an element bind name outright**, checked ahead of the root rule that was letting it through.
- **The row reports a path that names no array in its scope**, listing the ones that do. A warning, not an error: the catalogue covers the review event, and a contract may iterate something it doesn't know about.

## Effect on the existing dev binding

The stored `fotos.mensaje` → `{{reasons}}` now shows red and blocks the save, which is correct — it has never worked. Re-pick `{{content.reasons}}` from the dropdown.

Reasons still won't reach the partner until ecm-coordinator #353 is deployed: rounds are the only place the reviewer UI writes them now, and they currently fail to store on a `cm:contains` integrity violation. Two independent bugs, both needed.

## Verification

- `check-types` clean, `eslint` clean on the touched directory.
- Full app suite: **998 passed, 1 skipped**.
- 6 new tests covering the scope helper, the catalogue, and the validation rule.
- Not exercised in a browser — the picker's keyboard/portal behaviour reuses the dashboard's `useDropdown`/`DropdownList`, but a click-through is worth doing before this leaves draft.

Deliberately not reformatted: these files are not prettier-clean on trunk, and running the formatter buried the change in ~250 lines of churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collection path selector with autocomplete suggestions for review-process mappings.
  * Suggestions now reflect the current mapping scope, including nested content and reason collections.
  * Added localized labels for available collection options.

* **Bug Fixes**
  * Improved validation for unknown collection paths.
  * Prevented element-level variables from being used as collection sources.
  * Added clearer guidance for invalid mapping expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->