### PR TITLE
chore(release): prepare MIOT stack v0.5.30

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.18</version>
+        <version>0.5.19</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.18</version>
+    <version>0.5.19</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.29.mdx
+++ b/releases/notes/v1.31.29.mdx
@@ -1,0 +1,42 @@
+# 🔔 Release Notes v1.31.29 — ModularIoT
+
+### Fecha: 31/07/2026
+
+**Objetivo**: Esta release consolida mejoras de experiencia en la capa web pública y fortalece flujos funcionales clave del frontend operativo. El foco estuvo en calidad visual, localización multilenguaje y soporte de credenciales OAuth2 para integraciones más flexibles.
+
+## 🚀 Evolutivos
+
+- **📍 Landing pública, legales, pricing e i18n**
+  - **Key point**: Se mejoró de forma transversal la experiencia del sitio de landing con ajustes visuales, secciones con fondos alternados automáticos, bloque `Trusted by` con animación compatible con preferencias de movimiento reducido, y unificación de navegación, footer y espaciados.
+  - **Technical detail**: Se refactorizaron páginas legales (Términos y Privacidad) hacia layouts reutilizables, se amplió contenido multilenguaje (ES/EN/PT-BR), y se robusteció el módulo de pricing con mejor interacción, traducciones y estados explícitos de ruta no disponible. *(Integración OSS — MIOT-0.5.30)*
+
+- **📍 Formulario OAuth2 genérico y consistencia de estados de calendario**
+  - **Key point**: Se incorporó en frontend el formulario de credenciales OAuth2 client-credentials genérico (incluyendo `token URL`, `client id`, `client secret`, `audience`, `scope` opcional y formato de request), habilitando creación, edición, prueba y guardado.
+  - **Technical detail**: Se corrigió el tipado/parsing del listado de reservas para preservar `status`, `syncStatus` y `syncDetail`, reutilizando uniones de estado del cliente de calendario para mantener consistencia entre datos listados y render de UI operativa. *(Integración OSS — MIOT-0.5.30)*
+
+## 📊 Beneficios
+
+- Mejora clara de la percepción visual y coherencia de marca en la experiencia pública web.
+- Mayor accesibilidad en componentes animados al respetar preferencias de movimiento reducido.
+- Menor duplicación técnica en páginas legales y modales de credenciales gracias a reutilización de estructuras.
+- Soporte operativo ampliado para proveedores OAuth2 tipo machine-to-machine con `audience` como campo de primera clase.
+- Mejor trazabilidad funcional en calendario al conservar estados de ciclo de vida y sincronización en frontend.
+- Mayor cobertura multilenguaje en contenidos de marketing y pricing para despliegues internacionales.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.30`
+- **App**: `app@v0.5.30` (con cambios)
+- **Docs**: `docs@v0.5.30` (con cambios)
+- **Web**: `web@v0.5.30` (con cambios)
+- **Modulith**: `modulith@v0.5.19` (con cambios)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.29 refuerza dos frentes estratégicos: la calidad de la capa pública de producto y la capacidad de integración técnica en flujos reales de operación. Esto mejora tanto la primera impresión comercial como la robustez diaria en entornos conectados.
+
+Además, la consolidación de i18n, layouts reutilizables y formularios compartidos reduce deuda de mantenimiento y facilita iteraciones futuras en web y app. En paralelo, la consistencia de estados de calendario mejora la confiabilidad visual y funcional para equipos operativos.
+
+Con `stack` 0.5.30 como base, esta entrega deja una plataforma más consistente, extensible y preparada para nuevas integraciones y ajustes de experiencia en próximas releases.

--- a/releases/stacks/v0.5.30.plan.json
+++ b/releases/stacks/v0.5.30.plan.json
@@ -1,0 +1,140 @@
+{
+  "stack_version": "0.5.30",
+  "stack_tag": "miot-stack@v0.5.30",
+  "milestone": "MIOT-0.5.30",
+  "pull_requests": [
+    {
+      "number": 1034,
+      "title": "feat(credentials): generic OAuth 2.0 form + fix calendar status being stripped client-side",
+      "source_issues": [
+        {
+          "number": 1037,
+          "title": "feat(credentials): generic OAuth2 form and calendar status schema fix"
+        }
+      ]
+    },
+    {
+      "number": 1038,
+      "title": "Fixes in the main frame for the landing page",
+      "source_issues": [
+        {
+          "number": 1040,
+          "title": "feat(web): landing page UI, legal pages, pricing, and i18n polish"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-core/src/main/resources/application.properties",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/api/OrgAuth0ClientsResource.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/client/Auth0ApplicationsClient.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/Auth0ApplicationRow.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/Auth0ClientSummary.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/Auth0ClientDirectoryService.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/Auth0ClientDirectoryServiceTest.java",
+    "turbo-repo/apps/app/public/credential-logos/auth0-dark.svg",
+    "turbo-repo/apps/app/public/credential-logos/auth0-light.svg",
+    "turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/auth0/m2m-clients/route.ts",
+    "turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts",
+    "turbo-repo/apps/app/src/features/credentials/auth0-clients-data-service.ts",
+    "turbo-repo/apps/app/src/features/credentials/components/auth0-m2m-credential-modal.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/azure-entra-credential-modal.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/credential-form-shell.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/credential-modal-parts.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/credentials-page-content.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/m2m-client-combobox.test.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/m2m-client-combobox.tsx",
+    "turbo-repo/apps/app/src/features/credentials/components/oauth2-credential-modal.tsx",
+    "turbo-repo/apps/app/src/features/credentials/credential.types.test.ts",
+    "turbo-repo/apps/app/src/features/credentials/credential.types.ts",
+    "turbo-repo/apps/app/src/features/credentials/credentials-data-service.test.ts",
+    "turbo-repo/apps/app/src/features/credentials/credentials-data-service.ts",
+    "turbo-repo/apps/app/src/features/credentials/use-credential-form.test.ts",
+    "turbo-repo/apps/app/src/features/credentials/use-credential-form.ts",
+    "turbo-repo/apps/app/src/features/credentials/use-credentials.ts",
+    "turbo-repo/apps/app/src/features/credentials/use-m2m-clients.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/canales/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/contacto/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/layout.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/precios/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/proveedores-gps/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/superprofile/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/torre/page.tsx",
+    "turbo-repo/apps/web/app/globals.css",
+    "turbo-repo/apps/web/app/layout.tsx",
+    "turbo-repo/apps/web/app/page.tsx",
+    "turbo-repo/apps/web/app/privacy/page.tsx",
+    "turbo-repo/apps/web/app/terms/page.tsx",
+    "turbo-repo/apps/web/components/legal/LegalPageLayout.tsx",
+    "turbo-repo/apps/web/components/v2/ConceptGraphic.tsx",
+    "turbo-repo/apps/web/components/v2/ContactForm.tsx",
+    "turbo-repo/apps/web/components/v2/Counter.tsx",
+    "turbo-repo/apps/web/components/v2/DetailPage.tsx",
+    "turbo-repo/apps/web/components/v2/FAQ.tsx",
+    "turbo-repo/apps/web/components/v2/HeroTerminal.tsx",
+    "turbo-repo/apps/web/components/v2/ModuleTabs.tsx",
+    "turbo-repo/apps/web/components/v2/Nav.tsx",
+    "turbo-repo/apps/web/components/v2/PricingCalculator.tsx",
+    "turbo-repo/apps/web/components/v2/PricingFaq.tsx",
+    "turbo-repo/apps/web/components/v2/PricingPage.tsx",
+    "turbo-repo/apps/web/components/v2/PricingTiers.tsx",
+    "turbo-repo/apps/web/components/v2/StepsInteractive.tsx",
+    "turbo-repo/apps/web/components/v2/brand/Logo.tsx",
+    "turbo-repo/apps/web/components/v2/content.en.ts",
+    "turbo-repo/apps/web/components/v2/content.pt.ts",
+    "turbo-repo/apps/web/components/v2/content.ts",
+    "turbo-repo/apps/web/components/v2/pricing-utils.ts",
+    "turbo-repo/apps/web/components/v2/sections/Confiabilidad.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Deployment.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Features.tsx",
+    "turbo-repo/apps/web/components/v2/sections/FinalCta.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Footer.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Hero.tsx",
+    "turbo-repo/apps/web/components/v2/sections/PainOutcome.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Problem.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Stats.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Stories.tsx",
+    "turbo-repo/apps/web/components/v2/sections/TresActos.tsx",
+    "turbo-repo/apps/web/components/v2/sections/TrustedBy.tsx",
+    "turbo-repo/apps/web/components/v2/sections/UseCases.tsx",
+    "turbo-repo/apps/web/components/v2/sections/shared.tsx",
+    "turbo-repo/apps/web/messages/br.json",
+    "turbo-repo/apps/web/messages/en.json",
+    "turbo-repo/apps/web/messages/es.json",
+    "turbo-repo/apps/web/public/clients/mintral-logo.png"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.30",
+      "tag": "app@v0.5.30"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.28",
+      "version": "0.5.30",
+      "tag": "docs@v0.5.30"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.29",
+      "version": "0.5.30",
+      "tag": "web@v0.5.30"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.18",
+      "version": "0.5.19",
+      "tag": "modulith@v0.5.19"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.4",
+      "version": "0.1.4",
+      "tag": "harness@v0.1.4"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.29.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.29.mdx
@@ -1,0 +1,42 @@
+# 🔔 Release Notes v1.31.29 — ModularIoT
+
+### Fecha: 31/07/2026
+
+**Objetivo**: Esta release consolida mejoras de experiencia en la capa web pública y fortalece flujos funcionales clave del frontend operativo. El foco estuvo en calidad visual, localización multilenguaje y soporte de credenciales OAuth2 para integraciones más flexibles.
+
+## 🚀 Evolutivos
+
+- **📍 Landing pública, legales, pricing e i18n**
+  - **Key point**: Se mejoró de forma transversal la experiencia del sitio de landing con ajustes visuales, secciones con fondos alternados automáticos, bloque `Trusted by` con animación compatible con preferencias de movimiento reducido, y unificación de navegación, footer y espaciados.
+  - **Technical detail**: Se refactorizaron páginas legales (Términos y Privacidad) hacia layouts reutilizables, se amplió contenido multilenguaje (ES/EN/PT-BR), y se robusteció el módulo de pricing con mejor interacción, traducciones y estados explícitos de ruta no disponible. *(Integración OSS — MIOT-0.5.30)*
+
+- **📍 Formulario OAuth2 genérico y consistencia de estados de calendario**
+  - **Key point**: Se incorporó en frontend el formulario de credenciales OAuth2 client-credentials genérico (incluyendo `token URL`, `client id`, `client secret`, `audience`, `scope` opcional y formato de request), habilitando creación, edición, prueba y guardado.
+  - **Technical detail**: Se corrigió el tipado/parsing del listado de reservas para preservar `status`, `syncStatus` y `syncDetail`, reutilizando uniones de estado del cliente de calendario para mantener consistencia entre datos listados y render de UI operativa. *(Integración OSS — MIOT-0.5.30)*
+
+## 📊 Beneficios
+
+- Mejora clara de la percepción visual y coherencia de marca en la experiencia pública web.
+- Mayor accesibilidad en componentes animados al respetar preferencias de movimiento reducido.
+- Menor duplicación técnica en páginas legales y modales de credenciales gracias a reutilización de estructuras.
+- Soporte operativo ampliado para proveedores OAuth2 tipo machine-to-machine con `audience` como campo de primera clase.
+- Mejor trazabilidad funcional en calendario al conservar estados de ciclo de vida y sincronización en frontend.
+- Mayor cobertura multilenguaje en contenidos de marketing y pricing para despliegues internacionales.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.30`
+- **App**: `app@v0.5.30` (con cambios)
+- **Docs**: `docs@v0.5.30` (con cambios)
+- **Web**: `web@v0.5.30` (con cambios)
+- **Modulith**: `modulith@v0.5.19` (con cambios)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.29 refuerza dos frentes estratégicos: la calidad de la capa pública de producto y la capacidad de integración técnica en flujos reales de operación. Esto mejora tanto la primera impresión comercial como la robustez diaria en entornos conectados.
+
+Además, la consolidación de i18n, layouts reutilizables y formularios compartidos reduce deuda de mantenimiento y facilita iteraciones futuras en web y app. En paralelo, la consistencia de estados de calendario mejora la confiabilidad visual y funcional para equipos operativos.
+
+Con `stack` 0.5.30 como base, esta entrega deja una plataforma más consistente, extensible y preparada para nuevas integraciones y ajustes de experiencia en próximas releases.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.28",
+  "version": "0.5.30",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.29",
+      "version": "0.5.30",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -618,7 +618,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.28",
+      "version": "0.5.30",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -718,7 +718,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.29",
+      "version": "0.5.30",
       "dependencies": {
         "flowbite-icons": "^1.5.0",
         "flowbite-react": "^0.12.10",


### PR DESCRIPTION
Prepares miot-stack@v0.5.30 from milestone MIOT-0.5.30, with release notes v1.31.29.

Components:
- App: app@v0.5.30 (changed: true)
- Docs: docs@v0.5.30 (changed: true since docs@v0.5.28)
- Web: web@v0.5.30 (changed: true since web@v0.5.29)
- Modulith: modulith@v0.5.19 (changed: true since modulith@v0.5.18)
- Harness: harness@v0.1.4 (changed: false since harness@v0.1.4)

Milestones: Release 1.31.29, MIOT-0.5.30.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generic OAuth 2.0 client-credentials support.
  * Improved calendar status consistency.
  * Enhanced landing pages, legal pages, pricing information, internationalization, accessibility, and reusable layouts.

* **Documentation**
  * Added release notes and release planning details for version 1.31.29.
  * Documented updated application, web, documentation, and platform versions.

* **Chores**
  * Updated application, web, documentation, and backend component versions to align with the 0.5.30 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->