### PR TITLE
chore(release): prepare MIOT stack v0.5.32

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.20</version>
+        <version>0.5.21</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.20</version>
+    <version>0.5.21</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.31.mdx
+++ b/releases/notes/v1.31.31.mdx
@@ -1,0 +1,60 @@
+# 🔔 Release Notes v1.31.31 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida mejoras de experiencia en calendario y dashboard, y refuerza la confiabilidad del flujo de integraciones para que la operación diaria sea más clara, consistente y segura. También avanza la convergencia hacia despachos configurables por bindings, reduciendo acoplamientos entre lógica de negocio y vocabulario de partners.
+
+## 🚀 Evolutivos
+
+- **📍 Acreditación visual en asignaciones del calendario**
+  - **Key point**: Se reemplazó la etiqueta visible de acreditación por señalización en el icono de conductor, con colores por nivel y tooltip traducido con el detalle por recurso; se cubrieron casos de uno y dos conductores con pruebas. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: La lógica conserva el color por urgencia para asignaciones legacy sin datos de acreditación, manteniendo compatibilidad con estados previos del flujo de planificación.
+
+- **📍 Despacho por evento y bindings más expresivos**
+  - **Key point**: Se habilitaron defaults de campos y clasificación de respuestas por cuerpo (`response_conditions`) en bindings, además del despacho dirigido por tipo de evento en `integration_event_dispatch`. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: La selección del binding en ejecución reutiliza reglas compartidas de resolución por alcance; también se registró el evento `calendar.resource_assignment` con raíces de plantillas para mapear `service.*` y `resourceData.*`.
+
+- **📍 Materialización de bookings faltantes desde parches de estado**
+  - **Key point**: Cuando un patch de `calendar_sync` no encuentra booking, ahora puede crear y aplicar estado si el destino no es terminal y existe ETD parseable, evitando servicios “invisibles” en calendario. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: Se reutiliza la ruta existente de ensure/create con guardas de no-resurrección para estados terminales (`FINISHED`/`CANCELLED`), preservando el comportamiento benigno de skip cuando no corresponde crear.
+
+## 🐛 Correcciones
+
+- **🐛 Pérdida de sello de sincronización en `calendar_sync`**
+  - **Impacto**: En rutas de unassign y ensure de booking existente se perdía o quedaba obsoleto el estado de sincronización, mostrando información desactualizada.
+  - **Solución**: Se corrigió la propagación/actualización del stamp de sync en esos caminos y se alineó el detalle de sincronización para que pueda venir del encolador con fallback genérico. *(Integración OSS — MIOT-0.5.32)*
+
+- **🐛 Validación inconsistente en pruebas de conexiones HTTP**
+  - **Impacto**: Conexiones podían aprobar “Test” y activarse con URLs que luego el dispatcher bloquea por política SSRF (por ejemplo, hosts internos).
+  - **Solución**: El tester genérico aplica ahora la misma validación `OutboundUrlGuard.requirePublicHttpUrl` sobre la base URL, sin enviar requests, fallando temprano con mensaje explícito. *(Integración OSS — MIOT-0.5.32)*
+
+- **🐛 Scroll y comportamiento del sidebar en dashboard + branding Lynx**
+  - **Impacto**: La navegación lateral con muchos orígenes de datos degradaba usabilidad; además había inconsistencias visuales de marca e iconografía.
+  - **Solución**: Se restauró el scroll y el comportamiento expandible del sidebar, se corrigieron favicon/iconos y se aplicó branding Lynx consistente en modos claro/oscuro respetando logos personalizados. *(Integración OSS — MIOT-0.5.32)*
+
+## 📊 Beneficios
+
+- Mayor legibilidad operativa del calendario sin perder detalle funcional de acreditaciones.
+- Menor riesgo de estados de sincronización engañosos tras cambios de asignación.
+- Menos activaciones “falsamente verdes” en conexiones que fallarían en runtime.
+- Base más sólida para integraciones configurables por operadores mediante bindings.
+- Mejor continuidad del flujo en servicios que entran fuera de la etapa típica de planificación.
+- Navegación del dashboard más estable y consistente con la identidad visual actual.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.32`
+- **App**: `app@v0.5.32` (con cambios)
+- **Docs**: `docs@v0.5.32` (con cambios)
+- **Web**: `web@v0.5.32` (con cambios)
+- **Modulith**: `modulith@v0.5.21` (con cambios)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+- **Referencia de despliegue**: los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.31 prioriza robustez operativa y claridad de uso en dos frentes críticos: coordinación de agenda y confiabilidad de integraciones. El resultado es una plataforma más predecible para equipos que dependen de sincronización y despacho continuo.
+
+También deja preparada una evolución importante: mover decisiones de integración hacia configuración declarativa de bindings, con menor dependencia de implementaciones específicas por módulo. Esto simplifica futuros ajustes con partners y reduce fricción de mantenimiento.
+
+En conjunto, la versión fortalece la experiencia diaria de operación y la base técnica para escalar integraciones con menos riesgo y mayor control.

--- a/releases/stacks/v0.5.32.plan.json
+++ b/releases/stacks/v0.5.32.plan.json
@@ -1,0 +1,158 @@
+{
+  "stack_version": "0.5.32",
+  "stack_tag": "miot-stack@v0.5.32",
+  "milestone": "MIOT-0.5.32",
+  "pull_requests": [
+    {
+      "number": 1051,
+      "title": "Based/fixing tables in dashboard",
+      "source_issues": [
+        {
+          "number": 1053,
+          "title": "Fix dashboard sidebar scrolling and refresh Lynx branding"
+        }
+      ]
+    },
+    {
+      "number": 1055,
+      "title": "feat(calendar): materialize a missing booking from a status patch",
+      "source_issues": [
+        {
+          "number": 1054,
+          "title": "calendar_sync: materialize a missing booking from a status patch (create-then-apply)"
+        }
+      ]
+    },
+    {
+      "number": 1057,
+      "title": "feat(integrations): binding field defaults, body-verdict classification, event-addressed dispatch",
+      "source_issues": [
+        {
+          "number": 1056,
+          "title": "integrations: binding field defaults, response-body classification, event-addressed dispatch"
+        }
+      ]
+    },
+    {
+      "number": 1059,
+      "title": "feat(integrations): register the resource-assignment dispatch event",
+      "source_issues": [
+        {
+          "number": 1058,
+          "title": "integrations: register calendar.resource_assignment dispatch event"
+        }
+      ]
+    },
+    {
+      "number": 1061,
+      "title": "fix(integrations): fail the connection test on a base URL the dispatcher would refuse",
+      "source_issues": [
+        {
+          "number": 1060,
+          "title": "connections: Test button passes base URLs the dispatcher's SSRF guard rejects"
+        }
+      ]
+    },
+    {
+      "number": 1063,
+      "title": "fix(integrations): carry syncStatus through unassign and existing-booking ensure",
+      "source_issues": [
+        {
+          "number": 1062,
+          "title": "calendar_sync drops the sync-state stamp on unassign and existing-booking ensure"
+        }
+      ]
+    },
+    {
+      "number": 1065,
+      "title": "feat(calendar): show accreditation through the driver icon",
+      "source_issues": [
+        {
+          "number": 1064,
+          "title": "feat(calendar): show accreditation through the driver icon"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutor.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmFeature.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dispatch/HttpOperationDispatcher.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/domain/IntegrationEventBinding.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/IntegrationEventBindingResponse.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/dto/UpsertIntegrationEventBindingRequest.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationEventBindingRepository.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingFetchService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingSelector.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTester.java",
+    "quarkus-srv/miot-integrations/src/main/resources/db/migration/integrations/V0.6.14__add_binding_field_defaults_and_response_conditions.sql",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarConfirmExecutorTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/dispatch/HttpOperationDispatcherTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/EventBindingFetchServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/tester/GenericConnectionTesterTest.java",
+    "turbo-repo/apps/app/package.json",
+    "turbo-repo/apps/app/src/app/globals.css",
+    "turbo-repo/apps/app/src/app/icon.svg",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.test.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planned-service-chip.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/accreditation.tsx",
+    "turbo-repo/apps/app/src/features/common/components/app-logo/app-logo.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/release-view/build-info-modal.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/simple-navbar/simple-navbar.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/sidebar-section.test.tsx",
+    "turbo-repo/apps/app/src/features/task-forms/components/task-bento-form/components/side-data/multimedia-manager.tsx/viewer/sidebar/sidebar-section.tsx",
+    "turbo-repo/apps/app/src/test/setup.ts",
+    "turbo-repo/apps/web/components/legal/LegalPageLayout.tsx",
+    "turbo-repo/apps/web/components/v2/ConceptGraphic.tsx",
+    "turbo-repo/apps/web/components/v2/Nav.tsx",
+    "turbo-repo/apps/web/components/v2/SplashFlow.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Footer.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Hero.tsx",
+    "turbo-repo/apps/web/package.json",
+    "turbo-repo/package-lock.json",
+    "turbo-repo/packages/ui/src/brand/logo.tsx",
+    "turbo-repo/packages/ui/src/brand/lynx-geometry.ts",
+    "turbo-repo/packages/ui/src/index.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.32",
+      "tag": "app@v0.5.32"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.30",
+      "version": "0.5.32",
+      "tag": "docs@v0.5.32"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.31",
+      "version": "0.5.32",
+      "tag": "web@v0.5.32"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.20",
+      "version": "0.5.21",
+      "tag": "modulith@v0.5.21"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.4",
+      "version": "0.1.4",
+      "tag": "harness@v0.1.4"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.31.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.31.mdx
@@ -1,0 +1,60 @@
+# 🔔 Release Notes v1.31.31 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida mejoras de experiencia en calendario y dashboard, y refuerza la confiabilidad del flujo de integraciones para que la operación diaria sea más clara, consistente y segura. También avanza la convergencia hacia despachos configurables por bindings, reduciendo acoplamientos entre lógica de negocio y vocabulario de partners.
+
+## 🚀 Evolutivos
+
+- **📍 Acreditación visual en asignaciones del calendario**
+  - **Key point**: Se reemplazó la etiqueta visible de acreditación por señalización en el icono de conductor, con colores por nivel y tooltip traducido con el detalle por recurso; se cubrieron casos de uno y dos conductores con pruebas. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: La lógica conserva el color por urgencia para asignaciones legacy sin datos de acreditación, manteniendo compatibilidad con estados previos del flujo de planificación.
+
+- **📍 Despacho por evento y bindings más expresivos**
+  - **Key point**: Se habilitaron defaults de campos y clasificación de respuestas por cuerpo (`response_conditions`) en bindings, además del despacho dirigido por tipo de evento en `integration_event_dispatch`. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: La selección del binding en ejecución reutiliza reglas compartidas de resolución por alcance; también se registró el evento `calendar.resource_assignment` con raíces de plantillas para mapear `service.*` y `resourceData.*`.
+
+- **📍 Materialización de bookings faltantes desde parches de estado**
+  - **Key point**: Cuando un patch de `calendar_sync` no encuentra booking, ahora puede crear y aplicar estado si el destino no es terminal y existe ETD parseable, evitando servicios “invisibles” en calendario. *(Integración OSS — MIOT-0.5.32)*
+  - **Technical detail**: Se reutiliza la ruta existente de ensure/create con guardas de no-resurrección para estados terminales (`FINISHED`/`CANCELLED`), preservando el comportamiento benigno de skip cuando no corresponde crear.
+
+## 🐛 Correcciones
+
+- **🐛 Pérdida de sello de sincronización en `calendar_sync`**
+  - **Impacto**: En rutas de unassign y ensure de booking existente se perdía o quedaba obsoleto el estado de sincronización, mostrando información desactualizada.
+  - **Solución**: Se corrigió la propagación/actualización del stamp de sync en esos caminos y se alineó el detalle de sincronización para que pueda venir del encolador con fallback genérico. *(Integración OSS — MIOT-0.5.32)*
+
+- **🐛 Validación inconsistente en pruebas de conexiones HTTP**
+  - **Impacto**: Conexiones podían aprobar “Test” y activarse con URLs que luego el dispatcher bloquea por política SSRF (por ejemplo, hosts internos).
+  - **Solución**: El tester genérico aplica ahora la misma validación `OutboundUrlGuard.requirePublicHttpUrl` sobre la base URL, sin enviar requests, fallando temprano con mensaje explícito. *(Integración OSS — MIOT-0.5.32)*
+
+- **🐛 Scroll y comportamiento del sidebar en dashboard + branding Lynx**
+  - **Impacto**: La navegación lateral con muchos orígenes de datos degradaba usabilidad; además había inconsistencias visuales de marca e iconografía.
+  - **Solución**: Se restauró el scroll y el comportamiento expandible del sidebar, se corrigieron favicon/iconos y se aplicó branding Lynx consistente en modos claro/oscuro respetando logos personalizados. *(Integración OSS — MIOT-0.5.32)*
+
+## 📊 Beneficios
+
+- Mayor legibilidad operativa del calendario sin perder detalle funcional de acreditaciones.
+- Menor riesgo de estados de sincronización engañosos tras cambios de asignación.
+- Menos activaciones “falsamente verdes” en conexiones que fallarían en runtime.
+- Base más sólida para integraciones configurables por operadores mediante bindings.
+- Mejor continuidad del flujo en servicios que entran fuera de la etapa típica de planificación.
+- Navegación del dashboard más estable y consistente con la identidad visual actual.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.32`
+- **App**: `app@v0.5.32` (con cambios)
+- **Docs**: `docs@v0.5.32` (con cambios)
+- **Web**: `web@v0.5.32` (con cambios)
+- **Modulith**: `modulith@v0.5.21` (con cambios)
+- **Harness**: `harness@v0.1.4` (sin cambios)
+- **Referencia de despliegue**: los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.31 prioriza robustez operativa y claridad de uso en dos frentes críticos: coordinación de agenda y confiabilidad de integraciones. El resultado es una plataforma más predecible para equipos que dependen de sincronización y despacho continuo.
+
+También deja preparada una evolución importante: mover decisiones de integración hacia configuración declarativa de bindings, con menor dependencia de implementaciones específicas por módulo. Esto simplifica futuros ajustes con partners y reduce fricción de mantenimiento.
+
+En conjunto, la versión fortalece la experiencia diaria de operación y la base técnica para escalar integraciones con menos riesgo y mayor control.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.30",
+  "version": "0.5.32",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.31",
+      "version": "0.5.32",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.30",
+      "version": "0.5.32",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.31",
+      "version": "0.5.32",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.32 from milestone MIOT-0.5.32, with release notes v1.31.31.

Components:
- App: app@v0.5.32 (changed: true)
- Docs: docs@v0.5.32 (changed: true since docs@v0.5.30)
- Web: web@v0.5.32 (changed: true since web@v0.5.31)
- Modulith: modulith@v0.5.21 (changed: true since modulith@v0.5.20)
- Harness: harness@v0.1.4 (changed: false since harness@v0.1.4)

Milestones: Release 1.31.31, MIOT-0.5.32.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
