### PR TITLE
fix(task-end): read a rejection's reason from its round, not from the forum

### DIFF
--- a/turbo-repo/apps/app/src/app/api/task/end/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.test.ts
@@ -11,6 +11,7 @@ const endTaskMock = vi.fn();
 const updateTaskMock = vi.fn();
 const getChildrenNodesMock = vi.fn();
 const listContentTopicsMock = vi.fn();
+const getReviewRoundsMock = vi.fn();
 
 vi.mock("@/auth", () => ({
   auth: (...args: unknown[]) => authMock(...args),
@@ -21,6 +22,7 @@ vi.mock("@/features/common/providers/alfresco-api/alfresco-api.provider", () => 
   updateTask: (...args: unknown[]) => updateTaskMock(...args),
   getChildrenNodes: (...args: unknown[]) => getChildrenNodesMock(...args),
   listContentTopics: (...args: unknown[]) => listContentTopicsMock(...args),
+  getReviewRounds: (...args: unknown[]) => getReviewRoundsMock(...args),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -133,8 +135,12 @@ describe("POST /api/task/end — document-review gating is direction-aware", () 
     authMock.mockResolvedValue({ user: { email: "u@example.com" } });
     endTaskMock.mockResolvedValue({});
     updateTaskMock.mockResolvedValue(undefined);
-    // Every rejected document carries an observation, so REJECTED_WITHOUT_OBSERVATIONS
-    // never fires and the direction logic is what these tests actually exercise.
+    // Every rejected document carries a reason, so REJECTED_WITHOUT_OBSERVATIONS never fires
+    // and the direction logic is what these tests actually exercise. Both sources are stubbed
+    // because the gate reads rounds first and only falls back to the forum.
+    getReviewRoundsMock.mockResolvedValue({
+      rounds: [{ seq: 1, verdict: "REJECTED", reasons: ["wrong_format"], comment: "" }],
+    });
     listContentTopicsMock.mockResolvedValue({
       topics: [{ title: "Prueba de integración" }],
     });
@@ -219,5 +225,110 @@ describe("POST /api/task/end — document-review gating is direction-aware", () 
     const response = await post({ transitionId: "Preparar Servicio" });
 
     expect(response.status).toBe(422);
+  });
+});
+
+/**
+ * Where a rejection's reason is read from.
+ *
+ * A rejection is recorded as a review round, and the forum write that used to accompany it is
+ * gone. This gate went on asking the forum, so every rounds-era rejection looked unexplained
+ * and sending the trip back — the one move a rejection needs — was refused, with the reasons
+ * and the comment on screen in the confirm dialog the whole time.
+ */
+describe("POST /api/task/end — a rejection's reason comes from its round", () => {
+  const BPM_PACKAGE = "workspace://SpacesStore/83c596eb-159a-4037-8596-eb159ab0377a";
+
+  const rejectedDoc = {
+    list: {
+      entries: [
+        {
+          entry: {
+            id: "b",
+            aspectNames: ["mintral:reviewableAspect"],
+            properties: { "mintral:reviewStatus": "REJECTED" },
+          },
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({ user: { email: "u@example.com" } });
+    endTaskMock.mockResolvedValue({});
+    updateTaskMock.mockResolvedValue(undefined);
+    getChildrenNodesMock.mockResolvedValue(rejectedDoc);
+    // No forum topics anywhere: a rounds-era rejection has none, and leaving the old source
+    // empty is what makes these assertions about rounds rather than about the fallback.
+    listContentTopicsMock.mockResolvedValue({ topics: [] });
+  });
+
+  async function sendBack() {
+    const { POST } = await loadRoute();
+    return POST(
+      makePostRequest({
+        taskId: "2986645",
+        bpm_package: BPM_PACKAGE,
+        transitionId: "Preparar Servicio",
+        reasonId: "wfship2:missionControlTask",
+      })
+    );
+  }
+
+  it("allows the return when the latest round carries reason codes", async () => {
+    getReviewRoundsMock.mockResolvedValue({
+      rounds: [{ seq: 1, verdict: "REJECTED", reasons: ["wrong_format"], comment: "" }],
+    });
+
+    expect((await sendBack()).status).toBe(200);
+  });
+
+  it("allows the return when the round carries only a comment", async () => {
+    // Reasons are optional in the picker; a written explanation is an explanation.
+    getReviewRoundsMock.mockResolvedValue({
+      rounds: [{ seq: 1, verdict: "REJECTED", reasons: [], comment: "Se requiere un png" }],
+    });
+
+    expect((await sendBack()).status).toBe(200);
+  });
+
+  it("blocks when the latest round explains nothing", async () => {
+    getReviewRoundsMock.mockResolvedValue({
+      rounds: [{ seq: 1, verdict: "REJECTED", reasons: [], comment: "   " }],
+    });
+
+    const response = await sendBack();
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "REJECTED_WITHOUT_OBSERVATIONS" },
+    });
+  });
+
+  it("judges by the newest round, not by an older one that explained replaced content", async () => {
+    getReviewRoundsMock.mockResolvedValue({
+      rounds: [
+        { seq: 1, verdict: "REJECTED", reasons: ["poor_image_quality"], comment: "Borrosa" },
+        { seq: 2, verdict: "REJECTED", reasons: [], comment: "" },
+      ],
+    });
+
+    expect((await sendBack()).status).toBe(422);
+  });
+
+  it("falls back to the forum for content decided before rounds existed", async () => {
+    getReviewRoundsMock.mockResolvedValue({ rounds: [] });
+    listContentTopicsMock.mockResolvedValue({
+      topics: [{ title: "Calidad de imagen deficiente" }],
+    });
+
+    expect((await sendBack()).status).toBe(200);
+  });
+
+  it("does not count a verdict topic as an observation in that fallback", async () => {
+    getReviewRoundsMock.mockResolvedValue({ rounds: [] });
+    listContentTopicsMock.mockResolvedValue({ topics: [{ title: "REJECTED" }] });
+
+    expect((await sendBack()).status).toBe(422);
   });
 });

--- a/turbo-repo/apps/app/src/app/api/task/end/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.ts
@@ -3,6 +3,7 @@ import {
   endTask,
   updateTask,
   getChildrenNodes,
+  getReviewRounds,
   listContentTopics,
 } from "@/features/common/providers/alfresco-api/alfresco-api.provider";
 import {
@@ -94,6 +95,39 @@ function isForwardTransition(
 
 type ReviewViolation = { code: string; message: string };
 
+/** Forum topic titles that record a verdict rather than a reviewer's note. */
+const STATE_CHANGE_TITLES = new Set(["APPROVED", "REJECTED", "PENDING"]);
+
+/**
+ * Whether a rejected document carries the reason it was rejected for.
+ *
+ * Rounds first, the forum only as a fallback — the same order the review panel hydrates in,
+ * and for the same reason. A rejection is recorded as a review round now: its reason codes
+ * and the reviewer's comment are properties of the round, and the forum write that used to
+ * accompany it is gone. This check still asked the forum, so every rounds-era rejection
+ * looked unexplained and the gate refused the very move a rejection needs — with the reasons
+ * and the comment plainly on screen in the confirm dialog, read from the rounds it ignored.
+ *
+ * A node with no rounds at all was decided before they existed. Its reasons are still forum
+ * topics, so that read stays; it is not backfilled.
+ */
+async function hasRejectionReason(
+  session: Session,
+  contentNodeRef: string
+): Promise<boolean> {
+  const { rounds } = await getReviewRounds(session, contentNodeRef);
+
+  if (rounds.length > 0) {
+    // The verdict on record is REJECTED, so the newest round is the one that set it and the
+    // one that must explain it. An older round's reasons described content since replaced.
+    const latest = rounds[rounds.length - 1];
+    return (latest?.reasons?.length ?? 0) > 0 || !!latest?.comment?.trim();
+  }
+
+  const { topics } = await listContentTopics(session, contentNodeRef);
+  return (topics ?? []).some((t) => !STATE_CHANGE_TITLES.has(t.title));
+}
+
 async function checkDocumentReview(
   session: Session,
   bpmPackage: string,
@@ -143,31 +177,24 @@ async function checkDocumentReview(
       };
     }
 
-    // Business rule: every rejected document must have at least one observation
-    // (a forum topic that is not a state-change entry).
+    // Business rule: every rejected document must say why.
     if (rejectedEntries.length > 0) {
-      const STATE_CHANGE_TITLES = new Set(["APPROVED", "REJECTED", "PENDING"]);
-
-      const topicChecks = await Promise.allSettled(
-        rejectedEntries.map((e) => {
-          const nodeRef = `workspace://SpacesStore/${e.entry.id}`;
-          return listContentTopics(session, nodeRef);
-        })
+      const checks = await Promise.allSettled(
+        rejectedEntries.map((e) =>
+          hasRejectionReason(session, `workspace://SpacesStore/${e.entry.id}`)
+        )
       );
 
-      const hasDocWithoutObservation = topicChecks.some((result, i) => {
+      const hasDocWithoutObservation = checks.some((result, i) => {
         if (result.status === "rejected") {
           // Fail open for this document — log and skip the check.
           logError(result.reason as Error, {
-            context: "checkDocumentReview:listContentTopics",
+            context: "checkDocumentReview:hasRejectionReason",
             nodeId: rejectedEntries[i]?.entry.id,
           });
           return false;
         }
-        const observationTopics = (result.value.topics ?? []).filter(
-          (t) => !STATE_CHANGE_TITLES.has(t.title)
-        );
-        return observationTopics.length === 0;
+        return !result.value;
       });
 
       if (hasDocWithoutObservation) {

--- a/turbo-repo/apps/app/src/app/api/task/end/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/end/route.ts
@@ -120,7 +120,7 @@ async function hasRejectionReason(
   if (rounds.length > 0) {
     // The verdict on record is REJECTED, so the newest round is the one that set it and the
     // one that must explain it. An older round's reasons described content since replaced.
-    const latest = rounds[rounds.length - 1];
+    const latest = rounds.at(-1);
     return (latest?.reasons?.length ?? 0) > 0 || !!latest?.comment?.trim();
   }
 


### PR DESCRIPTION
## The bug

```
POST /app/api/task/end  {"transitionId":"Preparar Servicio", …}
→ {"success":false,"error":{"code":"REJECTED_WITHOUT_OBSERVATIONS",
   "message":"Cannot proceed: all rejected documents must have at least one observation."}}
```

…while the confirm dialog on screen listed both rejected documents with their reason chips (*Calidad de imagen deficiente*, *Formato incorrecto*) and the reviewer's written comment. The reasons were there. The gate was reading somewhere else.

## Why

A rejection is recorded as a **review round** — reason codes and comment are properties of the round — and the forum write that used to accompany it is gone (`handleStatusChange`: *"This used to be two independent writes… One request, one transaction"*).

This gate still asked `listContentTopics` for a topic that wasn't a state-change entry, found none, and concluded the rejection was unexplained. So it refused the one move a rejection exists to make: sending the trip back.

Same rounds-vs-forum seam as #1023, in the opposite direction — that one had a forum *write* aimed at a round, this one has a forum *read* where a round now lives.

## The change

`hasRejectionReason` reads rounds first and falls back to the forum only when a node has none — the same order, and the same reason, as the review panel's own hydration. A node with no rounds was decided before rounds existed and its reasons are still forum topics; that is not backfilled.

The **newest** round decides. An older round explained content that has since been replaced, so its reasons say nothing about the verdict on record now.

A comment with no reason codes counts: reasons are optional in the picker, and a written explanation is an explanation.

## The tests were green against the broken gate

Worth calling out. The provider mock had no `getReviewRounds`, so the call threw, `Promise.allSettled` marked it rejected, and the fail-open path let everything through — the suite passed without exercising the gate at all.

Stubbed now, plus the coverage that was missing:

- latest round carries reason codes → allowed
- latest round carries only a comment → allowed
- latest round explains nothing → `REJECTED_WITHOUT_OBSERVATIONS`
- an **older** round explained something, the newest does not → still blocked
- no rounds, forum has an observation topic → allowed (pre-rounds fallback)
- no rounds, forum has only a `REJECTED` verdict topic → blocked

The first of those has empty forum topics, so it fails 422 against the old gate — a real regression test, not a restatement.

## Checks

`check-types` clean. 1016 passed / 1 skipped across the app; 14 in this route, up from 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)