### PR TITLE
feat(integrations): optional dispatch context enrichment via a fetch binding

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/EventDispatchFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/EventDispatchFeature.java
@@ -33,6 +33,25 @@ public final class EventDispatchFeature {
      */
     public static final String PAYLOAD_CONTEXT = "context";
 
+    /**
+     * Optional: an event type whose <b>fetch-shaped</b> binding completes the context
+     * before rendering — for producers whose snapshot carries opaque resource ids that
+     * partner templates cannot use directly (the fetch resolves them into the fields the
+     * templates read). Resolved through {@code EventBindingFetchService} with the
+     * dispatch's own scope and context, so which connection answers and how fields map
+     * in both directions stays operator-authored binding config. Absent → the snapshot
+     * renders unchanged, exactly as before this key existed.
+     */
+    public static final String PAYLOAD_ENRICHMENT_EVENT = "enrichmentEvent";
+
+    /**
+     * Optional companion to {@link #PAYLOAD_ENRICHMENT_EVENT}: the context key whose
+     * map receives the fetched values (created if absent). Absent → fetched values merge
+     * at the context root. Fetched values win over the snapshot's own — a fresh
+     * resolution beats what rode along.
+     */
+    public static final String PAYLOAD_ENRICHMENT_MERGE_KEY = "enrichmentMergeKey";
+
     private EventDispatchFeature() {
     }
 }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
@@ -9,13 +9,16 @@ import com.microboxlabs.miot.integrations.domain.IntegrationOperation;
 import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationEventBindingRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import com.microboxlabs.miot.integrations.service.EventBindingFetchService;
 import com.microboxlabs.miot.integrations.service.EventBindingSelector;
 import com.microboxlabs.miot.integrations.template.PayloadRenderException;
 import com.microboxlabs.miot.integrations.template.PayloadRenderer;
 import com.microboxlabs.miot.integrations.template.PayloadSchema;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Delivers one bound event: load the binding, render its payload from the context snapshot,
@@ -41,6 +44,7 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
     private final EventBindingSelector selector;
     private final ChannelDispatcherRegistry dispatchers;
     private final PayloadRenderer renderer;
+    private final EventBindingFetchService fetchService;
 
     @Inject
     public IntegrationEventDispatchHandler(
@@ -49,13 +53,15 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
             IntegrationOperationRepository operationRepository,
             EventBindingSelector selector,
             ChannelDispatcherRegistry dispatchers,
-            PayloadRenderer renderer) {
+            PayloadRenderer renderer,
+            EventBindingFetchService fetchService) {
         this.bindingRepository = bindingRepository;
         this.connectionRepository = connectionRepository;
         this.operationRepository = operationRepository;
         this.selector = selector;
         this.dispatchers = dispatchers;
         this.renderer = renderer;
+        this.fetchService = fetchService;
     }
 
     @Override
@@ -89,7 +95,8 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
                     "Connection " + binding.connectionId() + " no longer exists");
         }
 
-        Object body = renderBody(binding, contractFor(binding), contextOf(payload));
+        Object body = renderBody(binding, contractFor(binding),
+                enrichContext(tenantClientId, payload, contextOf(payload)));
         ChannelDispatcher dispatcher = dispatchers.dispatcherFor(connection.providerType());
 
 
@@ -128,6 +135,49 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
                 string(payload, EventDispatchFeature.PAYLOAD_SCOPE_KIND),
                 string(payload, EventDispatchFeature.PAYLOAD_SCOPE_KEY),
                 contextOf(payload));
+    }
+
+    /**
+     * Optional pre-render enrichment: the producer names an event whose fetch-shaped
+     * binding completes the context — the case is a snapshot carrying opaque resource
+     * ids that partner templates cannot use directly, resolved here into the fields
+     * they read. Fetched values land under {@code enrichmentMergeKey} (a map, created
+     * if absent) or at the context root when no key is named, and win over the
+     * snapshot's own: a fresh resolution beats what rode along.
+     *
+     * <p>Inherits the fetch contract wholesale: no armed binding, or a context with
+     * nothing the fetch's mapping reads, returns the snapshot unchanged (rollout is
+     * flipping a row on); a configured fetch that cannot deliver throws, so the ledger
+     * retries or parks visibly rather than dispatching silently wrong data.
+     */
+    private Map<String, Object> enrichContext(
+            String tenantClientId, Map<String, Object> payload, Map<String, Object> context) {
+        String enrichmentEvent = string(payload, EventDispatchFeature.PAYLOAD_ENRICHMENT_EVENT);
+        if (enrichmentEvent == null) {
+            return context;
+        }
+        Optional<EventBindingFetchService.FetchedValues> fetched = fetchService.fetch(
+                tenantClientId,
+                enrichmentEvent,
+                string(payload, EventDispatchFeature.PAYLOAD_SCOPE_KIND),
+                string(payload, EventDispatchFeature.PAYLOAD_SCOPE_KEY),
+                context);
+        if (fetched.isEmpty()) {
+            return context;
+        }
+        Map<String, Object> enriched = new LinkedHashMap<>(context);
+        String mergeKey = string(payload, EventDispatchFeature.PAYLOAD_ENRICHMENT_MERGE_KEY);
+        if (mergeKey == null) {
+            enriched.putAll(fetched.get().values());
+            return enriched;
+        }
+        Map<String, Object> target = new LinkedHashMap<>();
+        if (context.get(mergeKey) instanceof Map<?, ?> existing) {
+            existing.forEach((k, v) -> target.put(String.valueOf(k), v));
+        }
+        target.putAll(fetched.get().values());
+        enriched.put(mergeKey, target);
+        return enriched;
     }
 
     private PayloadSchema contractFor(IntegrationEventBinding binding) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
@@ -15,12 +15,14 @@ import com.microboxlabs.miot.integrations.domain.ProviderType;
 import com.microboxlabs.miot.integrations.persistence.IntegrationConnectionRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationEventBindingRepository;
 import com.microboxlabs.miot.integrations.persistence.IntegrationOperationRepository;
+import com.microboxlabs.miot.integrations.service.EventBindingFetchService;
 import com.microboxlabs.miot.integrations.template.PayloadRenderer;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class IntegrationEventDispatchHandlerTest {
@@ -34,13 +36,15 @@ class IntegrationEventDispatchHandlerTest {
     private final FakeConnections connections = new FakeConnections();
     private final FakeOperations operations = new FakeOperations();
     private final RecordingDispatcher dispatcher = new RecordingDispatcher();
+    private final FakeFetch fetch = new FakeFetch();
 
     private IntegrationEventDispatchHandler handler() {
         return new IntegrationEventDispatchHandler(
                 bindings, connections, operations,
                 new com.microboxlabs.miot.integrations.service.EventBindingSelector(bindings),
                 new ChannelDispatcherRegistry(List.of(dispatcher), dispatcher),
-                new PayloadRenderer());
+                new PayloadRenderer(),
+                fetch);
     }
 
     private static Map<String, Object> payload() {
@@ -171,6 +175,84 @@ class IntegrationEventDispatchHandlerTest {
         assertThrows(NonRetryableJobException.class, () -> handler().handle(TENANT, payload));
     }
 
+    // --- context enrichment (producer names a fetch event to complete the snapshot) ---
+
+    /**
+     * The snapshot carries an opaque id plus a stale identity field; the named fetch
+     * resolves the id and its value must win over the stale one at the merge key.
+     */
+    private Map<String, Object> enrichedPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(EventDispatchFeature.PAYLOAD_TENANT_CLIENT_ID, TENANT);
+        payload.put(EventDispatchFeature.PAYLOAD_BINDING_ID, BINDING_ID);
+        payload.put(EventDispatchFeature.PAYLOAD_SCOPE_KIND, "scope-kind");
+        payload.put(EventDispatchFeature.PAYLOAD_SCOPE_KEY, "scope-key");
+        payload.put(EventDispatchFeature.PAYLOAD_ENRICHMENT_EVENT, "resource.identity");
+        payload.put(EventDispatchFeature.PAYLOAD_ENRICHMENT_MERGE_KEY, "resourceData");
+        payload.put(EventDispatchFeature.PAYLOAD_CONTEXT, Map.of(
+                "resourceData", Map.of("identifier", "stale-value", "opaqueId", "u-1"),
+                "review", Map.of("verdict", true)));
+        bindings.binding = bindingWithTemplates(Map.of(
+                "guidMultimedia", "{{resourceData.identifier}}",
+                "aprobado", "{{review.verdict}}"));
+        return payload;
+    }
+
+    @Test
+    void enrichmentValuesWinOverTheSnapshotAtTheMergeKey() {
+        fetch.values = Map.of("identifier", "fresh-value");
+
+        JobOutcome outcome = handler().handle(TENANT, enrichedPayload());
+
+        assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
+        assertEquals("fresh-value", dispatcher.lastPayloadMap().get("guidMultimedia"));
+        assertEquals("resource.identity", fetch.lastEvent);
+        assertEquals("scope-kind", fetch.lastScopeKind);
+        assertEquals("scope-key", fetch.lastScopeKey);
+    }
+
+    @Test
+    void unconfiguredEnrichmentDispatchesTheSnapshotUnchanged() {
+        fetch.values = null; // no armed binding / nothing mapped to ask
+
+        JobOutcome outcome = handler().handle(TENANT, enrichedPayload());
+
+        assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
+        assertEquals("stale-value", dispatcher.lastPayloadMap().get("guidMultimedia"));
+    }
+
+    @Test
+    void payloadWithoutAnEnrichmentEventNeverFetches() {
+        handler().handle(TENANT, payload());
+
+        assertEquals(0, fetch.calls, "no enrichment named, no fetch made");
+    }
+
+    @Test
+    void aFailingConfiguredEnrichmentStaysRetryable() {
+        fetch.failure = new IllegalStateException("Fetch rejected with 503");
+
+        RuntimeException failure = assertThrows(RuntimeException.class,
+                () -> handler().handle(TENANT, enrichedPayload()));
+
+        assertTrue(!(failure instanceof NonRetryableJobException),
+                "a partner that may recover must back off and retry, not park");
+    }
+
+    @Test
+    void enrichmentWithoutAMergeKeyMergesAtTheContextRoot() {
+        Map<String, Object> payload = enrichedPayload();
+        payload.remove(EventDispatchFeature.PAYLOAD_ENRICHMENT_MERGE_KEY);
+        bindings.binding = bindingWithTemplates(Map.of(
+                "guidMultimedia", "{{identifier}}",
+                "aprobado", "{{review.verdict}}"));
+        fetch.values = Map.of("identifier", "root-value");
+
+        handler().handle(TENANT, payload);
+
+        assertEquals("root-value", dispatcher.lastPayloadMap().get("guidMultimedia"));
+    }
+
     @Test
     void claimsTheEventDispatchJobTypeOnTheModulithLane() {
         assertEquals("integration_event_dispatch", handler().jobType());
@@ -248,6 +330,35 @@ class IntegrationEventDispatchHandlerTest {
                     Map.of("type", "object", "properties", properties,
                             "required", List.of("guidMultimedia", "aprobado")),
                     Map.of(), false);
+        }
+    }
+
+    /** Answers the enrichment fetch: {@code values == null} models "not configured". */
+    private static final class FakeFetch extends EventBindingFetchService {
+        private Map<String, Object> values;
+        private RuntimeException failure;
+        private int calls;
+        private String lastEvent;
+        private String lastScopeKind;
+        private String lastScopeKey;
+
+        private FakeFetch() {
+            super(null, null, null, null);
+        }
+
+        @Override
+        public Optional<FetchedValues> fetch(String tenantClientId, String eventType,
+                String scopeKind, String scopeKey, Map<String, Object> context) {
+            calls++;
+            lastEvent = eventType;
+            lastScopeKind = scopeKind;
+            lastScopeKey = scopeKey;
+            if (failure != null) {
+                throw failure;
+            }
+            return values == null
+                    ? Optional.empty()
+                    : Optional.of(new FetchedValues("fetch-binding", "fetch-connection", values));
         }
     }
 


### PR DESCRIPTION
Closes #1084.

`integration_event_dispatch` gains an optional, payload-declared pre-render enrichment:

- **`enrichmentEvent`** — an event type resolved through `EventBindingFetchService` with the dispatch's own scope and context. Which connection answers and how fields map in both directions (`field_templates` request, `response_templates` write-back) stays operator-authored binding rows — the handler learns no vocabulary.
- **`enrichmentMergeKey`** — context key whose map receives the fetched values (created if absent); when absent, values merge at the context root. Fetched values win over the snapshot: a fresh resolution beats what rode along.

Semantics inherit the fetch contract: no armed binding / a context with nothing the fetch's mapping reads → the snapshot dispatches unchanged (rollout = flipping a row on); a configured fetch that cannot deliver throws → the ledger retries or parks visibly instead of delivering silently wrong data. Payloads that name no enrichment are byte-for-byte unaffected.

Motivating case (details in #1084): an assignment dispatch rendered stand-in defaults although real resources were selected — the selection rode the context as opaque resource ids, and the identity fields the partner templates read were a stale snapshot that only the partner's own feed writes back. With this seam the producer adds the ids to the context and names an identity-resolution event; the resolving connection/operation/binding is pure config.

Tests: 5 new in `IntegrationEventDispatchHandlerTest` (merge-key win, unconfigured pass-through, no-event-no-fetch, configured-failure stays retryable, root merge). Module 434/434.

Producer-side companion (private repo): ecm-coordinator PR adding the resource ids to the assignment dispatch context and naming the enrichment event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event payloads can now optionally include additional context fetched from a related event.
  * Enriched values can be merged into the main context or placed under a specified key.
  * Existing rendering remains unchanged when enrichment is not configured.

* **Bug Fixes**
  * Failed enrichment requests remain retryable.
  * Missing enrichment data no longer alters the original event snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->