### PR TITLE
chore(release): prepare MIOT stack v0.5.31

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.19</version>
+        <version>0.5.20</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.19</version>
+    <version>0.5.20</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.30.mdx
+++ b/releases/notes/v1.31.30.mdx
@@ -1,0 +1,55 @@
+# 🔔 Release Notes v1.31.30 — ModularIoT
+
+### Fecha: 03/08/2026
+
+**Objetivo**: Esta versión fortalece la sincronización operativa entre calendario, workflows e integraciones para que los datos de recursos viajen completos y se configuren de forma segura por organización. Además, mejora la experiencia web pública con avances de SEO y contenido localizado para ampliar alcance y consistencia multilenguaje.
+
+## 🚀 Evolutivos
+
+- **📍 Enriquecimiento de recursos en sincronización de calendario**
+  - **Key point**: Se incorporó enriquecimiento de recursos en flujos de calendario usando bindings tipo fetch, incluyendo plantillas de respuesta para poblar campos del payload y comportamiento fail-closed cuando corresponde.
+  - **Technical detail**: La resolución de bindings considera el contexto del tenant y permite aplicar `calendar.resource_enrichment` antes de operaciones de booking, manteniendo el comportamiento previo cuando no hay binding configurado. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Advanced settings para configuración de enrichment en calendario**
+  - **Key point**: Se añadió un drawer de **Advanced settings** en planificación de calendario para administrar la configuración de resource enrichment sin depender de SQL manual.
+  - **Technical detail**: Incluye selección de conexión/operación, mapeos request/response, alcance por calendario o global, validación de templates con feedback visual y convergencia de componentes compartidos con otras superficies de configuración. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Modelo de integración `ams` con conexiones por tenant**
+  - **Key point**: Se modeló `ams` como template de integración con instancias por tenant y resolución por `(tenant, template)`.
+  - **Technical detail**: Se mantiene fallback al camino de credenciales por entorno para una transición gradual sin ruptura operativa inmediata. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Mejoras SEO y contenido localizado**
+  - **Key point**: Se mejoró metadata SEO, enlaces canónicos, vistas sociales y contenido localizado en páginas de producto.
+  - **Technical detail**: Se incorporaron datos estructurados (FAQ, organización, website), mejoras de navegación por idioma y fallback de locale a español cuando no se detecta idioma. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Identidad operativa completa en pushes de booking**
+  - **Key point**: Ahora cada push de booking de calendario transporta identidad raw del workflow (RUT de conductor, patentes de camión/remolque, código de proveedor) y ETD en formato ISO.
+  - **Technical detail**: La propagación aplica en rutas de estado y operaciones de ensure, preserva campos existentes y omite payload de identidad cuando no hay variables disponibles. 
+
+## 📊 Beneficios
+
+- Mayor trazabilidad de recursos en transiciones de viaje y booking al enviar identidad operativa de forma consistente.
+- Menor fricción operativa al habilitar configuración avanzada desde UI para bindings de enriquecimiento.
+- Mejor robustez de integración con resolución tenant-aware y estrategias fail-closed en fetch de bindings.
+- Evolución controlada de credenciales por tenant con fallback para continuidad durante despliegues progresivos.
+- Mejor visibilidad web y descubribilidad orgánica gracias a SEO técnico y datos estructurados.
+- Experiencia multilenguaje más consistente con mejoras de localización y fallback de idioma.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.31`
+- **App**: `app@v0.5.31` (actualizado)
+- **Docs**: `docs@v0.5.30` (sin cambios)
+- **Web**: `web@v0.5.31` (actualizado)
+- **Modulith**: `modulith@v0.5.20` (actualizado)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+
+Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.30` consolida una mejora clave: que la sincronización de calendario no solo ejecute estados, sino que transporte y resuelva identidad útil para operación en cada transición relevante. Esto reduce vacíos de datos al coordinar recursos en terreno.
+
+En paralelo, se eleva la capacidad de administración de integraciones desde producto, habilitando configuraciones avanzadas de enrichment con validación y alcance por calendario/organización. El resultado es una operación más gobernable y menos dependiente de intervenciones manuales.
+
+Finalmente, los avances de SEO y localización amplían calidad de presencia digital y coherencia de experiencia para audiencias multilenguaje, complementando el foco operativo de esta entrega con impacto de producto hacia afuera.

--- a/releases/stacks/v0.5.31.plan.json
+++ b/releases/stacks/v0.5.31.plan.json
@@ -1,0 +1,144 @@
+{
+  "stack_version": "0.5.31",
+  "stack_tag": "miot-stack@v0.5.31",
+  "milestone": "MIOT-0.5.31",
+  "pull_requests": [
+    {
+      "number": 1043,
+      "title": "Based/fixing seo",
+      "source_issues": [
+        {
+          "number": 1046,
+          "title": "Enhance SEO metadata and localized product content"
+        }
+      ]
+    },
+    {
+      "number": 1044,
+      "title": "feat(integrations): resolve a tenant's connection by template name (P2)",
+      "source_issues": [
+        {
+          "number": 1039,
+          "title": "feat(integrations): model ams as an integration template with per-tenant connections (P2)"
+        }
+      ]
+    },
+    {
+      "number": 1047,
+      "title": "feat(integrations): fetch-shaped event bindings + calendar resource enrichment",
+      "source_issues": [
+        {
+          "number": 1048,
+          "title": "Add fetch-shaped event bindings and calendar resource enrichment"
+        }
+      ]
+    },
+    {
+      "number": 1049,
+      "title": "feat(calendar): advanced-settings drawer with enrichment configurator",
+      "source_issues": [
+        {
+          "number": 1050,
+          "title": "feat(calendar): advanced-settings drawer with enrichment configurator"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-conversational/src/main/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandler.java",
+    "quarkus-srv/miot-conversational/src/test/java/com/microboxlabs/miot/conversational/jobs/JobFailureNotificationHandlerTest.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutor.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/AsyncJob.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationEventBinding.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/IntegrationEventBindingResponse.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/ReportJobRequest.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/UpsertIntegrationEventBindingRequest.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/JobOutcome.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobHandler.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorker.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/AsyncJobRepository.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationConnectionRepository.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationEventBindingRepository.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/AsyncJobService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingFetchService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolver.java",
+    "quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.13__add_binding_response_templates_and_job_result.sql",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectExecutorTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarRejectOnParkTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/events/JobEventEmitterTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/JobFailureNotifyOnParkTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/ModulithJobWorkerTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/AsyncJobServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/EventBindingFetchServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/TemplateConnectionResolverTest.java",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/calendar-rules/calendar-rules.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planning-header.tsx",
+    "turbo-repo/apps/app/src/features/calendar/enrichment/calendar-enrichment-drawer.tsx",
+    "turbo-repo/apps/app/src/features/calendar/enrichment/enrichment-data-service.ts",
+    "turbo-repo/apps/app/src/features/calendar/enrichment/enrichment.types.ts",
+    "turbo-repo/apps/app/src/features/common/components/settings-drawer/settings-drawer-shell.tsx",
+    "turbo-repo/apps/app/src/features/common/templating/template-input.tsx",
+    "turbo-repo/apps/app/src/features/shipping/components/lane/review-settings-drawer.tsx",
+    "turbo-repo/apps/app/src/features/shipping/components/lane/review-template-input.tsx",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/[...slug]/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/canales/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/contacto/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/layout.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/proveedores-gps/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/superprofile/page.tsx",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/torre/page.tsx",
+    "turbo-repo/apps/web/components/v2/Canales.tsx",
+    "turbo-repo/apps/web/components/v2/FAQ.tsx",
+    "turbo-repo/apps/web/components/v2/GpsProviders.tsx",
+    "turbo-repo/apps/web/components/v2/Nav.tsx",
+    "turbo-repo/apps/web/components/v2/SuperProfile.tsx",
+    "turbo-repo/apps/web/components/v2/TorreDeControl.tsx",
+    "turbo-repo/apps/web/components/v2/useLang.ts",
+    "turbo-repo/apps/web/lib/seo.ts",
+    "turbo-repo/apps/web/messages/br.json",
+    "turbo-repo/apps/web/next.config.ts",
+    "turbo-repo/apps/web/proxy.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.31",
+      "tag": "app@v0.5.31"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.30",
+      "version": "0.5.30",
+      "tag": "docs@v0.5.30"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.30",
+      "version": "0.5.31",
+      "tag": "web@v0.5.31"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.19",
+      "version": "0.5.20",
+      "tag": "modulith@v0.5.20"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.4",
+      "version": "0.1.4",
+      "tag": "harness@v0.1.4"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.30.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.30.mdx
@@ -1,0 +1,55 @@
+# 🔔 Release Notes v1.31.30 — ModularIoT
+
+### Fecha: 03/08/2026
+
+**Objetivo**: Esta versión fortalece la sincronización operativa entre calendario, workflows e integraciones para que los datos de recursos viajen completos y se configuren de forma segura por organización. Además, mejora la experiencia web pública con avances de SEO y contenido localizado para ampliar alcance y consistencia multilenguaje.
+
+## 🚀 Evolutivos
+
+- **📍 Enriquecimiento de recursos en sincronización de calendario**
+  - **Key point**: Se incorporó enriquecimiento de recursos en flujos de calendario usando bindings tipo fetch, incluyendo plantillas de respuesta para poblar campos del payload y comportamiento fail-closed cuando corresponde.
+  - **Technical detail**: La resolución de bindings considera el contexto del tenant y permite aplicar `calendar.resource_enrichment` antes de operaciones de booking, manteniendo el comportamiento previo cuando no hay binding configurado. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Advanced settings para configuración de enrichment en calendario**
+  - **Key point**: Se añadió un drawer de **Advanced settings** en planificación de calendario para administrar la configuración de resource enrichment sin depender de SQL manual.
+  - **Technical detail**: Incluye selección de conexión/operación, mapeos request/response, alcance por calendario o global, validación de templates con feedback visual y convergencia de componentes compartidos con otras superficies de configuración. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Modelo de integración `ams` con conexiones por tenant**
+  - **Key point**: Se modeló `ams` como template de integración con instancias por tenant y resolución por `(tenant, template)`.
+  - **Technical detail**: Se mantiene fallback al camino de credenciales por entorno para una transición gradual sin ruptura operativa inmediata. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Mejoras SEO y contenido localizado**
+  - **Key point**: Se mejoró metadata SEO, enlaces canónicos, vistas sociales y contenido localizado en páginas de producto.
+  - **Technical detail**: Se incorporaron datos estructurados (FAQ, organización, website), mejoras de navegación por idioma y fallback de locale a español cuando no se detecta idioma. *(Integración OSS — MIOT-0.5.31)*
+
+- **📍 Identidad operativa completa en pushes de booking**
+  - **Key point**: Ahora cada push de booking de calendario transporta identidad raw del workflow (RUT de conductor, patentes de camión/remolque, código de proveedor) y ETD en formato ISO.
+  - **Technical detail**: La propagación aplica en rutas de estado y operaciones de ensure, preserva campos existentes y omite payload de identidad cuando no hay variables disponibles. 
+
+## 📊 Beneficios
+
+- Mayor trazabilidad de recursos en transiciones de viaje y booking al enviar identidad operativa de forma consistente.
+- Menor fricción operativa al habilitar configuración avanzada desde UI para bindings de enriquecimiento.
+- Mejor robustez de integración con resolución tenant-aware y estrategias fail-closed en fetch de bindings.
+- Evolución controlada de credenciales por tenant con fallback para continuidad durante despliegues progresivos.
+- Mejor visibilidad web y descubribilidad orgánica gracias a SEO técnico y datos estructurados.
+- Experiencia multilenguaje más consistente con mejoras de localización y fallback de idioma.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.31`
+- **App**: `app@v0.5.31` (actualizado)
+- **Docs**: `docs@v0.5.30` (sin cambios)
+- **Web**: `web@v0.5.31` (actualizado)
+- **Modulith**: `modulith@v0.5.20` (actualizado)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+
+Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión `1.31.30` consolida una mejora clave: que la sincronización de calendario no solo ejecute estados, sino que transporte y resuelva identidad útil para operación en cada transición relevante. Esto reduce vacíos de datos al coordinar recursos en terreno.
+
+En paralelo, se eleva la capacidad de administración de integraciones desde producto, habilitando configuraciones avanzadas de enrichment con validación y alcance por calendario/organización. El resultado es una operación más gobernable y menos dependiente de intervenciones manuales.
+
+Finalmente, los avances de SEO y localización amplían calidad de presencia digital y coherencia de experiencia para audiencias multilenguaje, complementando el foco operativo de esta entrega con impacto de producto hacia afuera.

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.30",
+      "version": "0.5.31",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -718,7 +718,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.30",
+      "version": "0.5.31",
       "dependencies": {
         "flowbite-icons": "^1.5.0",
         "flowbite-react": "^0.12.10",


### PR DESCRIPTION
Prepares miot-stack@v0.5.31 from milestone MIOT-0.5.31, with release notes v1.31.30.

Components:
- App: app@v0.5.31 (changed: true)
- Docs: docs@v0.5.30 (changed: false since docs@v0.5.30)
- Web: web@v0.5.31 (changed: true since web@v0.5.30)
- Modulith: modulith@v0.5.20 (changed: true since modulith@v0.5.19)
- Harness: harness@v0.1.4 (changed: false since harness@v0.1.4)

Milestones: Release 1.31.30, MIOT-0.5.31.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release documentation covering calendar enrichment, advanced settings, tenant-scoped integrations, SEO, localization, and booking workflow details.
  * Added the v0.5.31 release plan covering backend, web, app, and integration updates.

* **Chores**
  * Updated application, web, and service components to version 0.5.31/0.5.20.
  * Added English and Spanish release notes for version 1.31.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->