### PR TITLE
fix(web): preserve standalone output in Next config

### DIFF
--- a/turbo-repo/apps/web/next.config.ts
+++ b/turbo-repo/apps/web/next.config.ts
@@ -10,7 +10,9 @@ const nextConfig: NextConfig = {
   transpilePackages: ["flowbite-react"],
 };
 
-// Cast: the monorepo has two hoisted copies of "next" (root + apps/web) with
-// slightly different NextConfig types; next-intl/plugin resolves the root's.
-// Both are structurally the same config object at runtime.
-export default withNextIntl(withFlowbiteReact(nextConfig) as Parameters<typeof withNextIntl>[0]);
+// Apply Flowbite last so it resolves next-intl's config function before
+// extending it. Applying next-intl last treats the function as an object and
+// drops base settings such as `output: "standalone"`.
+export default withFlowbiteReact(
+  withNextIntl(nextConfig) as Parameters<typeof withFlowbiteReact>[0],
+);


### PR DESCRIPTION
## Root cause

The Web CI build succeeded but produced no `.next/standalone` directory. `next.config.ts` applied `next-intl` after Flowbite; Flowbite returns an async Next config function, and `next-intl` treated that function as a plain config object. This dropped base settings including `output: "standalone"`.

This caused [Web CI run 30310677417](https://github.com/microboxlabs/modulariot/actions/runs/30310677417/job/90125303552) to fail while preparing the Docker context.

## Fix

Apply Flowbite last so it resolves and extends the config function returned by `next-intl`. The effective configuration now retains `output: "standalone"`.

## Validation

- verified the effective Next config reports `output: standalone`
- forced a non-cached `@modulariot/web` production build
- verified `.next/standalone/apps/web/server.js` exists
- ran the exact CI artifact-copy commands
- built the production Docker image for `linux/amd64`
- started the container and passed an HTTP smoke test