### PR TITLE
feat(integrations): resolve a tenant's connection by template name (P2)

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
@@ -56,14 +56,11 @@ public class IntegrationConnectionRepository {
             LIMIT 1
             """;
 
-    // Resolution for a caller that knows which contract it needs but not which instance serves
-    // it. A template's id is a per-environment UUID, so the portable coordinate is
-    // (tenant, template name) — that is what a workflow variable or a config value can name.
-    //
-    // The template is matched by subquery rather than JOIN so the shared COLUMNS list stays
-    // usable unqualified. Repeating $1 inside it also confines the match to templates the tenant
-    // owns: a connection whose template_id pointed at another tenant's row resolves to nothing
-    // rather than borrowing that tenant's contract.
+    // Keyed on template *name*, not id: template ids are per-environment UUIDs, so a workflow
+    // variable or config value can only name the template. Subquery rather than JOIN keeps the
+    // shared COLUMNS list usable unqualified, and repeating $1 inside it confines the match to
+    // templates the tenant owns — a template_id pointing at another tenant's row resolves to
+    // nothing rather than borrowing its contract.
     private static final String SELECT_ACTIVE_BY_TEMPLATE_NAME = "SELECT " + COLUMNS + """
 
             FROM miot_integrations.integration_connections
@@ -215,15 +212,10 @@ public class IntegrationConnectionRepository {
     }
 
     /**
-     * The connection a tenant uses for a named template, or {@code null} when it has none.
-     *
-     * <p>Ordered like {@link #findActiveByProvider}: ACTIVE first, then a connection whose last
-     * test passed, then the most recently tested — so the instance the operator most recently
-     * validated is the one that serves traffic.
-     *
-     * <p>A tenant with no instance of the template is the normal state during rollout, not an
-     * error. The blank guard runs before {@code client()} so an unnamed template never reaches
-     * the database, mirroring {@link #findByTenantAndId}.
+     * The connection a tenant uses for a named template, or {@code null} when it has none — the
+     * normal state during rollout, not an error. Ordered like {@link #findActiveByProvider} so
+     * the instance the operator most recently validated serves traffic. Blank guard runs before
+     * {@code client()}, mirroring {@link #findByTenantAndId}.
      */
     public IntegrationConnection findActiveByTemplateName(String tenantCode, String templateName) {
         if (tenantCode == null || tenantCode.isBlank()

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java
@@ -56,6 +56,29 @@ public class IntegrationConnectionRepository {
             LIMIT 1
             """;
 
+    // Resolution for a caller that knows which contract it needs but not which instance serves
+    // it. A template's id is a per-environment UUID, so the portable coordinate is
+    // (tenant, template name) — that is what a workflow variable or a config value can name.
+    //
+    // The template is matched by subquery rather than JOIN so the shared COLUMNS list stays
+    // usable unqualified. Repeating $1 inside it also confines the match to templates the tenant
+    // owns: a connection whose template_id pointed at another tenant's row resolves to nothing
+    // rather than borrowing that tenant's contract.
+    private static final String SELECT_ACTIVE_BY_TEMPLATE_NAME = "SELECT " + COLUMNS + """
+
+            FROM miot_integrations.integration_connections
+            WHERE tenant_code = $1
+              AND active
+              AND template_id IN (
+                  SELECT id FROM miot_integrations.integration_templates
+                  WHERE tenant_code = $1 AND lower(name) = lower($2) AND active
+              )
+            ORDER BY (status = 'ACTIVE') DESC,
+                     last_test_result DESC NULLS LAST,
+                     last_tested_at DESC NULLS LAST
+            LIMIT 1
+            """;
+
     // Reverse lookup for inbound Meta webhooks: an inbound event carries only the
     // phone_number_id (which of our numbers received it), so we map that back to the org that
     // owns the active WHATSAPP connection advertising it. provider_type is a literal so the
@@ -186,6 +209,29 @@ public class IntegrationConnectionRepository {
     public IntegrationConnection findActiveByProvider(String tenantCode, ProviderType providerType) {
         var rows = client().preparedQuery(SELECT_ACTIVE_BY_PROVIDER)
                 .execute(Tuple.of(tenantCode, providerType.name()))
+                .await().indefinitely();
+        var iterator = rows.iterator();
+        return iterator.hasNext() ? mapRow(iterator.next()) : null;
+    }
+
+    /**
+     * The connection a tenant uses for a named template, or {@code null} when it has none.
+     *
+     * <p>Ordered like {@link #findActiveByProvider}: ACTIVE first, then a connection whose last
+     * test passed, then the most recently tested — so the instance the operator most recently
+     * validated is the one that serves traffic.
+     *
+     * <p>A tenant with no instance of the template is the normal state during rollout, not an
+     * error. The blank guard runs before {@code client()} so an unnamed template never reaches
+     * the database, mirroring {@link #findByTenantAndId}.
+     */
+    public IntegrationConnection findActiveByTemplateName(String tenantCode, String templateName) {
+        if (tenantCode == null || tenantCode.isBlank()
+                || templateName == null || templateName.isBlank()) {
+            return null;
+        }
+        var rows = client().preparedQuery(SELECT_ACTIVE_BY_TEMPLATE_NAME)
+                .execute(Tuple.of(tenantCode, templateName))
                 .await().indefinitely();
         var iterator = rows.iterator();
         return iterator.hasNext() ? mapRow(iterator.next()) : null;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolver.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolver.java
@@ -10,25 +10,13 @@ import org.jboss.logging.Logger;
 /**
  * Which connection serves a named integration template for a tenant.
  *
- * <p>Callers name a template rather than a connection because a template is the contract they
- * depend on, while the connection is whichever instance a given tenant configured to satisfy it —
- * its own base URL and its own credential. That indirection is the point of the template model:
- * one caller, N tenant-specific credentials, no per-tenant branching in the caller.
+ * <p>Callers name a template — the contract — rather than a connection, so one caller can serve N
+ * tenants each with their own base URL and credential.
  *
- * <p><b>An unresolved template is not an error.</b> Until every tenant has an instance, most
- * lookups return empty and the caller falls back to whatever credential it used before. Failing
- * closed here would break every tenant that has not been migrated yet, which is the opposite of
- * what a rollout needs.
- *
- * <p><b>The logging is a deliverable, not decoration.</b> Retiring a shared environment-configured
- * credential is only safe once no tenant still depends on it, and because the fallback path
- * succeeds just as quietly as the connection path, an absence of errors proves nothing. These two
- * lines are the positive signal: the variable comes out when the "falls back" line has stopped
- * appearing, not when nothing has broken.
- *
- * <p>Both are logged at INFO deliberately. The fallback is an expected transitional state, and at
- * WARN it would be alarming enough to get filtered — which would destroy exactly the signal it
- * exists to provide.
+ * <p>Empty is the normal rollout state, not an error: an unmigrated tenant keeps the credential it
+ * used before. The two log lines are P3's gate — the shared credential comes out when "falls back"
+ * stops appearing, since both paths otherwise succeed equally quietly. Both at INFO because at
+ * WARN the expected fallback would get filtered.
  */
 @ApplicationScoped
 public class TemplateConnectionResolver {
@@ -43,19 +31,14 @@ public class TemplateConnectionResolver {
     }
 
     /**
-     * The tenant's connection for {@code templateName}, or empty when it has no instance and the
-     * caller should use its fallback credential.
-     *
-     * @param tenantCode   the tenant whose instance is wanted; its own templates only
-     * @param templateName the contract being asked for, matched case-insensitively
+     * The tenant's connection for {@code templateName}, or empty when it has none and the caller
+     * should use its fallback credential.
      */
     public Optional<IntegrationConnection> resolve(String tenantCode, String templateName) {
         IntegrationConnection connection =
                 connections.findActiveByTemplateName(tenantCode, templateName);
 
         if (connection == null) {
-            // Named rather than counted so the retirement check is a log query, and worded so
-            // whoever finds it knows what it blocks.
             LOG.infof("Integration template '%s' has no active connection for tenant %s; the "
                             + "caller falls back to its environment-configured credential. "
                             + "Retiring that variable stays blocked while this line appears.",
@@ -63,8 +46,8 @@ public class TemplateConnectionResolver {
             return Optional.empty();
         }
 
-        // The credential profile id is the attribution that matters: it is what distinguishes
-        // one tenant's grant from another's, and it is not itself a secret.
+        // Credential profile id is the attribution that separates one tenant's grant from
+        // another's, and is not itself a secret.
         LOG.infof("Integration template '%s' for tenant %s resolved to connection %s "
                         + "(credential profile %s).",
                 templateName, tenantCode, connection.id(), connection.credentialProfileId());

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolver.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolver.java
@@ -1,0 +1,73 @@
+package com.microboxlabs.miot.integrations.service;
+
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+
+/**
+ * Which connection serves a named integration template for a tenant.
+ *
+ * <p>Callers name a template rather than a connection because a template is the contract they
+ * depend on, while the connection is whichever instance a given tenant configured to satisfy it —
+ * its own base URL and its own credential. That indirection is the point of the template model:
+ * one caller, N tenant-specific credentials, no per-tenant branching in the caller.
+ *
+ * <p><b>An unresolved template is not an error.</b> Until every tenant has an instance, most
+ * lookups return empty and the caller falls back to whatever credential it used before. Failing
+ * closed here would break every tenant that has not been migrated yet, which is the opposite of
+ * what a rollout needs.
+ *
+ * <p><b>The logging is a deliverable, not decoration.</b> Retiring a shared environment-configured
+ * credential is only safe once no tenant still depends on it, and because the fallback path
+ * succeeds just as quietly as the connection path, an absence of errors proves nothing. These two
+ * lines are the positive signal: the variable comes out when the "falls back" line has stopped
+ * appearing, not when nothing has broken.
+ *
+ * <p>Both are logged at INFO deliberately. The fallback is an expected transitional state, and at
+ * WARN it would be alarming enough to get filtered — which would destroy exactly the signal it
+ * exists to provide.
+ */
+@ApplicationScoped
+public class TemplateConnectionResolver {
+
+    private static final Logger LOG = Logger.getLogger(TemplateConnectionResolver.class);
+
+    private final IntegrationConnectionRepository connections;
+
+    @Inject
+    public TemplateConnectionResolver(IntegrationConnectionRepository connections) {
+        this.connections = connections;
+    }
+
+    /**
+     * The tenant's connection for {@code templateName}, or empty when it has no instance and the
+     * caller should use its fallback credential.
+     *
+     * @param tenantCode   the tenant whose instance is wanted; its own templates only
+     * @param templateName the contract being asked for, matched case-insensitively
+     */
+    public Optional<IntegrationConnection> resolve(String tenantCode, String templateName) {
+        IntegrationConnection connection =
+                connections.findActiveByTemplateName(tenantCode, templateName);
+
+        if (connection == null) {
+            // Named rather than counted so the retirement check is a log query, and worded so
+            // whoever finds it knows what it blocks.
+            LOG.infof("Integration template '%s' has no active connection for tenant %s; the "
+                            + "caller falls back to its environment-configured credential. "
+                            + "Retiring that variable stays blocked while this line appears.",
+                    templateName, tenantCode);
+            return Optional.empty();
+        }
+
+        // The credential profile id is the attribution that matters: it is what distinguishes
+        // one tenant's grant from another's, and it is not itself a secret.
+        LOG.infof("Integration template '%s' for tenant %s resolved to connection %s "
+                        + "(credential profile %s).",
+                templateName, tenantCode, connection.id(), connection.credentialProfileId());
+        return Optional.of(connection);
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolverTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolverTest.java
@@ -1,0 +1,109 @@
+package com.microboxlabs.miot.integrations.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TemplateConnectionResolverTest {
+
+    private static final String TENANT = "tenant-1";
+    private static final String TEMPLATE = "ams";
+
+    private final FakeConnections connections = new FakeConnections();
+
+    private TemplateConnectionResolver resolver() {
+        return new TemplateConnectionResolver(connections);
+    }
+
+    private static IntegrationConnection connection(String id, String credentialProfileId) {
+        return new IntegrationConnection(
+                id,
+                TENANT,
+                "AMS reference data",
+                ProviderType.POSTGREST,
+                URI.create("https://example.invalid/api/v1"),
+                credentialProfileId,
+                ConnectionStatus.ACTIVE,
+                null,
+                null,
+                Map.of(),
+                "template-1");
+    }
+
+    @Test
+    void resolvesTheTenantsInstanceOfTheTemplate() {
+        IntegrationConnection stored = connection("conn-1", "cred-1");
+        connections.result = stored;
+
+        var resolved = resolver().resolve(TENANT, TEMPLATE);
+
+        assertTrue(resolved.isPresent());
+        assertSame(stored, resolved.get());
+        assertEquals(List.of(TENANT + "/" + TEMPLATE), connections.lookups);
+    }
+
+    @Test
+    void returnsEmptyWhenTheTenantHasNoInstanceYet() {
+        connections.result = null;
+
+        // The normal state during rollout: the caller keeps its previous credential rather than
+        // failing, so an unmigrated tenant is not broken by this lookup existing.
+        assertTrue(resolver().resolve(TENANT, TEMPLATE).isEmpty());
+    }
+
+    @Test
+    void asksTheRepositoryForTheCallersOwnTenant() {
+        connections.result = null;
+
+        resolver().resolve("other-tenant", TEMPLATE);
+
+        // The tenant is passed straight through: one tenant must never resolve to another's
+        // connection, and the repository's query is what enforces it.
+        assertEquals(List.of("other-tenant/" + TEMPLATE), connections.lookups);
+    }
+
+    @Test
+    void treatsABlankTemplateNameAsUnresolved() {
+        connections.result = connection("conn-1", "cred-1");
+
+        // Guarded in the repository rather than here, so a caller with an unset config value
+        // gets the fallback path instead of an arbitrary connection.
+        assertTrue(new TemplateConnectionResolver(new BlankGuardingConnections())
+                .resolve(TENANT, "")
+                .isEmpty());
+    }
+
+    /** Records what was asked for, so tenant scoping can be asserted without a database. */
+    private static class FakeConnections extends IntegrationConnectionRepository {
+        private final List<String> lookups = new ArrayList<>();
+        private IntegrationConnection result;
+
+        private FakeConnections() {
+            super(null);
+        }
+
+        @Override
+        public IntegrationConnection findActiveByTemplateName(
+                String tenantCode, String templateName) {
+            lookups.add(tenantCode + "/" + templateName);
+            return result;
+        }
+    }
+
+    /** The real blank-name guard, exercised without a pool. */
+    private static final class BlankGuardingConnections extends IntegrationConnectionRepository {
+        private BlankGuardingConnections() {
+            super(null);
+        }
+    }
+}

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolverTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolverTest.java
@@ -56,8 +56,7 @@ class TemplateConnectionResolverTest {
     void returnsEmptyWhenTheTenantHasNoInstanceYet() {
         connections.result = null;
 
-        // The normal state during rollout: the caller keeps its previous credential rather than
-        // failing, so an unmigrated tenant is not broken by this lookup existing.
+        // Rollout state: an unmigrated tenant keeps its previous credential rather than failing.
         assertTrue(resolver().resolve(TENANT, TEMPLATE).isEmpty());
     }
 
@@ -67,8 +66,7 @@ class TemplateConnectionResolverTest {
 
         resolver().resolve("other-tenant", TEMPLATE);
 
-        // The tenant is passed straight through: one tenant must never resolve to another's
-        // connection, and the repository's query is what enforces it.
+        // Passed straight through — one tenant must never resolve to another's connection.
         assertEquals(List.of("other-tenant/" + TEMPLATE), connections.lookups);
     }
 
@@ -76,14 +74,14 @@ class TemplateConnectionResolverTest {
     void treatsABlankTemplateNameAsUnresolved() {
         connections.result = connection("conn-1", "cred-1");
 
-        // Guarded in the repository rather than here, so a caller with an unset config value
-        // gets the fallback path instead of an arbitrary connection.
+        // Guarded in the repository, so an unset config value falls back instead of picking
+        // an arbitrary connection.
         assertTrue(new TemplateConnectionResolver(new BlankGuardingConnections())
                 .resolve(TENANT, "")
                 .isEmpty());
     }
 
-    /** Records what was asked for, so tenant scoping can be asserted without a database. */
+    /** Records lookups so tenant scoping can be asserted without a database. */
     private static class FakeConnections extends IntegrationConnectionRepository {
         private final List<String> lookups = new ArrayList<>();
         private IntegrationConnection result;


### PR DESCRIPTION
First half of P2 (#1039): the lookup a caller needs to reach a tenant's own credential instead of a shared, environment-configured one.

## What this adds

**`IntegrationConnectionRepository.findActiveByTemplateName(tenantCode, templateName)`**

Callers name a *template*, not a connection. The template is the contract they depend on; the connection is whichever instance a given tenant configured to satisfy it, with its own base URL and its own credential. That indirection is the point of the template model — one caller, N tenant-specific credentials, no per-tenant branching in the caller.

Three judgement calls:

- **Matched on name, not id.** A template's id is a per-environment UUID and nothing portable. A workflow variable or a config value can only name the template, so the name is the coordinate that has to work.
- **Subquery, not join.** Keeps the shared `COLUMNS` list usable unqualified — a join would need a `c.`-prefixed copy that drifts from it. Repeating `$1` inside the subquery also confines the match to templates the tenant owns: a connection whose `template_id` pointed at another tenant's row resolves to nothing rather than borrowing that tenant's contract.
- **Ordering mirrors `findActiveByProvider`** — ACTIVE first, then a connection whose last test passed, then most recently tested — so the instance the operator most recently validated is the one that serves traffic.

**`TemplateConnectionResolver`** — thin, but it carries P3's gate.

An unresolved template is *not* an error. Until every tenant has an instance, most lookups return empty and the caller keeps the credential it used before. Failing closed would break every tenant not yet migrated, which is the opposite of what a rollout needs.

The logging is a deliverable rather than decoration. Retiring the shared credential (P3) is only safe once no tenant still depends on it, and the fallback path succeeds exactly as quietly as the connection path — so an absence of errors proves nothing. Two lines carry the signal:

```
template 'ams' for tenant X resolved to connection <id> (credential profile <id>)
template 'ams' has no active connection for tenant X; the caller falls back to its
  environment-configured credential. Retiring that variable stays blocked while this appears.
```

Both at INFO on purpose. The fallback is an expected transitional state; at WARN it would be alarming enough to get filtered, destroying exactly the signal it exists to provide. Resolved calls log the connection id and credential profile id — the attribution that distinguishes one tenant's grant from another's, neither of which is a secret.

## Two corrections to the issue's framing, found while building

- **The modulith has no `ams` caller at all.** Every apparent hit was the unrelated `cl.streamhub.gps.model` package; the environment path lives entirely in ECM. So "env fallback so rollout breaks nothing" isn't about preserving modulith code — nothing there can break, because nothing is there yet. This resolver is infrastructure the call site consumes.
- **Most of the template machinery already existed.** `integration_templates` and `connections.template_id` shipped in V0.6.12, and the admin UI (`templates-list`, `template-form-modal`, `template-picker-modal`, `connection-form-modal`) is already built. P2 needed far less than the issue implied.

## Scope

No caller yet — the call site arrives with the inline-resolution work. The `ams` template and its per-tenant connections are **operator data** created through the existing admin UI, not seeded by migration: templates are tenant-scoped and operator-defined by design, and a seeding migration would collide with operator-created rows.

## Verification

- 374/374 tests pass in `miot-integrations`, including 4 new ones covering resolution, the unmigrated-tenant path, tenant pass-through, and the blank-template-name guard
- `mvn -pl miot-integrations -am test` — BUILD SUCCESS

Refs #1039


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-scoped resolution of active integration connections by template name.
  * Matching is case-insensitive and prioritizes the best available provider connection.
  * Added graceful fallback when the tenant or template is missing or blank.

* **Tests**
  * Added coverage for successful resolution, tenant isolation, missing connections, and blank inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->