### PR TITLE
fix(bento): stop sending a review round's detail to the forum delete

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/gallery/file-images.tsx
@@ -30,7 +30,7 @@ import ReplaceImageModal from "@/features/geographic-view/components/image-viewe
 import MediaInlineViewer, { MediaViewerItem } from "../viewer/media-inline-viewer";
 import type { ObservationEntry, ObservationType, TimelineEntry, StateChangeTimelineEntry, LooseObservationTimelineEntry } from "../viewer/media-inline-viewer";
 import MediaRow, { ReviewStatus } from "./media-row";
-import { observationReasonLabels } from "../viewer/observations/observation-utils";
+import { isRoundObservation, observationReasonLabels } from "../viewer/observations/observation-utils";
 import { useBentoReview } from "../../../../bento-review-context";
 
 /** The verdict each UI state records. "pending" is a reversal, not the absence of one. */
@@ -214,6 +214,8 @@ function buildObservationEntry(obs: FlatPost): ObservationEntry {
     description: plainDesc,
     createdAt: obs.created,
     createdBy: obs.author,
+    // A real forum post, so `id` is a ref the forum endpoints can act on.
+    source: "forum" as const,
     replies: obs.replies.map((r) => ({
       id: r.ref,
       description: stripHtmlEntities(r.content ?? r.title ?? ""),
@@ -249,6 +251,8 @@ export function roundsToTimeline(rounds: ReviewRoundResponse[]): TimelineEntry[]
             description: round.comment ?? "",
             createdAt: decidedAt,
             createdBy: reviewer,
+            // Not a note on the decision — the decision itself. Nothing may edit it.
+            source: "round" as const,
           }]
         : [],
     };
@@ -750,6 +754,12 @@ export default function FileImages({
   }, []);
 
   const handleRemoveCommittedObservation = useCallback((fileId: string, obsId: string) => {
+    // A round holds the decision itself and has no delete endpoint, so it is not removable —
+    // the card offers no control for it. Refused here as well, because stripping it from the
+    // panel is the half that always "works": it used to leave the note gone on screen and
+    // still recorded on the round, which read as a rejection that had lost its reasons.
+    if (isRoundObservation(committedTimeline.get(fileId) ?? [], obsId)) return;
+
     setCommittedTimeline((prev) => {
       const next = new Map(prev);
       const entries = (prev.get(fileId) ?? [])
@@ -763,10 +773,13 @@ export default function FileImages({
       if (refs) {
         deleteContentForumPost(refs.topicRef, refs.postRef).catch(() => {});
       } else {
+        // Only when the id really is a forum topic ref. It used to fall through to here for
+        // anything that was not a draft, which turned `round-1-detail` into
+        // `workspace://SpacesStore/round-1-detail` and posted it to topic/delete.
         deleteContentForumTopic(toNodeRef(obsId)).catch(() => {});
       }
     }
-  }, [forumRefMap]);
+  }, [committedTimeline, forumRefMap]);
 
   const handleAddReply = useCallback((fileId: string, obsId: string, description: string) => {
     const reply = { id: `reply-${obsId}-${Date.now()}`, description, createdAt: new Date(), createdBy: currentUserName };

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.test.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isSilentApproval } from "./observation-utils";
+import {
+  isImmutable,
+  isRoundObservation,
+  isSilentApproval,
+} from "./observation-utils";
 import type {
   ObservationEntry,
   StateChangeTimelineEntry,
@@ -56,5 +60,43 @@ describe("isSilentApproval", () => {
       createdAt: new Date("2026-07-27T15:19:00Z"),
     };
     expect(isSilentApproval(loose)).toBe(false);
+  });
+});
+
+describe("isImmutable", () => {
+  it("locks an observation that came from a review round", () => {
+    expect(isImmutable(note({ source: "round" }))).toBe(true);
+  });
+
+  it("leaves a forum post editable", () => {
+    expect(isImmutable(note({ source: "forum" }))).toBe(false);
+  });
+
+  it("leaves a staged draft editable — it has never been sent anywhere", () => {
+    expect(isImmutable(note())).toBe(false);
+  });
+});
+
+describe("isRoundObservation", () => {
+  const roundDetail = note({ id: "round-1-detail", source: "round" });
+  const forumPost = note({ id: "9f1c-forum-post", source: "forum" });
+  const entries: TimelineEntry[] = [
+    stateChange({ id: "round-1", status: "rejected", observations: [roundDetail] }),
+    stateChange({ id: "sc-forum", status: "rejected", observations: [forumPost] }),
+  ];
+
+  it("recognises a round's own detail", () => {
+    // The id that used to reach the forum as workspace://SpacesStore/round-1-detail.
+    expect(isRoundObservation(entries, "round-1-detail")).toBe(true);
+  });
+
+  it("does not claim a forum post", () => {
+    expect(isRoundObservation(entries, "9f1c-forum-post")).toBe(false);
+  });
+
+  it("does not claim an id it has never seen", () => {
+    // A draft, or an entry from another file: neither is a round, so neither is refused.
+    expect(isRoundObservation(entries, "obs-42")).toBe(false);
+    expect(isRoundObservation([], "round-1-detail")).toBe(false);
   });
 });

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation-utils.ts
@@ -3,6 +3,35 @@ import { tr } from "@/features/i18n/tr.service";
 import type { ObservationEntry, TimelineEntry } from "./observation.types";
 
 /**
+ * Whether this observation is a record rather than a note — nothing may delete or reply to it.
+ *
+ * True for a review round: its reasons and comment are the decision the repository stored, and
+ * there is no endpoint that could remove one. Everything else is a forum post or a staged draft,
+ * both of which the reviewer owns.
+ */
+export function isImmutable(obs: ObservationEntry): boolean {
+  return obs.source === "round";
+}
+
+/**
+ * Whether an id names an observation that came from a review round.
+ *
+ * Looks the entry up rather than reading its id, so it stays correct if the synthetic
+ * `round-<seq>-detail` shape ever changes — guessing a source from an id prefix is the
+ * mistake this exists to close.
+ */
+export function isRoundObservation(
+  entries: readonly TimelineEntry[],
+  obsId: string
+): boolean {
+  return entries.some(
+    (entry) =>
+      entry.kind === "state_change" &&
+      entry.observations.some((obs) => obs.id === obsId && isImmutable(obs))
+  );
+}
+
+/**
  * An approval nobody wrote a note on.
  *
  * It renders as a card whose entire body reads "no notes attached", and it says nothing the

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation.types.ts
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observation.types.ts
@@ -46,6 +46,24 @@ export type ObservationEntry = {
   createdAt: Date;
   createdBy?: string;
   replies?: ReplyEntry[];
+  /**
+   * Where this came from, which decides whether it can be edited at all.
+   *
+   * A `round` observation is not a note attached to a decision — it *is* the decision, its
+   * reasons and its comment as the repository recorded them. There is no endpoint to delete
+   * one, and no meaning in doing so: the history would then disagree with the verdict it
+   * explains.
+   *
+   * Stated rather than inferred from the id. The delete path used to read `obs-` as "draft"
+   * and everything else as "a forum topic", which was true only while those were the only two
+   * sources. Rounds became a third, so `round-1-detail` was posted to the forum as a nodeRef
+   * — `topic/delete workspace://SpacesStore/round-1-detail`, a 500 — while the card had
+   * already been stripped locally, leaving the panel and the repository disagreeing.
+   *
+   * Undefined means a draft the reviewer is still staging, which is removable and has never
+   * been sent anywhere.
+   */
+  source?: "forum" | "round";
 };
 
 export type StateChangeTimelineEntry = {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/state-change-entry.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/state-change-entry.tsx
@@ -5,6 +5,7 @@ import { tr } from "@/features/i18n/tr.service";
 import { formatDateString } from "@/features/common/components/formatted-date/formatted-date";
 import type { StateChangeTimelineEntry } from "./observation.types";
 import { ObservationCard } from "./observation-card";
+import { isImmutable } from "./observation-utils";
 
 const STATE_CHANGE_STYLES = {
   approved: {
@@ -65,9 +66,25 @@ export function StateChangeEntry({
               <ObservationCard
                 obs={obs}
                 dictionary={dictionary}
-                onDelete={onRemoveCommitted ? () => onRemoveCommitted(obs.id) : undefined}
-                onAddReply={onAddReply ? (desc) => onAddReply(obs.id, desc) : undefined}
-                onRemoveReply={onRemoveReply ? (rid) => onRemoveReply(obs.id, rid) : undefined}
+                // A round is the decision as the repository recorded it, so it offers no edit
+                // controls at all. Withholding them here rather than refusing the write later
+                // is the point: the panel used to strip the note locally and only then fail to
+                // delete it, leaving the card empty while the round still held the comment.
+                onDelete={
+                  onRemoveCommitted && !isImmutable(obs)
+                    ? () => onRemoveCommitted(obs.id)
+                    : undefined
+                }
+                onAddReply={
+                  onAddReply && !isImmutable(obs)
+                    ? (desc) => onAddReply(obs.id, desc)
+                    : undefined
+                }
+                onRemoveReply={
+                  onRemoveReply && !isImmutable(obs)
+                    ? (rid) => onRemoveReply(obs.id, rid)
+                    : undefined
+                }
                 pendingReplyRef={pendingReplyRef}
               />
             </div>


### PR DESCRIPTION
## The bug

Removing the note from a rejection posts to the forum with an id that has no forum behind it:

```
POST /app/api/forum/content
{"action":"topic/delete","topic":"workspace://SpacesStore/round-1-detail"}
→ {"error":"Failed to execute topic/delete"}
```

`round-1-detail` is synthesised by `roundsToTimeline` (`file-images.tsx:245`). There is no topic to delete.

## Why it happened

The delete path decided where an observation lived by reading its id:

```js
if (!obsId.startsWith("obs-")) {           // not a staged draft…
  const refs = forumRefMap.get(obsId);
  if (refs) deleteContentForumPost(...)    // …a known forum post
  else      deleteContentForumTopic(toNodeRef(obsId));  // …so, a forum topic
}
```

That was true while drafts and forum posts were the only two sources. Review rounds became a third, and a round's detail is neither — so it fell through the `else` and was turned into a nodeRef.

## Why it looked like something else

Only the server half failed. The panel strips the note from local state first (`:753-760`), and the forum call swallows its own error (`.catch(() => {})`). So the card stayed on screen as **a rejection with no reasons**, while the round still held the comment. That is the "Rechazado / Sin notas adjuntas" card that appeared to be stuck and unable to go back to pending — it was never state, just a locally-mutated view of immutable history.

## The change

- `ObservationEntry.source` records where an entry came from — `"round"`, `"forum"`, or absent for a staged draft. Stated at construction rather than inferred from an id prefix, which is the mistake being closed.
- A round's detail carries **no** edit controls: no delete, no reply, no reply-removal. It is not a note attached to a decision, it is the decision, and there is no endpoint that could remove one.
- `handleRemoveCommittedObservation` refuses a round id as well. Gating the affordance is the real fix, but stripping the panel is the half that always succeeds, so the write path must not depend on the menu being right.
- The forum-topic fallback now only runs for ids that really are forum refs.

Gating at the menu rather than at the persist boundary follows the rule from the calendar work: an operation that cannot succeed should not be offered, and a rollback that only restores half the state is worse than a refusal.

## Tests

`observation-utils.test.ts` — 102 pass across `features/task-forms`, `check-types` clean.

- `isImmutable` — round locked; forum and draft editable.
- `isRoundObservation` — recognises `round-1-detail`, does not claim a forum post, and does not claim an unknown id or work on an empty timeline.

## Not covered here

The round history and `mintral:reviewStatus` can still disagree, because `resetReviewForNewVersion` stamps the aspect without recording a round — on service 1660015 the node reads PENDING at v1.2 while the newest round is REJECTED at v1.1. That belongs in ecm-coordinator#354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)