### PR TITLE
fix(review): restore the two P3 commits that missed #1018's merge

### DIFF
--- a/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
+++ b/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
@@ -9,6 +9,28 @@ import { logError } from "@/lib/logger";
 
 const ROUTE = "/app/api/review/rounds";
 
+/**
+ * Turns an upstream failure into a response, keeping the repository's own message when it
+ * rejected the request.
+ *
+ * A blanket 500 here cost a debugging session: the repository answered a `PENDING` verdict
+ * with "verdict must be APPROVED or REJECTED, got: PENDING" — exactly the sentence needed —
+ * and this route replaced it with "Failed to record review decision". A 4xx is the caller
+ * being told what it got wrong, so it is passed through; anything else is ours to own and
+ * stays generic.
+ */
+function upstreamError(e: unknown, fallback: string): NextResponse {
+  const status = (e as { status?: number })?.status;
+  if (status === 401) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (typeof status === "number" && status >= 400 && status < 500) {
+    const message = (e as { message?: string })?.message;
+    return NextResponse.json({ error: message || fallback }, { status });
+  }
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
 export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session) {
@@ -27,13 +49,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(await getReviewRounds(session, contentNodeRef));
   } catch (e: unknown) {
     logError(e as Error, { route: `GET ${ROUTE}`, contentNodeRef });
-    if ((e as { status?: number })?.status === 401) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    return NextResponse.json(
-      { error: "Failed to fetch review rounds" },
-      { status: 500 }
-    );
+    return upstreamError(e, "Failed to fetch review rounds");
   }
 }
 
@@ -79,12 +95,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(round, { status: 201 });
   } catch (e: unknown) {
     logError(e as Error, { route: `POST ${ROUTE}`, contentNodeRef, verdict });
-    if ((e as { status?: number })?.status === 401) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    return NextResponse.json(
-      { error: "Failed to record review decision" },
-      { status: 500 }
-    );
+    return upstreamError(e, "Failed to record review decision");
   }
 }

--- a/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
+++ b/turbo-repo/apps/app/src/app/api/review/rounds/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
 
   let body: {
     contentNodeRef?: string;
-    verdict?: "APPROVED" | "REJECTED";
+    verdict?: "APPROVED" | "REJECTED" | "PENDING";
     reasons?: string[];
     comment?: string;
   };
@@ -62,10 +62,9 @@ export async function POST(req: NextRequest) {
       { status: 400 }
     );
   }
-  // PENDING is not a decision — returning content to review is the absence of a round.
-  if (verdict !== "APPROVED" && verdict !== "REJECTED") {
+  if (verdict !== "APPROVED" && verdict !== "REJECTED" && verdict !== "PENDING") {
     return NextResponse.json(
-      { error: "verdict must be APPROVED or REJECTED" },
+      { error: "verdict must be APPROVED, REJECTED or PENDING" },
       { status: 400 }
     );
   }

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.provider.ts
@@ -2279,7 +2279,7 @@ export async function recordReviewRound(
   session: Session,
   data: {
     contentNodeRef: string;
-    verdict: "APPROVED" | "REJECTED";
+    verdict: "APPROVED" | "REJECTED" | "PENDING";
     reasons?: string[];
     comment?: string;
   }

--- a/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/alfresco-api/alfresco-api.types.ts
@@ -590,7 +590,7 @@ export type LegacyPeopleSearchResponse = {
  */
 export type ReviewRoundResponse = {
   seq: number;
-  verdict: "APPROVED" | "REJECTED";
+  verdict: "APPROVED" | "REJECTED" | "PENDING";
   version: string | null;
   reasons: string[];
   comment: string | null;

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -2281,7 +2281,7 @@ export async function updateServiceCategory(
  */
 export async function recordReviewRound(data: {
   contentNodeRef: string;
-  verdict: "APPROVED" | "REJECTED";
+  verdict: "APPROVED" | "REJECTED" | "PENDING";
   reasons?: string[];
   comment?: string;
 }): Promise<ReviewRoundResponse> {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -33,6 +33,19 @@ import MediaRow, { ReviewStatus } from "./media-row";
 import { observationReasonLabels } from "../viewer/observations/observation-utils";
 import { useBentoReview } from "../../../../bento-review-context";
 
+/** The verdict each UI state records. "pending" is a reversal, not the absence of one. */
+const VERDICT_BY_STATUS: Record<ReviewStatus, "APPROVED" | "REJECTED" | "PENDING"> = {
+  approved: "APPROVED",
+  rejected: "REJECTED",
+  pending: "PENDING",
+};
+
+const STATUS_BY_VERDICT: Record<"APPROVED" | "REJECTED" | "PENDING", ReviewStatus> = {
+  APPROVED: "approved",
+  REJECTED: "rejected",
+  PENDING: "pending",
+};
+
 function toNodeRef(id: string): string {
   if (id.startsWith("workspace://")) return id;
   return `workspace://SpacesStore/${id}`;
@@ -226,7 +239,7 @@ export function roundsToTimeline(rounds: ReviewRoundResponse[]): TimelineEntry[]
     return {
       kind: "state_change" as const,
       id: `round-${round.seq}`,
-      status: round.verdict === "APPROVED" ? ("approved" as const) : ("rejected" as const),
+      status: STATUS_BY_VERDICT[round.verdict],
       committedAt: decidedAt,
       committedBy: reviewer,
       observations: hasDetail
@@ -655,15 +668,15 @@ export default function FileImages({
    * request, one transaction, so there is no half-state to reconcile.
    */
   const handleStatusChange = useCallback(async (id: string, status: ReviewStatus) => {
-    if (status === "pending") {
-      // Returning content to review is the absence of a decision, not a decision that says
-      // it is undecided, so it records no round.
-      return;
-    }
     const now = new Date();
     const staged = draftObservations.get(id) ?? [];
-    const reasons = [...new Set(staged.flatMap((obs) => obs.types ?? []))];
-    const comment = staged.map((obs) => obs.description).filter(Boolean).join("\n\n");
+    // Sending content back for another look reverses a verdict rather than explaining one,
+    // so it carries neither reasons nor a comment even if some were staged.
+    const isReturnToReview = status === "pending";
+    const reasons = isReturnToReview ? [] : [...new Set(staged.flatMap((obs) => obs.types ?? []))];
+    const comment = isReturnToReview
+      ? ""
+      : staged.map((obs) => obs.description).filter(Boolean).join("\n\n");
 
     // Snapshots for rollback, captured before the optimistic write.
     let snapStatuses: Map<string, ReviewStatus> | undefined;
@@ -689,7 +702,7 @@ export default function FileImages({
     try {
       await recordReviewRound({
         contentNodeRef: toNodeRef(id),
-        verdict: status === "approved" ? "APPROVED" : "REJECTED",
+        verdict: VERDICT_BY_STATUS[status],
         reasons,
         comment: comment || undefined,
       });

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/rounds-to-timeline.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/rounds-to-timeline.test.ts
@@ -70,4 +70,18 @@ describe("roundsToTimeline", () => {
   it("renders content with no rounds as an empty timeline", () => {
     expect(roundsToTimeline([])).toEqual([]);
   });
+
+  it("shows a return to review as its own entry in the history", () => {
+    // Sending content back is a reversal someone performed, not the absence of a decision.
+    // Treating it as nothing left the reviewer unable to undo at all.
+    const entries = roundsToTimeline([
+      round({ seq: 1, verdict: "REJECTED" }),
+      round({ seq: 2, verdict: "PENDING", reasons: [], comment: null }),
+    ]);
+
+    expect(entries.map((e) => (e.kind === "state_change" ? e.status : null))).toEqual([
+      "rejected",
+      "pending",
+    ]);
+  });
 });


### PR DESCRIPTION
## Why this exists

Both commits were pushed to `feat/review-rounds-p3` **after** #1018 merged at 14:33Z, so neither reached trunk. This is a straight cherry-pick of already-written work, not new code.

```
origin/trunk..origin/feat/review-rounds-p3
  e77a44531  surface the repository's own message on a rejected round
  1acb48487  let a reviewer send content back for another look again
```

Same mistake as #350 → #351 earlier today: I saw the push succeed and assumed it was in the PR without checking what the PR contained.

## What's restored

**"Devolver a revisión" works again.** Trunk still has the early return at `file-images.tsx:658` — pending "records no round, return" — which makes the control inert. It was wrong twice over: a reversal *is* an event, and resetting only the aspect would leave `latestRound()` still saying REJECTED, the exact drift rounds exist to prevent. The restored version records PENDING as its own round, carrying neither reasons nor comment.

**A 4xx from the repository keeps its own message.** Trunk returns a blanket 500, which is what turned "verdict must be APPROVED or REJECTED, got: PENDING" into "Failed to record review decision" and cost a debugging round. 5xx stays generic — those are ours to own, not to leak.

## Difference from the originals

`1acb48487` had swept 451 lines of `package-lock.json` churn along with it. Dropped here; the net diff is 6 files, code only.

## Verification

- `check-types` clean.
- Full app suite: **993 passed, 1 skipped**.
- Includes the `roundsToTimeline` case for a REJECTED round followed by a PENDING one rendering as two history entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)