### PR TITLE
chore(release): prepare MIOT stack v0.5.33

### DIFF
--- a/releases/notes/v1.31.32.mdx
+++ b/releases/notes/v1.31.32.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.32 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la operación del calendario en ModularIoT, ampliando la configuración avanzada de despacho y corrigiendo riesgos en acciones destructivas. Esta versión prioriza más control funcional para operaciones externas y mayor seguridad en flujos críticos de eliminación.
+
+## 🚀 Evolutivos
+
+- **📍 Configuración avanzada del binding de despacho en calendario**
+  - **Key point**: Se incorporó una nueva sección en la barra lateral de configuración avanzada del calendario para listar y editar el binding de despacho (`calendar.resource_assignment`) sin depender de llamadas manuales a `PUT /bindings`.
+  - **Technical detail**: La configuración permite seleccionar conexión y operación, administrar plantillas por campo con valores por defecto, definir condiciones de respuesta de éxito/reintento, y manejar alcance global con soporte de override por calendario, incluyendo toggle de habilitación. *(Integración OSS — MIOT-0.5.33)*
+
+## 🐛 Correcciones
+
+- **🐛 Prevención de solicitudes duplicadas al eliminar planes y asignaciones en calendario**
+  - **Impacto**: El botón de confirmación podía activarse múltiples veces durante una solicitud asíncrona pendiente, generando potencialmente más de una petición de eliminación para la misma acción.
+  - **Solución**: Se controló el estado de procesamiento por operación (remove-plan y remove-assignment), se deshabilitó la confirmación mientras la solicitud está en curso, se protegió el handler contra invocaciones duplicadas antes del rerender, y se asegura cierre/reset del modal al finalizar la operación, con cobertura automatizada para validar una sola llamada. *(Integración OSS — MIOT-0.5.33)*
+
+## 📊 Beneficios
+
+- Reduce fricción operativa al permitir administrar bindings de despacho desde UI en lugar de depender de configuración por API manual.
+- Mejora la trazabilidad de integraciones al centralizar parámetros de mapeo, defaults y condiciones de respuesta en el panel avanzado del calendario.
+- Disminuye el riesgo de efectos no deseados por dobles confirmaciones en acciones destructivas.
+- Refuerza la consistencia de UX en modales de eliminación con estados de procesamiento explícitos.
+- Aumenta la confiabilidad de procesos asíncronos críticos mediante protección adicional en handlers.
+- Mejora la mantenibilidad funcional al extender capacidades ya existentes del mismo flujo de bindings.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.33`
+- App: `app@v0.5.33` (actualizado en esta release)
+- Docs: `docs@v0.5.32` (sin cambios)
+- Web: `web@v0.5.32` (sin cambios)
+- Modulith: `modulith@v0.5.21` (sin cambios)
+- Harness: `harness@v0.1.4` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.32 entrega mejoras concretas en un punto clave de operación: el calendario. Por un lado, amplía la capacidad de configuración avanzada para integraciones de despacho; por otro, cierra una brecha de seguridad funcional en confirmaciones de eliminación.
+
+En conjunto, esta release aporta más control para equipos funcionales y reduce riesgos de ejecución accidental en flujos críticos, con impacto directo en estabilidad operativa diaria.
+
+Además, mantiene alineado el stack en `0.5.33`, concentrando cambios efectivos en `app` y preservando estabilidad en los demás componentes del plan de publicación.

--- a/releases/stacks/v0.5.33.plan.json
+++ b/releases/stacks/v0.5.33.plan.json
@@ -1,0 +1,74 @@
+{
+  "stack_version": "0.5.33",
+  "stack_tag": "miot-stack@v0.5.33",
+  "milestone": "MIOT-0.5.33",
+  "pull_requests": [
+    {
+      "number": 1068,
+      "title": "fix(calendar): prevent duplicate removal requests",
+      "source_issues": [
+        {
+          "number": 1067,
+          "title": "bug(calendar): prevent duplicate remove-plan requests"
+        }
+      ]
+    },
+    {
+      "number": 1073,
+      "title": "feat(calendar): assignment-dispatch binding section in advanced settings",
+      "source_issues": [
+        {
+          "number": 1072,
+          "title": "Calendar advanced settings: administer the assignment-dispatch binding from the sidebar"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/features/calendar/bindings/binding-section-ui.tsx",
+    "turbo-repo/apps/app/src/features/calendar/bindings/use-binding-section.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.test.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/use-service-actions.ts",
+    "turbo-repo/apps/app/src/features/calendar/dispatch/calendar-dispatch-section.tsx",
+    "turbo-repo/apps/app/src/features/calendar/dispatch/dispatch-upsert.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/dispatch/dispatch-upsert.ts",
+    "turbo-repo/apps/app/src/features/calendar/dispatch/dispatch.types.ts",
+    "turbo-repo/apps/app/src/features/calendar/enrichment/calendar-enrichment-drawer.tsx",
+    "turbo-repo/apps/app/src/features/calendar/enrichment/enrichment-data-service.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/packages/miot-calendar-ui/src/components/planning/delete-confirmation-modal.tsx",
+    "turbo-repo/packages/miot-calendar-ui/src/components/planning/planning-grid-overlays.tsx"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.33",
+      "tag": "app@v0.5.33"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.32",
+      "version": "0.5.32",
+      "tag": "docs@v0.5.32"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.32",
+      "version": "0.5.32",
+      "tag": "web@v0.5.32"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.21",
+      "version": "0.5.21",
+      "tag": "modulith@v0.5.21"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.4",
+      "version": "0.1.4",
+      "tag": "harness@v0.1.4"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.32.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.32.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.32 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la operación del calendario en ModularIoT, ampliando la configuración avanzada de despacho y corrigiendo riesgos en acciones destructivas. Esta versión prioriza más control funcional para operaciones externas y mayor seguridad en flujos críticos de eliminación.
+
+## 🚀 Evolutivos
+
+- **📍 Configuración avanzada del binding de despacho en calendario**
+  - **Key point**: Se incorporó una nueva sección en la barra lateral de configuración avanzada del calendario para listar y editar el binding de despacho (`calendar.resource_assignment`) sin depender de llamadas manuales a `PUT /bindings`.
+  - **Technical detail**: La configuración permite seleccionar conexión y operación, administrar plantillas por campo con valores por defecto, definir condiciones de respuesta de éxito/reintento, y manejar alcance global con soporte de override por calendario, incluyendo toggle de habilitación. *(Integración OSS — MIOT-0.5.33)*
+
+## 🐛 Correcciones
+
+- **🐛 Prevención de solicitudes duplicadas al eliminar planes y asignaciones en calendario**
+  - **Impacto**: El botón de confirmación podía activarse múltiples veces durante una solicitud asíncrona pendiente, generando potencialmente más de una petición de eliminación para la misma acción.
+  - **Solución**: Se controló el estado de procesamiento por operación (remove-plan y remove-assignment), se deshabilitó la confirmación mientras la solicitud está en curso, se protegió el handler contra invocaciones duplicadas antes del rerender, y se asegura cierre/reset del modal al finalizar la operación, con cobertura automatizada para validar una sola llamada. *(Integración OSS — MIOT-0.5.33)*
+
+## 📊 Beneficios
+
+- Reduce fricción operativa al permitir administrar bindings de despacho desde UI en lugar de depender de configuración por API manual.
+- Mejora la trazabilidad de integraciones al centralizar parámetros de mapeo, defaults y condiciones de respuesta en el panel avanzado del calendario.
+- Disminuye el riesgo de efectos no deseados por dobles confirmaciones en acciones destructivas.
+- Refuerza la consistencia de UX en modales de eliminación con estados de procesamiento explícitos.
+- Aumenta la confiabilidad de procesos asíncronos críticos mediante protección adicional en handlers.
+- Mejora la mantenibilidad funcional al extender capacidades ya existentes del mismo flujo de bindings.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.33`
+- App: `app@v0.5.33` (actualizado en esta release)
+- Docs: `docs@v0.5.32` (sin cambios)
+- Web: `web@v0.5.32` (sin cambios)
+- Modulith: `modulith@v0.5.21` (sin cambios)
+- Harness: `harness@v0.1.4` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.32 entrega mejoras concretas en un punto clave de operación: el calendario. Por un lado, amplía la capacidad de configuración avanzada para integraciones de despacho; por otro, cierra una brecha de seguridad funcional en confirmaciones de eliminación.
+
+En conjunto, esta release aporta más control para equipos funcionales y reduce riesgos de ejecución accidental en flujos críticos, con impacto directo en estabilidad operativa diaria.
+
+Además, mantiene alineado el stack en `0.5.33`, concentrando cambios efectivos en `app` y preservando estabilidad en los demás componentes del plan de publicación.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.32",
+      "version": "0.5.33",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.33 from milestone MIOT-0.5.33, with release notes v1.31.32.

Components:
- App: app@v0.5.33 (changed: true)
- Docs: docs@v0.5.32 (changed: false since docs@v0.5.32)
- Web: web@v0.5.32 (changed: false since web@v0.5.32)
- Modulith: modulith@v0.5.21 (changed: false since modulith@v0.5.21)
- Harness: harness@v0.1.4 (changed: false since harness@v0.1.4)

Milestones: Release 1.31.32, MIOT-0.5.33.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
