### PR TITLE
chore(release): prepare MIOT stack v0.5.36

### DIFF
--- a/releases/notes/v1.31.35.mdx
+++ b/releases/notes/v1.31.35.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.35 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Mejorar la capacidad de búsqueda histórica de servicios planificados en calendarios, manteniendo la API de calendario genérica y desacoplada del dominio de negocio. Esta versión también alinea aplicación, web y documentación con el stack `0.5.36`.
+
+## 🚀 Evolutivos
+
+- **📍 Búsqueda de reservas por identificador de recurso sin fechas**
+  - **Key point**: Se incorporó el filtro opcional `resourceIdContains` en el listado de reservas, con coincidencia por subcadena e insensible a mayúsculas/minúsculas.
+  - **Technical detail**: Cuando se usa este filtro sin fechas, la consulta puede abarcar históricos y múltiples calendarios (salvo que se indique uno), preservando la ventana por defecto de 30 días para listados sin filtro. *(Integración OSS — MIOT-0.5.36)*
+
+## 🐛 Correcciones
+
+- **🐛 Búsqueda de servicios planificados fuera de la ventana del calendario**
+  - **Impacto**: La búsqueda cruzada solo traía reservas en una ventana acotada y luego filtraba en cliente, por lo que servicios válidos fuera de ese rango no aparecían ni podían navegarse.
+  - **Solución**: Los términos de servicio se traducen al filtro genérico `resourceIdContains`, omitiendo fechas en consultas por servicio para permitir hallazgos históricos, manteniendo búsqueda cross-calendar, lógica OR entre múltiples chips y deduplicación de respuestas; se conserva el fallback acotado cuando no hay término de servicio. *(Integración OSS — MIOT-0.5.36)*
+
+## 📊 Beneficios
+
+- Mejora la trazabilidad operativa al encontrar servicios históricos que antes quedaban ocultos.
+- Reduce falsas ausencias en búsquedas de planificación y mejora la navegación desde la UI.
+- Mantiene compatibilidad funcional con filtros existentes (cliente, origen, destino, placa, tipo de viaje y asignación).
+- Refuerza el desacoplamiento entre dominio de aplicación y API de calendario con un filtro genérico reutilizable.
+- Conserva comportamiento eficiente por defecto (ventana de 30 días) para listados no filtrados.
+- Mejora la consistencia entre app y servicios al unificar el criterio de búsqueda por identificador de recurso.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.36`.
+- App: `app@v0.5.36` (actualizado).
+- Docs: `docs@v0.5.36` (actualizado).
+- Web: `web@v0.5.36` (actualizado).
+- Modulith: `modulith@v0.5.22` (sin cambios).
+- Harness: `harness@v0.1.5` (sin cambios).
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+Esta entrega fortalece una capacidad crítica de operación: encontrar servicios planificados más allá de la ventana temporal por defecto, sin romper los filtros actuales ni introducir acoplamientos de dominio en `miot-calendar`.
+
+La combinación entre el ajuste en calendario OSS y su adopción en la búsqueda cross-calendar de la aplicación resuelve una limitación funcional real, especialmente relevante para auditoría operativa y seguimiento histórico.
+
+Con la actualización coordinada de app, web y documentación sobre el stack `0.5.36`, la plataforma queda más consistente para uso diario y más sólida para futuras extensiones de búsqueda.

--- a/releases/stacks/v0.5.36.plan.json
+++ b/releases/stacks/v0.5.36.plan.json
@@ -1,0 +1,59 @@
+{
+  "stack_version": "0.5.36",
+  "stack_tag": "miot-stack@v0.5.36",
+  "milestone": "MIOT-0.5.36",
+  "pull_requests": [
+    {
+      "number": 1081,
+      "title": "[calendar] Search planned services beyond date window",
+      "source_issues": [
+        {
+          "number": 1080,
+          "title": "bug: find planned services outside the calendar search window"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/app/api/calendar/bookings/route.test.ts",
+    "turbo-repo/apps/app/src/app/api/calendar/bookings/route.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/calendar-search.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/calendar-search.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/use-calendar-search.ts",
+    "turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts",
+    "turbo-repo/packages/miot-calendar-client/openapi.json",
+    "turbo-repo/packages/miot-calendar-client/src/__tests__/bookings.test.ts",
+    "turbo-repo/packages/miot-calendar-client/src/resources/bookings.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.36",
+      "tag": "app@v0.5.36"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.34",
+      "version": "0.5.36",
+      "tag": "docs@v0.5.36"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.34",
+      "version": "0.5.36",
+      "tag": "web@v0.5.36"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.22",
+      "version": "0.5.22",
+      "tag": "modulith@v0.5.22"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.35.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.35.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.35 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Mejorar la capacidad de búsqueda histórica de servicios planificados en calendarios, manteniendo la API de calendario genérica y desacoplada del dominio de negocio. Esta versión también alinea aplicación, web y documentación con el stack `0.5.36`.
+
+## 🚀 Evolutivos
+
+- **📍 Búsqueda de reservas por identificador de recurso sin fechas**
+  - **Key point**: Se incorporó el filtro opcional `resourceIdContains` en el listado de reservas, con coincidencia por subcadena e insensible a mayúsculas/minúsculas.
+  - **Technical detail**: Cuando se usa este filtro sin fechas, la consulta puede abarcar históricos y múltiples calendarios (salvo que se indique uno), preservando la ventana por defecto de 30 días para listados sin filtro. *(Integración OSS — MIOT-0.5.36)*
+
+## 🐛 Correcciones
+
+- **🐛 Búsqueda de servicios planificados fuera de la ventana del calendario**
+  - **Impacto**: La búsqueda cruzada solo traía reservas en una ventana acotada y luego filtraba en cliente, por lo que servicios válidos fuera de ese rango no aparecían ni podían navegarse.
+  - **Solución**: Los términos de servicio se traducen al filtro genérico `resourceIdContains`, omitiendo fechas en consultas por servicio para permitir hallazgos históricos, manteniendo búsqueda cross-calendar, lógica OR entre múltiples chips y deduplicación de respuestas; se conserva el fallback acotado cuando no hay término de servicio. *(Integración OSS — MIOT-0.5.36)*
+
+## 📊 Beneficios
+
+- Mejora la trazabilidad operativa al encontrar servicios históricos que antes quedaban ocultos.
+- Reduce falsas ausencias en búsquedas de planificación y mejora la navegación desde la UI.
+- Mantiene compatibilidad funcional con filtros existentes (cliente, origen, destino, placa, tipo de viaje y asignación).
+- Refuerza el desacoplamiento entre dominio de aplicación y API de calendario con un filtro genérico reutilizable.
+- Conserva comportamiento eficiente por defecto (ventana de 30 días) para listados no filtrados.
+- Mejora la consistencia entre app y servicios al unificar el criterio de búsqueda por identificador de recurso.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.36`.
+- App: `app@v0.5.36` (actualizado).
+- Docs: `docs@v0.5.36` (actualizado).
+- Web: `web@v0.5.36` (actualizado).
+- Modulith: `modulith@v0.5.22` (sin cambios).
+- Harness: `harness@v0.1.5` (sin cambios).
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+Esta entrega fortalece una capacidad crítica de operación: encontrar servicios planificados más allá de la ventana temporal por defecto, sin romper los filtros actuales ni introducir acoplamientos de dominio en `miot-calendar`.
+
+La combinación entre el ajuste en calendario OSS y su adopción en la búsqueda cross-calendar de la aplicación resuelve una limitación funcional real, especialmente relevante para auditoría operativa y seguimiento histórico.
+
+Con la actualización coordinada de app, web y documentación sobre el stack `0.5.36`, la plataforma queda más consistente para uso diario y más sólida para futuras extensiones de búsqueda.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.34",
+  "version": "0.5.36",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.34",
+  "version": "0.5.36",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.35",
+      "version": "0.5.36",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.34",
+      "version": "0.5.36",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.34",
+      "version": "0.5.36",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.36 from milestone MIOT-0.5.36, with release notes v1.31.35.

Components:
- App: app@v0.5.36 (changed: true)
- Docs: docs@v0.5.36 (changed: true since docs@v0.5.34)
- Web: web@v0.5.36 (changed: true since web@v0.5.34)
- Modulith: modulith@v0.5.22 (changed: false since modulith@v0.5.22)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.35, MIOT-0.5.36.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * Añadido el filtro opcional `resourceIdContains` para buscar reservas por coincidencias parciales y sin distinguir mayúsculas de minúsculas.
  * Las búsquedas pueden abarcar históricos y múltiples calendarios cuando no se indican fechas.

* **Correcciones**
  * Corregidas las búsquedas de servicios planificados fuera de la ventana temporal predeterminada.
  * Mejorados los resultados combinados, evitando duplicados y manteniendo la búsqueda entre varios criterios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->