### PR TITLE
chore(release): prepare MIOT stack v0.5.39

### DIFF
--- a/releases/notes/v1.31.38.mdx
+++ b/releases/notes/v1.31.38.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.38 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Reforzar la calidad operativa del flujo de asignaciones en calendario para evitar registros incompletos en servicios con camión. Esta iteración del stack prioriza validaciones de captura en la interfaz para proteger la consistencia de datos aguas abajo.
+
+## 🚀 Evolutivos
+
+- **📍 Asignación de remolque obligatoria al seleccionar camión**
+  - **Key point**: Se preparó el ajuste del formulario de asignación para que, al elegir un camión, la sección de remolque se abra automáticamente, quede obligatoria y el botón **Asignar** permanezca deshabilitado hasta seleccionar remolque.
+  - **Technical detail**: La regla compartida de validación pasa a exigir `carrier && driver && truck && (truck → trailer)`, incluyendo rehidratación de asignaciones persistidas con camión sin remolque para mostrarlas como incompletas requeridas en la UI. *(Integración OSS — MIOT-0.5.39)*
+
+## 📊 Beneficios
+
+- Reduce la probabilidad de asignaciones incompletas desde el punto de captura.
+- Mejora la calidad de datos operativos antes de que lleguen a integraciones externas.
+- Disminuye correcciones manuales posteriores por valores de remolque sustitutos.
+- Alinea la experiencia de calendario con la lógica real de operación de servicios con camión.
+- Fortalece la coherencia entre estado visual del formulario y reglas de validación.
+- Facilita auditoría funcional al hacer explícito cuándo una asignación no está lista para enviarse.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.39`
+- App: `app@v0.5.39` (con cambios en este release)
+- Docs: `docs@v0.5.38` (sin cambios)
+- Web: `web@v0.5.38` (sin cambios)
+- Modulith: `modulith@v0.5.24` (sin cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.38 concentra el alcance en una mejora funcional puntual, pero de alto impacto operativo: impedir que una asignación con camión avance sin remolque definido. Con esto, la captura en frontend actúa como primera barrera de calidad.
+
+A nivel de plataforma, este release mantiene estabilidad en los demás componentes y encapsula el cambio en `app`, lo que simplifica despliegue y seguimiento técnico del ajuste.
+
+Dado que el ítem asociado permanece abierto, el contenido se presenta como trabajo planificado/preparado dentro del alcance de la release, con foco en consistencia de operación y trazabilidad de datos.

--- a/releases/stacks/v0.5.39.plan.json
+++ b/releases/stacks/v0.5.39.plan.json
@@ -1,0 +1,58 @@
+{
+  "stack_version": "0.5.39",
+  "stack_tag": "miot-stack@v0.5.39",
+  "milestone": "MIOT-0.5.39",
+  "pull_requests": [
+    {
+      "number": 1091,
+      "title": "feat(calendar): trailer slot driven by the truck's trailer_need flag",
+      "source_issues": [
+        {
+          "number": 1090,
+          "title": "feat(calendar): assignment form must require a trailer once a truck is picked"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.39",
+      "tag": "app@v0.5.39"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.38",
+      "version": "0.5.38",
+      "tag": "docs@v0.5.38"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.38",
+      "version": "0.5.38",
+      "tag": "web@v0.5.38"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.24",
+      "version": "0.5.24",
+      "tag": "modulith@v0.5.24"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.38",
+  "version": "0.5.39",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.38.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.38.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.38 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Reforzar la calidad operativa del flujo de asignaciones en calendario para evitar registros incompletos en servicios con camión. Esta iteración del stack prioriza validaciones de captura en la interfaz para proteger la consistencia de datos aguas abajo.
+
+## 🚀 Evolutivos
+
+- **📍 Asignación de remolque obligatoria al seleccionar camión**
+  - **Key point**: Se preparó el ajuste del formulario de asignación para que, al elegir un camión, la sección de remolque se abra automáticamente, quede obligatoria y el botón **Asignar** permanezca deshabilitado hasta seleccionar remolque.
+  - **Technical detail**: La regla compartida de validación pasa a exigir `carrier && driver && truck && (truck → trailer)`, incluyendo rehidratación de asignaciones persistidas con camión sin remolque para mostrarlas como incompletas requeridas en la UI. *(Integración OSS — MIOT-0.5.39)*
+
+## 📊 Beneficios
+
+- Reduce la probabilidad de asignaciones incompletas desde el punto de captura.
+- Mejora la calidad de datos operativos antes de que lleguen a integraciones externas.
+- Disminuye correcciones manuales posteriores por valores de remolque sustitutos.
+- Alinea la experiencia de calendario con la lógica real de operación de servicios con camión.
+- Fortalece la coherencia entre estado visual del formulario y reglas de validación.
+- Facilita auditoría funcional al hacer explícito cuándo una asignación no está lista para enviarse.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.39`
+- App: `app@v0.5.39` (con cambios en este release)
+- Docs: `docs@v0.5.38` (sin cambios)
+- Web: `web@v0.5.38` (sin cambios)
+- Modulith: `modulith@v0.5.24` (sin cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.38 concentra el alcance en una mejora funcional puntual, pero de alto impacto operativo: impedir que una asignación con camión avance sin remolque definido. Con esto, la captura en frontend actúa como primera barrera de calidad.
+
+A nivel de plataforma, este release mantiene estabilidad en los demás componentes y encapsula el cambio en `app`, lo que simplifica despliegue y seguimiento técnico del ajuste.
+
+Dado que el ítem asociado permanece abierto, el contenido se presenta como trabajo planificado/preparado dentro del alcance de la release, con foco en consistencia de operación y trazabilidad de datos.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.38",
+      "version": "0.5.39",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.39 from milestone MIOT-0.5.39, with release notes v1.31.38.

Components:
- App: app@v0.5.39 (changed: true)
- Docs: docs@v0.5.38 (changed: false since docs@v0.5.38)
- Web: web@v0.5.38 (changed: false since web@v0.5.38)
- Modulith: modulith@v0.5.24 (changed: false since modulith@v0.5.24)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.38, MIOT-0.5.39.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
