### PR TITLE
fix(integrations): carry syncStatus through unassign and existing-booking ensure

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java
@@ -10,8 +10,8 @@ import org.jboss.logging.Logger;
 /**
  * {@link ModulithJobHandler} for {@code calendar_confirm}: stamps
  * {@code syncStatus=CONFIRMED} on the booking once its chain predecessor (the
- * {@code alerce_assignment} push) has SUCCEEDED — see
- * {@link CalendarConfirmFeature} for the chain semantics.
+ * partner dispatch push) has SUCCEEDED — see {@link CalendarConfirmFeature}
+ * for the chain semantics.
  *
  * <p>Outcome policy mirrors {@link CalendarSyncExecutor}: 404 (booking gone —
  * unplanned or cancelled while the push was in flight) is a benign SKIP;
@@ -52,10 +52,11 @@ public class CalendarConfirmExecutor implements ModulithJobHandler {
         }
         java.util.UUID calendarId = calendarIdRaw == null ? null : java.util.UUID.fromString(calendarIdRaw);
 
+        String syncDetail = str(payload, CalendarConfirmFeature.PAYLOAD_SYNC_DETAIL);
         try {
             client.patchByResource(resourceId, calendarId, null, null,
                     CalendarConfirmFeature.SYNC_STATUS_CONFIRMED,
-                    "Alerce accepted the assignment (code=OK)");
+                    syncDetail != null ? syncDetail : CalendarConfirmFeature.DEFAULT_SYNC_DETAIL);
             return JobOutcome.succeeded("Booking sync CONFIRMED for " + resourceId);
         } catch (CalendarBookingsHttpException e) {
             if (e.getStatus() == 404) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmFeature.java
@@ -1,18 +1,19 @@
 package com.microboxlabs.miot.integrations.calendar;
 
 /**
- * Constants for the modulith-executed {@code calendar_confirm} job — the third
- * leg of ECM's assign chain ({@code calendar_sync} seq 0 → {@code
- * alerce_assignment} seq 1 → this, seq 2). Payload field names MUST stay in
- * lockstep with ECM's {@code CalendarConfirmFeature} (the payload is the wire
+ * Constants for the modulith-executed {@code calendar_confirm} job — the
+ * closing leg of a producer's calendar chain, gated behind the
+ * {@code integration_event_dispatch} push that precedes it. Payload field names
+ * MUST stay in lockstep with the producer's enqueuer (the payload is the wire
  * contract).
  *
  * <p>The ledger's chain gate is the whole design: this job becomes claimable
- * only once the {@code alerce_assignment} leg reports SUCCEEDED — which, since
- * the executor fails jobs on a non-OK Alerce body, means Alerce genuinely
- * accepted the tuple. A rejected/parked push keeps this leg blocked and the
- * booking stays {@code syncStatus=PENDING} ("planned but unconfirmed"); a
- * later successful manual retry unblocks it with no extra machinery.
+ * only once the dispatch leg reports SUCCEEDED — which, since the dispatcher
+ * fails jobs whose response body misses the binding's success condition, means
+ * the partner genuinely accepted the push. A rejected/parked dispatch keeps
+ * this leg blocked and the booking stays {@code syncStatus=PENDING} ("planned
+ * but unconfirmed"); a later successful manual retry unblocks it with no extra
+ * machinery.
  */
 public final class CalendarConfirmFeature {
 
@@ -25,7 +26,18 @@ public final class CalendarConfirmFeature {
     public static final String PAYLOAD_SERVICE_CODE = "serviceCode";
     public static final String PAYLOAD_CALENDAR_ID = "calendarId";
     public static final String PAYLOAD_RESOURCE_ID = "resourceId";
+    /**
+     * Optional human-readable text written to the booking's {@code syncDetail}
+     * on confirmation. The enqueuer supplies it because only the enqueuer knows
+     * what was confirmed — an assignment tuple, an unassignment's stand-in
+     * values — and the partner's name is operator vocabulary that does not
+     * belong in this executor. Absent: a generic fallback is written.
+     */
+    public static final String PAYLOAD_SYNC_DETAIL = "syncDetail";
 
     /** Value written to the booking's {@code syncStatus} on confirmation. */
     public static final String SYNC_STATUS_CONFIRMED = "CONFIRMED";
+
+    /** {@code syncDetail} fallback when the payload names none. */
+    public static final String DEFAULT_SYNC_DETAIL = "Partner accepted the sync";
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -185,8 +185,20 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         List<String> clearDataKeys = asStringList(payload.get(CalendarSyncFeature.PAYLOAD_CLEAR_DATA_KEYS));
         try {
             client.unassignByResource(resourceId, calendarId, clearDataKeys);
+            // An optional syncStatus rides the unassign (not the ensure): on the
+            // backward revert the booking is at ASSIGNED, so the ensure leg's
+            // PLANNED patch is refused as a regression and would drop the stamp
+            // with it. The unassign is the one call that succeeds in both
+            // directions, and it must also displace whatever sync verdict the
+            // previous assignment left behind — a stale REJECTED belongs to a
+            // tuple that no longer exists. Status-only patch: no 409 possible.
+            String syncStatus = str(payload, CalendarSyncFeature.PAYLOAD_SYNC_STATUS);
+            if (syncStatus != null) {
+                client.patchByResource(resourceId, calendarId, null, null, syncStatus, null);
+            }
             return JobOutcome.succeeded("Booking unassigned for " + resourceId
-                    + " (cleared " + clearDataKeys.size() + " data key(s))");
+                    + " (cleared " + clearDataKeys.size() + " data key(s)"
+                    + (syncStatus == null ? ")" : ", sync " + syncStatus + ")"));
         } catch (CalendarBookingsHttpException e) {
             if (e.getStatus() == 404) {
                 return JobOutcome.skipped("No booking to unassign for " + resourceId);
@@ -341,9 +353,14 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         }
         // Forward-only status, plus a shallow resource-data merge so a re-plan keeps
         // the row current. 404/409 are benign (raced delete / status regression).
-        if (targetStatus != null || (resourceData != null && !resourceData.isEmpty())) {
+        // The payload's syncStatus rides along (null leaves it untouched) — the
+        // existing-booking path must not drop the confirmation window the push
+        // opened, exactly like applyStatus on the create path.
+        String syncStatus = str(payload, CalendarSyncFeature.PAYLOAD_SYNC_STATUS);
+        if (targetStatus != null || syncStatus != null
+                || (resourceData != null && !resourceData.isEmpty())) {
             try {
-                client.patchByResource(resourceId, calendarId, targetStatus, resourceData);
+                client.patchByResource(resourceId, calendarId, targetStatus, resourceData, syncStatus, null);
             } catch (CalendarBookingsHttpException e) {
                 if (benignSkip(e, resourceId, targetStatus) == null) {
                     throw e;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -191,10 +191,19 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
             // with it. The unassign is the one call that succeeds in both
             // directions, and it must also displace whatever sync verdict the
             // previous assignment left behind — a stale REJECTED belongs to a
-            // tuple that no longer exists. Status-only patch: no 409 possible.
+            // tuple that no longer exists. A rejected follow-up does not undo
+            // the successful unassign and must be reported as such.
             String syncStatus = str(payload, CalendarSyncFeature.PAYLOAD_SYNC_STATUS);
             if (syncStatus != null) {
-                client.patchByResource(resourceId, calendarId, null, null, syncStatus, null);
+                try {
+                    client.patchByResource(resourceId, calendarId, null, null, syncStatus, null);
+                } catch (CalendarBookingsHttpException e) {
+                    if (e.getStatus() == 404 || e.getStatus() == 409) {
+                        return JobOutcome.skipped("Booking unassigned for " + resourceId
+                                + "; sync-status patch skipped (" + e.getStatus() + ")");
+                    }
+                    throw e;
+                }
             }
             return JobOutcome.succeeded("Booking unassigned for " + resourceId
                     + " (cleared " + clearDataKeys.size() + " data key(s)"

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
@@ -60,11 +60,14 @@ class CalendarConfirmExecutorTest {
         assertEquals("TMS accepted the stand-in values", client.lastSyncDetail);
     }
 
-    /** Producers that predate the field keep a generic, partner-neutral detail. */
+    /** Blank producer detail falls back to a generic, partner-neutral value. */
     @Test
     void confirmFallsBackToGenericSyncDetail() {
         FakeClient client = new FakeClient();
-        new CalendarConfirmExecutor(client).handle("tenant-1", payload());
+        var p = payload();
+        p.put(CalendarConfirmFeature.PAYLOAD_SYNC_DETAIL, "   ");
+
+        new CalendarConfirmExecutor(client).handle("tenant-1", p);
 
         assertEquals(CalendarConfirmFeature.DEFAULT_SYNC_DETAIL, client.lastSyncDetail);
     }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Outcome policy for the calendar_confirm leg: stamp CONFIRMED on success,
  * benign-skip a vanished booking (404), propagate everything else for retry.
- * The chain-ordering guarantees (runs only after alerce_assignment SUCCEEDED)
+ * The chain-ordering guarantees (runs only after the dispatch leg SUCCEEDED)
  * live in the ledger's claim SQL, not here.
  */
 class CalendarConfirmExecutorTest {
@@ -42,6 +42,31 @@ class CalendarConfirmExecutorTest {
         assertNull(client.lastStatus);
         assertEquals(RESOURCE, client.lastResourceId);
         assertEquals(CAL, client.lastCalendarId);
+    }
+
+    /**
+     * The detail text is the enqueuer's: only it knows whether an assignment
+     * tuple or an unassignment's stand-in values were confirmed, and the
+     * partner's name is operator vocabulary this executor must not hardcode.
+     */
+    @Test
+    void confirmWritesThePayloadSyncDetail() {
+        FakeClient client = new FakeClient();
+        var p = payload();
+        p.put(CalendarConfirmFeature.PAYLOAD_SYNC_DETAIL, "TMS accepted the stand-in values");
+
+        new CalendarConfirmExecutor(client).handle("tenant-1", p);
+
+        assertEquals("TMS accepted the stand-in values", client.lastSyncDetail);
+    }
+
+    /** Producers that predate the field keep a generic, partner-neutral detail. */
+    @Test
+    void confirmFallsBackToGenericSyncDetail() {
+        FakeClient client = new FakeClient();
+        new CalendarConfirmExecutor(client).handle("tenant-1", payload());
+
+        assertEquals(CalendarConfirmFeature.DEFAULT_SYNC_DETAIL, client.lastSyncDetail);
     }
 
     @Test
@@ -78,6 +103,7 @@ class CalendarConfirmExecutorTest {
         UUID lastCalendarId;
         String lastStatus;
         String lastSyncStatus;
+        String lastSyncDetail;
 
         @Override
         public boolean isConfigured() {
@@ -93,6 +119,7 @@ class CalendarConfirmExecutorTest {
             lastCalendarId = calendarId;
             lastStatus = targetStatus;
             lastSyncStatus = syncStatus;
+            lastSyncDetail = syncDetail;
             if (patchThrows != null) {
                 throw patchThrows;
             }

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -424,6 +424,22 @@ class CalendarSyncExecutorTest {
     }
 
     @Test
+    void unassignSuccessThenSyncStatus409ReportsPatchSkip() {
+        FakeClient client = new FakeClient();
+        client.patchThrows = new CalendarBookingsHttpException(409, "sync patch rejected");
+        var payload = unassignPayload(CLEAR_KEYS);
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+        assertEquals(1, client.unassignCalls);
+        assertEquals(1, client.patchCalls);
+        assertTrue(result.detail().contains("Booking unassigned"), result.detail());
+        assertTrue(result.detail().contains("sync-status patch skipped (409)"), result.detail());
+    }
+
+    @Test
     void unassignWithoutSyncStatusDoesNotPatch() {
         FakeClient client = new FakeClient();
         var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", unassignPayload(CLEAR_KEYS));
@@ -612,13 +628,14 @@ class CalendarSyncExecutorTest {
     void ensureExistingForwardsSyncStatus() {
         FakeClient client = new FakeClient();
         client.listResult = List.of(booking(LocalDate.of(2026, 7, 16))); // 09:00
-        var payload = withExplicitSlot(ensurePayload("ASSIGNED"), LocalDate.of(2026, 7, 16), 9, 0);
+        var payload = withExplicitSlot(ensurePayload(null), LocalDate.of(2026, 7, 16), 9, 0);
         payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
 
         var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
 
         assertEquals(JobOutcome.SUCCEEDED, result.outcome());
         assertEquals(1, client.patchCalls);
+        assertNull(client.lastPatchStatus);
         assertEquals("PENDING", client.lastPatchSyncStatus);
     }
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -401,6 +401,51 @@ class CalendarSyncExecutorTest {
         assertEquals(List.of(), client.lastClearDataKeys);
     }
 
+    /**
+     * The confirmation window opens on the unassign, not the ensure: on the
+     * backward revert the booking is at ASSIGNED, so the ensure's PLANNED
+     * patch 409s away and any stamp riding it is lost. The stamp is a
+     * follow-up status-only patch so it can never regress the lifecycle —
+     * and it displaces a stale sync verdict left by the previous assignment.
+     */
+    @Test
+    void unassignForwardsSyncStatusAsStatusOnlyPatch() {
+        FakeClient client = new FakeClient();
+        var payload = unassignPayload(CLEAR_KEYS);
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.unassignCalls);
+        assertEquals(1, client.patchCalls);
+        assertNull(client.lastPatchStatus, "sync stamp must not touch the lifecycle status");
+        assertEquals("PENDING", client.lastPatchSyncStatus);
+    }
+
+    @Test
+    void unassignWithoutSyncStatusDoesNotPatch() {
+        FakeClient client = new FakeClient();
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", unassignPayload(CLEAR_KEYS));
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(0, client.patchCalls);
+    }
+
+    /** A refused unassign left the booking assigned — its sync state still describes reality. */
+    @Test
+    void unassign409SkipsTheSyncStamp() {
+        FakeClient client = new FakeClient();
+        client.unassignThrows = new CalendarBookingsHttpException(409, "past ASSIGNED");
+        var payload = unassignPayload(CLEAR_KEYS);
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SKIPPED, result.outcome());
+        assertEquals(0, client.patchCalls);
+    }
+
     /** Null and blank entries would silently target nothing — drop them. */
     @Test
     void unassignSkipsNullAndBlankKeys() {
@@ -556,6 +601,25 @@ class CalendarSyncExecutorTest {
         assertEquals(0, client.moveCalls, "ETD auto-pick never re-slots an existing booking");
         assertEquals(0, client.listAvailableCalls);
         assertEquals("IN_TRANSIT", client.lastPatchStatus);
+    }
+
+    /**
+     * The existing-booking path used to drop the payload's syncStatus (only the
+     * create path's applyStatus carried it), silently losing the confirmation
+     * window on any ensure that found its booking already there.
+     */
+    @Test
+    void ensureExistingForwardsSyncStatus() {
+        FakeClient client = new FakeClient();
+        client.listResult = List.of(booking(LocalDate.of(2026, 7, 16))); // 09:00
+        var payload = withExplicitSlot(ensurePayload("ASSIGNED"), LocalDate.of(2026, 7, 16), 9, 0);
+        payload.put(CalendarSyncFeature.PAYLOAD_SYNC_STATUS, "PENDING");
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(1, client.patchCalls);
+        assertEquals("PENDING", client.lastPatchSyncStatus);
     }
 
     @Test


### PR DESCRIPTION
Closes #1062.

A producer that opens a confirmation window with `syncStatus=PENDING` lost it on two paths, and a booking reverted to planned kept the previous assignment's sync verdict forever (stale `REJECTED` tooltip).

- **`executeUnassign`**: an optional payload `syncStatus` is written after a successful unassign as a **status-only follow-up patch** — it cannot 409, and it displaces the stale verdict. Deliberately skipped on 404 (nothing to stamp) and 409 (the unassign was refused, so the old sync state still describes reality). The stamp rides the unassign rather than the ensure because on the backward revert the booking sits at ASSIGNED — the ensure's PLANNED patch is refused as a regression and would drop the stamp with it.
- **`ensureExisting`**: forwards the payload `syncStatus` (and triggers the patch when only `syncStatus` is present), matching the create path's `applyStatus`.
- **`calendar_confirm`**: `syncDetail` now rides the payload with a generic fallback — the enqueuer knows what was confirmed; the partner's name is operator vocabulary and no longer appears in this executor.

Tests: 3 new unassign cases, 1 ensure-existing case, 2 confirm-detail cases. Module 426/426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Calendar confirmations now preserve optional synchronization details, with a default message when none is provided.
  - Calendar synchronization updates now propagate synchronization status during unassign and existing-booking operations.
  - Successful unassign operations include the applied synchronization status in their confirmation message.

- **Bug Fixes**
  - Prevented synchronization status from being applied when an operation is skipped due to a conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->