### PR TITLE
chore(release): prepare MIOT stack v0.5.28

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miot-harness"
-version = "0.1.3"
+version = "0.1.4"
 description = "ASK MIOT multi-agent backend harness pilot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1415,7 +1415,7 @@ wheels = [
 
 [[package]]
 name = "miot-harness"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.17</version>
+        <version>0.5.18</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.17</version>
+    <version>0.5.18</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.27.mdx
+++ b/releases/notes/v1.31.27.mdx
@@ -1,0 +1,33 @@
+# 🔔 Release Notes v1.31.27 — ModularIoT
+
+### Fecha: 28/07/2026
+
+**Objetivo**: Esta entrega consolida actualizaciones internas de la plataforma ModularIoT, incluyendo mejoras en la aplicación principal, la documentación, el módulo Modulith y el harness de pruebas. Se garantiza la estabilidad del stack en su versión `0.5.28` sin cambios en el componente web.
+
+## 📊 Beneficios
+
+- Actualización coordinada de múltiples componentes del stack para mantener la coherencia entre servicios.
+- La documentación actualizada (`docs@v0.5.28`) refleja el estado actual de la plataforma y facilita la adopción por parte de nuevos equipos.
+- Las mejoras en `modulith@v0.5.18` contribuyen a la estabilidad del núcleo de orquestación de servicios Quarkus.
+- El harness actualizado (`harness@v0.1.4`) fortalece la capacidad de pruebas automatizadas y validación de integraciones.
+- La aplicación Next.js (`app@v0.5.28`) incorpora los ajustes necesarios para alinearse con las versiones actualizadas del stack.
+- El componente web (`web@v0.5.27`) se mantiene estable sin cambios, evitando regresiones en la interfaz de usuario.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.28` — versión de referencia del stack completo.
+- **App** *(actualizada)*: `app@v0.5.28` — aplicación principal Next.js.
+- **Docs** *(actualizada)*: `docs@v0.5.28` — documentación oficial de la plataforma.
+- **Web** *(sin cambios)*: `web@v0.5.27` — componente web estático sin modificaciones en este ciclo.
+- **Modulith** *(actualizado)*: `modulith@v0.5.18` — módulo de orquestación de servicios Quarkus.
+- **Harness** *(actualizado)*: `harness@v0.1.4` — entorno de pruebas y validación de integraciones.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de compilación dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.27` representa un ciclo de mantenimiento y consolidación del stack ModularIoT, enfocado en mantener la coherencia entre los componentes principales de la plataforma. Aunque no se registran issues públicos asociados a este release, los cambios en `app`, `docs`, `modulith` y `harness` reflejan trabajo continuo de evolución interna.
+
+La estabilidad del componente `web` sin modificaciones garantiza continuidad en la experiencia del usuario final, mientras que las actualizaciones en el harness sientan las bases para ciclos de validación más robustos en próximas entregas.
+
+Se recomienda a los equipos de operaciones verificar el `stack-manifest.json` incluido en los artefactos del release para confirmar los digests de imágenes antes del despliegue en entornos productivos.

--- a/releases/stacks/v0.5.28.plan.json
+++ b/releases/stacks/v0.5.28.plan.json
@@ -1,0 +1,38 @@
+{
+  "stack_version": "0.5.28",
+  "stack_tag": "miot-stack@v0.5.28",
+  "milestone": "MIOT-0.5.28",
+  "pull_requests": [],
+  "milestone_changed_files": [],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.28",
+      "tag": "app@v0.5.28"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.22",
+      "version": "0.5.28",
+      "tag": "docs@v0.5.28"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.27",
+      "version": "0.5.27",
+      "tag": "web@v0.5.27"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.17",
+      "version": "0.5.18",
+      "tag": "modulith@v0.5.18"
+    },
+    "harness": {
+      "changed": true,
+      "changed_since": "harness@v0.1.3",
+      "version": "0.1.4",
+      "tag": "harness@v0.1.4"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.27.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.27.mdx
@@ -1,0 +1,33 @@
+# 🔔 Release Notes v1.31.27 — ModularIoT
+
+### Fecha: 28/07/2026
+
+**Objetivo**: Esta entrega consolida actualizaciones internas de la plataforma ModularIoT, incluyendo mejoras en la aplicación principal, la documentación, el módulo Modulith y el harness de pruebas. Se garantiza la estabilidad del stack en su versión `0.5.28` sin cambios en el componente web.
+
+## 📊 Beneficios
+
+- Actualización coordinada de múltiples componentes del stack para mantener la coherencia entre servicios.
+- La documentación actualizada (`docs@v0.5.28`) refleja el estado actual de la plataforma y facilita la adopción por parte de nuevos equipos.
+- Las mejoras en `modulith@v0.5.18` contribuyen a la estabilidad del núcleo de orquestación de servicios Quarkus.
+- El harness actualizado (`harness@v0.1.4`) fortalece la capacidad de pruebas automatizadas y validación de integraciones.
+- La aplicación Next.js (`app@v0.5.28`) incorpora los ajustes necesarios para alinearse con las versiones actualizadas del stack.
+- El componente web (`web@v0.5.27`) se mantiene estable sin cambios, evitando regresiones en la interfaz de usuario.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.28` — versión de referencia del stack completo.
+- **App** *(actualizada)*: `app@v0.5.28` — aplicación principal Next.js.
+- **Docs** *(actualizada)*: `docs@v0.5.28` — documentación oficial de la plataforma.
+- **Web** *(sin cambios)*: `web@v0.5.27` — componente web estático sin modificaciones en este ciclo.
+- **Modulith** *(actualizado)*: `modulith@v0.5.18` — módulo de orquestación de servicios Quarkus.
+- **Harness** *(actualizado)*: `harness@v0.1.4` — entorno de pruebas y validación de integraciones.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de compilación dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.27` representa un ciclo de mantenimiento y consolidación del stack ModularIoT, enfocado en mantener la coherencia entre los componentes principales de la plataforma. Aunque no se registran issues públicos asociados a este release, los cambios en `app`, `docs`, `modulith` y `harness` reflejan trabajo continuo de evolución interna.
+
+La estabilidad del componente `web` sin modificaciones garantiza continuidad en la experiencia del usuario final, mientras que las actualizaciones en el harness sientan las bases para ciclos de validación más robustos en próximas entregas.
+
+Se recomienda a los equipos de operaciones verificar el `stack-manifest.json` incluido en los artefactos del release para confirmar los digests de imágenes antes del despliegue en entornos productivos.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.22",
+  "version": "0.5.28",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.27",
+      "version": "0.5.28",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -618,7 +618,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.22",
+      "version": "0.5.28",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",


### PR DESCRIPTION
Prepares miot-stack@v0.5.28 from milestone MIOT-0.5.28, with release notes v1.31.27.

Components:
- App: app@v0.5.28 (changed: true)
- Docs: docs@v0.5.28 (changed: true since docs@v0.5.22)
- Web: web@v0.5.27 (changed: false since web@v0.5.27)
- Modulith: modulith@v0.5.18 (changed: true since modulith@v0.5.17)
- Harness: harness@v0.1.4 (changed: true since harness@v0.1.3)

Milestones: Release 1.31.27, MIOT-0.5.28.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
