### PR TITLE
fix(ci): resolve release-train component versions from git, not the milestone

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -55,6 +55,24 @@ const bumpPatch = (version) => {
   return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
 };
 
+// An absent milestone makes every `gh` query below return an empty set, which used to
+// plan a silent no-change release: every component fell back to its last released tag.
+const milestoneTitles = run("gh", [
+  "api",
+  "--paginate",
+  `repos/${repo}/milestones?state=all&per_page=100`,
+  "--jq",
+  ".[].title",
+])
+  .split("\n")
+  .map((title) => title.trim());
+
+if (!milestoneTitles.includes(milestone)) {
+  throw new Error(
+    `Milestone ${milestone} does not exist in ${repo}. Create it and attach this release's issues before running the release train.`,
+  );
+}
+
 const prListJson = run("gh", [
   "pr",
   "list",
@@ -107,6 +125,13 @@ for (const issue of JSON.parse(issueListJson)) {
 }
 
 const prs = [...prByNumber.values()].sort((a, b) => a.number - b.number);
+
+if (prs.length === 0) {
+  throw new Error(
+    `Milestone ${milestone} has no merged pull requests. Attach the release's PRs, or the issues they closed, to the milestone before running the release train.`,
+  );
+}
+
 const changedFiles = new Set();
 
 for (const pr of prs) {
@@ -119,12 +144,29 @@ for (const pr of prs) {
   }
 }
 
-const pathStarts = (prefixes) => [...changedFiles].some((file) => prefixes.some((prefix) => file.startsWith(prefix)));
+// Change detection compares the tree against each component's last released tag rather
+// than against the milestone's file set. Work merged to trunk without being attached to
+// the milestone is invisible to `gh`, and treating that as "unchanged" pins the component
+// to its last tag and reships a stale image.
+const changedSince = (baselineTag, prefixes) => {
+  if (!baselineTag) return true;
+  return run("git", ["diff", "--name-only", `${baselineTag}..HEAD`, "--", ...prefixes]).length > 0;
+};
+
+const latestDocsVersion = latestVersion("docs@v*", "docs@v");
+const latestWebVersion = latestVersion("web@v*", "web@v");
+const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
+const latestHarnessVersion = latestVersion("harness@v*", "harness@v");
+
+const docsBaseline = latestDocsVersion ? `docs@v${latestDocsVersion}` : "";
+const webBaseline = latestWebVersion ? `web@v${latestWebVersion}` : "";
+const modulithBaseline = latestModulithVersion ? `modulith@v${latestModulithVersion}` : "";
+const harnessBaseline = latestHarnessVersion ? `harness@v${latestHarnessVersion}` : "";
 
 // Stack release notes are bundled into the Next.js app, so the app package,
 // tag, and image intentionally stay in sync with the stack version.
 const appChanged = true;
-const docsChanged = pathStarts([
+const docsChanged = changedSince(docsBaseline, [
   "turbo-repo/apps/docs/",
   "turbo-repo/packages/ui/",
   "turbo-repo/packages/typescript-config/",
@@ -132,23 +174,18 @@ const docsChanged = pathStarts([
   "turbo-repo/package-lock.json",
   "turbo-repo/docker/nextjs.standalone-docs.Dockerfile",
 ]);
-const latestWebVersion = latestVersion("web@v*", "web@v");
-const webChanged =
-  pathStarts([
-    "turbo-repo/apps/web/",
-    "turbo-repo/packages/typescript-config/",
-    "turbo-repo/packages/eslint-config/",
-    "turbo-repo/package-lock.json",
-    "turbo-repo/docker/nextjs.standalone.Dockerfile",
-  ]) || !latestWebVersion;
-const modulithChanged = pathStarts(["quarkus-srv/"]);
+const webChanged = changedSince(webBaseline, [
+  "turbo-repo/apps/web/",
+  "turbo-repo/packages/typescript-config/",
+  "turbo-repo/packages/eslint-config/",
+  "turbo-repo/package-lock.json",
+  "turbo-repo/docker/nextjs.standalone.Dockerfile",
+]);
+const modulithChanged = changedSince(modulithBaseline, ["quarkus-srv/"]);
+const harnessChanged = changedSince(harnessBaseline, ["miot-harness/"]);
 
-const latestDocsVersion = latestVersion("docs@v*", "docs@v");
-const latestModulithVersion = latestVersion("modulith@v*", "modulith@v");
-const latestHarnessVersion = latestVersion("harness@v*", "harness@v");
 const currentHarnessVersion = projectVersion("miot-harness/pyproject.toml");
 const harnessBaseVersion = maxVersion(latestHarnessVersion, currentHarnessVersion);
-const harnessChanged = pathStarts(["miot-harness/"]) || !latestHarnessVersion;
 const appVersion = stackVersion;
 const docsVersion = docsChanged ? stackVersion : latestDocsVersion;
 const webVersion = webChanged ? stackVersion : latestWebVersion;
@@ -156,26 +193,27 @@ const modulithVersion = modulithChanged ? bumpPatch(latestModulithVersion) : lat
 const harnessVersion = harnessChanged ? bumpPatch(harnessBaseVersion) : harnessBaseVersion;
 
 if (!appVersion) {
-  throw new Error("No app@v* tag exists and the app did not change in this milestone.");
+  throw new Error("Could not resolve an app version: no app@v* tag and no stack version.");
 }
 if (!docsVersion) {
-  throw new Error("No docs@v* tag exists and the docs did not change in this milestone.");
+  throw new Error("Could not resolve a docs version: no docs@v* tag and docs reported unchanged.");
 }
 if (!webVersion) {
-  throw new Error("No web@v* tag exists and the web app did not change in this milestone.");
+  throw new Error("Could not resolve a web version: no web@v* tag and the web app reported unchanged.");
 }
 if (!modulithVersion) {
-  throw new Error("No modulith@v* tag exists and the modulith did not change in this milestone.");
+  throw new Error("Could not resolve a modulith version: no modulith@v* tag and the modulith reported unchanged.");
 }
 if (!harnessVersion) {
-  throw new Error("No harness@v* tag exists and the harness did not change in this milestone.");
+  throw new Error("Could not resolve a harness version: no harness@v* tag and the harness reported unchanged.");
 }
 const plan = {
   stack_version: stackVersion,
   stack_tag: `miot-stack@v${stackVersion}`,
   milestone,
   pull_requests: prs,
-  changed_files: [...changedFiles].sort(),
+  // Provenance of the milestone, not the input to change detection: see changedSince.
+  milestone_changed_files: [...changedFiles].sort(),
   components: {
     app: {
       changed: appChanged,
@@ -184,21 +222,25 @@ const plan = {
     },
     docs: {
       changed: docsChanged,
+      changed_since: docsBaseline || null,
       version: docsVersion,
       tag: `docs@v${docsVersion}`,
     },
     web: {
       changed: webChanged,
+      changed_since: webBaseline || null,
       version: webVersion,
       tag: `web@v${webVersion}`,
     },
     modulith: {
       changed: modulithChanged,
+      changed_since: modulithBaseline || null,
       version: modulithVersion,
       tag: `modulith@v${modulithVersion}`,
     },
     harness: {
       changed: harnessChanged,
+      changed_since: harnessBaseline || null,
       version: harnessVersion,
       tag: `harness@v${harnessVersion}`,
     },
@@ -214,15 +256,19 @@ const outputs = {
   app_version: appVersion,
   app_tag: plan.components.app.tag,
   docs_changed: String(docsChanged),
+  docs_changed_since: docsBaseline || "no previous tag",
   docs_version: docsVersion,
   docs_tag: plan.components.docs.tag,
   web_changed: String(webChanged),
+  web_changed_since: webBaseline || "no previous tag",
   web_version: webVersion,
   web_tag: plan.components.web.tag,
   modulith_changed: String(modulithChanged),
+  modulith_changed_since: modulithBaseline || "no previous tag",
   modulith_version: modulithVersion,
   modulith_tag: plan.components.modulith.tag,
   harness_changed: String(harnessChanged),
+  harness_changed_since: harnessBaseline || "no previous tag",
   harness_version: harnessVersion,
   harness_tag: plan.components.harness.tag,
   stack_tag: plan.stack_tag,

--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -369,10 +369,10 @@ jobs:
 
           Components:
           - App: ${{ steps.plan.outputs.app_tag }} (changed: ${{ steps.plan.outputs.app_changed }})
-          - Docs: ${{ steps.plan.outputs.docs_tag }} (changed: ${{ steps.plan.outputs.docs_changed }})
-          - Web: ${{ steps.plan.outputs.web_tag }} (changed: ${{ steps.plan.outputs.web_changed }})
-          - Modulith: ${{ steps.plan.outputs.modulith_tag }} (changed: ${{ steps.plan.outputs.modulith_changed }})
-          - Harness: ${{ steps.plan.outputs.harness_tag }} (changed: ${{ steps.plan.outputs.harness_changed }})
+          - Docs: ${{ steps.plan.outputs.docs_tag }} (changed: ${{ steps.plan.outputs.docs_changed }} since ${{ steps.plan.outputs.docs_changed_since }})
+          - Web: ${{ steps.plan.outputs.web_tag }} (changed: ${{ steps.plan.outputs.web_changed }} since ${{ steps.plan.outputs.web_changed_since }})
+          - Modulith: ${{ steps.plan.outputs.modulith_tag }} (changed: ${{ steps.plan.outputs.modulith_changed }} since ${{ steps.plan.outputs.modulith_changed_since }})
+          - Harness: ${{ steps.plan.outputs.harness_tag }} (changed: ${{ steps.plan.outputs.harness_changed }} since ${{ steps.plan.outputs.harness_changed_since }})
 
           Milestones: ${{ steps.version.outputs.private_milestone }}, ${{ steps.version.outputs.oss_milestone }}.
 


### PR DESCRIPTION
## The bug

Stack `miot-stack@v0.5.27` ([run 30367831811](https://github.com/microboxlabs/modulariot/actions/runs/30367831811)) shipped `modulith-v0.5.17` — an image built on 2026-07-13, **62 `quarkus-srv/` commits stale**. The prior release, v0.5.26, shipped the same stale image (31 commits behind at the time).

Cause: `resolve-stack-release-plan.js` derived every component's `changed` flag from the union of files touched by PRs attached to the `MIOT-<version>` milestone. The train derives that milestone name from the tag counter (`MIOT-0.5.27`), and **that milestone was never created**. Both `gh` queries returned empty, `changedFiles` was empty, so every path-based flag came out `false`:

```
- Docs: docs@v0.5.22 (changed: false)
- Modulith: modulith@v0.5.17 (changed: false)
- Harness: harness@v0.1.3 (changed: false)
```

(`Web: changed: true` was not a counter-example — it came from the `|| !latestWebVersion` fallback, `web@v0.5.27` being the first web tag ever.)

`modulith_changed=false` made `build-modulith` skip its wait+promote steps and simply re-resolve the digest of the existing `modulith-v0.5.17` tag, which then went into the deploy dispatch.

## The fix

**1. Change detection from git, not the milestone.** `pathStarts()` is replaced by `changedSince(baselineTag, prefixes)`, which runs `git diff --name-only <component's last released tag>..HEAD -- <paths>`. Each component compares against its own tag (`docs@v*`, `web@v*`, `modulith@v*`, `harness@v*`), so work that lands on trunk without milestone attachment still triggers a bump. No tag → changed, which absorbs the old `|| !latestWebVersion` / `|| !latestHarnessVersion` special cases and extends the same safety to docs and modulith.

**2. Fail loudly on a missing or empty milestone.** The script now verifies the milestone exists before querying it, and errors if it carries no merged PRs — instead of silently planning a no-change release.

Supporting changes: each component in the plan JSON gains `changed_since`; `changed_files` → `milestone_changed_files` (kept for provenance, no longer drives anything, and the old name invited exactly this misreading — no consumers, grepped); the release PR body prints the baseline.

## Verification

```
$ OSS_MILESTONE=MIOT-0.5.27 node .github/scripts/resolve-stack-release-plan.js
Error: Milestone MIOT-0.5.27 does not exist in microboxlabs/modulariot. ...

$ OSS_MILESTONE=MIOT-0.5.25 node .github/scripts/resolve-stack-release-plan.js
modulith_changed=true
modulith_version=0.5.18
modulith_changed_since=modulith@v0.5.17
```

Also: `node --check`; workflow YAML parses; `git diff` with matching, non-matching and nonexistent pathspecs all exit 0 with empty output, so the `false` branch is reachable.

## Trade-off

Detection is now conservative: a docs-only commit under `quarkus-srv/` flags the modulith as changed, costing a version bump and the up-to-60-minute wait for the trunk CI image. No exclusion patterns were added — over-releasing beats shipping stale.

The workflow re-fetches this script from `$GITHUB_SHA` at run time, so it takes effect on the first release-train run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release planning now stops when the specified milestone is missing or contains no merged pull requests.
  * Component changes are detected more reliably based on changes since each component’s latest release.

* **Release Information**
  * Release pull requests now show when Docs, Web, Modulith, and Harness changes occurred relative to their previous releases.
  * Release plans include clearer component change tracking and version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->