### PR TITLE
fix(integrations): fail the connection test on a base URL the dispatcher would refuse

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java
@@ -5,14 +5,21 @@ import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
 import com.microboxlabs.miot.integrations.domain.ProviderType;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestRequest;
 import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import com.microboxlabs.miot.integrations.net.OutboundUrlGuard;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 /**
- * Fallback tester for providers without a live probe. Validates the connection
- * contract only (preserves the original pre-probe behaviour). Never matches a
- * specific provider; the registry uses it as the default.
+ * Fallback tester for providers without a live probe. Never matches a specific
+ * provider; the registry uses it as the default.
+ *
+ * <p>No request is sent — for an arbitrary HTTP API there is no request known to be
+ * safe — but the runtime's URL policy is still checkable offline: the dispatcher
+ * refuses a base URL that resolves to an internal address, so a test that ignored
+ * that would bless a connection every dispatch then rejects. That exact case
+ * happened: a base URL of {@code http://localhost:8080} tested green and failed on
+ * first use.
  */
 @ApplicationScoped
 public class GenericConnectionTester implements ConnectionTester {
@@ -27,6 +34,14 @@ public class GenericConnectionTester implements ConnectionTester {
             IntegrationConnection connection,
             CredentialProfile credential,
             ConnectionTestRequest request) {
+        if (connection.baseUrl() != null) {
+            try {
+                OutboundUrlGuard.requirePublicHttpUrl(connection.baseUrl(), "base URL");
+            } catch (IllegalArgumentException e) {
+                return new ConnectionTestResponse(false, OffsetDateTime.now(ZoneOffset.UTC),
+                        e.getMessage() + " — the dispatcher will refuse this URL at runtime");
+            }
+        }
         return new ConnectionTestResponse(true, OffsetDateTime.now(ZoneOffset.UTC), message(request));
     }
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTesterTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTesterTest.java
@@ -1,0 +1,75 @@
+package com.microboxlabs.miot.integrations.tester;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microboxlabs.miot.integrations.domain.ConnectionStatus;
+import com.microboxlabs.miot.integrations.domain.IntegrationConnection;
+import com.microboxlabs.miot.integrations.domain.ProviderType;
+import com.microboxlabs.miot.integrations.dto.ConnectionTestResponse;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The fallback tester sends nothing, but it must not bless a base URL the dispatcher's
+ * SSRF guard will refuse on first use — that mismatch is exactly how a connection with
+ * {@code http://localhost:8080} once tested green and then failed every dispatch.
+ *
+ * <p>Hosts are IP literals or names that resolve locally, so no live DNS is needed.
+ */
+class GenericConnectionTesterTest {
+
+    private final GenericConnectionTester tester = new GenericConnectionTester();
+
+    private static IntegrationConnection connection(String baseUrl) {
+        return new IntegrationConnection(
+                "c-1", "tenant-1", "Partner", ProviderType.CUSTOM_HTTP,
+                baseUrl == null ? null : URI.create(baseUrl),
+                "cred-1", ConnectionStatus.DRAFT, null, null, Map.of(), null);
+    }
+
+    private ConnectionTestResponse test(String baseUrl) {
+        return tester.test(connection(baseUrl), null, null);
+    }
+
+    @Test
+    void aPublicAddressPasses() {
+        assertTrue(test("https://8.8.8.8/api").success());
+    }
+
+    @Test
+    void aLoopbackAddressFails() {
+        ConnectionTestResponse response = test("http://127.0.0.1:8080/alfresco/s");
+        assertFalse(response.success());
+        assertTrue(response.message().contains("internal"), response.message());
+    }
+
+    @Test
+    void localhostFails() {
+        assertFalse(test("http://localhost:8080/alfresco/s").success());
+    }
+
+    @Test
+    void aSiteLocalAddressFails() {
+        assertFalse(test("http://10.0.0.5/api").success());
+    }
+
+    @Test
+    void anUnresolvableHostFails() {
+        // RFC 2606 reserves .invalid: never resolves, no live DNS involved.
+        ConnectionTestResponse response = test("http://mock.invalid/api");
+        assertFalse(response.success());
+        assertTrue(response.message().contains("resolved"), response.message());
+    }
+
+    @Test
+    void aNonHttpSchemeFails() {
+        assertFalse(test("ftp://partner.example/api").success());
+    }
+
+    @Test
+    void aConnectionWithoutABaseUrlKeepsTheContractOnlyBehaviour() {
+        assertTrue(test(null).success());
+    }
+}


### PR DESCRIPTION
Closes #1060

## What

`GenericConnectionTester` — the fallback for every provider without a live probe — returned `success=true` unconditionally. It now applies `OutboundUrlGuard.requirePublicHttpUrl` to the connection's base URL first: the exact check the dispatcher runs before every fetch, evaluated offline (no request is sent, preserving the fallback's no-side-effects property).

- Loopback / link-local / site-local / unresolvable / non-http(s) base URLs now fail the Test button with the guard's message plus "the dispatcher will refuse this URL at runtime".
- Public URLs and connections without a base URL behave exactly as before.

## Why

Observed in dev: a connection with base URL `http://localhost:8080/alfresco/s` tested green ("runtime probe pending"), flipped ACTIVE, and would have failed on the first dispatch with the SSRF guard's rejection — turning a config mistake the operator was standing right there to fix into a parked job later.

## Tests

7 new in `GenericConnectionTesterTest` (public IP literal passes; loopback, localhost, site-local, `.invalid` host, ftp scheme fail; null base URL keeps contract-only behavior). Hosts are IP literals or locally-resolving names — no live DNS. Module suite 420/420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)