### PR TITLE
fix(ci): warn, don't fail, when a release milestone carries no PRs

### DIFF
--- a/.github/scripts/resolve-stack-release-plan.js
+++ b/.github/scripts/resolve-stack-release-plan.js
@@ -126,9 +126,11 @@ for (const issue of JSON.parse(issueListJson)) {
 
 const prs = [...prByNumber.values()].sort((a, b) => a.number - b.number);
 
+// Not fatal: component versions come from git below, so an unpopulated milestone costs
+// provenance in the plan file, not correctness. Hard-failing here would block hotfixes.
 if (prs.length === 0) {
-  throw new Error(
-    `Milestone ${milestone} has no merged pull requests. Attach the release's PRs, or the issues they closed, to the milestone before running the release train.`,
+  console.log(
+    `::warning::Milestone ${milestone} has no merged pull requests. Component versions still come from git, but this release plan will record no milestone provenance.`,
   );
 }
 


### PR DESCRIPTION
Follow-up to #1030, which added two guards. The second one was the wrong severity.

`prs.length === 0` threw. But since #1030 resolves component versions from `git diff` against each component's last released tag, an unpopulated milestone now costs the plan file its **provenance**, not its **correctness**. Meanwhile, checking the actual history: **no PR merged since `miot-stack@v0.5.26` carries a milestone or a linked closing issue** (`gh pr list --search "merged:>=2026-07-22"`, 40+ PRs, all `NO MILESTONE`). The throw would have blocked every release train run — including the v0.5.28 hotfix needed to unship the stale `modulith-v0.5.17` currently deployed.

So it becomes a `::warning::` annotation instead, surfaced in the run summary.

The missing-milestone check from #1030 stays a hard error: that means release prep was skipped entirely, it's cheap to satisfy, and it's the exact condition that shipped a stale modulith in v0.5.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)