### PR TITLE
chore(release): prepare MIOT stack v0.5.34

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miot-harness"
-version = "0.1.4"
+version = "0.1.5"
 description = "ASK MIOT multi-agent backend harness pilot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1412,7 +1412,7 @@ wheels = [
 
 [[package]]
 name = "miot-harness"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/releases/notes/v1.31.33.mdx
+++ b/releases/notes/v1.31.33.mdx
@@ -1,0 +1,39 @@
+# 🔔 Release Notes v1.31.33 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida la experiencia del calendario de servicios planificados eliminando acciones redundantes en el menú contextual, mejorando la claridad de la interfaz para los usuarios operativos de la plataforma.
+
+## 🐛 Correcciones
+
+- **🐛 Acción duplicada en el menú de servicio del calendario**
+  - **Impacto**: El menú contextual de servicios planificados presentaba dos acciones de solo lectura visualmente equivalentes (*Open service (Read-only)* y *Preview as viewer*), lo que generaba ambigüedad sobre cuál utilizar. *(Integración OSS — MIOT-0.5.34)*
+  - **Solución**: Se eliminó la entrada *Preview as viewer* y su manejador de URL asociado, conservando únicamente *Open service (Read-only)* como acción de lectura. Se actualizó el cálculo de altura del menú para reflejar el número reducido de acciones y se añadió cobertura de regresión para validar el comportamiento esperado.
+
+## 📊 Beneficios
+
+- La interfaz del calendario de servicios resulta más clara y predecible al eliminar opciones duplicadas que generaban confusión en los usuarios.
+- La reducción de entradas redundantes en menús contextuales disminuye la carga cognitiva durante la operación diaria de coordinación de servicios.
+- La corrección del cálculo de altura del menú garantiza una presentación visual consistente sin desbordamientos ni espacios innecesarios.
+- La cobertura de regresión incorporada reduce el riesgo de que esta clase de duplicaciones reaparezca en futuras iteraciones.
+- La actualización impacta positivamente los componentes `app`, `docs` y `web`, reflejando una mejora coherente en toda la capa de presentación.
+- El harness de pruebas (`harness@v0.1.5`) recibe actualizaciones que refuerzan la calidad general del ciclo de validación del stack.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.34` — versión base del stack desplegado en esta release.
+- **App** (`app@v0.5.34`): actualizada con la corrección del menú contextual del calendario.
+- **Docs** (`docs@v0.5.34`): documentación actualizada en línea con los cambios de esta versión.
+- **Web** (`web@v0.5.34`): capa web actualizada para reflejar la interfaz corregida.
+- **Modulith** (`modulith@v0.5.21`): sin cambios en esta release.
+- **Harness** (`harness@v0.1.5`): actualizado con nueva cobertura de regresión.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de compilación dentro de la aplicación y en el asset `stack-manifest.json` de esta release.
+
+## 📌 Conclusión
+
+La versión 1.31.33 de ModularIoT representa una mejora puntual pero significativa en la usabilidad del módulo de calendario, abordando una inconsistencia de interfaz que afectaba la claridad de las acciones disponibles sobre servicios planificados. Al estandarizar el menú contextual con una única acción de solo lectura, se simplifica la experiencia del usuario y se elimina una fuente potencial de errores operativos.
+
+Desde una perspectiva técnica, la corrección incluye ajustes en la lógica de renderizado del menú, eliminación de manejadores de URL innecesarios y validación mediante pruebas de regresión, lo que fortalece la estabilidad del componente para iteraciones futuras.
+
+Esta release mantiene la cadencia de mejoras continuas del stack OSS `MIOT-0.5.34`, consolidando la base sobre la cual se construirán las próximas funcionalidades evolutivas de la plataforma ModularIoT.

--- a/releases/stacks/v0.5.34.plan.json
+++ b/releases/stacks/v0.5.34.plan.json
@@ -1,0 +1,52 @@
+{
+  "stack_version": "0.5.34",
+  "stack_tag": "miot-stack@v0.5.34",
+  "milestone": "MIOT-0.5.34",
+  "pull_requests": [
+    {
+      "number": 1076,
+      "title": "fix(calendar): remove duplicate viewer menu action",
+      "source_issues": [
+        {
+          "number": 1075,
+          "title": "bug(calendar): remove duplicate viewer action from service menu"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.test.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/service-context-menu.tsx"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.34",
+      "tag": "app@v0.5.34"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.32",
+      "version": "0.5.34",
+      "tag": "docs@v0.5.34"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.32",
+      "version": "0.5.34",
+      "tag": "web@v0.5.34"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.21",
+      "version": "0.5.21",
+      "tag": "modulith@v0.5.21"
+    },
+    "harness": {
+      "changed": true,
+      "changed_since": "harness@v0.1.4",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.33.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.33.mdx
@@ -1,0 +1,39 @@
+# 🔔 Release Notes v1.31.33 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida la experiencia del calendario de servicios planificados eliminando acciones redundantes en el menú contextual, mejorando la claridad de la interfaz para los usuarios operativos de la plataforma.
+
+## 🐛 Correcciones
+
+- **🐛 Acción duplicada en el menú de servicio del calendario**
+  - **Impacto**: El menú contextual de servicios planificados presentaba dos acciones de solo lectura visualmente equivalentes (*Open service (Read-only)* y *Preview as viewer*), lo que generaba ambigüedad sobre cuál utilizar. *(Integración OSS — MIOT-0.5.34)*
+  - **Solución**: Se eliminó la entrada *Preview as viewer* y su manejador de URL asociado, conservando únicamente *Open service (Read-only)* como acción de lectura. Se actualizó el cálculo de altura del menú para reflejar el número reducido de acciones y se añadió cobertura de regresión para validar el comportamiento esperado.
+
+## 📊 Beneficios
+
+- La interfaz del calendario de servicios resulta más clara y predecible al eliminar opciones duplicadas que generaban confusión en los usuarios.
+- La reducción de entradas redundantes en menús contextuales disminuye la carga cognitiva durante la operación diaria de coordinación de servicios.
+- La corrección del cálculo de altura del menú garantiza una presentación visual consistente sin desbordamientos ni espacios innecesarios.
+- La cobertura de regresión incorporada reduce el riesgo de que esta clase de duplicaciones reaparezca en futuras iteraciones.
+- La actualización impacta positivamente los componentes `app`, `docs` y `web`, reflejando una mejora coherente en toda la capa de presentación.
+- El harness de pruebas (`harness@v0.1.5`) recibe actualizaciones que refuerzan la calidad general del ciclo de validación del stack.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.34` — versión base del stack desplegado en esta release.
+- **App** (`app@v0.5.34`): actualizada con la corrección del menú contextual del calendario.
+- **Docs** (`docs@v0.5.34`): documentación actualizada en línea con los cambios de esta versión.
+- **Web** (`web@v0.5.34`): capa web actualizada para reflejar la interfaz corregida.
+- **Modulith** (`modulith@v0.5.21`): sin cambios en esta release.
+- **Harness** (`harness@v0.1.5`): actualizado con nueva cobertura de regresión.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de compilación dentro de la aplicación y en el asset `stack-manifest.json` de esta release.
+
+## 📌 Conclusión
+
+La versión 1.31.33 de ModularIoT representa una mejora puntual pero significativa en la usabilidad del módulo de calendario, abordando una inconsistencia de interfaz que afectaba la claridad de las acciones disponibles sobre servicios planificados. Al estandarizar el menú contextual con una única acción de solo lectura, se simplifica la experiencia del usuario y se elimina una fuente potencial de errores operativos.
+
+Desde una perspectiva técnica, la corrección incluye ajustes en la lógica de renderizado del menú, eliminación de manejadores de URL innecesarios y validación mediante pruebas de regresión, lo que fortalece la estabilidad del componente para iteraciones futuras.
+
+Esta release mantiene la cadencia de mejoras continuas del stack OSS `MIOT-0.5.34`, consolidando la base sobre la cual se construirán las próximas funcionalidades evolutivas de la plataforma ModularIoT.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.32",
+  "version": "0.5.34",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.32",
+  "version": "0.5.34",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.33",
+      "version": "0.5.34",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.32",
+      "version": "0.5.34",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.32",
+      "version": "0.5.34",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.34 from milestone MIOT-0.5.34, with release notes v1.31.33.

Components:
- App: app@v0.5.34 (changed: true)
- Docs: docs@v0.5.34 (changed: true since docs@v0.5.32)
- Web: web@v0.5.34 (changed: true since web@v0.5.32)
- Modulith: modulith@v0.5.21 (changed: false since modulith@v0.5.21)
- Harness: harness@v0.1.5 (changed: true since harness@v0.1.4)

Milestones: Release 1.31.33, MIOT-0.5.34.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
