### PR TITLE
refactor(bento): draw the review history as a timeline

### DIFF
--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.test.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.test.tsx
@@ -113,6 +113,24 @@ describe("ObservationsSection — a rejection the content has outlived", () => {
     expect(screen.queryByText("Sin notas adjuntas")).toBeNull();
   });
 
+  it("centres every marker on the rail, not beside it", async () => {
+    // jsdom does no layout, so this asserts the rule that does the centering rather than the
+    // resulting pixels. `-left-5` alone only lands a marker's left edge on the line — which is
+    // what left the dots hanging off its right side — so the translate has to be on all of them.
+    const { container } = renderPanel([rejectionAt("1.0")], "1.1");
+    screen.getByRole("button", { name: /Revisiones de versiones anteriores/ }).click();
+    await vi.waitFor(() => {
+      expect(container.querySelector("ol")).not.toBeNull();
+    });
+
+    const markers = [...container.querySelectorAll("ol > li > span:first-child")];
+    expect(markers).toHaveLength(2); // the revision marker and its one decision
+    for (const marker of markers) {
+      expect(marker.className).toContain("-left-5");
+      expect(marker.className).toContain("-translate-x-1/2");
+    }
+  });
+
   it("runs every revision down one rail, newest decision first", async () => {
     const older: StateChangeTimelineEntry = { ...rejectionAt("1.0"), id: "round-1" };
     const newer: StateChangeTimelineEntry = {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.test.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/observations-section.test.tsx
@@ -28,7 +28,8 @@ const dictionary = {
       sidebar_obs_history_unversioned: "Antes del control de versiones",
       sidebar_obs_state_rejected: "Rechazado",
       sidebar_obs_state_approved: "Aprobado",
-      sidebar_obs_state_pending: "Pendiente",
+      // Wording copied from src/lang/es.json, so these assertions read as what ships.
+      sidebar_obs_state_pending: "Devuelto a revisión",
       obs_poor_image_quality: "Calidad de imagen deficiente",
     },
   },
@@ -88,8 +89,52 @@ describe("ObservationsSection — a rejection the content has outlived", () => {
       expect(screen.getByText("no se percibe la patente")).toBeDefined();
     });
     expect(screen.getByText("Versión v1.0")).toBeDefined();
+    // The reason reads as prose on the rail, not as a chip in a card.
+    expect(screen.getByText("Calidad de imagen deficiente")).toBeDefined();
     // A round is the decision as stored, so history offers nothing that edits it.
-    expect(container.querySelectorAll('button[aria-label], button[title]')).toHaveLength(0);
+    expect(container.querySelectorAll("button[aria-label], button[title]")).toHaveLength(0);
+  });
+
+  it("renders a decision nobody wrote on as its line alone", async () => {
+    // "Devuelto a revisión" carries no reasons and no comment by construction. In a card it
+    // filled a bordered box with "Sin notas adjuntas"; four of those was most of the panel.
+    const returned: StateChangeTimelineEntry = {
+      ...rejectionAt("1.0"),
+      id: "round-2",
+      status: "pending",
+      observations: [],
+    };
+    renderPanel([returned], "1.1");
+
+    screen.getByRole("button", { name: /Revisiones de versiones anteriores/ }).click();
+    await vi.waitFor(() => {
+      expect(screen.getByText("Devuelto a revisión")).toBeDefined();
+    });
+    expect(screen.queryByText("Sin notas adjuntas")).toBeNull();
+  });
+
+  it("runs every revision down one rail, newest decision first", async () => {
+    const older: StateChangeTimelineEntry = { ...rejectionAt("1.0"), id: "round-1" };
+    const newer: StateChangeTimelineEntry = {
+      ...rejectionAt("1.1"),
+      id: "round-2",
+      committedAt: new Date("2026-07-27T20:32:56Z"),
+    };
+    const { container } = renderPanel([older, newer], "1.2");
+
+    screen.getByRole("button", { name: /Revisiones de versiones anteriores/ }).click();
+    await vi.waitFor(() => {
+      expect(screen.getByText("Versión v1.1")).toBeDefined();
+    });
+
+    // One list, so the line is continuous across revisions rather than restarting per group.
+    expect(container.querySelectorAll("ol")).toHaveLength(1);
+    const markers = [...container.querySelectorAll("ol > li")].map((li) =>
+      li.textContent?.startsWith("Versión") ? "version" : "decision"
+    );
+    expect(markers).toEqual(["version", "decision", "version", "decision"]);
+    // Newest revision reached first.
+    expect(container.querySelector("ol > li")?.textContent).toContain("v1.1");
   });
 
   it("shows the rejection as the live state while it still describes the photo on screen", () => {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/version-history.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/version-history.tsx
@@ -30,6 +30,17 @@ const VERDICT = {
 const muted = "text-xs text-gray-400 dark:text-gray-500";
 
 /**
+ * Puts a marker on the rail rather than beside it.
+ *
+ * `-left-5` cancels the list's `pl-5`, which lands the marker's *left edge* on the line;
+ * `-translate-x-1/2` then pulls it back by half its own width so its *centre* sits there. Both
+ * halves are needed — the offset alone is what left the dots hanging off the right of the line.
+ *
+ * `top-1` centres it on a 16px `text-xs` line: (16 - 8) / 2 = 4px.
+ */
+const MARKER = "absolute -left-5 top-1 h-2 w-2 -translate-x-1/2 rounded-full";
+
+/**
  * One decision, as a point on the rail.
  *
  * Deliberately not an ObservationCard. History is read past-tense and several entries at a
@@ -48,7 +59,7 @@ function DecisionPoint({
   const style = VERDICT[entry.status];
   return (
     <li className="relative">
-      <span className={`absolute -left-5 top-1.5 h-2 w-2 rounded-full ${style.dot}`} />
+      <span className={`${MARKER} ${style.dot}`} />
       <div className="flex flex-wrap items-baseline gap-x-2">
         <span className={`text-xs font-semibold ${style.label}`}>
           {tr(style.key, dictionary)}
@@ -126,7 +137,7 @@ export function VersionHistory({
             <Fragment key={group.version ?? "unversioned"}>
               <li className="relative">
                 {/* Hollow, so a revision marker never reads as a decision. */}
-                <span className="absolute -left-5 top-1 h-2 w-2 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800" />
+                <span className={`${MARKER} border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800`} />
                 <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
                   {group.version
                     ? tr("bento.multimedia.sidebar_obs_history_version", dictionary, {

--- a/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/version-history.tsx
+++ b/turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/observations/version-history.tsx
@@ -1,11 +1,83 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { HiChevronRight } from "react-icons/hi2";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 import { tr } from "@/features/i18n/tr.service";
+import { formatDateString } from "@/features/common/components/formatted-date/formatted-date";
+import type { StateChangeTimelineEntry } from "./observation.types";
+import { observationTypeLabel } from "./observation-utils";
 import type { VersionGroup } from "./review-version";
-import { StateChangeEntry } from "./state-change-entry";
+
+const VERDICT = {
+  approved: {
+    dot: "bg-green-500",
+    label: "text-green-700 dark:text-green-400",
+    key: "bento.multimedia.sidebar_obs_state_approved",
+  },
+  rejected: {
+    dot: "bg-red-500",
+    label: "text-red-700 dark:text-red-400",
+    key: "bento.multimedia.sidebar_obs_state_rejected",
+  },
+  pending: {
+    dot: "bg-amber-500",
+    label: "text-amber-700 dark:text-amber-400",
+    key: "bento.multimedia.sidebar_obs_state_pending",
+  },
+} as const;
+
+const muted = "text-xs text-gray-400 dark:text-gray-500";
+
+/**
+ * One decision, as a point on the rail.
+ *
+ * Deliberately not an ObservationCard. History is read past-tense and several entries at a
+ * time, and a card each stacked four bordered boxes down a narrow column for what is really
+ * four lines of text. The dot carries the verdict, which frees the reasons and the comment to
+ * be plain prose underneath it.
+ *
+ * A decision nobody wrote anything on renders as its line alone. The live panel says "sin notas
+ * adjuntas" in that spot, which earns its room when you are being asked to act on the thing; in
+ * a list of matters already settled it is four words of nothing, repeated.
+ */
+function DecisionPoint({
+  entry,
+  dictionary,
+}: Readonly<{ entry: StateChangeTimelineEntry; dictionary: I18nRecord }>) {
+  const style = VERDICT[entry.status];
+  return (
+    <li className="relative">
+      <span className={`absolute -left-5 top-1.5 h-2 w-2 rounded-full ${style.dot}`} />
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className={`text-xs font-semibold ${style.label}`}>
+          {tr(style.key, dictionary)}
+        </span>
+        <span className={muted}>{formatDateString(entry.committedAt.toISOString())}</span>
+        {entry.committedBy && (
+          <span className={`${muted} truncate max-w-28`} title={entry.committedBy}>
+            · {entry.committedBy}
+          </span>
+        )}
+      </div>
+      {entry.observations.map((obs) => (
+        <div key={obs.id} className="mt-0.5">
+          {obs.types.length > 0 && (
+            // Middots rather than chips: a chip is a box, and these are read, not clicked.
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {obs.types.map((type) => observationTypeLabel(type, dictionary)).join(" · ")}
+            </p>
+          )}
+          {obs.description && (
+            <p className="text-xs text-gray-600 dark:text-gray-300 whitespace-pre-line">
+              {obs.description}
+            </p>
+          )}
+        </div>
+      ))}
+    </li>
+  );
+}
 
 /**
  * Decisions taken against revisions this content has since replaced.
@@ -15,9 +87,9 @@ import { StateChangeEntry } from "./state-change-entry";
  * screen — but deleting it from view would lose the only record of why the driver was asked to
  * re-send. Collapsed by default: the reviewer's job is the revision in front of them.
  *
- * Read-only throughout: no handlers are passed, so no card offers a control. Every entry here
- * is a review round, which the repository stores as the decision itself and gives no endpoint
- * to edit — the same reason the live panel withholds those controls from round observations.
+ * Read-only throughout — no handler reaches any of it. Every entry here is a review round,
+ * which the repository stores as the decision itself and gives no endpoint to edit, the same
+ * reason the live panel withholds those controls from round observations.
  */
 export function VersionHistory({
   groups,
@@ -46,25 +118,32 @@ export function VersionHistory({
       </button>
 
       {isOpen && (
-        <div className="flex flex-col gap-3 pl-1">
+        // One rail for the whole history rather than one per revision, so the eye follows a
+        // single line from the newest decision back to the first and the version labels read as
+        // markers along it.
+        <ol className="ml-1.5 pl-5 border-l border-gray-200 dark:border-gray-700 flex flex-col gap-3">
           {groups.map((group) => (
-            <div key={group.version ?? "unversioned"} className="flex flex-col gap-2">
-              <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
-                {group.version
-                  ? tr("bento.multimedia.sidebar_obs_history_version", dictionary, {
-                      version: group.version,
-                    })
-                  : tr("bento.multimedia.sidebar_obs_history_unversioned", dictionary)}
-              </span>
-              {/* Newest decision first, as the live panel above orders its own. */}
+            <Fragment key={group.version ?? "unversioned"}>
+              <li className="relative">
+                {/* Hollow, so a revision marker never reads as a decision. */}
+                <span className="absolute -left-5 top-1 h-2 w-2 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800" />
+                <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
+                  {group.version
+                    ? tr("bento.multimedia.sidebar_obs_history_version", dictionary, {
+                        version: group.version,
+                      })
+                    : tr("bento.multimedia.sidebar_obs_history_unversioned", dictionary)}
+                </span>
+              </li>
+              {/* Newest decision first, as the live panel orders its own. */}
               {[...group.entries].reverse().map((entry) =>
                 entry.kind === "state_change" ? (
-                  <StateChangeEntry key={entry.id} entry={entry} dictionary={dictionary} />
+                  <DecisionPoint key={entry.id} entry={entry} dictionary={dictionary} />
                 ) : null
               )}
-            </div>
+            </Fragment>
           ))}
-        </div>
+        </ol>
       )}
     </div>
   );


### PR DESCRIPTION
Follow-up to #1025, which shipped the version-scoped review history as a stack of cards.

Four decisions on one revision rendered as four bordered boxes down a ~300px column — two of
them a box whose entire body read *"Sin notas adjuntas"*. The card is right for the live panel,
where each entry is something to act on; history is read past-tense and several at a time, and
the borders were only taking room.

**Before → after**

```
┌──────────────────────────────┐        ○ Versión v1.1
│ Rechazado    14:32 · mdavid… │        ● Rechazado            14:32 · mdavid…
├──────────────────────────────┤            Documento dañado
│ [Documento dañado]  mdavid…  │            Mensaje de prueba el documento…
│ Mensaje de prueba el docum…  │        ● Devuelto a revisión  14:32 · mdavid…
└──────────────────────────────┘        ● Rechazado            13:23 · mdavid…
┌──────────────────────────────┐            Calidad de imagen deficiente
│ Devuelto a revisión   14:32  │            La imagen es deficiente
├──────────────────────────────┤        ● Devuelto a revisión  13:22 · mdavid…
│ Sin notas adjuntas           │
└──────────────────────────────┘
```

- **No borders.** The dot carries the verdict colour — which is all the coloured header bar was
  doing — so reasons and comment become plain prose beneath it.
- **Reason chips → middot-separated text.** A chip is a small box, and these are read, not clicked.
- **`Sin notas adjuntas` dropped from history.** It earns its room in the live panel, where you
  are being asked to act; in a list of settled matters it is three words of nothing, repeated.
- **One rail across all revisions**, version labels as hollow markers along it rather than each
  revision restarting its own list. Hollow vs filled keeps a revision marker from reading as a
  decision.

The live panel still uses the cards — only history changed.

## Second commit: the markers were off the line

`-left-5` cancels the list's `pl-5`, which lands a marker's left *edge* on the rail, so every
dot hung off to its right. `-translate-x-1/2` pulls it back half its own width, putting the
centre there. Both markers now share one constant — they have to agree with each other *and*
with the list padding to sit on the line at all. Decision dots also moved `top-1.5` → `top-1`,
where an 8px dot actually centres on a 16px `text-xs` line.

## Verification

`check-types` clean, 117 tests pass. New cases cover the empty-decision line, reasons rendering
as prose, the single-`<ol>` marker ordering, and that both markers carry `-left-5` **and**
`-translate-x-1/2` — jsdom does no layout, so that last one guards the rule rather than the
pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
