### PR TITLE
[calendar] Search planned services beyond date window

### DIFF
--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.test.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.test.ts
@@ -324,3 +324,34 @@ describe("bookings POST — P2 plan-path task-driven flag gating", () => {
     expect(endTaskMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("bookings GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuthMock.mockResolvedValue({
+      authenticated: true,
+      session: { user: { rawJWT: "jwt" } },
+    });
+    bookingsListMock.mockResolvedValue({ data: [], total: 0 });
+    createMiotCalendarClientMock.mockReturnValue({
+      bookings: { list: bookingsListMock },
+    });
+  });
+
+  it("forwards the generic resource identifier filter", async () => {
+    const request = new Request(
+      "http://localhost/api/calendar/bookings?resourceIdContains=1584908"
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(bookingsListMock).toHaveBeenCalledWith({
+      calendarId: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      resourceIdContains: "1584908",
+    });
+  });
+});

--- a/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
+++ b/turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts
@@ -93,6 +93,8 @@ export async function GET(request: Request) {
   const calendarId = searchParams.get("calendarId") ?? undefined;
   const startDate = searchParams.get("startDate") ?? undefined;
   const endDate = searchParams.get("endDate") ?? undefined;
+  const resourceIdContains =
+    searchParams.get("resourceIdContains") ?? undefined;
 
   const client = createMiotCalendarClient({
     baseUrl: MIOT_CALENDAR_URL,
@@ -106,6 +108,7 @@ export async function GET(request: Request) {
       calendarId,
       startDate,
       endDate,
+      resourceIdContains,
     });
     return NextResponse.json(bookings);
   } catch (error) {

--- a/turbo-repo/apps/app/src/features/calendar/services/calendar-search.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/calendar-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assignmentStateOf,
+  bookingQueriesForCalendarSearch,
   isCalendarSearchActive,
   matchesCalendarSearch,
   orderMatchesByCalendar,
@@ -89,6 +90,34 @@ describe("isCalendarSearchActive", () => {
     expect(isCalendarSearchActive(params({ assignment: ["unassigned"] }))).toBe(
       true
     );
+  });
+});
+
+describe("bookingQueriesForCalendarSearch", () => {
+  const range = { startDate: "2026-07-05", endDate: "2026-09-03" };
+
+  it("uses an unbounded generic resource query for a service term", () => {
+    expect(
+      bookingQueriesForCalendarSearch(params({ service: ["1584908"] }), range)
+    ).toEqual([{ resourceIdContains: "1584908" }]);
+  });
+
+  it("keeps multiple service chips as OR-ed resource queries", () => {
+    expect(
+      bookingQueriesForCalendarSearch(
+        params({ service: ["1584908", "1626876"] }),
+        range
+      )
+    ).toEqual([
+      { resourceIdContains: "1584908" },
+      { resourceIdContains: "1626876" },
+    ]);
+  });
+
+  it("keeps the bounded fallback for non-service filters", () => {
+    expect(
+      bookingQueriesForCalendarSearch(params({ customer: ["ACME"] }), range)
+    ).toEqual([range]);
   });
 });
 

--- a/turbo-repo/apps/app/src/features/calendar/services/calendar-search.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/calendar-search.ts
@@ -1,7 +1,7 @@
 import type { SelectedService } from "@/features/calendar/components/planning/planning-selection-types";
 
 /**
- * How far either side of **today** the search sweeps, in days.
+ * How far either side of **today** non-resource searches sweep, in days.
  *
  * Sized to match the window the grid already loads for one calendar
  * (planning-selection-wrapper's bookingsRange) — search just sweeps it across
@@ -11,11 +11,39 @@ import type { SelectedService } from "@/features/calendar/components/planning/pl
  * Anchored on today rather than the viewed date so the window holds still while
  * the user steps through matches; see the rationale in use-calendar-search.
  *
- * The cost of that choice: a service planned outside this window is not found.
- * Widening it is a one-line change here, but the honest fix is a server-side
- * query (the bookings API has no `q` param and no pagination today).
+ * Service searches use the backend's date-less generic resource-id filter and
+ * are not constrained by this window. Searches without a service term still
+ * use this bounded fallback because their fields live in the resource payload.
  */
 export const SEARCH_WINDOW_DAYS = 30;
+
+export interface CalendarBookingSearchQuery {
+  startDate?: string;
+  endDate?: string;
+  resourceIdContains?: string;
+}
+
+/**
+ * Translate calendar UI filters into resource-neutral booking API queries.
+ *
+ * The app knows that its service identifier is represented in the booking's
+ * generic resource id; miot-calendar does not need to know what a service code
+ * is. Multiple service chips are OR-ed by issuing one narrow query per term.
+ */
+export function bookingQueriesForCalendarSearch(
+  params: CalendarSearchParams,
+  range: Readonly<{ startDate: string; endDate: string }>
+): CalendarBookingSearchQuery[] {
+  if (params.service.length === 0) return [range];
+
+  const uniqueTerms = new Map<string, string>();
+  for (const term of params.service) {
+    uniqueTerms.set(term.toLowerCase(), term);
+  }
+  return [...uniqueTerms.values()].map((resourceIdContains) => ({
+    resourceIdContains,
+  }));
+}
 
 /**
  * Orders search matches so each calendar's matches are contiguous, sorted by

--- a/turbo-repo/apps/app/src/features/calendar/services/use-calendar-search.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/use-calendar-search.ts
@@ -8,13 +8,19 @@ import { listBookings } from "@/features/common/providers/client-api.provider";
 import { mapBookingToPlannedService } from "@/features/calendar/services/booking-service-mapper";
 import {
   SEARCH_WINDOW_DAYS,
+  bookingQueriesForCalendarSearch,
   isCalendarSearchActive,
   matchesCalendarSearch,
   orderMatchesByCalendar,
   parseCalendarSearchParams,
+  type CalendarBookingSearchQuery,
   type CalendarSearchParams,
 } from "@/features/calendar/services/calendar-search";
 import type { MappedBooking } from "@/features/calendar/services/booking-service-mapper";
+import type {
+  BookingListResponse,
+  BookingResponse,
+} from "@microboxlabs/miot-calendar-client";
 
 export interface CalendarSearchResult {
   /** A search is running (at least one filter badge has a value). */
@@ -32,23 +38,16 @@ export interface CalendarSearchResult {
 /**
  * Cross-calendar search over planned bookings.
  *
- * Fetches with **no `calendarId`**, which the bookings API already reads as
- * "every calendar" (BookingService.getBookings -> Booking.findByDateRange), so
- * a service planned in a calendar you are not looking at is still found. No
- * backend change was needed for this.
+ * Fetches with **no `calendarId`**, so matches span every calendar.
  *
- * Two deliberate cost choices:
+ * Service terms are translated to miot-calendar's generic
+ * `resourceIdContains` filter. Those requests intentionally omit dates, so an
+ * old planned service remains findable without teaching the calendar backend
+ * what a service code means.
  *
- * 1. The SWR key holds only the date window, *not* the query. So typing into a
- *    badge re-filters an already-fetched set instead of refetching — one fat
- *    request per window, then instant local narrowing.
- * 2. The key is `null` while no search is active, so a planner who never
- *    searches never pays for the fetch at all.
- *
- * The result set is unpaginated and each booking carries the whole service blob,
- * so this leans on the org having few calendars (it does — `parallelism` exists
- * precisely so that docks don't become calendars). If that stops holding, the
- * fix is a server-side query, and this hook is the seam to swap.
+ * Other filters still narrow a ±30-day client-side set because they live in the
+ * generic resource payload. The key is `null` while no search is active, so a
+ * planner who never searches never pays for either request.
  */
 export function useCalendarSearch(): CalendarSearchResult {
   const searchParams = useSearchParams();
@@ -75,11 +74,14 @@ export function useCalendarSearch(): CalendarSearchResult {
       endDate: today.add(SEARCH_WINDOW_DAYS, "day").format("YYYY-MM-DD"),
     };
   }, []);
+  const bookingQueries = useMemo(
+    () => bookingQueriesForCalendarSearch(params, range),
+    [params, range]
+  );
 
   const { data, error, isLoading } = useSWR(
-    // Query terms are intentionally absent from the key — see above.
-    active ? ["calendar-search", range.startDate, range.endDate] : null,
-    ([, startDate, endDate]) => listBookings({ startDate, endDate }),
+    active ? ["calendar-search", bookingQueries] : null,
+    ([, queries]) => listSearchBookings(queries),
     { revalidateOnFocus: false, keepPreviousData: true }
   );
 
@@ -101,6 +103,20 @@ export function useCalendarSearch(): CalendarSearchResult {
     isLoading: active && isLoading,
     error: error as Error | undefined,
   };
+}
+
+async function listSearchBookings(
+  queries: readonly CalendarBookingSearchQuery[]
+): Promise<BookingListResponse> {
+  const responses = await Promise.all(
+    queries.map((query) => listBookings({ ...query }))
+  );
+
+  const bookings = new Map<string, BookingResponse>();
+  for (const response of responses) {
+    for (const booking of response.data) bookings.set(booking.id, booking);
+  }
+  return { data: [...bookings.values()], total: bookings.size };
 }
 
 function slotTime(m: MappedBooking): dayjs.Dayjs {

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -2173,16 +2173,24 @@ const BookingListResponseSchema = z.object({
 });
 
 /**
- * List bookings for a calendar, optionally filtered by date range.
+ * List bookings, optionally filtered by calendar, date range, or resource id.
  */
 export async function listBookings(
-  params?: { calendarId?: string; startDate?: string; endDate?: string },
+  params?: {
+    calendarId?: string;
+    startDate?: string;
+    endDate?: string;
+    resourceIdContains?: string;
+  },
   signal?: AbortSignal
 ): Promise<BookingListResponse> {
   const searchParams = new URLSearchParams();
   if (params?.calendarId) searchParams.set("calendarId", params.calendarId);
   if (params?.startDate) searchParams.set("startDate", params.startDate);
   if (params?.endDate) searchParams.set("endDate", params.endDate);
+  if (params?.resourceIdContains) {
+    searchParams.set("resourceIdContains", params.resourceIdContains);
+  }
   const query = searchParams.toString();
   const url = query
     ? `/app/api/calendar/bookings?${query}`

--- a/turbo-repo/packages/miot-calendar-client/openapi.json
+++ b/turbo-repo/packages/miot-calendar-client/openapi.json
@@ -930,7 +930,7 @@
     "/api/v1/miot-calendar/bookings" : {
       "get" : {
         "summary" : "List bookings",
-        "description" : "Retrieve bookings filtered by calendar and date range. Defaults to the next 30 days if no dates are provided.",
+        "description" : "Retrieve bookings filtered by calendar, date range, lifecycle status, and resource identifier. Date-less resource searches span all booking dates; other date-less searches default to the next 30 days.",
         "operationId" : "listBookings",
         "tags" : [ "Bookings" ],
         "parameters" : [ {
@@ -954,6 +954,13 @@
           },
           "name" : "startDate",
           "in" : "query"
+        }, {
+          "description" : "Case-insensitive substring to match against the generic resource identifier",
+          "name" : "resourceIdContains",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts
@@ -45,12 +45,14 @@ describe("bookings", () => {
         calendarId: "cal-1",
         startDate: "2025-01-01",
         endDate: "2025-12-31",
+        resourceIdContains: "resource-42",
       });
 
       const url = new URL(call.url);
       expect(url.searchParams.get("calendarId")).toBe("cal-1");
       expect(url.searchParams.get("startDate")).toBe("2025-01-01");
       expect(url.searchParams.get("endDate")).toBe("2025-12-31");
+      expect(url.searchParams.get("resourceIdContains")).toBe("resource-42");
     });
 
     it("returns the booking list response", async () => {

--- a/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
+++ b/turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts
@@ -15,6 +15,7 @@ export function createBookingsApi(fetcher: Fetcher) {
       calendarId?: string;
       startDate?: string;
       endDate?: string;
+      resourceIdContains?: string;
     }): Promise<BookingListResponse> {
       return fetcher("GET", BASE, { query: params });
     },


### PR DESCRIPTION
Closes #1080.

Depends on microboxlabs/miot-calendar#45 and microboxlabs/miot-calendar#46.

## What changed

- Added `resourceIdContains` to the calendar client, generated API snapshot, application booking provider, and bookings BFF route.
- Translated service-search chips into date-less generic resource-identifier queries; miot-calendar remains unaware of service-code terminology.
- Kept the search cross-calendar by omitting `calendarId`.
- Preserved OR behavior for multiple service chips by querying them in parallel and deduplicating bookings by ID.
- Retained the final client-side matcher so combined customer, origin, destination, plate, trip-type, and assignment filters behave as before.
- Kept the existing ±30-day fallback for searches without a service term.

## Root cause

The search previously downloaded only today ±30 days and matched service codes in the browser. Bookings outside that response could never be highlighted or navigated to.

## Validation

- Calendar app tests: 36 passed
- Calendar client tests: 17 passed
- App and calendar-client TypeScript checks
- Calendar-client lint
- Targeted app lint with no errors
- OpenAPI JSON validation and `git diff --check`

## Rollout

Deploy miot-calendar PR #46 before this application change. An older backend ignores the new query parameter and would apply its default 30-day window.