### PR TITLE
fix(calendar): remove duplicate viewer menu action

### DIFF
--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.test.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PlannedService } from "./planning-selection-context";
+import { ServiceContextMenu } from "./service-context-menu";
+
+vi.mock("./use-calendar-view-mode", () => ({
+  useCalendarViewMode: () => ({
+    canPlan: true,
+    canAssign: true,
+  }),
+}));
+
+vi.mock("./planning-selection-context", () => ({
+  usePlanningSelection: () => ({
+    inspectPlannedService: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/calendar/services/task-driven-guard", () => ({
+  canAssignAtStage: () => true,
+  canReplanAtStage: () => true,
+}));
+
+vi.mock("@/features/calendar/services/use-task-driven-origins", () => ({
+  useTaskDrivenOrigins: () => [],
+}));
+
+const plannedService: PlannedService = {
+  service: {
+    id: "1659176-V",
+    cliente: "ACME",
+    origen: "CPP",
+    lugarCarguio: "",
+    destino: "CAS",
+    tipoViaje: "Rampla",
+    ocupacion: 0,
+    permanencia: "",
+    leadTime: {
+      total_lineasoc_cumplen: 0,
+      total_lineasoc_incumplen: 0,
+      lineasoc_pctn_cumplimiento: 0,
+    },
+    eta: "",
+    incidencias: [],
+    observaciones: "",
+    prioridad: 0,
+    mintral_serviceCode: "1659176",
+  },
+  slot: { date: new Date("2026-08-04T00:00:00Z"), hour: 9, minutes: 45 },
+};
+
+const dict = {
+  pages: {
+    planning: {
+      sidebar: {
+        contextMenu: {
+          service: "Servicio",
+          assign: "Asignar",
+          deleteAssignment: "Eliminar asignación",
+          replan: "Volver a planificar",
+          deletePlanning: "Eliminar planificación",
+          openReadOnly: "Abrir servicio (Solo Lectura)",
+          previewAsViewer: "Previsualizar como visor",
+        },
+      },
+    },
+  },
+};
+
+describe("ServiceContextMenu", () => {
+  it("keeps the read-only action without rendering the duplicate viewer preview", () => {
+    render(
+      <ServiceContextMenu
+        isOpen
+        position={{ x: 0, y: 0 }}
+        plannedService={plannedService}
+        onReassign={vi.fn()}
+        onAssign={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteAssignment={vi.fn()}
+        onClose={vi.fn()}
+        dict={dict}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Abrir servicio (Solo Lectura)",
+      })
+    ).toBeTruthy();
+    expect(screen.queryByText("Previsualizar como visor")).toBeNull();
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx
@@ -4,14 +4,13 @@ import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { HiEye, HiSwitchHorizontal, HiTrash, HiUserAdd } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   usePlanningSelection,
   type PlannedService,
 } from "./planning-selection-context";
 import { Button } from "flowbite-react";
 import type { I18nRecord } from "@/features/i18n/i18n.service.types";
-import { tr, trDynamic } from "@/features/i18n/tr.service";
+import { tr } from "@/features/i18n/tr.service";
 import { useCalendarViewMode } from "./use-calendar-view-mode";
 import {
   canAssignAtStage,
@@ -90,12 +89,8 @@ export function ServiceContextMenu({
   // Effective view-mode — already accounts for `?as=viewer` for users with
   // GROUP_CALENDAR_VIEWER. Fail-closed: both flags are false while
   // permissions load and while the override is active.
-  const { canPlan, canAssign, forceViewer, canTogglePreview } =
-    useCalendarViewMode();
+  const { canPlan, canAssign } = useCalendarViewMode();
   const taskDrivenOrigins = useTaskDrivenOrigins();
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { inspectPlannedService } = usePlanningSelection();
 
   // Role says who may assign; the workflow stage says whether assigning is
@@ -143,7 +138,6 @@ export function ServiceContextMenu({
     (canStartAssignment ? 1 : 0) +
     (canDeleteAssignment ? 1 : 0) +
     (canReplan ? 2 : 0) +
-    (canTogglePreview ? 1 : 0) +
     // "Abrir servicio (Solo Lectura)" always renders.
     1;
   const MENU_HEIGHT =
@@ -218,37 +212,6 @@ export function ServiceContextMenu({
   // trip already under way) has no entry to the sidebar at all.
   const handleOpenReadOnly = () => {
     inspectPlannedService(plannedService);
-    onClose();
-  };
-
-  // Flip the `?as=viewer` URL param without losing any other params
-  // (`date`, `view`, `groupCode`, etc.). Push, don't replace, so back
-  // navigates out of the preview. Closes the menu so the click feels
-  // discrete; the page re-renders with the new mode on the next tick.
-  // When entering preview (not exiting), also populate the sidebar with
-  // the right-clicked chip's data so the read-only view has content to
-  // show on the same gesture — without this, the user would have to
-  // right-click a second time after the URL flip to inspect the chip.
-  const handleTogglePreview = () => {
-    const params = new URLSearchParams(searchParams?.toString() ?? "");
-    const wasForcingViewer = forceViewer;
-    if (wasForcingViewer) {
-      params.delete("as");
-    } else {
-      params.set("as", "viewer");
-      if (plannedService) {
-        inspectPlannedService(plannedService);
-      }
-    }
-    const query = params.toString();
-    const url = query ? `${pathname}?${query}` : pathname;
-    // Replace on exit so Back doesn't bounce the user back into preview;
-    // push on entry so Back is a natural escape hatch out of preview.
-    if (wasForcingViewer) {
-      router.replace(url);
-    } else {
-      router.push(url);
-    }
     onClose();
   };
 
@@ -346,25 +309,6 @@ export function ServiceContextMenu({
             {tr("pages.planning.sidebar.contextMenu.openReadOnly", dict)}
           </span>
         </Button>
-
-        {canTogglePreview && (
-          <Button
-            color={"alternative"}
-            type="button"
-            onClick={handleTogglePreview}
-            className="border-0 rounded-none w-full justify-start gap-2"
-          >
-            <HiEye className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-            <span>
-              {trDynamic(
-                forceViewer
-                  ? "pages.planning.sidebar.contextMenu.exitPreview"
-                  : "pages.planning.sidebar.contextMenu.previewAsViewer",
-                dict
-              )}
-            </span>
-          </Button>
-        )}
       </div>
     </div>,
     document.body


### PR DESCRIPTION
## Summary

- keep Open service (Read-only) as the context menu's single read-only action
- remove the duplicate Preview as viewer entry and its context-menu URL toggle handler
- update the menu height calculation for the reduced action count
- add regression coverage proving the retained action renders while the duplicate does not

## Root cause

The menu exposed both direct read-only inspection and a full viewer-mode preview as adjacent eye-icon actions. In this context they presented the same user intent and created a duplicate, ambiguous choice.

## User impact

Planners now see one clear read-only action when opening a planned service's context menu.

## Validation

- 48 focused calendar tests passed
- ESLint passed for both changed files

Closes #1075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate viewer-preview action from the service context menu.
  * Simplified available menu actions to reflect current planning and assignment permissions.
* **Tests**
  * Added coverage verifying that read-only actions remain available and the removed viewer-preview action is not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->