### PR TITLE
chore(release): prepare MIOT stack v0.5.35

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.21</version>
+        <version>0.5.22</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.21</version>
+    <version>0.5.22</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.34.mdx
+++ b/releases/notes/v1.31.34.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.34 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la consistencia operativa entre la planificación y desplanificación de servicios en calendario, evitando estados visuales incorrectos. Esta versión también alinea el comportamiento funcional con la lógica temporal real de cada calendario para reducir errores de operación.
+
+## 🐛 Correcciones
+
+- **🐛 Servicio desplanificado permanecía visible como tarjeta planificada en la grilla de calendario**
+  - **Impacto**: Un servicio con reserva en estado `CANCELLED` podía seguir apareciendo como planificado, seleccionable y con acciones de planificación disponibles, generando confusión operativa y riesgo de acciones inválidas. *(Integración OSS — MIOT-0.5.35)*
+  - **Solución**: Se corrige la evaluación de “pasado/futuro” para desplanificación usando la zona horaria del calendario (con fallback a la zona de runtime cuando no esté definida) y se ajusta el mapeo compartido de booking a servicio planificado para excluir reservas `CANCELLED`, evitando que aparezcan en grilla y búsqueda. *(Integración OSS — MIOT-0.5.35)*
+
+## 📊 Beneficios
+
+- Mayor coherencia entre estado real de reservas y representación en UI de planificación.
+- Reducción de “tarjetas fantasma” tras ciclos de plan/desplan en ventanas horarias sensibles.
+- Menor probabilidad de reintentos o acciones de planificación sobre servicios ya cancelados.
+- Comportamiento temporal más robusto en despliegues con zona horaria de contenedor distinta a la del calendario.
+- Mejor trazabilidad funcional entre sincronización de calendario y experiencia de operación diaria.
+- Disminución de ruido operativo en búsqueda de calendario al ocultar estados terminales cancelados.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.35`
+- App: `app@v0.5.35` (actualizado)
+- Docs: `docs@v0.5.34` (sin cambios)
+- Web: `web@v0.5.34` (sin cambios)
+- Modulith: `modulith@v0.5.22` (actualizado)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release `v1.31.34` prioriza confiabilidad en una ruta crítica de operación: la planificación en calendario. Al corregir la referencia temporal por zona horaria y depurar la representación de estados cancelados, se elimina una fuente concreta de inconsistencia entre backend y UI.
+
+El resultado es una operación más predecible para equipos que planifican servicios en tiempo real, especialmente en escenarios multi-zona o con infraestructura en UTC. Esta mejora fortalece tanto la exactitud funcional como la seguridad operativa del flujo diario.
+
+En conjunto con `Stack v0.5.35`, esta entrega consolida una base más estable para iteraciones futuras sobre planificación y sincronización de calendario.

--- a/releases/stacks/v0.5.35.plan.json
+++ b/releases/stacks/v0.5.35.plan.json
@@ -1,0 +1,55 @@
+{
+  "stack_version": "0.5.35",
+  "stack_tag": "miot-stack@v0.5.35",
+  "milestone": "MIOT-0.5.35",
+  "pull_requests": [
+    {
+      "number": 1079,
+      "title": "fix(calendar): cancel in the calendar's timezone; hide CANCELLED bookings from grid and search",
+      "source_issues": [
+        {
+          "number": 1078,
+          "title": "Unplanned service lingers as a planned card in the calendar grid"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarBookingsClient.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutor.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncExecutorTest.java",
+    "turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/booking-service-mapper.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.35",
+      "tag": "app@v0.5.35"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.34",
+      "version": "0.5.34",
+      "tag": "docs@v0.5.34"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.34",
+      "version": "0.5.34",
+      "tag": "web@v0.5.34"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.21",
+      "version": "0.5.22",
+      "tag": "modulith@v0.5.22"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.34.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.34.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.34 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la consistencia operativa entre la planificación y desplanificación de servicios en calendario, evitando estados visuales incorrectos. Esta versión también alinea el comportamiento funcional con la lógica temporal real de cada calendario para reducir errores de operación.
+
+## 🐛 Correcciones
+
+- **🐛 Servicio desplanificado permanecía visible como tarjeta planificada en la grilla de calendario**
+  - **Impacto**: Un servicio con reserva en estado `CANCELLED` podía seguir apareciendo como planificado, seleccionable y con acciones de planificación disponibles, generando confusión operativa y riesgo de acciones inválidas. *(Integración OSS — MIOT-0.5.35)*
+  - **Solución**: Se corrige la evaluación de “pasado/futuro” para desplanificación usando la zona horaria del calendario (con fallback a la zona de runtime cuando no esté definida) y se ajusta el mapeo compartido de booking a servicio planificado para excluir reservas `CANCELLED`, evitando que aparezcan en grilla y búsqueda. *(Integración OSS — MIOT-0.5.35)*
+
+## 📊 Beneficios
+
+- Mayor coherencia entre estado real de reservas y representación en UI de planificación.
+- Reducción de “tarjetas fantasma” tras ciclos de plan/desplan en ventanas horarias sensibles.
+- Menor probabilidad de reintentos o acciones de planificación sobre servicios ya cancelados.
+- Comportamiento temporal más robusto en despliegues con zona horaria de contenedor distinta a la del calendario.
+- Mejor trazabilidad funcional entre sincronización de calendario y experiencia de operación diaria.
+- Disminución de ruido operativo en búsqueda de calendario al ocultar estados terminales cancelados.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.35`
+- App: `app@v0.5.35` (actualizado)
+- Docs: `docs@v0.5.34` (sin cambios)
+- Web: `web@v0.5.34` (sin cambios)
+- Modulith: `modulith@v0.5.22` (actualizado)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release `v1.31.34` prioriza confiabilidad en una ruta crítica de operación: la planificación en calendario. Al corregir la referencia temporal por zona horaria y depurar la representación de estados cancelados, se elimina una fuente concreta de inconsistencia entre backend y UI.
+
+El resultado es una operación más predecible para equipos que planifican servicios en tiempo real, especialmente en escenarios multi-zona o con infraestructura en UTC. Esta mejora fortalece tanto la exactitud funcional como la seguridad operativa del flujo diario.
+
+En conjunto con `Stack v0.5.35`, esta entrega consolida una base más estable para iteraciones futuras sobre planificación y sincronización de calendario.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.34",
+      "version": "0.5.35",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.35 from milestone MIOT-0.5.35, with release notes v1.31.34.

Components:
- App: app@v0.5.35 (changed: true)
- Docs: docs@v0.5.34 (changed: false since docs@v0.5.34)
- Web: web@v0.5.34 (changed: false since web@v0.5.34)
- Modulith: modulith@v0.5.22 (changed: true since modulith@v0.5.21)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.34, MIOT-0.5.35.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
