### PR TITLE
chore(release): prepare MIOT stack v0.5.37

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.22</version>
+        <version>0.5.23</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.22</version>
+    <version>0.5.23</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.36.mdx
+++ b/releases/notes/v1.31.36.mdx
@@ -1,0 +1,46 @@
+# 🔔 Release Notes v1.31.36 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la estabilidad operativa en coordinación de servicios y mejorar la calidad de los datos enviados a integraciones externas. Esta versión reduce reversiones no deseadas en planificación y habilita despachos de eventos con contexto enriquecido cuando el snapshot no alcanza.
+
+## 🚀 Evolutivos
+
+- **📍 Enriquecimiento opcional de contexto en despacho de eventos**
+  - **Key point**: Se incorporó una capacidad opcional para enriquecer el contexto antes de renderizar plantillas en `integration_event_dispatch`, permitiendo resolver datos faltantes desde un `enrichmentEvent`.
+  - **Technical detail**: El enriquecimiento se resuelve vía `EventBindingFetchService` y puede fusionarse en una clave específica con `enrichmentMergeKey` (o en la raíz). Si el fetch no está configurado, el flujo permanece igual; si falla estando configurado, el proceso falla de forma visible para reintento o estacionamiento. *(Integración OSS — MIOT-0.5.37)*
+
+## 🐛 Correcciones
+
+- **🐛 Reversión de planificación por prioridad `PL` en sincronización externa**
+  - **Impacto**: Servicios recién planificados desde calendario podían volver hacia atrás automáticamente en el siguiente ciclo de sync cuando el partner seguía reportando `PL`, generando ciclos de creación/cancelación de reserva y pushes duplicados.
+  - **Solución**: Se agregó una marca temporal en la transición de calendario y una ventana de gracia configurable para bloquear movimientos hacia atrás (`EC`/`SD`/`PL`) cuando la tarea actual proviene de una acción humana reciente en calendario.
+
+## 📊 Beneficios
+
+- Menos “tira y afloje” entre operador y sincronización automática en etapas de planificación.
+- Mayor consistencia entre acciones de calendario y estado efectivo del workflow.
+- Reducción de efectos colaterales operativos (rebookings/cancelaciones repetidas).
+- Mejor calidad de payloads hacia partners cuando el contexto trae identificadores opacos.
+- Integraciones más seguras al fallar de forma explícita ante enriquecimientos configurados con error.
+- Compatibilidad hacia atrás: productores sin enriquecimiento definido no cambian su comportamiento.
+
+## 🧾 Versiones del stack
+
+- Versión de release: **1.31.36**
+- Versión de stack: **0.5.37**
+- Tag de stack: `miot-stack@v0.5.37`
+- App: `app@v0.5.37` (**con cambios**)
+- Docs: `docs@v0.5.36` (sin cambios)
+- Web: `web@v0.5.36` (sin cambios)
+- Modulith: `modulith@v0.5.23` (**con cambios**)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.36 se enfoca en confiabilidad operacional y calidad de integración, atacando un problema de reversión de estado con impacto directo en la operación diaria y habilitando un patrón de enriquecimiento que mejora la fidelidad de los datos despachados.
+
+En términos funcionales, el resultado combina una corrección crítica de flujo en coordinación de servicios con una evolución reutilizable para escenarios de integración donde el snapshot no contiene toda la identidad necesaria.
+
+Para los equipos de operación e integración, esto se traduce en menos fricción, mayor trazabilidad de errores y una base más robusta para escalar automatizaciones sin degradar control humano reciente.

--- a/releases/stacks/v0.5.37.plan.json
+++ b/releases/stacks/v0.5.37.plan.json
@@ -1,0 +1,53 @@
+{
+  "stack_version": "0.5.37",
+  "stack_tag": "miot-stack@v0.5.37",
+  "milestone": "MIOT-0.5.37",
+  "pull_requests": [
+    {
+      "number": 1085,
+      "title": "feat(integrations): optional dispatch context enrichment via a fetch binding",
+      "source_issues": [
+        {
+          "number": 1084,
+          "title": "Event dispatch: optional context enrichment via a fetch binding before rendering"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/EventDispatchFeature.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.37",
+      "tag": "app@v0.5.37"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.36",
+      "version": "0.5.36",
+      "tag": "docs@v0.5.36"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.36",
+      "version": "0.5.36",
+      "tag": "web@v0.5.36"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.22",
+      "version": "0.5.23",
+      "tag": "modulith@v0.5.23"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.36.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.36.mdx
@@ -1,0 +1,46 @@
+# 🔔 Release Notes v1.31.36 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la estabilidad operativa en coordinación de servicios y mejorar la calidad de los datos enviados a integraciones externas. Esta versión reduce reversiones no deseadas en planificación y habilita despachos de eventos con contexto enriquecido cuando el snapshot no alcanza.
+
+## 🚀 Evolutivos
+
+- **📍 Enriquecimiento opcional de contexto en despacho de eventos**
+  - **Key point**: Se incorporó una capacidad opcional para enriquecer el contexto antes de renderizar plantillas en `integration_event_dispatch`, permitiendo resolver datos faltantes desde un `enrichmentEvent`.
+  - **Technical detail**: El enriquecimiento se resuelve vía `EventBindingFetchService` y puede fusionarse en una clave específica con `enrichmentMergeKey` (o en la raíz). Si el fetch no está configurado, el flujo permanece igual; si falla estando configurado, el proceso falla de forma visible para reintento o estacionamiento. *(Integración OSS — MIOT-0.5.37)*
+
+## 🐛 Correcciones
+
+- **🐛 Reversión de planificación por prioridad `PL` en sincronización externa**
+  - **Impacto**: Servicios recién planificados desde calendario podían volver hacia atrás automáticamente en el siguiente ciclo de sync cuando el partner seguía reportando `PL`, generando ciclos de creación/cancelación de reserva y pushes duplicados.
+  - **Solución**: Se agregó una marca temporal en la transición de calendario y una ventana de gracia configurable para bloquear movimientos hacia atrás (`EC`/`SD`/`PL`) cuando la tarea actual proviene de una acción humana reciente en calendario.
+
+## 📊 Beneficios
+
+- Menos “tira y afloje” entre operador y sincronización automática en etapas de planificación.
+- Mayor consistencia entre acciones de calendario y estado efectivo del workflow.
+- Reducción de efectos colaterales operativos (rebookings/cancelaciones repetidas).
+- Mejor calidad de payloads hacia partners cuando el contexto trae identificadores opacos.
+- Integraciones más seguras al fallar de forma explícita ante enriquecimientos configurados con error.
+- Compatibilidad hacia atrás: productores sin enriquecimiento definido no cambian su comportamiento.
+
+## 🧾 Versiones del stack
+
+- Versión de release: **1.31.36**
+- Versión de stack: **0.5.37**
+- Tag de stack: `miot-stack@v0.5.37`
+- App: `app@v0.5.37` (**con cambios**)
+- Docs: `docs@v0.5.36` (sin cambios)
+- Web: `web@v0.5.36` (sin cambios)
+- Modulith: `modulith@v0.5.23` (**con cambios**)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.36 se enfoca en confiabilidad operacional y calidad de integración, atacando un problema de reversión de estado con impacto directo en la operación diaria y habilitando un patrón de enriquecimiento que mejora la fidelidad de los datos despachados.
+
+En términos funcionales, el resultado combina una corrección crítica de flujo en coordinación de servicios con una evolución reutilizable para escenarios de integración donde el snapshot no contiene toda la identidad necesaria.
+
+Para los equipos de operación e integración, esto se traduce en menos fricción, mayor trazabilidad de errores y una base más robusta para escalar automatizaciones sin degradar control humano reciente.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.36",
+      "version": "0.5.37",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.37 from milestone MIOT-0.5.37, with release notes v1.31.36.

Components:
- App: app@v0.5.37 (changed: true)
- Docs: docs@v0.5.36 (changed: false since docs@v0.5.36)
- Web: web@v0.5.36 (changed: false since web@v0.5.36)
- Modulith: modulith@v0.5.23 (changed: true since modulith@v0.5.22)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.36, MIOT-0.5.37.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
