### PR TITLE
chore(release): prepare MIOT stack v0.5.41

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.24</version>
+        <version>0.5.25</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.24</version>
+    <version>0.5.25</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.40.mdx
+++ b/releases/notes/v1.31.40.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.40 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la confiabilidad de las integraciones configurables para que los cambios operativos se reflejen correctamente en sistemas externos. Esta versión se enfoca en mejorar el control de payloads cuando un dato debe limpiarse explícitamente en el partner.
+
+## 🚀 Evolutivos
+
+- **📍 Limpieza explícita de campos nulos en payloads de integración**
+  - **Key point**: Se habilitó, vía configuración, que un `field_default` con valor JSON `null` envíe el campo explícitamente en `null` cuando el mapeo no entrega valor, en lugar de omitir la clave.
+  - **Technical detail**: Esto permite que APIs externas con semántica de merge por ausencia (como Alerce) puedan borrar valores previamente persistidos (por ejemplo `conductor2`) sin agregar lógica específica por partner. *(Integración OSS — MIOT-0.5.41)*
+
+## 📊 Beneficios
+
+- Mejora la consistencia entre el estado operativo en ModularIoT y el estado final en plataformas externas.
+- Reduce errores de datos residuales en integraciones donde omitir una clave no implica borrar su valor.
+- Mantiene el enfoque low-code al resolver el comportamiento desde configuración y no desde código por cliente.
+- Preserva compatibilidad con comportamientos existentes: valor real, default string y omisión sin default.
+- Disminuye retrabajos manuales en casos de desasignaciones o limpiezas de campos opcionales.
+- Refuerza la trazabilidad técnica del envío de payloads en escenarios de integración crítica.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.41`
+- App: `app@v0.5.41` (con cambios)
+- Docs: `docs@v0.5.40` (sin cambios)
+- Web: `web@v0.5.40` (sin cambios)
+- Modulith: `modulith@v0.5.25` (con cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.40 aporta una mejora puntual pero estratégica en el motor de integraciones: ahora los valores nulos intencionales pueden propagarse de forma explícita cuando el caso de negocio lo requiere.
+
+Esto impacta directamente en la calidad de datos compartidos con partners y en la previsibilidad de flujos operativos, especialmente en procesos de asignación/desasignación.
+
+En conjunto con el stack `0.5.41`, la entrega consolida una base más robusta para integraciones configurables sin comprometer el enfoque reusable y escalable de ModularIoT.

--- a/releases/stacks/v0.5.41.plan.json
+++ b/releases/stacks/v0.5.41.plan.json
@@ -1,0 +1,56 @@
+{
+  "stack_version": "0.5.41",
+  "stack_tag": "miot-stack@v0.5.41",
+  "milestone": "MIOT-0.5.41",
+  "pull_requests": [
+    {
+      "number": 1097,
+      "title": "feat(integrations): a JSON-null field default sends an explicit null",
+      "source_issues": [
+        {
+          "number": 1096,
+          "title": "feat(integrations): a JSON-null field default sends an explicit null to the partner"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/persistence/IntegrationEventBindingRepository.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/template/PayloadRenderer.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/jobs/IntegrationEventDispatchHandlerTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/template/PayloadRendererTest.java"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.41",
+      "tag": "app@v0.5.41"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.40",
+      "version": "0.5.40",
+      "tag": "docs@v0.5.40"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.40",
+      "version": "0.5.40",
+      "tag": "web@v0.5.40"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.24",
+      "version": "0.5.25",
+      "tag": "modulith@v0.5.25"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.40",
+  "version": "0.5.41",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.40.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.40.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.40 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Fortalecer la confiabilidad de las integraciones configurables para que los cambios operativos se reflejen correctamente en sistemas externos. Esta versión se enfoca en mejorar el control de payloads cuando un dato debe limpiarse explícitamente en el partner.
+
+## 🚀 Evolutivos
+
+- **📍 Limpieza explícita de campos nulos en payloads de integración**
+  - **Key point**: Se habilitó, vía configuración, que un `field_default` con valor JSON `null` envíe el campo explícitamente en `null` cuando el mapeo no entrega valor, en lugar de omitir la clave.
+  - **Technical detail**: Esto permite que APIs externas con semántica de merge por ausencia (como Alerce) puedan borrar valores previamente persistidos (por ejemplo `conductor2`) sin agregar lógica específica por partner. *(Integración OSS — MIOT-0.5.41)*
+
+## 📊 Beneficios
+
+- Mejora la consistencia entre el estado operativo en ModularIoT y el estado final en plataformas externas.
+- Reduce errores de datos residuales en integraciones donde omitir una clave no implica borrar su valor.
+- Mantiene el enfoque low-code al resolver el comportamiento desde configuración y no desde código por cliente.
+- Preserva compatibilidad con comportamientos existentes: valor real, default string y omisión sin default.
+- Disminuye retrabajos manuales en casos de desasignaciones o limpiezas de campos opcionales.
+- Refuerza la trazabilidad técnica del envío de payloads en escenarios de integración crítica.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.41`
+- App: `app@v0.5.41` (con cambios)
+- Docs: `docs@v0.5.40` (sin cambios)
+- Web: `web@v0.5.40` (sin cambios)
+- Modulith: `modulith@v0.5.25` (con cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.40 aporta una mejora puntual pero estratégica en el motor de integraciones: ahora los valores nulos intencionales pueden propagarse de forma explícita cuando el caso de negocio lo requiere.
+
+Esto impacta directamente en la calidad de datos compartidos con partners y en la previsibilidad de flujos operativos, especialmente en procesos de asignación/desasignación.
+
+En conjunto con el stack `0.5.41`, la entrega consolida una base más robusta para integraciones configurables sin comprometer el enfoque reusable y escalable de ModularIoT.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.40",
+      "version": "0.5.41",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",


### PR DESCRIPTION
Prepares miot-stack@v0.5.41 from milestone MIOT-0.5.41, with release notes v1.31.40.

Components:
- App: app@v0.5.41 (changed: true)
- Docs: docs@v0.5.40 (changed: false since docs@v0.5.40)
- Web: web@v0.5.40 (changed: false since web@v0.5.40)
- Modulith: modulith@v0.5.25 (changed: true since modulith@v0.5.24)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.40, MIOT-0.5.41.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable integration fields can now send explicit JSON `null` values when no mapped value exists, enabling persisted values to be cleared where supported.

* **Documentation**
  * Added release notes describing null-value handling, operational benefits, affected components, and stack versions.
  * Added the v0.5.41 release plan and updated application release metadata.

* **Chores**
  * Aligned platform components with the latest release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->