### PR TITLE
feat(integrations): a JSON-null field default sends an explicit null

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationEventBindingRepository.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationEventBindingRepository.java
@@ -241,7 +241,7 @@ public class IntegrationEventBindingRepository {
                 toMap(row.getJsonObject("match_condition")),
                 toStringMap(row.getJsonObject("field_templates")),
                 toStringMap(row.getJsonObject("response_templates")),
-                toStringMap(row.getJsonObject("field_defaults")),
+                toStringMapKeepingNulls(row.getJsonObject("field_defaults")),
                 toMap(row.getJsonObject("response_conditions")),
                 row.getBoolean("enabled"),
                 row.getOffsetDateTime("created_at"),
@@ -269,7 +269,15 @@ public class IntegrationEventBindingRepository {
     private JsonObject toJsonFromStrings(Map<String, String> value) {
         JsonObject json = new JsonObject();
         if (value != null) {
-            value.forEach(json::put);
+            // putNull, not put(key, null): a null field default is a stored fact (an
+            // explicit-null default the renderer honors), and it must survive the trip.
+            value.forEach((key, text) -> {
+                if (text == null) {
+                    json.putNull(key);
+                } else {
+                    json.put(key, text);
+                }
+            });
         }
         return json;
     }
@@ -283,6 +291,20 @@ public class IntegrationEventBindingRepository {
         if (value != null) {
             value.forEach(entry ->
                     map.put(entry.getKey(), entry.getValue() == null ? "" : entry.getValue().toString()));
+        }
+        return map;
+    }
+
+    /**
+     * Like {@link #toStringMap} but a JSON null stays a map null: in {@code field_defaults}
+     * a present-but-null value is an explicit-null default (the renderer sends
+     * {@code "field": null}), not a blank to coalesce away.
+     */
+    private Map<String, String> toStringMapKeepingNulls(JsonObject value) {
+        Map<String, String> map = new LinkedHashMap<>();
+        if (value != null) {
+            value.forEach(entry -> map.put(entry.getKey(),
+                    entry.getValue() == null ? null : entry.getValue().toString()));
         }
         return map;
     }

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -224,6 +224,10 @@ public class IntegrationEventBindingService {
      * A default is a stand-in for a mapping that rendered empty, so a default for a field
      * with no mapping is a mistake to name, not to ignore — the constant the operator
      * wanted is expressed by making the mapping itself a literal.
+     *
+     * <p>A JSON-null default is meaningful, not empty: it declares that an empty render
+     * sends an explicit {@code null} — the clear signal a merge-on-missing partner needs
+     * to dissociate a value it already stores. Only blank strings are rejected.
      */
     private static List<String> fieldDefaultsProblems(
             Map<String, String> defaults, Map<String, String> fieldTemplates) {
@@ -238,8 +242,9 @@ public class IntegrationEventBindingService {
                 problems.add("default for '" + fieldId + "' has no mapping to fall back from"
                         + " — map the field, or make its mapping the literal itself");
             }
-            if (value == null || value.isBlank()) {
-                problems.add("default for '" + fieldId + "' is empty; remove it instead");
+            if (value != null && value.isBlank()) {
+                problems.add("default for '" + fieldId + "' is empty; remove it instead,"
+                        + " or use a JSON null to send an explicit null");
             }
         });
         return problems;

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java
@@ -26,6 +26,10 @@ import java.util.Set;
  *       An empty <i>required</i> field is an error — silently writing a blank into a
  *       required slot is worse than failing. A structural field whose expansion is empty is
  *       treated the same: omitted when optional, kept when required.
+ *   <li><b>A field default of JSON {@code null} sends an explicit null.</b> To a
+ *       merge-on-missing partner an absent key means "no statement" and keeps whatever it
+ *       stored; a null default is the operator declaring that an empty render must clear
+ *       the slot out loud. Like any default, it satisfies requiredness.
  *   <li><b>A template that is exactly one variable keeps the context value's own type.</b>
  *       {@code {{review.verdict}}} over a real boolean sends JSON {@code false}, not
  *       {@code "false"}, without depending on a string round-trip.
@@ -53,7 +57,8 @@ public class PayloadRenderer {
     /**
      * @param defaults fieldId → literal used when that field's template renders empty; a
      *        default satisfies requiredness, because the operator explicitly chose the
-     *        stand-in over an omission
+     *        stand-in over an omission. A present-but-null value sends an explicit JSON
+     *        null instead of omitting the key.
      */
     public Map<String, Object> render(
             Map<String, String> templates, Map<String, String> defaults,
@@ -295,6 +300,12 @@ public class PayloadRenderer {
             String fallback = defaults.get(templateKey);
             if (fallback != null && !fallback.isBlank()) {
                 rendered = fallback;
+            } else if (fallback == null && defaults.containsKey(templateKey)) {
+                // A JSON-null default is the explicit clear: a merge-on-missing partner
+                // keeps its stored value when the key is absent, so "no value" has to be
+                // said out loud as "field": null rather than by omission.
+                payload.put(jsonKey, null);
+                return;
             } else {
                 if (required) {
                     problems.add("'" + templateKey + "' is required but its mapping produced no value");

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java
@@ -1,6 +1,7 @@
 package com.microboxlabs.miot.integrations.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -264,6 +265,29 @@ class IntegrationEventDispatchHandlerTest {
     }
 
     @Test
+    void aNullDefaultTurnsAClearedKeyIntoAnExplicitNull() {
+        // The production shape of a driver de-association: enrichment owns the key and
+        // resolved nothing, and the binding's null default says the partner must hear
+        // "usuarioRevisor": null, not silence — omission keeps its stored value.
+        Map<String, Object> payload = enrichedPayload();
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("usuarioRevisor", null);
+        bindings.binding = bindingWith(Map.of(
+                "guidMultimedia", "{{resourceData.opaqueId}}",
+                "aprobado", "{{review.verdict}}",
+                "usuarioRevisor", "{{resourceData.identifier}}"), defaults);
+        fetch.values = Map.of();
+        fetch.mappedKeys = Set.of("identifier");
+
+        JobOutcome outcome = handler().handle(TENANT, payload);
+
+        assertEquals(JobOutcome.SUCCEEDED, outcome.outcome());
+        assertTrue(dispatcher.lastPayloadMap().containsKey("usuarioRevisor"),
+                "the explicit null must keep the key in the body");
+        assertNull(dispatcher.lastPayloadMap().get("usuarioRevisor"));
+    }
+
+    @Test
     void aKeyTheFetchMappingDoesNotOwnKeepsItsSnapshotValue() {
         Map<String, Object> payload = enrichedPayload();
         fetch.values = Map.of("somethingElse", "resolved");
@@ -307,6 +331,15 @@ class IntegrationEventDispatchHandlerTest {
 
     private static IntegrationEventBinding bindingWithTemplates(Map<String, String> templates) {
         return bindingWith(true, templates);
+    }
+
+    private static IntegrationEventBinding bindingWith(
+            Map<String, String> templates, Map<String, String> defaults) {
+        return new IntegrationEventBinding(
+                BINDING_ID, TENANT, "gama", "review.verdict", "activiti_task",
+                "wfship2:presentDriverTask", CONNECTION_ID, OPERATION_ID,
+                Map.of(), templates, Map.of(), defaults, Map.of(), true,
+                OffsetDateTime.now(), OffsetDateTime.now(), "a", "a");
     }
 
     private static IntegrationEventBinding bindingWith(boolean enabled, Map<String, String> templates) {

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
@@ -215,6 +215,28 @@ class IntegrationEventBindingServiceTest {
     }
 
     @Test
+    void acceptsANullDefaultAsAnExplicitNull() {
+        // Not an empty value: a JSON-null default declares that an empty render must send
+        // "field": null — the clear signal merge-on-missing partners need.
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("guidMultimedia", null);
+
+        var stored = service().upsert(TENANT, CHILD_ORG, requestWith(defaults, Map.of()), ACTOR);
+
+        assertTrue(stored.fieldDefaults().containsKey("guidMultimedia"));
+        assertNull(stored.fieldDefaults().get("guidMultimedia"));
+    }
+
+    @Test
+    void rejectsABlankDefault() {
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service().upsert(TENANT, CHILD_ORG,
+                        requestWith(Map.of("guidMultimedia", "  "), Map.of()), ACTOR));
+
+        assertTrue(failure.getMessage().contains("empty"), failure.getMessage());
+    }
+
+    @Test
     void rejectsResponseConditionsWithoutASuccessMatcher() {
         IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
                 () -> service().upsert(TENANT, CHILD_ORG,

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java
@@ -2,6 +2,7 @@ package com.microboxlabs.miot.integrations.template;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -248,5 +249,50 @@ class PayloadRendererTest {
                 schema(), CONTEXT);
 
         assertFalse(payload.containsKey("mensaje"));
+    }
+
+    @Test
+    void aNullDefaultSendsAnExplicitNullInsteadOfOmitting() {
+        // A merge-on-missing partner keeps its stored value for an absent key; the
+        // operator's JSON-null default says the empty slot must be cleared out loud.
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("mensaje", null);
+
+        Map<String, Object> payload = renderer.render(
+                Map.of("guidMultimedia", "{{content.mediaId}}", "aprobado", "{{review.verdict}}",
+                        "mensaje", "{{review.comment}}"),
+                defaults,
+                schema(), CONTEXT);
+
+        assertTrue(payload.containsKey("mensaje"), "explicit null must keep the key");
+        assertNull(payload.get("mensaje"));
+    }
+
+    @Test
+    void aNullDefaultSatisfiesARequiredField() {
+        // Same principle as a literal default: null is a chosen value, not an omission.
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("guidMultimedia", null);
+
+        Map<String, Object> payload = renderer.render(
+                Map.of("guidMultimedia", "{{content.missing}}", "aprobado", "{{review.verdict}}"),
+                defaults,
+                schema(), CONTEXT);
+
+        assertTrue(payload.containsKey("guidMultimedia"));
+        assertNull(payload.get("guidMultimedia"));
+    }
+
+    @Test
+    void aRenderedValueBeatsANullDefault() {
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("guidMultimedia", null);
+
+        Map<String, Object> payload = renderer.render(
+                Map.of("guidMultimedia", "{{content.mediaId}}", "aprobado", "{{review.verdict}}"),
+                defaults,
+                schema(), CONTEXT);
+
+        assertEquals("19f8-a8ad", payload.get("guidMultimedia"));
     }
 }


### PR DESCRIPTION
Closes #1096

## Why

Alerce's `ModificacionRecursoServicios` **merges on missing**: an absent key keeps the stored value. #1088 correctly stopped sending a stale `conductor2` — verified in prod job `1c57bce6-5de3…`:

```json
{"camion":"SZBS12","remolque":"PWSC75","proveedor":"21","conductor1":"8569003-5","tipo_servicio":"V","numero_servicio":"1611553"}
```

— but omission can't *clear* the `conductor2` Alerce already holds (the placeholder `10000000-8` pushed before #1088 deployed). Dissociation needs an explicit `"conductor2": null`.

## What

Config-driven, no partner-specific code: **a field default whose value is JSON `null` (key present, value null) means "when this mapping renders empty, emit an explicit JSON null instead of omitting the key."**

| empty render + | body |
|---|---|
| no default | key omitted *(unchanged)* |
| string default | default literal *(unchanged)* |
| **null default** | **`"field": null`** *(new)* |

A null default satisfies requiredness like any default — it's a chosen value, not an omission. Blank-string defaults stay rejected at save time.

Touches:
- `PayloadRenderer.renderScalar` — distinguishes present-null (`containsKey`) from absent.
- `IntegrationEventBindingService.fieldDefaultsProblems` — admits null values (a mapping is still required); blank strings still rejected.
- `IntegrationEventBindingRepository` — `field_defaults` round-trips nulls (`toStringMap` coalesced JSON null → `""`, which the renderer ignores); writes use `putNull`.

The wire already survives: `IntegrationOperationInvoker` serializes with a default Jackson `ObjectMapper` (`"key":null`), and `attempt_history` traces will show the null.

## Tests

- Renderer: null default emits explicit null; satisfies a required field; rendered value beats it (24/24).
- Service: null default accepted, stored with the key present; blank rejected (24/24).
- Dispatch handler end-to-end, the production shape: enrichment owns the key + resolved nothing + null default → body carries the explicit null (20/20).
- Full miot-integrations suite green.

## Config follow-up (after deploy)

```sql
UPDATE miot_integrations.integration_event_bindings
SET field_defaults = field_defaults || '{"conductor2": null}'::jsonb
WHERE id = '4000de8b-...';  -- calendar.resource_assignment
```

Covers both real assignments without a second driver and the placeholder dispatches (empty `resourceData`), so unplan clears `conductor2` too.

⚠️ The calendar drawer's binding editor doesn't know about null defaults yet — editing the binding from the FE could silently drop the row until the editor learns the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)