### PR TITLE
fix(integrations): dispatch enrichment clears mapped keys the fetch resolved as empty

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java
@@ -142,8 +142,11 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
      * binding completes the context — the case is a snapshot carrying opaque resource
      * ids that partner templates cannot use directly, resolved here into the fields
      * they read. Fetched values land under {@code enrichmentMergeKey} (a map, created
-     * if absent) or at the context root when no key is named, and win over the
-     * snapshot's own: a fresh resolution beats what rode along.
+     * if absent) or at the context root when no key is named, and the fetch is
+     * <b>authoritative for every key its mapping declares</b>: a resolved value wins
+     * over the snapshot's own, and a mapped slot the partner resolved to nothing
+     * <i>clears</i> the snapshot's value — otherwise a stale rider (the previous
+     * assignment's identifier, a placeholder) would be dispatched as if fresh.
      *
      * <p>Inherits the fetch contract wholesale: no armed binding, or a context with
      * nothing the fetch's mapping reads, returns the snapshot unchanged (rollout is
@@ -168,16 +171,27 @@ public class IntegrationEventDispatchHandler implements ModulithJobHandler {
         Map<String, Object> enriched = new LinkedHashMap<>(context);
         String mergeKey = string(payload, EventDispatchFeature.PAYLOAD_ENRICHMENT_MERGE_KEY);
         if (mergeKey == null) {
-            enriched.putAll(fetched.get().values());
+            applyFetched(enriched, fetched.get());
             return enriched;
         }
         Map<String, Object> target = new LinkedHashMap<>();
         if (context.get(mergeKey) instanceof Map<?, ?> existing) {
             existing.forEach((k, v) -> target.put(String.valueOf(k), v));
         }
-        target.putAll(fetched.get().values());
+        applyFetched(target, fetched.get());
         enriched.put(mergeKey, target);
         return enriched;
+    }
+
+    /** Merge resolved values in, then drop mapped keys the partner resolved to nothing. */
+    private static void applyFetched(
+            Map<String, Object> target, EventBindingFetchService.FetchedValues fetched) {
+        target.putAll(fetched.values());
+        for (String key : fetched.mappedKeys()) {
+            if (!fetched.values().containsKey(key)) {
+                target.remove(key);
+            }
+        }
     }
 
     private PayloadSchema contractFor(IntegrationEventBinding binding) {

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingFetchService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingFetchService.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
 /**
@@ -64,8 +66,23 @@ public class EventBindingFetchService {
         this.renderer = renderer;
     }
 
-    /** A completed fetch: which binding answered, and the values to merge. */
-    public record FetchedValues(String bindingId, String connectionId, Map<String, Object> values) {
+    /**
+     * A completed fetch: which binding answered, and the values to merge.
+     *
+     * <p>{@code mappedKeys} is the set of keys the binding's {@code response_templates}
+     * declare — the keys the operator made this fetch <b>authoritative</b> for. A mapped
+     * key absent from {@code values} is not "no news": the partner answered and resolved
+     * that slot to nothing. A caller merging over a snapshot that may carry a stale value
+     * under such a key should drop it; a caller accumulating into its own record (where an
+     * unresolved lookup must not erase data) can ignore the set. Empty when the binding has
+     * no response mapping — a raw pass-through claims authority over nothing.
+     */
+    public record FetchedValues(String bindingId, String connectionId,
+            Map<String, Object> values, Set<String> mappedKeys) {
+
+        public FetchedValues(String bindingId, String connectionId, Map<String, Object> values) {
+            this(bindingId, connectionId, values, Set.of());
+        }
     }
 
     /**
@@ -93,7 +110,18 @@ public class EventBindingFetchService {
         OperationInvocationResult response = invoke(binding, request);
         Map<String, Object> parsed = parseObject(binding, response.body());
         return Optional.of(new FetchedValues(binding.id(), binding.connectionId(),
-                renderResponse(binding, parsed)));
+                renderResponse(binding, parsed), mappedKeys(binding)));
+    }
+
+    /** The keys the binding's response mapping owns; see {@link FetchedValues#mappedKeys()}. */
+    private static Set<String> mappedKeys(IntegrationEventBinding binding) {
+        if (binding.responseTemplates() == null) {
+            return Set.of();
+        }
+        return binding.responseTemplates().entrySet().stream()
+                .filter(entry -> entry.getValue() != null && !entry.getValue().isBlank())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     private Object renderRequest(IntegrationEventBinding binding, Map<String, Object> context) {
@@ -148,8 +176,10 @@ public class EventBindingFetchService {
     /**
      * The write-back. Rendered under root {@code response}, with the renderer's own
      * empty-is-omitted rule — a null slot in the response (no second driver) writes nothing
-     * rather than a blank. No {@code response_templates} means the caller wants the response
-     * as-is.
+     * rather than a blank. What "nothing" means is the caller's call: the omitted key still
+     * appears in {@link FetchedValues#mappedKeys()}, so a merger can distinguish "the partner
+     * resolved this slot to none" from "this fetch never spoke for that key". No
+     * {@code response_templates} means the caller wants the response as-is.
      */
     private Map<String, Object> renderResponse(
             IntegrationEventBinding binding, Map<String, Object> parsed) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class IntegrationEventDispatchHandlerTest {
@@ -239,6 +240,41 @@ class IntegrationEventDispatchHandlerTest {
                 "a partner that may recover must back off and retry, not park");
     }
 
+    /**
+     * The stale snapshot maps an optional body field; the fetch's mapping owns that key
+     * but resolved it to nothing (the new assignment has no such resource). The stale
+     * value must not ride into the body — the field is omitted, exactly as a producer
+     * building the body directly would omit a null slot.
+     */
+    @Test
+    void aMappedKeyTheFetchResolvedToNothingClearsTheStaleValue() {
+        Map<String, Object> payload = enrichedPayload();
+        bindings.binding = bindingWithTemplates(Map.of(
+                "guidMultimedia", "{{resourceData.opaqueId}}",
+                "aprobado", "{{review.verdict}}",
+                "usuarioRevisor", "{{resourceData.identifier}}"));
+        fetch.values = Map.of();
+        fetch.mappedKeys = Set.of("identifier");
+
+        JobOutcome outcome = handler().handle(TENANT, payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
+        assertTrue(!dispatcher.lastPayloadMap().containsKey("usuarioRevisor"),
+                "the stale value under a fetch-owned key must not be dispatched");
+    }
+
+    @Test
+    void aKeyTheFetchMappingDoesNotOwnKeepsItsSnapshotValue() {
+        Map<String, Object> payload = enrichedPayload();
+        fetch.values = Map.of("somethingElse", "resolved");
+        fetch.mappedKeys = Set.of("somethingElse");
+
+        handler().handle(TENANT, payload);
+
+        // "identifier" is not the fetch's to speak for — the snapshot's value stands.
+        assertEquals("stale-value", dispatcher.lastPayloadMap().get("guidMultimedia"));
+    }
+
     @Test
     void enrichmentWithoutAMergeKeyMergesAtTheContextRoot() {
         Map<String, Object> payload = enrichedPayload();
@@ -336,6 +372,7 @@ class IntegrationEventDispatchHandlerTest {
     /** Answers the enrichment fetch: {@code values == null} models "not configured". */
     private static final class FakeFetch extends EventBindingFetchService {
         private Map<String, Object> values;
+        private Set<String> mappedKeys = Set.of();
         private RuntimeException failure;
         private int calls;
         private String lastEvent;
@@ -358,7 +395,8 @@ class IntegrationEventDispatchHandlerTest {
             }
             return values == null
                     ? Optional.empty()
-                    : Optional.of(new FetchedValues("fetch-binding", "fetch-connection", values));
+                    : Optional.of(new FetchedValues(
+                            "fetch-binding", "fetch-connection", values, mappedKeys));
         }
     }
 

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/EventBindingFetchServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/EventBindingFetchServiceTest.java
@@ -14,6 +14,7 @@ import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class EventBindingFetchServiceTest {
@@ -86,6 +87,9 @@ class EventBindingFetchServiceTest {
         // Renamed by response_templates; the null trailer slot writes nothing.
         assertEquals(Map.of("assignedDriver", "d-uuid", "assignedTruck", "t-uuid"), fetched.values());
         assertEquals("b-1", fetched.bindingId());
+        // ...but the mapping still owns every key it declares, so a merger can
+        // tell "resolved to nothing" apart from "never spoke for this key".
+        assertEquals(Set.of("assignedDriver", "assignedTruck"), fetched.mappedKeys());
     }
 
     @Test
@@ -169,6 +173,8 @@ class EventBindingFetchServiceTest {
                 .orElseThrow();
 
         assertEquals(Map.of("driver_id", "d-uuid"), fetched.values());
+        // A raw pass-through claims authority over nothing.
+        assertTrue(fetched.mappedKeys().isEmpty());
     }
 
     /* ------------------------------------------------------------------ fakes */


### PR DESCRIPTION
Closes #1087.

## The gap

The optional dispatch-context enrichment (#1084) merges the fetch's mapped response values over the context snapshot — but the write-back applies the renderer's empty-is-omitted rule. A mapped slot the partner resolves to `null` (the optional co-resource of an assignment that has none) writes nothing back, so the **stale snapshot value under that key survives the merge** and is rendered into the outbound body. Observed in production: a re-assignment without the optional resource re-sent the placeholder identifier riding in the snapshot; with a different history it would re-send the *previous* assignment's real value.

## The fix

The write-back mapping is authoritative for its keys:

- `FetchedValues` gains `mappedKeys` — the key set the binding's `response_templates` declare (empty for a raw pass-through, which claims authority over nothing).
- The dispatch merge (`enrichContext` → `applyFetched`) removes merged-context keys that are mapped but absent from the fetched values. The body renderer's empty-is-omitted rule then drops the field, matching producers that build these bodies directly (a null slot omits the key).

## Explicitly unchanged

The calendar_sync enrichment call site keeps merge-only semantics — there, a lookup that cannot resolve must not clear existing booking resource data. It ignores `mappedKeys` (the 3-arg `FetchedValues` convenience constructor preserves that contract).

## Tests

- `aMappedKeyTheFetchResolvedToNothingClearsTheStaleValue` — the stale value under a fetch-owned key is not dispatched; the optional field is omitted.
- `aKeyTheFetchMappingDoesNotOwnKeepsItsSnapshotValue` — authority is scoped: unowned keys keep their snapshot values.
- Fetch-service assertions that `mappedKeys` reflects the declared mapping and is empty for raw pass-through.

`miot-integrations`: 436/436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enrichment now prioritizes values retrieved from configured mappings over existing snapshot values.
  * Stale snapshot values are removed when a mapped field has no resolved value.
  * Nested and top-level enrichment targets now apply mapping results consistently.

* **Tests**
  * Added coverage for resolved, unresolved, and unmapped fields during enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->