### PR TITLE
feat(calendar): show accreditation through the driver icon

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx
@@ -13,7 +13,8 @@ import type { PlannedService } from "./planning-selection-context";
 function plannedService(
   workflowStage?: string,
   syncStatus?: PlannedService["syncStatus"],
-  syncDetail?: string
+  syncDetail?: string,
+  serviceOverrides?: Partial<PlannedService["service"]>
 ): PlannedService {
   return {
     service: {
@@ -35,6 +36,7 @@ function plannedService(
       observaciones: "",
       prioridad: 0,
       mintral_serviceCode: "1658427",
+      ...serviceOverrides,
     },
     slot: { date: new Date("2026-07-13T00:00:00Z"), hour: 5, minutes: 0 },
     ...(workflowStage ? { workflowStage } : {}),
@@ -42,6 +44,25 @@ function plannedService(
     ...(syncDetail ? { syncDetail } : {}),
   };
 }
+
+const dict = {
+  pages: {
+    planning: {
+      sidebar: {
+        assignment: {
+          carrier: "Transportista",
+          driver: "Conductor",
+          secondDriver: "Segundo Conductor",
+          truck: "Camión",
+          trailer: "Remolque",
+          enabled: "Acreditado",
+          notEnabled: "No Acreditado",
+          superAccredited: "Súper Acreditado",
+        },
+      },
+    },
+  },
+};
 
 function renderChip(
   workflowStage?: string,
@@ -122,5 +143,55 @@ describe("PlannedServiceChip — sync status dot", () => {
     renderChip("finished", "REJECTED");
     expect(screen.getByLabelText("workflow-stage-finished")).toBeTruthy();
     expect(screen.getByLabelText("sync-status-rejected")).toBeTruthy();
+  });
+});
+
+describe("PlannedServiceChip — assignment accreditation", () => {
+  it.each([
+    ["accredited", "text-gray-700", "Acreditado"],
+    ["notAccredited", "text-amber-700", "No Acreditado"],
+    ["superAccredited", "text-green-700", "Súper Acreditado"],
+  ] as const)(
+    "uses the %s color on the driver icon without rendering a label",
+    (level, colorClass, label) => {
+      render(
+        <PlannedServiceChip
+          plannedService={plannedService(undefined, undefined, undefined, {
+            assignedDriver: "driver-1",
+            assignedDriverAccreditation: level,
+          })}
+          onContextMenu={vi.fn()}
+          dict={dict}
+        />
+      );
+
+      const icon = screen.getByLabelText("assigned-driver");
+      expect(icon.getAttribute("class")).toContain(colorClass);
+      expect(screen.queryByText(label)).toBeNull();
+      expect(screen.getByTitle(`Conductor: ${label}`)).toBeTruthy();
+    }
+  );
+
+  it("uses the same accreditation color and tooltip for two drivers", () => {
+    render(
+      <PlannedServiceChip
+        plannedService={plannedService(undefined, undefined, undefined, {
+          assignedDriver: "driver-1",
+          assignedDriverAccreditation: "superAccredited",
+          assignedDriver2: "driver-2",
+          assignedDriver2Accreditation: "accredited",
+        })}
+        onContextMenu={vi.fn()}
+        dict={dict}
+      />
+    );
+
+    const icon = screen.getByLabelText("assigned-drivers");
+    expect(icon.getAttribute("class")).toContain("text-gray-700");
+    expect(
+      screen.getByTitle(
+        /Conductor: Súper Acreditado\s+Segundo Conductor: Acreditado/
+      )
+    ).toBeTruthy();
   });
 });

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -17,7 +17,7 @@ import {
   getAssignmentAccreditation,
   assignmentAccreditationTooltip,
 } from "./assignment-accreditation";
-import { AccreditationBadge } from "./sidebar-tabs/assignment/accreditation";
+import { ACCREDITATION_ICON_TONE } from "./sidebar-tabs/assignment/accreditation";
 import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 /**
@@ -194,11 +194,19 @@ export function PlannedServiceChip({
   const workflowStage = plannedService.workflowStage;
   const { isTerminal, isFinished, isCancelled, isInCourse, titleSuffix } =
     getStageIndicator(workflowStage, dict);
-  // Weakest accreditation level across the assigned resources — rendered with
-  // the same labelled badge the service card and sidebar show (icon + text),
-  // with the per-resource breakdown as tooltip. Unknown levels (legacy
-  // bookings) render nothing.
+  // Weakest accreditation level across the assigned resources. The compact
+  // calendar chip communicates it through the driver icon color; its tooltip
+  // retains the translated per-resource breakdown. Legacy bookings keep the
+  // original urgency-aware driver color.
   const accreditation = getAssignmentAccreditation(plannedService.service);
+  const driverIconColor = accreditation
+    ? ACCREDITATION_ICON_TONE[accreditation.level]
+    : hasUrgencia
+      ? "text-purple-700 dark:text-purple-300"
+      : "text-blue-700 dark:text-blue-300";
+  const accreditationTooltip = accreditation
+    ? assignmentAccreditationTooltip(accreditation, dict)
+    : undefined;
   // Downstream sync ack (grey pending / green confirmed / red rejected).
   // Untracked bookings render no dot. A red dot means the slot is planned but
   // the external system refused its current data — hover shows the reason.
@@ -291,36 +299,29 @@ export function PlannedServiceChip({
             variant="ghost"
             className="shrink-0 px-1 text-[9px] font-semibold leading-none"
           />
-          {accreditation && (
-            <AccreditationBadge
-              level={accreditation.level}
-              dict={dict}
-              title={assignmentAccreditationTooltip(accreditation, dict)}
-              className="cursor-help px-1 py-0 text-[9px] leading-none"
-            />
-          )}
         </div>
       </div>
-      {/* Right: Driver icon centered vertically */}
-      {driverCount === 1 && (
-        <IoPerson
+      {/* Right: accreditation is conveyed by the assigned-driver icon color. */}
+      {driverCount > 0 && (
+        <span
+          title={accreditationTooltip}
           className={twMerge(
-            "ml-1 shrink-0 w-4 h-4",
-            hasUrgencia
-              ? "text-purple-700 dark:text-purple-300"
-              : "text-blue-700 dark:text-blue-300"
+            "ml-1 shrink-0 flex items-center",
+            accreditation && "cursor-help"
           )}
-        />
-      )}
-      {driverCount === 2 && (
-        <IoPeople
-          className={twMerge(
-            "ml-1 shrink-0 w-4 h-4",
-            hasUrgencia
-              ? "text-purple-700 dark:text-purple-300"
-              : "text-blue-700 dark:text-blue-300"
+        >
+          {driverCount === 1 ? (
+            <IoPerson
+              aria-label="assigned-driver"
+              className={twMerge("w-4 h-4", driverIconColor)}
+            />
+          ) : (
+            <IoPeople
+              aria-label="assigned-drivers"
+              className={twMerge("w-4 h-4", driverIconColor)}
+            />
           )}
-        />
+        </span>
       )}
       {isInCourse && (
         <IoNavigate

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx
@@ -17,7 +17,10 @@ import {
   getAssignmentAccreditation,
   assignmentAccreditationTooltip,
 } from "./assignment-accreditation";
-import { ACCREDITATION_ICON_TONE } from "./sidebar-tabs/assignment/accreditation";
+import {
+  ACCREDITATION_ICON_TONE,
+  type AccreditationLevel,
+} from "./sidebar-tabs/assignment/accreditation";
 import { ServiceCategoryBadge } from "@/features/common/components/service-category-badge/service-category-badge";
 
 /**
@@ -144,6 +147,18 @@ function getStageIndicator(
   };
 }
 
+function getDriverIconColor(
+  accreditationLevel: AccreditationLevel | undefined,
+  hasUrgencia: boolean
+): string {
+  if (accreditationLevel) {
+    return ACCREDITATION_ICON_TONE[accreditationLevel];
+  }
+  return hasUrgencia
+    ? "text-purple-700 dark:text-purple-300"
+    : "text-blue-700 dark:text-blue-300";
+}
+
 interface PlannedServiceChipProps {
   readonly plannedService: PlannedService;
   readonly isBeingReassigned?: boolean;
@@ -199,11 +214,10 @@ export function PlannedServiceChip({
   // retains the translated per-resource breakdown. Legacy bookings keep the
   // original urgency-aware driver color.
   const accreditation = getAssignmentAccreditation(plannedService.service);
-  const driverIconColor = accreditation
-    ? ACCREDITATION_ICON_TONE[accreditation.level]
-    : hasUrgencia
-      ? "text-purple-700 dark:text-purple-300"
-      : "text-blue-700 dark:text-blue-300";
+  const driverIconColor = getDriverIconColor(
+    accreditation?.level,
+    hasUrgencia
+  );
   const accreditationTooltip = accreditation
     ? assignmentAccreditationTooltip(accreditation, dict)
     : undefined;

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx
@@ -70,6 +70,13 @@ const DOT_TONE: Record<AccreditationLevel, string> = {
   superAccredited: "bg-green-200 dark:bg-green-800/50",
 };
 
+/** Text color used when accreditation is communicated by an icon alone. */
+export const ACCREDITATION_ICON_TONE: Record<AccreditationLevel, string> = {
+  accredited: "text-gray-700 dark:text-gray-200",
+  notAccredited: "text-amber-700 dark:text-amber-400",
+  superAccredited: "text-green-700 dark:text-green-400",
+};
+
 interface AccreditationBadgeProps {
   readonly level: AccreditationLevel;
   readonly dict: I18nRecord;


### PR DESCRIPTION
## Summary

- remove the labeled accreditation badge from compact assigned-service calendar cards
- color the single- or two-driver user icon using the assignment's weakest known accreditation level
- preserve translated per-resource accreditation details in the icon tooltip
- keep the existing urgency-aware icon color for legacy assignments without accreditation data
- add coverage for all three accreditation states and two-driver aggregation

## User impact

Assigned-service cards remain lighter and easier to scan while retaining accreditation status through color and hover detail.

## Validation

- 21 focused calendar tests passed
- ESLint completed with no errors; one pre-existing dynamic translation-key warning remains in the shared accreditation component
- full app type-check is currently blocked by unrelated existing resolution errors for @modulariot/ui/brand/logo

Closes #1064