### PR TITLE
fix(calendar): prevent duplicate removal requests

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.test.tsx
@@ -1,0 +1,89 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PlannedService } from "./planning-selection-context";
+import { useServiceActions } from "./use-service-actions";
+
+const { showNotification } = vi.hoisted(() => ({
+  showNotification: vi.fn(),
+}));
+
+vi.mock("@/features/notifications/notification", () => ({
+  ShowNotification: showNotification,
+}));
+
+const PLANNED_SERVICE: PlannedService = {
+  service: {
+    id: "1658427-V",
+    cliente: "ACME",
+    origen: "ANF",
+    lugarCarguio: "",
+    destino: "SPC",
+    tipoViaje: "Rampla",
+    ocupacion: 0,
+    permanencia: "",
+    leadTime: {
+      total_lineasoc_cumplen: 0,
+      total_lineasoc_incumplen: 0,
+      lineasoc_pctn_cumplimiento: 0,
+    },
+    eta: "",
+    incidencias: [],
+    observaciones: "",
+    prioridad: 0,
+    mintral_serviceCode: "1658427",
+  },
+  slot: { date: new Date("2026-08-04T00:00:00Z"), hour: 9, minutes: 0 },
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("useServiceActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables remove-plan confirmation and ignores duplicate submissions while pending", async () => {
+    const pending = deferred();
+    const removeService = vi.fn(() => pending.promise);
+    const { result } = renderHook(() =>
+      useServiceActions({
+        removeService,
+        removeAssignment: vi.fn(),
+        startReassignment: vi.fn(),
+        startAssignment: vi.fn(),
+      })
+    );
+
+    act(() => {
+      result.current.handleDeleteRequest(PLANNED_SERVICE);
+    });
+
+    let firstRequest!: Promise<void>;
+    let duplicateRequest!: Promise<void>;
+    act(() => {
+      firstRequest = result.current.handleConfirmDelete(PLANNED_SERVICE);
+      duplicateRequest = result.current.handleConfirmDelete(PLANNED_SERVICE);
+    });
+
+    expect(result.current.deleteModal.isProcessing).toBe(true);
+    expect(removeService).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve();
+      await Promise.all([firstRequest, duplicateRequest]);
+    });
+
+    expect(result.current.deleteModal).toEqual({
+      isOpen: false,
+      plannedService: null,
+      isProcessing: false,
+    });
+    expect(removeService).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { PlannedService } from "./planning-selection-context";
 import type { ContextMenuPosition } from "./service-context-menu";
 import { ShowNotification } from "@/features/notifications/notification";
@@ -14,6 +14,7 @@ export interface ContextMenuState {
 export interface DeleteModalState {
   isOpen: boolean;
   plannedService: PlannedService | null;
+  isProcessing: boolean;
 }
 
 interface UseServiceActionsProps {
@@ -65,14 +66,18 @@ export function useServiceActions({
   const [deleteModal, setDeleteModal] = useState<DeleteModalState>({
     isOpen: false,
     plannedService: null,
+    isProcessing: false,
   });
+  const deleteInFlightRef = useRef(false);
 
   // Delete assignment confirmation modal state
   const [deleteAssignmentModal, setDeleteAssignmentModal] =
     useState<DeleteModalState>({
       isOpen: false,
       plannedService: null,
+      isProcessing: false,
     });
+  const deleteAssignmentInFlightRef = useRef(false);
 
   // Context menu handlers
   const handleContextMenu = useCallback(
@@ -114,34 +119,47 @@ export function useServiceActions({
     setDeleteModal({
       isOpen: true,
       plannedService,
+      isProcessing: false,
     });
   }, []);
 
   const handleConfirmDelete = useCallback(
     async (plannedService: PlannedService) => {
-      if (plannedService) {
-        try {
-          await removeService(plannedService.service.id);
-          ShowNotification({
-            type: "success",
-            message: "Asignación eliminada",
-          });
-        } catch (error) {
-          console.error("Error deleting planned service:", error);
-          ShowNotification({
-            type: "error",
-            message:
-              "Error al eliminar la asignación. Por favor, intente nuevamente.",
-          });
-        }
+      if (!plannedService || deleteInFlightRef.current) return;
+
+      deleteInFlightRef.current = true;
+      setDeleteModal((current) => ({ ...current, isProcessing: true }));
+      try {
+        await removeService(plannedService.service.id);
+        ShowNotification({
+          type: "success",
+          message: "Asignación eliminada",
+        });
+      } catch (error) {
+        console.error("Error deleting planned service:", error);
+        ShowNotification({
+          type: "error",
+          message:
+            "Error al eliminar la asignación. Por favor, intente nuevamente.",
+        });
+      } finally {
+        deleteInFlightRef.current = false;
+        setDeleteModal({
+          isOpen: false,
+          plannedService: null,
+          isProcessing: false,
+        });
       }
-      setDeleteModal({ isOpen: false, plannedService: null });
     },
     [removeService]
   );
 
   const handleCancelDelete = useCallback(() => {
-    setDeleteModal({ isOpen: false, plannedService: null });
+    setDeleteModal({
+      isOpen: false,
+      plannedService: null,
+      isProcessing: false,
+    });
   }, []);
 
   // Delete assignment handlers
@@ -150,6 +168,7 @@ export function useServiceActions({
       setDeleteAssignmentModal({
         isOpen: true,
         plannedService,
+        isProcessing: false,
       });
     },
     []
@@ -157,29 +176,44 @@ export function useServiceActions({
 
   const handleConfirmDeleteAssignment = useCallback(
     async (plannedService: PlannedService) => {
-      if (plannedService) {
-        try {
-          await removeAssignment(plannedService.service.id);
-          ShowNotification({
-            type: "success",
-            message: "Asignación eliminada",
-          });
-        } catch (error) {
-          console.error("Error deleting assignment:", error);
-          ShowNotification({
-            type: "error",
-            message:
-              "Error al eliminar la asignación. Por favor, intente nuevamente.",
-          });
-        }
+      if (!plannedService || deleteAssignmentInFlightRef.current) return;
+
+      deleteAssignmentInFlightRef.current = true;
+      setDeleteAssignmentModal((current) => ({
+        ...current,
+        isProcessing: true,
+      }));
+      try {
+        await removeAssignment(plannedService.service.id);
+        ShowNotification({
+          type: "success",
+          message: "Asignación eliminada",
+        });
+      } catch (error) {
+        console.error("Error deleting assignment:", error);
+        ShowNotification({
+          type: "error",
+          message:
+            "Error al eliminar la asignación. Por favor, intente nuevamente.",
+        });
+      } finally {
+        deleteAssignmentInFlightRef.current = false;
+        setDeleteAssignmentModal({
+          isOpen: false,
+          plannedService: null,
+          isProcessing: false,
+        });
       }
-      setDeleteAssignmentModal({ isOpen: false, plannedService: null });
     },
     [removeAssignment]
   );
 
   const handleCancelDeleteAssignment = useCallback(() => {
-    setDeleteAssignmentModal({ isOpen: false, plannedService: null });
+    setDeleteAssignmentModal({
+      isOpen: false,
+      plannedService: null,
+      isProcessing: false,
+    });
   }, []);
 
   return {

--- a/turbo-repo/packages/miot-calendar-ui/src/components/planning/delete-confirmation-modal.tsx
+++ b/turbo-repo/packages/miot-calendar-ui/src/components/planning/delete-confirmation-modal.tsx
@@ -16,6 +16,7 @@ export interface DeleteConfirmationModalMessages {
 
 interface DeleteConfirmationModalProps<TItem extends { id: string } = CalendarItem> {
   isOpen: boolean;
+  isProcessing: boolean;
   plannedService: PlannedService<TItem> | null;
   messages: DeleteConfirmationModalMessages;
   onConfirm: (plannedService: PlannedService<TItem>) => void;
@@ -65,6 +66,7 @@ export function DeleteConfirmationModal<
   TItem extends { id: string } = CalendarItem,
 >({
   isOpen,
+  isProcessing,
   plannedService,
   messages,
   onConfirm,
@@ -81,6 +83,7 @@ export function DeleteConfirmationModal<
       isOpen={isOpen}
       onClose={onCancel}
       onConfirm={handleConfirm}
+      isProcessing={isProcessing}
       title={messages.title}
       description={
         <>

--- a/turbo-repo/packages/miot-calendar-ui/src/components/planning/planning-grid-overlays.tsx
+++ b/turbo-repo/packages/miot-calendar-ui/src/components/planning/planning-grid-overlays.tsx
@@ -13,6 +13,7 @@ import { ReassignmentConnector } from "./reassignment-connector";
 interface DeleteModalState<TItem extends { id: string }> {
   isOpen: boolean;
   plannedService: PlannedService<TItem> | null;
+  isProcessing: boolean;
 }
 
 export interface PlanningGridOverlaysProps<
@@ -73,6 +74,7 @@ export function PlanningGridOverlays<
       {deleteModal.plannedService && (
         <DeleteConfirmationModal
           isOpen={deleteModal.isOpen}
+          isProcessing={deleteModal.isProcessing}
           plannedService={deleteModal.plannedService}
           messages={deleteModalMessages}
           onConfirm={onConfirmDelete}
@@ -84,6 +86,7 @@ export function PlanningGridOverlays<
       {deleteAssignmentModal.plannedService && (
         <DeleteConfirmationModal
           isOpen={deleteAssignmentModal.isOpen}
+          isProcessing={deleteAssignmentModal.isProcessing}
           plannedService={deleteAssignmentModal.plannedService}
           messages={deleteAssignmentMessages}
           onConfirm={onConfirmDeleteAssignment}


### PR DESCRIPTION
## Summary

- track in-flight state for remove-plan and remove-assignment confirmations
- disable the destructive confirmation button until the asynchronous request settles
- guard both handlers synchronously so rapid repeated confirmations cannot send duplicate requests before React rerenders
- reset modal processing state after success or failure
- add regression coverage using a deliberately pending removal request

## Root cause

The confirmation modal already supported a processing state, but the calendar removal flow never produced or forwarded that state. Its async handlers also had no synchronous in-flight guard, leaving a short duplicate-submission window before a disabled state could render.

## User impact

Planners can no longer submit the same removal multiple times while waiting for the backend response.

## Validation

- 48 calendar app tests passed
- 20 shared calendar UI tests passed
- ESLint passed for changed files
- shared calendar UI TypeScript check passed

Closes #1067