### PR TITLE
feat(calendar): materialize a missing booking from a status patch

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -232,13 +232,15 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
      * the status, so the service materializes at whatever stage first touches
      * the calendar.
      *
-     * <p>Returns {@code null} — falling back to the benign skip — in two cases:
+     * <p>Returns {@code null} — falling back to the benign skip — in three cases:
      * <ul>
      *   <li><b>Terminal target.</b> A missing booking on a FINISHED/CANCELLED
      *       push is usually the cancel's own work (a future-slot cancel deletes
      *       the booking); creating one here would resurrect what was just
      *       released, only to close it. The modulith cannot consult the
      *       workflow, so terminal pushes never create.
+     *   <li><b>No target status.</b> A data-only patch names no lifecycle stage
+     *       — there is no "stage the service first touched" to materialize at.
      *   <li><b>No ETD.</b> Patch payloads carry no explicit slot, so without a
      *       parseable ETD there is nothing to place the booking at.
      * </ul>
@@ -246,7 +248,8 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
     private JobOutcome materializeFromPatch(Map<String, Object> payload, String resourceId,
                                             UUID calendarId, String targetStatus,
                                             Map<String, Object> resourceData) {
-        if (calendarId == null || CalendarSyncFeature.isTerminalStatus(targetStatus)) {
+        if (calendarId == null || targetStatus == null
+                || CalendarSyncFeature.isTerminalStatus(targetStatus)) {
             return null;
         }
         String etd = resourceData == null ? null
@@ -307,7 +310,8 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
             }
             throw e;
         }
-        applyStatus(resourceId, calendarId, targetStatus);
+        applyStatus(resourceId, calendarId, targetStatus,
+                str(payload, CalendarSyncFeature.PAYLOAD_SYNC_STATUS));
         LOG.infof("calendar_sync ensure created booking %s for %s at %s %02d:%02d -> %s",
                 bookingId, resourceId, slot.date(), slot.hour(), slot.minutes(), targetStatus);
         return JobOutcome.succeeded("Ensured (created) booking " + bookingId + " for " + resourceId
@@ -351,19 +355,21 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
     }
 
     /**
-     * Set the stage status on the booking we just created. Unlike a status-only
-     * push, a 404 here is NOT benign — the booking exists (we just created it), so
-     * a 404 is a visibility-lag anomaly; propagate it so a retry (whose
-     * {@code listByResource} then finds the booking) converges rather than
-     * reporting success with the status unset. Only 409 (the create default
-     * already at/ahead of the target) is benign.
+     * Set the stage status on the booking we just created, carrying the
+     * originating push's {@code syncStatus} (null leaves it untouched) — a
+     * materialized patch must not lose the confirmation window its payload
+     * opened. Unlike a status-only push, a 404 here is NOT benign — the booking
+     * exists (we just created it), so a 404 is a visibility-lag anomaly;
+     * propagate it so a retry (whose {@code listByResource} then finds the
+     * booking) converges rather than reporting success with the status unset.
+     * Only 409 (the create default already at/ahead of the target) is benign.
      */
-    private void applyStatus(String resourceId, UUID calendarId, String targetStatus) {
+    private void applyStatus(String resourceId, UUID calendarId, String targetStatus, String syncStatus) {
         if (targetStatus == null) {
             return;
         }
         try {
-            client.patchByResource(resourceId, calendarId, targetStatus, null);
+            client.patchByResource(resourceId, calendarId, targetStatus, null, syncStatus, null);
         } catch (CalendarBookingsHttpException e) {
             if (e.getStatus() != 409) {
                 throw e;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -25,11 +25,14 @@ import org.jboss.logging.Logger;
  * self-contained payload into miot-calendar calls. Ported verbatim from ECM's
  * {@code CalendarSyncJobExecutor} — the moved runtime is the only change.
  *
- * <p>Outcome policy: 404 (no booking) and 409 (status regression — a newer
- * status already applied by an out-of-order sibling) are benign SKIPs; transport
- * / 5xx / network ({@code -1}) errors are thrown so the worker reports FAILED and
- * the ledger retries with backoff. miot-calendar only moves statuses forward, so
- * unordered jobs converge on the max status.
+ * <p>Outcome policy: 409 (status regression — a newer status already applied by
+ * an out-of-order sibling) is a benign SKIP; transport / 5xx / network
+ * ({@code -1}) errors are thrown so the worker reports FAILED and the ledger
+ * retries with backoff. miot-calendar only moves statuses forward, so unordered
+ * jobs converge on the max status. A patch 404 (no booking) creates the booking
+ * and applies the status when the payload carries an ETD and the target is
+ * non-terminal (see {@code materializeFromPatch}); otherwise it too is a benign
+ * SKIP.
  *
  * <p><b>Except when a regression is the point.</b> The workflow is not
  * monotonic — a service can go back from {@code presentDriver} to
@@ -205,12 +208,57 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
             client.patchByResource(resourceId, calendarId, targetStatus, resourceData, syncStatus, null);
             return JobOutcome.succeeded("Booking patched to " + targetStatus + " for " + resourceId);
         } catch (CalendarBookingsHttpException e) {
+            if (e.getStatus() == 404) {
+                JobOutcome materialized = materializeFromPatch(payload, resourceId, calendarId,
+                        targetStatus, resourceData);
+                if (materialized != null) {
+                    return materialized;
+                }
+            }
             JobOutcome benign = benignSkip(e, resourceId, targetStatus);
             if (benign != null) {
                 return benign;
             }
             throw e;
         }
+    }
+
+    /**
+     * A patch that finds no booking used to be a benign skip in every case —
+     * right for a straggler, wrong for a service that entered the workflow
+     * without ever being planned through the calendar: each of its pushes 404'd
+     * and it never appeared at all. When the patch carries an ETD (it rides
+     * {@code resourceData} on every push), create the booking and then apply
+     * the status, so the service materializes at whatever stage first touches
+     * the calendar.
+     *
+     * <p>Returns {@code null} — falling back to the benign skip — in two cases:
+     * <ul>
+     *   <li><b>Terminal target.</b> A missing booking on a FINISHED/CANCELLED
+     *       push is usually the cancel's own work (a future-slot cancel deletes
+     *       the booking); creating one here would resurrect what was just
+     *       released, only to close it. The modulith cannot consult the
+     *       workflow, so terminal pushes never create.
+     *   <li><b>No ETD.</b> Patch payloads carry no explicit slot, so without a
+     *       parseable ETD there is nothing to place the booking at.
+     * </ul>
+     */
+    private JobOutcome materializeFromPatch(Map<String, Object> payload, String resourceId,
+                                            UUID calendarId, String targetStatus,
+                                            Map<String, Object> resourceData) {
+        if (calendarId == null || CalendarSyncFeature.isTerminalStatus(targetStatus)) {
+            return null;
+        }
+        String etd = resourceData == null ? null
+                : str(resourceData, CalendarSyncFeature.DATA_EXPECTED_DEPARTURE_DATE);
+        if (etd == null) {
+            return null;
+        }
+        Map<String, Object> createPayload = new LinkedHashMap<>(payload);
+        createPayload.put(CalendarSyncFeature.PAYLOAD_ETD, etd);
+        LOG.infof("calendar_sync patch: no booking for %s — materializing one from the patch "
+                + "(etd=%s, target=%s)", resourceId, etd, targetStatus);
+        return ensureCreate(createPayload, resourceId, calendarId, targetStatus, resourceData);
     }
 
     /**

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
@@ -97,4 +97,19 @@ public final class CalendarSyncFeature {
 
     /** Terminal booking status pushed for a past-slot cancel (keep history). */
     public static final String STATUS_CANCELLED = "CANCELLED";
+
+    /** Terminal booking status pushed when the trip ends normally. */
+    public static final String STATUS_FINISHED = "FINISHED";
+
+    /**
+     * {@link #PAYLOAD_RESOURCE_DATA} key carrying the workflow's ISO ETD on
+     * every push — the producer writes it alongside the {@code mintral_*}
+     * identity, so a patch holds enough to place a booking that never existed.
+     */
+    public static final String DATA_EXPECTED_DEPARTURE_DATE = "expectedDepartureDate";
+
+    /** After these a booking's lifecycle is over — a missing one must stay missing. */
+    public static boolean isTerminalStatus(String status) {
+        return STATUS_FINISHED.equals(status) || STATUS_CANCELLED.equals(status);
+    }
 }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -275,6 +275,41 @@ class CalendarSyncExecutorTest {
     }
 
     @Test
+    void patch404MaterializationForwardsSyncStatus() {
+        // The assign chain stamps syncStatus=PENDING to open the confirmation
+        // window — a materialized patch must carry it onto the created booking.
+        FakeClient client = new FakeClient();
+        client.patchThrowsOnce = new CalendarBookingsHttpException(404, "no booking");
+        client.availableSlots = List.of(slot(LocalDate.of(2026, 7, 15), 14, 0, 1));
+        Map<String, Object> payload = patchPayload("ASSIGNED");
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                identityDataWithEtd("2026-07-15T10:00:00Z"));
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(2, client.patchCalls, "the 404'd patch, then the post-create status apply");
+        assertEquals("PENDING", client.lastPatchSyncStatus,
+                "the post-create patch must forward the original syncStatus");
+    }
+
+    @Test
+    void patch404DataOnlyPatchStaysSkipped() {
+        // No target status → no stage to materialize at, even with an ETD.
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(404, "no booking");
+        Map<String, Object> payload = patchPayload(null);
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                identityDataWithEtd("2026-07-15T10:00:00Z"));
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+        assertEquals(0, client.createCalls, "a data-only patch must not create");
+    }
+
+    @Test
     void patch404WithTerminalTargetStaysSkipped() {
         // FINISHED/CANCELLED on a missing booking is usually the cancel's own work
         // (future-slot cancels DELETE) — creating here would resurrect it.

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -225,6 +225,88 @@ class CalendarSyncExecutorTest {
         assertThrows(CalendarBookingsHttpException.class, () -> executor.handle("tenant-1", payload));
     }
 
+    // --- patch 404 materialization (create-then-apply) ------------------------
+
+    /** Payload push data with the ISO ETD the producer writes on every push. */
+    private static Map<String, Object> identityDataWithEtd(String etdIso) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("mintral_truckLicensePlate", "AB1234");
+        data.put(CalendarSyncFeature.DATA_EXPECTED_DEPARTURE_DATE, etdIso);
+        return data;
+    }
+
+    @Test
+    void patch404WithEtdCreatesThenAppliesStatus() {
+        FakeClient client = new FakeClient();
+        client.patchThrowsOnce = new CalendarBookingsHttpException(404, "no booking");
+        client.availableSlots = List.of(slot(LocalDate.of(2026, 7, 15), 14, 0, 1));
+        Map<String, Object> payload = patchPayload("IN_TRANSIT");
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                identityDataWithEtd("2026-07-15T10:00:00Z"));
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.createCalls, "the missing booking is created");
+        assertEquals(LocalDate.of(2026, 7, 15), client.lastCreateDate);
+        assertEquals(14, client.lastCreateHour);
+        assertEquals(2, client.patchCalls, "the 404'd patch, then the post-create status apply");
+        assertEquals("IN_TRANSIT", client.lastPatchStatus);
+    }
+
+    @Test
+    void patch404PastEtdPicksSlotFromNow() {
+        // ETD already behind the fixed clock (12:00Z) — the search window clamps to
+        // now, so an in-flight service lands on the next slot with capacity.
+        FakeClient client = new FakeClient();
+        client.patchThrowsOnce = new CalendarBookingsHttpException(404, "no booking");
+        client.availableSlots = List.of(
+                slot(LocalDate.of(2026, 7, 15), 9, 0, 1),
+                slot(LocalDate.of(2026, 7, 15), 16, 30, 1));
+        Map<String, Object> payload = patchPayload("IN_TRANSIT");
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                identityDataWithEtd("2026-07-14T08:00:00Z"));
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(16, client.lastCreateHour, "the 09:00 slot is already past — 16:30 wins");
+        assertEquals(30, client.lastCreateMinutes);
+    }
+
+    @Test
+    void patch404WithTerminalTargetStaysSkipped() {
+        // FINISHED/CANCELLED on a missing booking is usually the cancel's own work
+        // (future-slot cancels DELETE) — creating here would resurrect it.
+        for (String terminal : List.of(CalendarSyncFeature.STATUS_FINISHED,
+                CalendarSyncFeature.STATUS_CANCELLED)) {
+            FakeClient client = new FakeClient();
+            client.patchThrows = new CalendarBookingsHttpException(404, "no booking");
+            Map<String, Object> payload = patchPayload(terminal);
+            payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                    identityDataWithEtd("2026-07-15T10:00:00Z"));
+
+            var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+            assertEquals(JobOutcome.SKIPPED, result.outcome(), terminal + " must not create");
+            assertEquals(0, client.createCalls, terminal + " must not create");
+        }
+    }
+
+    @Test
+    void patch404WithoutEtdStaysSkipped() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(404, "no booking");
+        Map<String, Object> payload = patchPayload("IN_TRANSIT");
+        payload.put(CalendarSyncFeature.PAYLOAD_RESOURCE_DATA,
+                Map.of("mintral_truckLicensePlate", "AB1234"));
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+        assertEquals(0, client.createCalls, "no ETD → nothing to place the booking at");
+    }
+
     // --- unassign ------------------------------------------------------------
 
     @Test
@@ -581,6 +663,9 @@ class CalendarSyncExecutorTest {
         List<CalendarBookingsClient.BookingView> listResult = List.of();
         List<CalendarBookingsClient.AvailableSlot> availableSlots = List.of();
         RuntimeException patchThrows;
+        // Thrown by the FIRST patch only — models a 404 whose follow-up
+        // (the post-create status apply) must succeed.
+        RuntimeException patchThrowsOnce;
         int patchCalls;
         String lastPatchStatus;
         Map<String, Object> lastPatchData;
@@ -623,6 +708,11 @@ class CalendarSyncExecutorTest {
             lastPatchStatus = targetStatus;
             lastPatchData = resourceDataPatch;
             lastPatchSyncStatus = syncStatus;
+            if (patchThrowsOnce != null) {
+                RuntimeException once = patchThrowsOnce;
+                patchThrowsOnce = null;
+                throw once;
+            }
             if (patchThrows != null) {
                 throw patchThrows;
             }


### PR DESCRIPTION
Closes #1054

## What

A `calendar_sync` patch that 404s (no booking) no longer always benign-skips. When the target status is non-terminal and the payload carries the ISO ETD that now rides `resourceData` on every push, the executor routes into the existing ensure-create path: create the booking at the next available slot from the ETD (clamped to now for in-flight services), then apply the status.

This is what finally gives the direct-to-`monitorTrip` services — the ones that skip `assignDriver` and used to ship status-only patches into the void — a booking at whatever stage first touches the calendar.

## Resurrection guard

Terminal targets (`FINISHED`/`CANCELLED`) never create. A missing booking on a terminal push is usually the cancel's own DELETE (future-slot cancels release capacity by deleting); creating there would resurrect what was just released, only to close it. The modulith cannot consult the workflow, so the guard is on the target status.

## Behavior notes

- No ETD / unparseable ETD / no calendarId → benign skip, exactly as before.
- Reuses `ensureCreate` unchanged: a create-409 race re-lists and converges via retry; ETD auto-pick with no capacity stays retryable and self-heals when a slot frees.
- Inert on current traffic: patches only start carrying the ETD once the producer-side identity enrichment (ecm-coordinator PR #355) deploys.
- Known edge under a disabled flag: a materialized create does not stamp the initial `syncStatus` (PENDING); the confirm leg still stamps the final state when enabled.

## Tests

4 new cases in `CalendarSyncExecutorTest` (create-then-apply happy path, past-ETD clamp to now, terminal-target guard for both statuses, no-ETD skip). Module suite: 390/390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar updates can now recover missing bookings when a calendar and valid expected departure date are provided.
  * Recovered bookings are assigned to an available slot and receive the requested synchronization status.
  * Missing bookings with terminal statuses, unavailable calendars, or missing or invalid departure dates remain safely skipped.
  * Status updates continue to handle missing resources correctly while treating conflicts as benign.

* **New Features**
  * Added support for the `FINISHED` terminal booking status.
  * Added expected departure date handling for calendar synchronization.

* **Documentation**
  * Updated documentation to clarify missing-booking recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->