### PR TITLE
feat(integrations): register the resource-assignment dispatch event

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
@@ -27,6 +27,25 @@ public final class CalendarSyncFeature {
     public static final String EVENT_RESOURCE_ENRICHMENT = "calendar.resource_enrichment";
     public static final String SCOPE_CALENDAR = "calendar";
 
+    /**
+     * Dispatch-shaped sibling of {@link #EVENT_RESOURCE_ENRICHMENT}: when a service's
+     * resource assignment is (re)made, an {@code integration_event_dispatch} job addressed
+     * to this event pushes it to whatever system the operator bound — connection, field
+     * mapping, stand-in defaults and response verdicts are all binding rows. The producer
+     * owns the context vocabulary; this module only registers which roots templates may
+     * read.
+     */
+    public static final String EVENT_RESOURCE_ASSIGNMENT = "calendar.resource_assignment";
+
+    /**
+     * Context roots for {@link #EVENT_RESOURCE_ASSIGNMENT} bindings: {@code service}
+     * (nested scalars — {@code service.code}, {@code service.kind}) and the same
+     * {@code resourceData} identity map every calendar push carries. Scalars are nested
+     * because a bare root reads as a whole object to the validator.
+     */
+    public static final java.util.Set<String> ASSIGNMENT_TEMPLATE_ROOTS =
+            java.util.Set.of("service", "resourceData");
+
     /** Payload field names (self-contained — the worker never re-reads process vars). */
     public static final String PAYLOAD_OP = "op";
     public static final String PAYLOAD_SERVICE_CODE = "serviceCode";

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
@@ -65,7 +65,12 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
 
     @Override
     public JobOutcome handle(String tenantCode, Map<String, Object> payload) {
+        // The intake path stamps the tenant into the payload; a producer outside this
+        // module doesn't have to — the ledger row already knows whose job this is.
         String tenantClientId = string(payload, EventDispatchFeature.PAYLOAD_TENANT_CLIENT_ID);
+        if (tenantClientId == null) {
+            tenantClientId = tenantCode;
+        }
         if (tenantClientId == null) {
             throw new NonRetryableJobException("Event dispatch payload is missing its tenant");
         }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -137,6 +137,9 @@ public class IntegrationEventBindingService {
         if (CalendarSyncFeature.EVENT_RESOURCE_ENRICHMENT.equals(normalized)) {
             return CalendarSyncFeature.ENRICHMENT_TEMPLATE_ROOTS;
         }
+        if (CalendarSyncFeature.EVENT_RESOURCE_ASSIGNMENT.equals(normalized)) {
+            return CalendarSyncFeature.ASSIGNMENT_TEMPLATE_ROOTS;
+        }
         return PayloadTemplate.DEFAULT_ROOTS;
     }
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
@@ -142,6 +142,19 @@ class IntegrationEventDispatchHandlerTest {
     }
 
     @Test
+    void aPayloadWithoutATenantUsesTheRowsTenant() {
+        // A producer outside this module enqueues without stamping the tenant into the
+        // payload — the ledger row already knows whose job it is.
+        bindings.armed = List.of(binding(true));
+        Map<String, Object> payload = eventAddressedPayload();
+        payload.remove(EventDispatchFeature.PAYLOAD_TENANT_CLIENT_ID);
+
+        JobOutcome outcome = handler().handle(TENANT, payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
+    }
+
+    @Test
     void skipsWhenNothingIsArmedForTheEvent() {
         bindings.armed = List.of();
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
@@ -122,6 +122,21 @@ class IntegrationEventBindingServiceTest {
                 bindings.saved.get(0).responseTemplates().get("assignedDriver"));
     }
 
+    @Test
+    void assignmentBindingsMayReadTheDispatchContextRoots() {
+        var assignment = new UpsertIntegrationEventBindingRequest(
+                "calendar.resource_assignment", null, null, CONNECTION_ID, OPERATION_ID,
+                Map.of(),
+                Map.of("guidMultimedia", "{{service.code}}",
+                        "aprobado", "{{resourceData.mintral_serviceKind}}"),
+                Map.of(), null, null, true);
+
+        service().upsert(TENANT, CHILD_ORG, assignment, ACTOR);
+
+        assertEquals("{{service.code}}",
+                bindings.saved.get(0).fieldTemplates().get("guidMultimedia"));
+    }
+
     /** A review binding still cannot read job-payload roots — the roots are per event. */
     @Test
     void reviewBindingsStillCannotReadJobPayloadRoots() {


### PR DESCRIPTION
Closes #1058

Companion to #1057 — the piece that lets a producer outside the module actually use event-addressed dispatch for assignment pushes:

- **`calendar.resource_assignment`** registered with its template roots (`service`, `resourceData`) in `requestRootsFor`, so the bindings API accepts mappings over the dispatch context. Scalars ride nested (`service.code`, `service.kind`) because the validator reads a bare root as a whole object.
- **Tenant fallback**: an `integration_event_dispatch` payload may omit `tenantClientId` — the handler uses the ledger row's tenant. The intake path keeps stamping it; producers outside the module don't repeat what the row knows.

Inert until a binding is armed for the event (nothing bound → SKIPPED). 2 new tests; module suite 413/413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for calendar resource-assignment events.
  - Resource-assignment bindings can now use `service` and `resourceData` template data.
  - Event processing can identify the tenant from the associated job when it is missing from the event payload.

- **Bug Fixes**
  - Prevented valid event-dispatch jobs from failing when tenant information is omitted from the payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->