### PR TITLE
fix(calendar): cancel in the calendar's timezone; hide CANCELLED bookings from grid and search

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java
@@ -11,14 +11,17 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 /**
  * Minimal miot-calendar HTTP client for the two operations {@code calendar_sync}
@@ -35,6 +38,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class CalendarBookingsClient {
 
+    private static final Logger LOG = Logger.getLogger(CalendarBookingsClient.class);
+
     // Paths are pinned by the miot-calendar API contract — not a deployment
     // choice — so hardcoding them (java:S1075) is deliberate: a configurable
     // path would let an operator point at an incompatible endpoint shape.
@@ -42,6 +47,8 @@ public class CalendarBookingsClient {
     private static final String BASE_PATH = "/api/v1/miot-calendar/bookings";
     @SuppressWarnings("java:S1075")
     private static final String SLOTS_PATH = "/api/v1/miot-calendar/slots";
+    @SuppressWarnings("java:S1075")
+    private static final String CALENDARS_PATH = "/api/v1/miot-calendar/calendars";
     private static final String X_USER_ID = "miot-integrations";
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(15);
 
@@ -198,6 +205,26 @@ public class CalendarBookingsClient {
         if (response.statusCode() != 200) {
             throw httpError("move", url, response);
         }
+    }
+
+    /**
+     * The calendar's IANA timezone — the zone its slot wall-clock times live
+     * in, and therefore the zone the cancel future-vs-past decision must be
+     * evaluated in. Empty when the calendar is gone (404) or carries no usable
+     * timezone; transport and 5xx errors throw like every other call, so the
+     * surrounding job retries instead of silently judging slots in the wrong
+     * zone.
+     */
+    public Optional<ZoneId> getCalendarTimezone(UUID calendarId) {
+        String url = base() + CALENDARS_PATH + "/" + calendarId;
+        HttpResponse<String> response = send("GET", url, null);
+        if (response.statusCode() == 404) {
+            return Optional.empty();
+        }
+        if (response.statusCode() != 200) {
+            throw httpError("getCalendarTimezone", url, response);
+        }
+        return parseTimezone(response.body(), url);
     }
 
     /**
@@ -368,6 +395,31 @@ public class CalendarBookingsClient {
         }
         JsonArray data = obj.getJsonArray("data");
         return (data == null || data.isEmpty()) ? null : data;
+    }
+
+    private static Optional<ZoneId> parseTimezone(String body, String url) {
+        if (body == null || body.isBlank()) {
+            return Optional.empty();
+        }
+        String timezone;
+        try {
+            timezone = new JsonObject(body).getString("timezone");
+        } catch (RuntimeException e) {
+            throw new CalendarBookingsHttpException(200,
+                    "miot-calendar calendar response unparseable from " + url + ": " + e.getMessage());
+        }
+        if (timezone == null || timezone.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(ZoneId.of(timezone));
+        } catch (DateTimeException e) {
+            // An unknown zone id must not fail the cancel — but a silent empty
+            // would reintroduce the wrong-zone bug invisibly, so say why.
+            LOG.warnf("miot-calendar calendar at %s has unparseable timezone '%s': %s",
+                    url, timezone, e.getMessage());
+            return Optional.empty();
+        }
     }
 
     private static CalendarBookingsHttpException httpError(String op, String url, HttpResponse<String> response) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java
@@ -455,7 +455,8 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
     /**
      * Cancel decided from the freshest slot: future slot → DELETE (release
      * capacity); past slot → PATCH CANCELLED (keep history). No matching
-     * booking → SKIPPED.
+     * booking → SKIPPED. The future-vs-past comparison runs in the calendar's
+     * timezone (see {@link #calendarClock}).
      */
     private JobOutcome executeCancel(String resourceId, UUID calendarId) {
         List<CalendarBookingsClient.BookingView> bookings = client.listByResource(resourceId, calendarId);
@@ -463,7 +464,7 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
             return JobOutcome.skipped("No booking to cancel for " + resourceId);
         }
 
-        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime now = LocalDateTime.now(calendarClock(calendarId));
         int deleted = 0;
         boolean pastRemains = false;
         for (var booking : bookings) {
@@ -485,6 +486,21 @@ public class CalendarSyncExecutor implements ModulithJobHandler {
         }
         return JobOutcome.succeeded(String.format(
                 "Cancel applied for %s (deleted=%d, pastPatched=%b)", resourceId, deleted, pastRemains));
+    }
+
+    /**
+     * Slot times are wall-clock in the calendar's timezone, so the cancel
+     * future-vs-past decision must be taken there — the runtime's own zone
+     * (UTC in the containers) can run hours ahead and misclassify a
+     * still-future slot as past, patching CANCELLED (a ghost row the planning
+     * grid keeps showing) where a delete was due. Falls back to the executor
+     * clock's zone when the calendar has no usable timezone.
+     */
+    private Clock calendarClock(UUID calendarId) {
+        if (calendarId == null) {
+            return clock;
+        }
+        return client.getCalendarTimezone(calendarId).map(clock::withZone).orElse(clock);
     }
 
     private int tryDelete(CalendarBookingsClient.BookingView booking, String resourceId) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java
@@ -10,6 +10,7 @@ import com.microboxlabs.miot.integrations.jobs.NonRetryableJobException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -511,6 +512,41 @@ class CalendarSyncExecutorTest {
         assertEquals(CalendarSyncFeature.STATUS_CANCELLED, client.lastPatchStatus);
     }
 
+    /**
+     * Slot wall-clock times live in the calendar's timezone, not the
+     * runtime's. Clock at 12:00Z, slot today 09:00 — naively past; but the
+     * calendar runs at UTC-4 where it is 08:00, so the slot is still an hour
+     * away and must be DELETED, not patched CANCELLED. A CANCELLED row here is
+     * a ghost the planning grid keeps drawing.
+     */
+    @Test
+    void cancelSlotStillFutureInCalendarZoneDeletes() {
+        FakeClient client = new FakeClient();
+        client.calendarTimezone = ZoneId.of("-04:00");
+        var todaySlot = booking(LocalDate.of(2026, 7, 15)); // 09:00 wall-clock
+        client.listResult = List.of(todaySlot);
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", cancelPayload());
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertEquals(List.of(todaySlot.id()), client.cancelled);
+        assertEquals(0, client.patchCalls, "still-future slot in the calendar zone deletes, never patches");
+    }
+
+    /** No usable calendar timezone → the decision stays in the executor clock's zone. */
+    @Test
+    void cancelWithoutCalendarTimezoneFallsBackToClockZone() {
+        FakeClient client = new FakeClient();
+        client.calendarTimezone = null;
+        client.listResult = List.of(booking(LocalDate.of(2026, 7, 15))); // 09:00 < 12:00Z
+
+        var result = new CalendarSyncExecutor(client, NO_ENRICHMENT, CLOCK).handle("tenant-1", cancelPayload());
+
+        assertEquals(JobOutcome.SUCCEEDED, result.outcome());
+        assertTrue(client.cancelled.isEmpty(), "09:00 is past 12:00 in the clock's own zone");
+        assertEquals(CalendarSyncFeature.STATUS_CANCELLED, client.lastPatchStatus);
+    }
+
     // --- ensure (Phase 2 upsert) ---------------------------------------------
 
     @Test
@@ -799,6 +835,9 @@ class CalendarSyncExecutorTest {
         int unassignCalls;
         List<String> lastClearDataKeys;
 
+        // Null models a calendar with no usable timezone (fallback path).
+        ZoneId calendarTimezone;
+
         int moveCalls;
         UUID lastMoveBookingId;
         LocalDate lastMoveDate;
@@ -887,6 +926,11 @@ class CalendarSyncExecutorTest {
             if (unassignThrows != null) {
                 throw unassignThrows;
             }
+        }
+
+        @Override
+        public Optional<ZoneId> getCalendarTimezone(UUID calendarId) {
+            return Optional.ofNullable(calendarTimezone);
         }
     }
 }

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts
@@ -32,9 +32,8 @@ describe("mapBookingToPlannedService — workflowStage from booking status", () 
     expect(mapped?.planned.workflowStage).toBe("finished");
   });
 
-  it("maps CANCELLED to the terminal 'cancelled' stage", () => {
-    const mapped = mapBookingToPlannedService(booking({ status: "CANCELLED" }));
-    expect(mapped?.planned.workflowStage).toBe("cancelled");
+  it("returns null for CANCELLED bookings — history rows neither the grid nor the search may surface", () => {
+    expect(mapBookingToPlannedService(booking({ status: "CANCELLED" }))).toBeNull();
   });
 
   it("leaves planning-segment statuses unset (the live index owns them)", () => {

--- a/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts
@@ -103,12 +103,16 @@ function serviceTypeFromResourceId(id: string): string | undefined {
  * a booking the grid then refuses to render, and the highlight would point at
  * nothing. One transform, one notion of a valid planned service.
  *
- * Returns null for bookings with no slot — there is nowhere to place them.
+ * Returns null for bookings with no slot — there is nowhere to place them —
+ * and for CANCELLED bookings: those rows exist only as history (a past-slot
+ * unplan patches CANCELLED instead of deleting), and drawing one would offer
+ * plan actions on a service the workflow already pulled off the calendar.
  */
 export function mapBookingToPlannedService(
   booking: BookingResponse
 ): MappedBooking | null {
   if (!booking.slot) return null;
+  if (booking.status === "CANCELLED") return null;
 
   const storedParse = StoredServiceSchema.safeParse(booking.resource.data);
   const stored = storedParse.success ? storedParse.data : undefined;
@@ -149,9 +153,10 @@ export function mapBookingToPlannedService(
   };
 
   // Terminal stages ride the booking row itself (ECM writes the status);
-  // load-time is fine for them because a FINISHED/CANCELLED booking never
-  // goes live again. Live stages overlay this at render time via the
-  // provider's workflow-stage merge, and win on conflict.
+  // load-time is fine for them because a FINISHED booking never goes live
+  // again (CANCELLED never reaches this point — filtered above). Live stages
+  // overlay this at render time via the provider's workflow-stage merge, and
+  // win on conflict.
   const workflowStage = bookingStatusToWorkflowStage(booking.status);
 
   return {


### PR DESCRIPTION
Closes #1078.

Production trace of the defect pair (all times UTC; slot at 09:45 calendar-local, UTC-4):

1. **12:39:59 plan** — ensure created the booking, PLANNED.
2. **12:41:01 unplan** — cancel reported `deleted=0, pastPatched=true`: the 09:45 slot was judged *past* at 12:41Z even though it was 08:41 calendar-local — the decision ran in the pod's UTC zone. The booking was patched CANCELLED instead of deleted.
3. **12:43:12 re-plan** — ensure found the CANCELLED row, `PATCH PLANNED` → 409 status-regression → benign skip (can never resurrect).
4. The grid kept drawing the CANCELLED row as a normal planned card with plan actions in its menu.

### Commit 1 — modulith (`miot-integrations`)

`CalendarBookingsClient` gains `getCalendarTimezone` (`GET /calendars/{id}`, IANA `timezone` field); `CalendarSyncExecutor.executeCancel` takes the future-vs-past decision on `clock.withZone(calendarZone)`. No usable timezone (404 / absent / unparseable) falls back to the runtime zone — the previous behaviour; transport/5xx throw so the job retries rather than silently judging in the wrong zone. Tests: still-future-in-calendar-zone deletes; no-timezone falls back.

### Commit 2 — app

`mapBookingToPlannedService` returns null for `CANCELLED` bookings. The mapper is shared by the grid loader and the calendar search on purpose, so both stop surfacing history rows; `FINISHED` keeps rendering. Existing "maps CANCELLED to the terminal stage" test replaced by the new contract.

### Not addressed here (known follow-ups)

- Re-plan after a past-slot cancel still cannot resurrect the booking (monotonic-status 409) — needs a dedicated op/design.
- The ensure ETD auto-pick window also compares against the runtime zone; milder skew, same pattern.

Module tests: miot-integrations 429/429. App: calendar feature suite 189/189, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)