### PR TITLE
Fixed recommendations on the spotlight search

### DIFF
--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-empty-state.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-empty-state.tsx
@@ -1,40 +1,108 @@
-import { memo } from "react";
-import { HiClock } from "react-icons/hi";
+import { memo, type ComponentType } from "react";
+import { HiClock, HiArrowRight } from "react-icons/hi";
+import { BsStars } from "react-icons/bs";
 import type { SpotlightItem } from "./types";
 import { SpotlightRow } from "./spotlight-row";
+
+interface EmptyStateSectionProps {
+  Icon: ComponentType<{ className?: string }>;
+  label: string;
+  items: SpotlightItem[];
+  selectedItemId: string | null;
+  onSelect: (item: SpotlightItem) => void;
+  onHover: (id: string | null) => void;
+  accentHover?: boolean;
+}
+
+function EmptyStateSection({
+  Icon,
+  label,
+  items,
+  selectedItemId,
+  onSelect,
+  onHover,
+  accentHover,
+}: Readonly<EmptyStateSectionProps>) {
+  if (!items.length) return null;
+
+  return (
+    <div className="py-1">
+      <div className="flex items-center gap-2 px-4 py-1.5 select-none">
+        <Icon className="h-3 w-3 shrink-0 text-gray-400 dark:text-gray-500" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          {label}
+        </span>
+        <div className="h-px flex-1 bg-gray-100 dark:bg-gray-700" />
+      </div>
+
+      {items.map((item) => (
+        <SpotlightRow
+          key={item.id}
+          item={item}
+          isSelected={item.id === selectedItemId}
+          onSelect={onSelect}
+          onHover={onHover}
+          accentHover={accentHover}
+        />
+      ))}
+    </div>
+  );
+}
 
 interface SpotlightEmptyStateProps {
   recentItems: SpotlightItem[];
   recentLabel: string;
-  onSelectRecent: (item: SpotlightItem) => void;
+  suggestedHarnessItems: SpotlightItem[];
+  suggestedHarnessLabel: string;
+  suggestedGotoItems: SpotlightItem[];
+  suggestedGotoLabel: string;
+  selectedItemId: string | null;
+  onSelect: (item: SpotlightItem) => void;
+  onHover: (id: string | null) => void;
 }
 
 export const SpotlightEmptyState = memo(function SpotlightEmptyState({
   recentItems,
   recentLabel,
-  onSelectRecent,
+  suggestedHarnessItems,
+  suggestedHarnessLabel,
+  suggestedGotoItems,
+  suggestedGotoLabel,
+  selectedItemId,
+  onSelect,
+  onHover,
 }: Readonly<SpotlightEmptyStateProps>) {
-  if (!recentItems.length) return null;
+  if (!recentItems.length && !suggestedHarnessItems.length && !suggestedGotoItems.length) {
+    return null;
+  }
 
   return (
-    <div className="py-1">
-      <div className="flex items-center gap-2 px-4 py-1.5 select-none">
-        <HiClock className="h-3 w-3 shrink-0 text-gray-400 dark:text-gray-500" />
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-          {recentLabel}
-        </span>
-        <div className="h-px flex-1 bg-gray-100 dark:bg-gray-700" />
-      </div>
-
-      {recentItems.map((item) => (
-        <SpotlightRow
-          key={item.id}
-          item={item}
-          isSelected={false}
-          onSelect={onSelectRecent}
-          onHover={() => {}}
-        />
-      ))}
-    </div>
+    <>
+      <EmptyStateSection
+        Icon={HiClock}
+        label={recentLabel}
+        items={recentItems}
+        selectedItemId={selectedItemId}
+        onSelect={onSelect}
+        onHover={onHover}
+      />
+      <EmptyStateSection
+        Icon={BsStars}
+        label={suggestedHarnessLabel}
+        items={suggestedHarnessItems}
+        selectedItemId={selectedItemId}
+        onSelect={onSelect}
+        onHover={onHover}
+        accentHover
+      />
+      <EmptyStateSection
+        Icon={HiArrowRight}
+        label={suggestedGotoLabel}
+        items={suggestedGotoItems}
+        selectedItemId={selectedItemId}
+        onSelect={onSelect}
+        onHover={onHover}
+      />
+    </>
   );
 });

--- a/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx
@@ -59,6 +59,32 @@ const KIND_ICONS: Record<SpotlightResultKind, IconConfig> = {
   },
 };
 
+// Shown in the empty state's "Try asking" section when the dictionary
+// carries no `spotlight.suggestions.harness` override.
+const DEFAULT_HARNESS_SUGGESTIONS = [
+  "How many trucks are active right now?",
+  "What deliveries are scheduled for today?",
+  "Which drivers have pending tasks?",
+];
+
+/** How many distinct sections to sample for the empty state's "Go to" suggestions. */
+const SUGGESTED_GOTO_LIMIT = 3;
+
+/** One item per parent section (plus any top-level items), in registry order. */
+function pickSuggestedGotoItems(navigateItems: SpotlightItem[]): SpotlightItem[] {
+  const seenGroups = new Set<string>();
+  const picks: SpotlightItem[] = [];
+  for (const item of navigateItems) {
+    if (item.isGroupHeader) continue;
+    const groupKey = item.sublabel ?? item.id;
+    if (seenGroups.has(groupKey)) continue;
+    seenGroups.add(groupKey);
+    picks.push(item);
+    if (picks.length >= SUGGESTED_GOTO_LIMIT) break;
+  }
+  return picks;
+}
+
 function urlBlockToItem(
   block: HarnessBlock & { type: "url" },
   i: number,
@@ -118,6 +144,17 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
   const harnessErrorLabel = (spotlightDict?.harnessError as string | undefined) ?? "Something went wrong while searching.";
   const harnessRetryLabel = (spotlightDict?.harnessRetry as string | undefined) ?? "Retry";
 
+  // Empty-state recommendations — sample questions to try with Harness, and
+  // a diverse slice of "Go to" destinations, so the modal isn't blank on open.
+  const suggestionsDict = spotlightDict?.suggestions as I18nRecord | undefined;
+  const suggestedAskLabel = (suggestionsDict?.ask as string | undefined) ?? "Try asking";
+  const suggestedGotoLabel = (suggestionsDict?.goto as string | undefined) ?? "Recommended";
+  // Pipe-delimited, matching this dict's existing list convention (see navigate.triggers).
+  const harnessSuggestionsRaw = suggestionsDict?.harness as string | undefined;
+  const harnessSuggestionQuestions = harnessSuggestionsRaw
+    ? harnessSuggestionsRaw.split("|").map((s) => s.trim()).filter(Boolean)
+    : DEFAULT_HARNESS_SUGGESTIONS;
+
   // Chain-of-thought labels for the live progress panel. The dictionary
   // carries both the phase lines and the per-primitive tool labels.
   const progressDict = spotlightDict?.progress as I18nRecord | undefined;
@@ -173,6 +210,14 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
     onEnterSelect: handleEnterSelect,
   });
 
+  // Empty-state "Go to" recommendations — one destination per section, minus
+  // whatever's already pinned in Recent (same underlying item/id would
+  // otherwise render — and highlight — in both sections at once).
+  const suggestedGotoItems = useMemo(() => {
+    const recentIds = new Set(recentItems.map((i) => i.id));
+    return pickSuggestedGotoItems(navigateItems.filter((i) => !recentIds.has(i.id)));
+  }, [navigateItems, recentItems]);
+
   // ── Harness url opener — relative paths navigate in-app (locale-aware),
   //    absolute http(s) urls open a new tab ──────────────────────────────────
   const onOpenHarnessUrl = useCallback(
@@ -194,11 +239,48 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
   // Bumped by the retry row to re-fire the same committed query.
   const [searchAttempt, setSearchAttempt] = useState(0);
 
+  // Set by `askHarness` so the reset effect below can tell "query changed
+  // because we just asked this exact question" apart from the user typing —
+  // otherwise the effect would immediately wipe the commit it just made.
+  const askedQueryRef = useRef<string | null>(null);
+
   // Reset when user types a new query so harness results clear.
   useEffect(() => {
+    if (askedQueryRef.current === query) {
+      askedQueryRef.current = null;
+      return;
+    }
     setCommittedQuery("");
     setSearchAttempt(0);
   }, [query]);
+
+  // Empty-state suggestion click: sets the query and commits it in one shot,
+  // firing the harness search immediately instead of requiring a second click.
+  const askHarness = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      askedQueryRef.current = trimmed;
+      setQuery(trimmed);
+      setCommittedQuery(trimmed);
+    },
+    [setQuery],
+  );
+
+  // Empty-state "Try asking" recommendations — clicking one asks Harness directly.
+  const harnessSuggestionItems = useMemo<SpotlightItem[]>(
+    () =>
+      harnessSuggestionQuestions.map((text, i) => ({
+        id: `harness-suggestion-${i}`,
+        label: text,
+        kind: "harness" as const,
+        icon: BsStars,
+        keywords: [],
+        // Reuses the "ask" prompt's keep-modal-open semantics (see handleSelectAction).
+        isHarnessPrompt: true,
+        onSelect: () => askHarness(text),
+      })),
+    [harnessSuggestionQuestions, askHarness],
+  );
 
   // ── Pagefind static search (falls back to fuzzy in dev) ──────────────────
   const staticResults = usePagefindSearch(query, navigateItems, canAccess, onNavigate);
@@ -260,14 +342,29 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
   // ── Flat selectable list (no group headers) ───────────────────────────────
   // Order matches visual layout: prompt → harness gotos → static navigate.
   // Harness markdown answers are non-interactive prose — excluded from keyboard nav.
+  // Empty state (no query yet) has its own layout — recent → ask suggestions →
+  // goto suggestions — matching SpotlightEmptyState's render order.
   const selectableItems = useMemo(
-    () => [
-      ...(showHarnessPrompt ? [harnessPromptItem] : []),
-      ...(harnessRetryItem ? [harnessRetryItem] : []),
-      ...harnessGoToItems,
-      ...staticResults.filter((i) => !i.isGroupHeader),
+    () =>
+      isEmpty
+        ? [...recentItems, ...harnessSuggestionItems, ...suggestedGotoItems]
+        : [
+            ...(showHarnessPrompt ? [harnessPromptItem] : []),
+            ...(harnessRetryItem ? [harnessRetryItem] : []),
+            ...harnessGoToItems,
+            ...staticResults.filter((i) => !i.isGroupHeader),
+          ],
+    [
+      isEmpty,
+      recentItems,
+      harnessSuggestionItems,
+      suggestedGotoItems,
+      showHarnessPrompt,
+      harnessPromptItem,
+      harnessRetryItem,
+      harnessGoToItems,
+      staticResults,
     ],
-    [showHarnessPrompt, harnessPromptItem, harnessRetryItem, harnessGoToItems, staticResults],
   );
 
   // Keep refs current — runs synchronously during render, before any event.
@@ -371,7 +468,13 @@ export default function SpotlightSearch({ dict }: Readonly<SpotlightSearchProps>
                 <SpotlightEmptyState
                   recentItems={recentItems}
                   recentLabel={recentLabel}
-                  onSelectRecent={handleSelectAction}
+                  suggestedHarnessItems={harnessSuggestionItems}
+                  suggestedHarnessLabel={suggestedAskLabel}
+                  suggestedGotoItems={suggestedGotoItems}
+                  suggestedGotoLabel={suggestedGotoLabel}
+                  selectedItemId={selectableItems[selectedIndex]?.id ?? null}
+                  onSelect={handleSelectAction}
+                  onHover={setHoveredId}
                 />
               )}
 

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -4865,6 +4865,11 @@
       "triggers": "goto,go to,navigate,open"
     },
     "recent": "Recent",
+    "suggestions": {
+      "ask": "Try asking",
+      "goto": "Recommended",
+      "harness": "How many trucks are active right now?|What deliveries are scheduled for today?|Which drivers have pending tasks?"
+    },
     "ask": {
       "heading": "Ask",
       "triggers": "ask,question,help"

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -4865,6 +4865,11 @@
       "triggers": "ir a,goto,navegar,abrir,go to"
     },
     "recent": "Reciente",
+    "suggestions": {
+      "ask": "Prueba preguntar",
+      "goto": "Recomendado",
+      "harness": "¿Cuántos camiones están activos ahora?|¿Qué entregas hay programadas para hoy?|¿Qué conductores tienen tareas pendientes?"
+    },
     "ask": {
       "heading": "Preguntar",
       "triggers": "preguntar,pregunta,ayuda"


### PR DESCRIPTION
Added "recommendations" and fixing saving of past used elements in the spotlight search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spotlight recommendations for asking Harness questions and navigating to key destinations.
  * Added contextual sections for recent items, suggested questions, and navigation shortcuts.
  * Enabled keyboard and hover selection across all Spotlight suggestions.
  * Selecting a question now starts the Harness search without closing the Spotlight modal.

* **Localization**
  * Added English and Spanish labels and sample suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1108