### PR TITLE
chore(release): prepare MIOT stack v0.5.40

### DIFF
--- a/releases/notes/v1.31.39.mdx
+++ b/releases/notes/v1.31.39.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.39 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión refuerza la calidad operativa del flujo de asignaciones en calendario para evitar despachos incompletos. Se prioriza que la selección de recursos críticos quede validada desde la interfaz antes de enviar la operación.
+
+## 🚀 Evolutivos
+
+- **📍 Remolque obligatorio al seleccionar camión en asignaciones de calendario**
+  - **Key point**: Se actualizó el formulario para que, al elegir un camión, la sección de remolque se abra automáticamente, su checkbox quede bloqueado en activo y el botón **Asignar** permanezca deshabilitado hasta seleccionar remolque.
+  - **Technical detail**: La regla compartida de validación queda en `carrier && driver && truck && (truck → trailer)`, incluyendo rehidratación de asignaciones persistidas con camión sin remolque para forzar visibilidad y completitud del dato. *(Integración OSS — MIOT-0.5.40)*
+
+## 📊 Beneficios
+
+- Reduce asignaciones incompletas desde el origen del flujo operativo.
+- Mejora la consistencia de datos que consumen integraciones y bindings aguas abajo.
+- Disminuye retrabajos manuales del operador para corregir remolques faltantes.
+- Refuerza validaciones de UI con una regla funcional explícita y reutilizable.
+- Alinea el comportamiento del formulario con la realidad de operación camión-remolque.
+- Mejora la confiabilidad de re-apertura de asignaciones persistidas en calendario.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.40`
+- **App**: `app@v0.5.40` (con cambios)
+- **Docs**: `docs@v0.5.40` (con cambios)
+- **Web**: `web@v0.5.40` (con cambios)
+- **Modulith**: `modulith@v0.5.24` (sin cambios)
+- **Harness**: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release `v1.31.39` consolida una mejora puntual pero de alto impacto en la calidad del proceso de asignación, asegurando que los recursos requeridos se completen antes de confirmar una operación.
+
+Con este ajuste, la plataforma reduce ambigüedad en la captura de datos y evita propagar valores de reemplazo no deseados en etapas posteriores de integración.
+
+En conjunto con el stack `0.5.40`, esta entrega mantiene estabilidad de componentes no modificados y concentra los cambios en superficies de producto y documentación con foco en operación diaria.

--- a/releases/stacks/v0.5.40.plan.json
+++ b/releases/stacks/v0.5.40.plan.json
@@ -1,0 +1,58 @@
+{
+  "stack_version": "0.5.40",
+  "stack_tag": "miot-stack@v0.5.40",
+  "milestone": "MIOT-0.5.40",
+  "pull_requests": [
+    {
+      "number": 1091,
+      "title": "feat(calendar): trailer slot driven by the truck's trailer_need flag",
+      "source_issues": [
+        {
+          "number": 1090,
+          "title": "feat(calendar): assignment form must require a trailer once a truck is picked"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/app/api/utils/pgrest-client.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts",
+    "turbo-repo/apps/app/src/features/calendar/services/accredited-resources.service.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.40",
+      "tag": "app@v0.5.40"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.38",
+      "version": "0.5.40",
+      "tag": "docs@v0.5.40"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.38",
+      "version": "0.5.40",
+      "tag": "web@v0.5.40"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.24",
+      "version": "0.5.24",
+      "tag": "modulith@v0.5.24"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.39.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.39.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.39 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión refuerza la calidad operativa del flujo de asignaciones en calendario para evitar despachos incompletos. Se prioriza que la selección de recursos críticos quede validada desde la interfaz antes de enviar la operación.
+
+## 🚀 Evolutivos
+
+- **📍 Remolque obligatorio al seleccionar camión en asignaciones de calendario**
+  - **Key point**: Se actualizó el formulario para que, al elegir un camión, la sección de remolque se abra automáticamente, su checkbox quede bloqueado en activo y el botón **Asignar** permanezca deshabilitado hasta seleccionar remolque.
+  - **Technical detail**: La regla compartida de validación queda en `carrier && driver && truck && (truck → trailer)`, incluyendo rehidratación de asignaciones persistidas con camión sin remolque para forzar visibilidad y completitud del dato. *(Integración OSS — MIOT-0.5.40)*
+
+## 📊 Beneficios
+
+- Reduce asignaciones incompletas desde el origen del flujo operativo.
+- Mejora la consistencia de datos que consumen integraciones y bindings aguas abajo.
+- Disminuye retrabajos manuales del operador para corregir remolques faltantes.
+- Refuerza validaciones de UI con una regla funcional explícita y reutilizable.
+- Alinea el comportamiento del formulario con la realidad de operación camión-remolque.
+- Mejora la confiabilidad de re-apertura de asignaciones persistidas en calendario.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.40`
+- **App**: `app@v0.5.40` (con cambios)
+- **Docs**: `docs@v0.5.40` (con cambios)
+- **Web**: `web@v0.5.40` (con cambios)
+- **Modulith**: `modulith@v0.5.24` (sin cambios)
+- **Harness**: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release `v1.31.39` consolida una mejora puntual pero de alto impacto en la calidad del proceso de asignación, asegurando que los recursos requeridos se completen antes de confirmar una operación.
+
+Con este ajuste, la plataforma reduce ambigüedad en la captura de datos y evita propagar valores de reemplazo no deseados en etapas posteriores de integración.
+
+En conjunto con el stack `0.5.40`, esta entrega mantiene estabilidad de componentes no modificados y concentra los cambios en superficies de producto y documentación con foco en operación diaria.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.38",
+  "version": "0.5.40",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.38",
+  "version": "0.5.40",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.39",
+      "version": "0.5.40",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.38",
+      "version": "0.5.40",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.38",
+      "version": "0.5.40",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.40 from milestone MIOT-0.5.40, with release notes v1.31.39.

Components:
- App: app@v0.5.40 (changed: true)
- Docs: docs@v0.5.40 (changed: true since docs@v0.5.38)
- Web: web@v0.5.40 (changed: true since web@v0.5.38)
- Modulith: modulith@v0.5.24 (changed: false since modulith@v0.5.24)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.39, MIOT-0.5.40.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
