### PR TITLE
feat(calendar): trailer slot driven by the truck's trailer_need flag

### DIFF
--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -610,13 +610,15 @@ export interface PgrestAccreditedResourceRow {
   integration: "INTEGRATED" | "NOT INTEGRATED" | null;
   /**
    * Whether this truck runs with a trailer (TRUCK rows only): drives the
-   * assignment form's trailer slot — hidden when `false`, required when
-   * `true`. Optional because older fn deployments don't emit it yet; the UI
-   * treats absent/null as "required" so an unknown truck can never ship an
-   * assignment whose trailer slot downstream bindings would fill with a
-   * placeholder.
+   * assignment form's trailer slot — hidden when falsy-but-present, required
+   * when truthy. The upstream fn emits it as `0 | 1`; the union also admits
+   * booleans so a future fn change doesn't break the contract — clients
+   * normalize with `Boolean()`. Optional because older fn deployments don't
+   * emit it at all; the UI treats absent/null as "required" so an unknown
+   * truck can never ship an assignment whose trailer slot downstream
+   * bindings would fill with a placeholder.
    */
-  trailer_need?: boolean | null;
+  trailer_need?: 0 | 1 | boolean | null;
   /**
    * Last-known position as EWKB hex (SRID-prefixed point, 4326) for TRUCK
    * rows. Null when the asset has no position recorded. Decoded server-side

--- a/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
+++ b/turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts
@@ -609,6 +609,15 @@ export interface PgrestAccreditedResourceRow {
    */
   integration: "INTEGRATED" | "NOT INTEGRATED" | null;
   /**
+   * Whether this truck runs with a trailer (TRUCK rows only): drives the
+   * assignment form's trailer slot — hidden when `false`, required when
+   * `true`. Optional because older fn deployments don't emit it yet; the UI
+   * treats absent/null as "required" so an unknown truck can never ship an
+   * assignment whose trailer slot downstream bindings would fill with a
+   * placeholder.
+   */
+  trailer_need?: boolean | null;
+  /**
    * Last-known position as EWKB hex (SRID-prefixed point, 4326) for TRUCK
    * rows. Null when the asset has no position recorded. Decoded server-side
    * by `decodeEwkbPoint`; the calendar route surfaces the resulting

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -33,6 +33,7 @@ import {
   AssignmentForm,
   type AssignmentFormData,
 } from "./sidebar-tabs";
+import { assignmentIncomplete } from "./sidebar-tabs/assignment/assignment-rules";
 import { useCalendarViewMode } from "./use-calendar-view-mode";
 import {
   TabButtons,
@@ -73,7 +74,7 @@ function assignmentOverrides(
     out.assignedTruck = data.truck;
     out.assignedTruckAccreditation = data.truckAccreditation;
   }
-  if (data.hasTrailer && data.trailer) {
+  if (data.trailer) {
     out.assignedTrailer = data.trailer;
     out.assignedTrailerAccreditation = data.trailerAccreditation;
   }
@@ -84,8 +85,10 @@ function assignmentOverrides(
  * Build the initial `AssignmentFormData` from a service, hydrating the
  * carrier / driver / truck / trailer slots from the values persisted on the
  * previous `confirmService` call. Missing fields collapse to empty strings;
- * `hasSecondDriver` / `hasTrailer` toggle on when the matching slot is
- * set so the conditional UI opens automatically on reassign.
+ * `hasSecondDriver` toggles on when the matching slot is set so the
+ * conditional UI opens automatically on reassign. `truckTrailerNeed` starts
+ * unknown (null → trailer required, fail closed) and is refreshed from the
+ * truck's accredited row once the feed pins it in (assignment-form effect).
  */
 function assignmentDataFromService(
   service: SelectedService | undefined
@@ -106,7 +109,7 @@ function assignmentDataFromService(
     truckAccreditation: service?.assignedTruckAccreditation ?? null,
     trailer: service?.assignedTrailer ?? "",
     trailerAccreditation: service?.assignedTrailerAccreditation ?? null,
-    hasTrailer: Boolean(service?.assignedTrailer),
+    truckTrailerNeed: null,
   };
 }
 
@@ -772,9 +775,7 @@ export function PlanningSidebarForm({
                   onClick={handleAssign}
                   disabled={
                     !assigningService ||
-                    !assignmentData.carrier ||
-                    !assignmentData.driver ||
-                    !assignmentData.truck ||
+                    assignmentIncomplete(assignmentData) ||
                     isSubmitting
                   }
                 >

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -12,7 +12,7 @@ import {
   type AccreditedResource,
 } from "@/features/calendar/services/accredited-resources.service";
 import { toAccreditationLevel, type AccreditationLevel } from "./accreditation";
-import { trailerRequired } from "./assignment-rules";
+import { normalizeTrailerNeed, trailerRequired } from "./assignment-rules";
 import { DriverSearchDropdown } from "./driver-search-dropdown";
 import {
   CarrierSearchDropdown,
@@ -294,17 +294,19 @@ function carrierExternalIdFromRows(
 }
 
 /**
- * The `trailer_need` flag of the row backing a just-selected truck. `null`
- * when the selection was cleared, the row is not on the loaded page, or the
- * upstream fn predates the flag — all treated as "trailer required" by
- * `assignment-rules`.
+ * The `trailer_need` flag of the row backing a just-selected truck,
+ * normalized from the wire's `0 | 1`. `null` when the selection was cleared,
+ * the row is not on the loaded page, or the upstream fn predates the flag —
+ * all treated as "trailer required" by `assignment-rules`.
  */
 function trailerNeedFromRows(
   rows: AccreditedResource[],
   resourceId: string | boolean
 ): boolean | null {
   if (typeof resourceId !== "string" || resourceId.length === 0) return null;
-  return rows.find((row) => row.resource_id === resourceId)?.trailer_need ?? null;
+  return normalizeTrailerNeed(
+    rows.find((row) => row.resource_id === resourceId)?.trailer_need
+  );
 }
 
 function clearCarrierScopedAssignment(updated: AssignmentFormData): void {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx
@@ -12,6 +12,7 @@ import {
   type AccreditedResource,
 } from "@/features/calendar/services/accredited-resources.service";
 import { toAccreditationLevel, type AccreditationLevel } from "./accreditation";
+import { trailerRequired } from "./assignment-rules";
 import { DriverSearchDropdown } from "./driver-search-dropdown";
 import {
   CarrierSearchDropdown,
@@ -245,7 +246,14 @@ export interface AssignmentFormData {
   hasSecondDriver: boolean;
   truck: string;
   trailer: string;
-  hasTrailer: boolean;
+  /**
+   * The picked truck's `trailer_need` flag, captured from its accredited row
+   * on every truck change (same lifecycle as the accreditation capture).
+   * Decides the trailer slot's fate — hidden when `false`, shown and required
+   * otherwise (see `assignment-rules`). `null` when no truck is selected, the
+   * row wasn't on the loaded page, or the upstream fn predates the flag.
+   */
+  truckTrailerNeed: boolean | null;
   /**
    * Accreditation level of each selected resource, captured from the
    * accredited-resources row on every change (same lifecycle as
@@ -285,6 +293,20 @@ function carrierExternalIdFromRows(
   );
 }
 
+/**
+ * The `trailer_need` flag of the row backing a just-selected truck. `null`
+ * when the selection was cleared, the row is not on the loaded page, or the
+ * upstream fn predates the flag — all treated as "trailer required" by
+ * `assignment-rules`.
+ */
+function trailerNeedFromRows(
+  rows: AccreditedResource[],
+  resourceId: string | boolean
+): boolean | null {
+  if (typeof resourceId !== "string" || resourceId.length === 0) return null;
+  return rows.find((row) => row.resource_id === resourceId)?.trailer_need ?? null;
+}
+
 function clearCarrierScopedAssignment(updated: AssignmentFormData): void {
   updated.driver = "";
   updated.secondDriver = "";
@@ -294,6 +316,7 @@ function clearCarrierScopedAssignment(updated: AssignmentFormData): void {
   updated.secondDriverAccreditation = null;
   updated.truckAccreditation = null;
   updated.trailerAccreditation = null;
+  updated.truckTrailerNeed = null;
 }
 
 function updateSelectedResourceAccreditation(
@@ -557,8 +580,27 @@ export function AssignmentForm({
     carrierId: value.carrier,
     query: trailerQuery,
     selectedIds: value.trailer ? [value.trailer] : undefined,
-    enabled: Boolean(value.carrier && value.hasTrailer),
+    enabled: Boolean(value.carrier) && trailerRequired(value),
   });
+
+  // A rehydrated assignment carries the truck id but not its trailer_need —
+  // the flag lives on the accredited row, which arrives async (pinned via
+  // selectedIds). Refresh the captured value once the row is on the page so
+  // a trailerless truck's slot hides (and its stale trailer drops) instead of
+  // staying fail-closed-required forever.
+  useEffect(() => {
+    const need = trailerNeedFromRows(accreditedTrucks, value.truck);
+    if (!value.truck || need === null || need === value.truckTrailerNeed) {
+      return;
+    }
+    const updated = { ...value, truckTrailerNeed: need };
+    if (!trailerRequired(updated)) {
+      updated.trailer = "";
+      updated.trailerAccreditation = null;
+      setTrailerQuery("");
+    }
+    onChange(updated);
+  }, [accreditedTrucks, value, onChange]);
 
   const carrierOptions = useMemo(
     () => accreditedCarriers.map(carrierRowToOption),
@@ -629,11 +671,19 @@ export function AssignmentForm({
       updated.secondDriverAccreditation = null;
     }
 
-    // When disabling trailer section, clear the selection and search.
-    if (field === "hasTrailer" && fieldValue === false) {
-      updated.trailer = "";
-      updated.trailerAccreditation = null;
-      setTrailerQuery("");
+    // The truck's own trailer_need decides the trailer slot's fate (see
+    // assignment-rules): capture it with the pick, and drop any trailer that
+    // was chosen for a previous truck when this one runs trailerless.
+    if (field === "truck") {
+      updated.truckTrailerNeed = trailerNeedFromRows(
+        accreditedTrucks,
+        fieldValue
+      );
+      if (!trailerRequired(updated)) {
+        updated.trailer = "";
+        updated.trailerAccreditation = null;
+        setTrailerQuery("");
+      }
     }
 
     onChange(updated);
@@ -722,19 +772,6 @@ export function AssignmentForm({
           onQueryChange={setTruckQuery}
           onReachEnd={loadMoreTrucks}
           isLoadingMore={isLoadingMoreTrucks}
-          labelRightElement={
-            <label className="flex items-center gap-1 cursor-pointer">
-              <span className="text-[10px] text-gray-500 dark:text-gray-400">
-                {tr("pages.planning.sidebar.assignment.trailerLabel", dict)}
-              </span>
-              <Checkbox
-                id="trailer-check"
-                checked={value.hasTrailer}
-                onChange={(e) => handleChange("hasTrailer", e.target.checked)}
-                className="w-3 h-3"
-              />
-            </label>
-          }
         />
         {selectedCamion && (
           <TruckMapDisplay
@@ -746,8 +783,9 @@ export function AssignmentForm({
         )}
       </div>
 
-      {/* Remolque Dropdown (conditional) */}
-      {value.hasTrailer && (
+      {/* Remolque Dropdown — the picked truck's trailer_need decides:
+          hidden for a trailerless vehicle, shown (and required) otherwise. */}
+      {trailerRequired(value) && (
         <TrailerSearchDropdown
           label={tr("pages.planning.sidebar.assignment.trailer", dict)}
           trailers={trailerOptions}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { assignmentIncomplete, trailerRequired } from "./assignment-rules";
+
+function selection(
+  overrides: Partial<Parameters<typeof assignmentIncomplete>[0]> = {}
+) {
+  return {
+    carrier: "carrier-1",
+    driver: "driver-1",
+    truck: "truck-1",
+    trailer: "",
+    truckTrailerNeed: null as boolean | null,
+    ...overrides,
+  };
+}
+
+describe("trailerRequired", () => {
+  it("is required for a truck that needs its trailer", () => {
+    expect(trailerRequired(selection({ truckTrailerNeed: true }))).toBe(true);
+  });
+
+  it("is hidden (not required) for a trailerless vehicle", () => {
+    expect(trailerRequired(selection({ truckTrailerNeed: false }))).toBe(false);
+  });
+
+  it("fails closed when the flag is unknown", () => {
+    // Row not on the page yet, or an fn deployment that predates the flag —
+    // requiring beats dispatching an empty slot a binding fills with a
+    // placeholder.
+    expect(trailerRequired(selection({ truckTrailerNeed: null }))).toBe(true);
+  });
+
+  it("is moot without a truck", () => {
+    expect(trailerRequired(selection({ truck: "" }))).toBe(false);
+  });
+});
+
+describe("assignmentIncomplete", () => {
+  it("requires carrier, driver and truck as before", () => {
+    expect(assignmentIncomplete(selection({ carrier: "" }))).toBe(true);
+    expect(assignmentIncomplete(selection({ driver: "" }))).toBe(true);
+    expect(assignmentIncomplete(selection({ truck: "" }))).toBe(true);
+  });
+
+  it("blocks a trailer-needing truck until the trailer is picked", () => {
+    expect(
+      assignmentIncomplete(selection({ truckTrailerNeed: true }))
+    ).toBe(true);
+    expect(
+      assignmentIncomplete(
+        selection({ truckTrailerNeed: true, trailer: "trailer-1" })
+      )
+    ).toBe(false);
+  });
+
+  it("lets a trailerless vehicle through without one", () => {
+    expect(
+      assignmentIncomplete(selection({ truckTrailerNeed: false }))
+    ).toBe(false);
+  });
+
+  it("blocks while the flag is still unknown", () => {
+    expect(assignmentIncomplete(selection())).toBe(true);
+  });
+});

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { assignmentIncomplete, trailerRequired } from "./assignment-rules";
+import {
+  assignmentIncomplete,
+  normalizeTrailerNeed,
+  trailerRequired,
+} from "./assignment-rules";
 
 function selection(
   overrides: Partial<Parameters<typeof assignmentIncomplete>[0]> = {}
@@ -13,6 +17,23 @@ function selection(
     ...overrides,
   };
 }
+
+describe("normalizeTrailerNeed", () => {
+  it("maps the fn's 0|1 to booleans", () => {
+    expect(normalizeTrailerNeed(1)).toBe(true);
+    expect(normalizeTrailerNeed(0)).toBe(false);
+  });
+
+  it("admits booleans unchanged", () => {
+    expect(normalizeTrailerNeed(true)).toBe(true);
+    expect(normalizeTrailerNeed(false)).toBe(false);
+  });
+
+  it("keeps absent/null as unknown", () => {
+    expect(normalizeTrailerNeed(null)).toBeNull();
+    expect(normalizeTrailerNeed(undefined)).toBeNull();
+  });
+});
 
 describe("trailerRequired", () => {
   it("is required for a truck that needs its trailer", () => {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
@@ -1,0 +1,38 @@
+import type { AssignmentFormData } from "./assignment-form";
+
+/**
+ * Whether the current selection makes the trailer slot mandatory — which is
+ * also when the trailer selector is shown at all (no checkbox: the truck's
+ * own `trailer_need` decides, not the operator).
+ *
+ * The picked truck's accredited row carries `trailer_need`: `false` means the
+ * vehicle runs trailerless (camioneta, furgón) and the slot is hidden;
+ * `true` means it never runs a service without its trailer, so the slot is
+ * shown and required. Absent/`null` — a row from an fn deployment that
+ * predates the flag, or a rehydrated assignment whose row hasn't loaded yet —
+ * is treated as required: failing closed beats shipping an assignment whose
+ * empty trailer slot downstream bindings fill with a placeholder.
+ */
+export function trailerRequired(
+  data: Pick<AssignmentFormData, "truck" | "truckTrailerNeed">
+): boolean {
+  return Boolean(data.truck) && data.truckTrailerNeed !== false;
+}
+
+/**
+ * The submit gate for the Asignar button: carrier, driver and truck are always
+ * required, and a truck that needs a trailer additionally requires one.
+ */
+export function assignmentIncomplete(
+  data: Pick<
+    AssignmentFormData,
+    "carrier" | "driver" | "truck" | "trailer" | "truckTrailerNeed"
+  >
+): boolean {
+  return (
+    !data.carrier ||
+    !data.driver ||
+    !data.truck ||
+    (trailerRequired(data) && !data.trailer)
+  );
+}

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
@@ -1,4 +1,17 @@
 import type { AssignmentFormData } from "./assignment-form";
+import type { AccreditedResource } from "@/features/calendar/services/accredited-resources.service";
+
+/**
+ * The wire flag → the form's `truckTrailerNeed`. The upstream fn emits
+ * `0 | 1`; booleans are admitted too so an fn change can't flip the rule
+ * silently. Absent/null stays `null` — "unknown", which `trailerRequired`
+ * treats as required.
+ */
+export function normalizeTrailerNeed(
+  value: AccreditedResource["trailer_need"] | undefined
+): boolean | null {
+  return value == null ? null : Boolean(value);
+}
 
 /**
  * Whether the current selection makes the trailer slot mandatory — which is

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -35,6 +35,13 @@ export interface AccreditedResource {
   last_trip: string | null;
   /** GPS integration flag (TRUCK rows). Independent of whether a position is on file. */
   integration: "INTEGRATED" | "NOT INTEGRATED" | null;
+  /**
+   * Whether this truck runs with a trailer (TRUCK rows only). Drives the
+   * assignment form's trailer slot: hidden when `false`, required when
+   * `true`. Absent/null (older fn deployments) is treated as "required" —
+   * fail closed rather than let an assignment ship an empty trailer slot.
+   */
+  trailer_need?: boolean | null;
   symptoms: Record<string, number> | null;
   updated_at: string | null;
   // Server-decoded last-known position for TRUCK rows (from row.location

--- a/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
+++ b/turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts
@@ -37,11 +37,13 @@ export interface AccreditedResource {
   integration: "INTEGRATED" | "NOT INTEGRATED" | null;
   /**
    * Whether this truck runs with a trailer (TRUCK rows only). Drives the
-   * assignment form's trailer slot: hidden when `false`, required when
-   * `true`. Absent/null (older fn deployments) is treated as "required" —
-   * fail closed rather than let an assignment ship an empty trailer slot.
+   * assignment form's trailer slot: hidden when falsy-but-present, required
+   * when truthy. The upstream fn emits `0 | 1` (booleans also admitted —
+   * normalize with `normalizeTrailerNeed`). Absent/null (older fn
+   * deployments) is treated as "required" — fail closed rather than let an
+   * assignment ship an empty trailer slot.
    */
-  trailer_need?: boolean | null;
+  trailer_need?: 0 | 1 | boolean | null;
   symptoms: Record<string, number> | null;
   updated_at: string | null;
   // Server-decoded last-known position for TRUCK rows (from row.location

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -632,7 +632,6 @@
             "rut": "RUT",
             "status": "Status"
           },
-          "trailerLabel": "Trailer",
           "trailer": "Trailer",
           "selectTrailer": "Select trailer...",
           "status": "Status",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -632,7 +632,6 @@
             "rut": "RUT",
             "status": "Estado"
           },
-          "trailerLabel": "Remolque",
           "trailer": "Remolque",
           "selectTrailer": "Seleccionar remolque...",
           "status": "Estado",


### PR DESCRIPTION
Closes #1090.

## Rule

The accredited-resources feed now carries **`trailer_need`** on TRUCK rows (wire shape `0 | 1`, normalized at the boundary; booleans also admitted), and that flag — not a checkbox — decides the Remolque slot:

| `trailer_need` | Trailer selector |
|---|---|
| `0` (falsy) | hidden (vehicle runs trailerless); any trailer picked for a previous truck is dropped |
| `1` (truthy) | shown and **required** — Asignar stays disabled until one is picked |
| absent / `null` | treated as required (fail closed) |

The checkbox is gone. `hasTrailer` is removed from `AssignmentFormData`, replaced by `truckTrailerNeed` captured from the row on every truck pick (same lifecycle as the accreditation capture).

## Why fail-closed on unknown

An assignment shipped without a trailer travels downstream to partner bindings that fill the empty slot with their stand-in placeholder value. Requiring a trailer for an unknown flag can over-ask; sending a placeholder to the partner cannot be un-sent. Two sources of "unknown": an fn deployment that predates the flag (see deploy note), and a rehydrated assignment whose truck row hasn't loaded yet — for the latter, an effect refreshes the captured flag once the pinned row arrives (`selectedIds` pinning guarantees it), hiding the slot for a trailerless vehicle.

## Changes

- `assignment-rules.ts` (new): `trailerRequired` / `assignmentIncomplete` — one predicate shared by the form's render gate and the Asignar button.
- `assignment-form.tsx`: checkbox removed; `trailer_need` captured on truck change; trailer cleared when the picked truck runs trailerless; trailer feed enabled only while the slot is live; row-refresh effect.
- `planning-sidebar-form.tsx`: submit gate uses `assignmentIncomplete`; overrides write `assignedTrailer` whenever picked; rehydration starts the flag as unknown.
- `pgrest-client.ts` / `accredited-resources.service.ts`: `trailer_need?: boolean | null` on the row types (route passes rows through untouched, so typing is the only plumbing).
- `trailerLabel` i18n key removed (checkbox label, now unused).

## Deploy note

`ams.fn_rd_accredited_resources` must emit `trailer_need` for the rule to differentiate — as verified today, **prod's fn does not emit it yet**. Shipping this before the fn lands is safe but strict: every truck will require a trailer until the data catches up.

## Tests

`assignment-rules.test.ts` (8 cases: required/hidden/unknown/moot × submit gate). Calendar suites: 21 files, 226 tests green; `tsc --noEmit` clean (the pre-existing `resourceIdContains` error resolves by rebuilding `@microboxlabs/miot-calendar-client`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Trailer requirements are now determined automatically from the selected truck’s accreditation data.
  - Trailer selection appears only when required, and outdated trailer selections are cleared automatically.
  - Assignments cannot be submitted until required carrier, driver, truck, and trailer details are complete.

- **Bug Fixes**
  - Selected trailers are now preserved correctly when applicable.
  - Unknown trailer requirements are handled conservatively to prevent incomplete assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

