### PR TITLE
fix(bento): drop the empty approval card from the observations panel

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isSilentApproval } from "./observation-utils";
+import type {
+  ObservationEntry,
+  StateChangeTimelineEntry,
+  TimelineEntry,
+} from "./observation.types";
+
+const note = (over: Partial<ObservationEntry> = {}): ObservationEntry => ({
+  id: "obs-1",
+  types: ["poor_image_quality"],
+  description: "No se ve el sello",
+  createdAt: new Date("2026-07-27T15:19:00Z"),
+  ...over,
+});
+
+const stateChange = (
+  over: Partial<StateChangeTimelineEntry> = {}
+): TimelineEntry => ({
+  kind: "state_change",
+  id: "sc-1",
+  status: "approved",
+  committedAt: new Date("2026-07-27T15:19:00Z"),
+  committedBy: "reviewer",
+  observations: [],
+  ...over,
+});
+
+describe("isSilentApproval", () => {
+  it("hides an approval that carries no notes", () => {
+    // The card this would render says only "Aprobado / no notes attached" — the same fact the
+    // file's status badge already shows, at the cost of the panel's whole height.
+    expect(isSilentApproval(stateChange())).toBe(true);
+  });
+
+  it("keeps an approval that someone wrote a note on", () => {
+    expect(isSilentApproval(stateChange({ observations: [note()] }))).toBe(false);
+  });
+
+  it("keeps a rejection with no notes, because an empty one is a bug worth seeing", () => {
+    // Committing a rejection requires at least one observation, so this shape should not exist.
+    // Hiding it would hide the defect rather than the noise.
+    expect(isSilentApproval(stateChange({ status: "rejected" }))).toBe(false);
+  });
+
+  it("keeps a pending entry, which marks content going back for another look", () => {
+    expect(isSilentApproval(stateChange({ status: "pending" }))).toBe(false);
+  });
+
+  it("keeps a loose observation", () => {
+    const loose: TimelineEntry = {
+      kind: "observation",
+      id: "loose-1",
+      types: ["poor_image_quality"],
+      description: "Nota suelta",
+      createdAt: new Date("2026-07-27T15:19:00Z"),
+    };
+    expect(isSilentApproval(loose)).toBe(false);
+  });
+});

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.ts
@@ -1,6 +1,25 @@
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
-import type { ObservationEntry } from "./observation.types";
+import type { ObservationEntry, TimelineEntry } from "./observation.types";
+
+/**
+ * An approval nobody wrote a note on.
+ *
+ * It renders as a card whose entire body reads "no notes attached", and it says nothing the
+ * file's own status badge — which already carries who approved it and when — does not. Several
+ * in a row push the observations panel tall enough to hide what sits under it.
+ *
+ * Only approvals. A rejection cannot be committed without a reason, so an empty one is a bug
+ * worth seeing rather than hiding, and a `pending` entry marks content going back for another
+ * look, which is a real event even with nothing written on it.
+ */
+export function isSilentApproval(entry: TimelineEntry): boolean {
+  return (
+    entry.kind === "state_change" &&
+    entry.status === "approved" &&
+    entry.observations.length === 0
+  );
+}
 
 /**
  * Display label for one observation code, falling back to the raw code.

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.tsx
@@ -8,6 +8,7 @@ import BrandedMultiSelect from "@/features/task-forms/components/task-confirm-mo
 import type { ObservationType, ObservationEntry, TimelineEntry } from "./observation.types";
 import { OBSERVATION_TYPE_KEYS } from "./observation.types";
 import { ObservationCard } from "./observation-card";
+import { isSilentApproval } from "./observation-utils";
 import { StateChangeEntry } from "./state-change-entry";
 import { LooseObservationEntry } from "./loose-observation-entry";
 import { useObservationTypes } from "@/features/common/providers/client-api.provider";
@@ -115,7 +116,12 @@ export function ObservationsSection({
     setNewTypes([]);
   };
 
-  const allEntries = useMemo(() => [...committedTimeline].reverse(), [committedTimeline]);
+  // Filtered here rather than skipped while rendering, so the empty state, the preview limit
+  // and the infinite-scroll total all count the entries the panel actually shows.
+  const allEntries = useMemo(
+    () => [...committedTimeline].reverse().filter((entry) => !isSilentApproval(entry)),
+    [committedTimeline]
+  );
   const hasContent = allEntries.length > 0 || draftObservations.length > 0;
 
   // Preview mode: show last 3 entries


### PR DESCRIPTION
## Before

An approval with no notes rendered a full card whose entire body read *"Sin notas adjuntas"*:

```
┌─────────────────────────────────────────────────┐
│ Aprobado          27-07-2026, 15:19 · mdavid@…  │
├─────────────────────────────────────────────────┤
│ Sin notas adjuntas                              │
└─────────────────────────────────────────────────┘
```

It repeats what the file's own status badge already carries — approved, when, by whom — and a few in a row push the OBSERVACIONES panel tall enough to bury what sits under it.

## The change

`isSilentApproval` moves to `observation-utils.ts` (pure, so it can be tested directly) and filters the entry list in `ObservationsSection`.

Filtered out of the **list**, not skipped while rendering: `hasContent`, the three-entry preview limit and the infinite-scroll total all read `allEntries`, so hiding it lower down would leave the empty state and the "show more" affordance counting entries that render nothing.

**Approvals only.** A rejection cannot be committed without at least one observation — the rule is enforced in `app/api/task/end/route.ts` — so an empty one is a defect worth seeing rather than hiding. A `pending` entry marks content going back for another look, which is a real event even with nothing written on it.

## Tests

`observation-utils.test.ts` — 5 cases pinning each side of that boundary: the silent approval hidden, an annotated approval kept, and rejected / pending / loose-observation entries all kept.

Suite: 79 passed across the multimedia-manager tree, `check-types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Timeline views now automatically hide approval entries that contain no observations, reducing visual clutter.
  - Approvals with observations, rejections, pending entries, and standalone observations continue to appear normally.
  - Empty-state messaging, preview counts, “Show all” totals, and scrolling behavior now reflect only visible timeline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->