### PR TITLE
chore(release): prepare MIOT stack v0.5.38

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.24</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.23</version>
+    <version>0.5.24</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.37.mdx
+++ b/releases/notes/v1.31.37.mdx
@@ -1,0 +1,37 @@
+# 🔔 Release Notes v1.31.37 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la confiabilidad de los flujos de integración en la versión `1.31.37`, alineada con el stack `0.5.38`. Esta entrega se enfoca en evitar envío de datos residuales en eventos enriquecidos y mantener consistencia en las cargas hacia sistemas externos.
+
+## 🐛 Correcciones
+
+- **🐛 Limpieza de claves mapeadas vacías en enriquecimiento de dispatch**
+  - **Impacto**: En `integration_event_dispatch`, cuando una resolución devolvía valores vacíos o nulos, podían conservarse claves antiguas del snapshot y terminar reenviando identificadores obsoletos en el body.
+  - **Solución**: El mapeo de escritura de enriquecimiento pasó a tratar sus claves como autoritativas: si una clave está mapeada pero no llega en los valores obtenidos, se elimina del contexto fusionado para que el renderizado omita ese campo vacío. *(Integración OSS — MIOT-0.5.38)*
+
+## 📊 Beneficios
+
+- Se reduce el riesgo de enviar identificadores desactualizados a partners externos.
+- Mejora la consistencia entre payloads enriquecidos y payloads construidos directamente por productores.
+- Disminuyen efectos colaterales por estado residual en snapshots de contexto.
+- Se refuerza la calidad operativa de flujos de reasignación con datos opcionales.
+- Se mantiene comportamiento controlado en escenarios donde la semántica de merge debe preservarse.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.38`
+- **App**: `app@v0.5.38` (con cambios)
+- **Docs**: `docs@v0.5.38` (con cambios)
+- **Web**: `web@v0.5.38` (con cambios)
+- **Modulith**: `modulith@v0.5.24` (con cambios)
+- **Harness**: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.37` prioriza robustez en integraciones, corrigiendo un caso sensible de contaminación de datos por valores previos en contexto. Con este ajuste, los eventos enriquecidos reflejan mejor el estado real al momento de renderizar y despachar.
+
+A nivel de plataforma, este cambio mejora la confianza en automatizaciones industriales y reduce riesgos de inconsistencias aguas abajo en sistemas conectados.
+
+En conjunto con la actualización de componentes del stack `0.5.38`, la versión consolida una base más segura para operaciones continuas y escalables.

--- a/releases/stacks/v0.5.38.plan.json
+++ b/releases/stacks/v0.5.38.plan.json
@@ -1,0 +1,54 @@
+{
+  "stack_version": "0.5.38",
+  "stack_tag": "miot-stack@v0.5.38",
+  "milestone": "MIOT-0.5.38",
+  "pull_requests": [
+    {
+      "number": 1088,
+      "title": "fix(integrations): dispatch enrichment clears mapped keys the fetch resolved as empty",
+      "source_issues": [
+        {
+          "number": 1087,
+          "title": "fix(integrations): dispatch enrichment must clear mapped keys the fetch resolved as empty"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandler.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/EventBindingFetchService.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/EventBindingFetchServiceTest.java"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.38",
+      "tag": "app@v0.5.38"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.36",
+      "version": "0.5.38",
+      "tag": "docs@v0.5.38"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.36",
+      "version": "0.5.38",
+      "tag": "web@v0.5.38"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.23",
+      "version": "0.5.24",
+      "tag": "modulith@v0.5.24"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.37.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.37.mdx
@@ -1,0 +1,37 @@
+# 🔔 Release Notes v1.31.37 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la confiabilidad de los flujos de integración en la versión `1.31.37`, alineada con el stack `0.5.38`. Esta entrega se enfoca en evitar envío de datos residuales en eventos enriquecidos y mantener consistencia en las cargas hacia sistemas externos.
+
+## 🐛 Correcciones
+
+- **🐛 Limpieza de claves mapeadas vacías en enriquecimiento de dispatch**
+  - **Impacto**: En `integration_event_dispatch`, cuando una resolución devolvía valores vacíos o nulos, podían conservarse claves antiguas del snapshot y terminar reenviando identificadores obsoletos en el body.
+  - **Solución**: El mapeo de escritura de enriquecimiento pasó a tratar sus claves como autoritativas: si una clave está mapeada pero no llega en los valores obtenidos, se elimina del contexto fusionado para que el renderizado omita ese campo vacío. *(Integración OSS — MIOT-0.5.38)*
+
+## 📊 Beneficios
+
+- Se reduce el riesgo de enviar identificadores desactualizados a partners externos.
+- Mejora la consistencia entre payloads enriquecidos y payloads construidos directamente por productores.
+- Disminuyen efectos colaterales por estado residual en snapshots de contexto.
+- Se refuerza la calidad operativa de flujos de reasignación con datos opcionales.
+- Se mantiene comportamiento controlado en escenarios donde la semántica de merge debe preservarse.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.38`
+- **App**: `app@v0.5.38` (con cambios)
+- **Docs**: `docs@v0.5.38` (con cambios)
+- **Web**: `web@v0.5.38` (con cambios)
+- **Modulith**: `modulith@v0.5.24` (con cambios)
+- **Harness**: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.37` prioriza robustez en integraciones, corrigiendo un caso sensible de contaminación de datos por valores previos en contexto. Con este ajuste, los eventos enriquecidos reflejan mejor el estado real al momento de renderizar y despachar.
+
+A nivel de plataforma, este cambio mejora la confianza en automatizaciones industriales y reduce riesgos de inconsistencias aguas abajo en sistemas conectados.
+
+En conjunto con la actualización de componentes del stack `0.5.38`, la versión consolida una base más segura para operaciones continuas y escalables.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.36",
+  "version": "0.5.38",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.36",
+  "version": "0.5.38",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.37",
+      "version": "0.5.38",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.36",
+      "version": "0.5.38",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.36",
+      "version": "0.5.38",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.38 from milestone MIOT-0.5.38, with release notes v1.31.37.

Components:
- App: app@v0.5.38 (changed: true)
- Docs: docs@v0.5.38 (changed: true since docs@v0.5.36)
- Web: web@v0.5.38 (changed: true since web@v0.5.36)
- Modulith: modulith@v0.5.24 (changed: true since modulith@v0.5.23)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.37, MIOT-0.5.38.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
