### PR TITLE
fix(calendar): an assignment is a complete statement — clear dropped slots; register calendar.resource_release

### DIFF
--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java
@@ -38,10 +38,24 @@ public final class CalendarSyncFeature {
     public static final String EVENT_RESOURCE_ASSIGNMENT = "calendar.resource_assignment";
 
     /**
-     * Context roots for {@link #EVENT_RESOURCE_ASSIGNMENT} bindings: {@code service}
-     * (nested scalars — {@code service.code}, {@code service.kind}) and the same
-     * {@code resourceData} identity map every calendar push carries. Scalars are nested
-     * because a bare root reads as a whole object to the validator.
+     * The clean counterpart of {@link #EVENT_RESOURCE_ASSIGNMENT}: dispatched when a
+     * service leaves its assignment (unassign, unplan) to clear the partner's resource
+     * view. Its context is deliberately empty, so the binding's field defaults render
+     * the whole body — with explicit-null defaults saying "remove this slot" out loud
+     * (a merge-on-missing partner keeps a stored value for an omitted key) and literal
+     * defaults carrying whatever stand-in the partner expects (e.g. a placeholder
+     * provider). Splitting the event is what lets the assignment binding drop its
+     * stand-ins without this flow losing them.
+     */
+    public static final String EVENT_RESOURCE_RELEASE = "calendar.resource_release";
+
+    /**
+     * Context roots for {@link #EVENT_RESOURCE_ASSIGNMENT} and
+     * {@link #EVENT_RESOURCE_RELEASE} bindings: {@code service} (nested scalars —
+     * {@code service.code}, {@code service.kind}) and the same {@code resourceData}
+     * identity map every calendar push carries. Scalars are nested because a bare
+     * root reads as a whole object to the validator. The release event shares the
+     * vocabulary — its context is simply empty at dispatch time.
      */
     public static final java.util.Set<String> ASSIGNMENT_TEMPLATE_ROOTS =
             java.util.Set.of("service", "resourceData");

--- a/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
+++ b/quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java
@@ -137,7 +137,8 @@ public class IntegrationEventBindingService {
         if (CalendarSyncFeature.EVENT_RESOURCE_ENRICHMENT.equals(normalized)) {
             return CalendarSyncFeature.ENRICHMENT_TEMPLATE_ROOTS;
         }
-        if (CalendarSyncFeature.EVENT_RESOURCE_ASSIGNMENT.equals(normalized)) {
+        if (CalendarSyncFeature.EVENT_RESOURCE_ASSIGNMENT.equals(normalized)
+                || CalendarSyncFeature.EVENT_RESOURCE_RELEASE.equals(normalized)) {
             return CalendarSyncFeature.ASSIGNMENT_TEMPLATE_ROOTS;
         }
         return PayloadTemplate.DEFAULT_ROOTS;

--- a/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
+++ b/quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java
@@ -137,6 +137,22 @@ class IntegrationEventBindingServiceTest {
                 bindings.saved.get(0).fieldTemplates().get("guidMultimedia"));
     }
 
+    /** The release event shares the assignment's context vocabulary. */
+    @Test
+    void releaseBindingsMayReadTheDispatchContextRoots() {
+        var release = new UpsertIntegrationEventBindingRequest(
+                "calendar.resource_release", null, null, CONNECTION_ID, OPERATION_ID,
+                Map.of(),
+                Map.of("guidMultimedia", "{{service.code}}",
+                        "aprobado", "{{resourceData.mintral_serviceKind}}"),
+                Map.of(), null, null, true);
+
+        service().upsert(TENANT, CHILD_ORG, release, ACTOR);
+
+        assertEquals("{{service.code}}",
+                bindings.saved.get(0).fieldTemplates().get("guidMultimedia"));
+    }
+
     /** A review binding still cannot read job-payload roots — the roots are per event. */
     @Test
     void reviewBindingsStillCannotReadJobPayloadRoots() {

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx
@@ -33,53 +33,15 @@ import {
   AssignmentForm,
   type AssignmentFormData,
 } from "./sidebar-tabs";
-import { assignmentIncomplete } from "./sidebar-tabs/assignment/assignment-rules";
+import {
+  assignmentIncomplete,
+  assignmentOverrides,
+} from "./sidebar-tabs/assignment/assignment-rules";
 import { useCalendarViewMode } from "./use-calendar-view-mode";
 import {
   TabButtons,
   type TabItem,
 } from "@/features/common/components/tab-buttons";
-
-/**
- * Build the service-override patch that travels with `confirmService` so the
- * booking payload reflects the user's current selections. Each slot is only
- * written when the user actually filled it in (or kept its conditional
- * section open) — partial assignments shouldn't wipe previously-saved fields
- * with empty strings.
- */
-function assignmentOverrides(
-  data: AssignmentFormData
-): Partial<SelectedService> {
-  const out: Partial<SelectedService> = {};
-  if (data.carrier) {
-    out.assignedCarrier = data.carrier;
-    // Carry the upstream prve_codigo alongside the UUID so the binding
-    // extractor can ship `carrier_external_id` for Alerce `proveedor`.
-    // `null` is a real value (carrier with no upstream code on file) and
-    // must be preserved — don't gate this on truthiness.
-    out.assignedCarrierExternalId = data.carrierExternalId;
-    // Same lifecycle for the accreditation level the calendar card renders:
-    // `null` (unknown) is a real value too.
-    out.assignedCarrierAccreditation = data.carrierAccreditation;
-  }
-  if (data.driver) {
-    out.assignedDriver = data.driver;
-    out.assignedDriverAccreditation = data.driverAccreditation;
-  }
-  if (data.hasSecondDriver && data.secondDriver) {
-    out.assignedDriver2 = data.secondDriver;
-    out.assignedDriver2Accreditation = data.secondDriverAccreditation;
-  }
-  if (data.truck) {
-    out.assignedTruck = data.truck;
-    out.assignedTruckAccreditation = data.truckAccreditation;
-  }
-  if (data.trailer) {
-    out.assignedTrailer = data.trailer;
-    out.assignedTrailerAccreditation = data.trailerAccreditation;
-  }
-  return out;
-}
 
 /**
  * Build the initial `AssignmentFormData` from a service, hydrating the

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   assignmentIncomplete,
+  assignmentOverrides,
   normalizeTrailerNeed,
   trailerRequired,
 } from "./assignment-rules";
+import type { AssignmentFormData } from "./assignment-form";
 
 function selection(
   overrides: Partial<Parameters<typeof assignmentIncomplete>[0]> = {}
@@ -82,5 +84,82 @@ describe("assignmentIncomplete", () => {
 
   it("blocks while the flag is still unknown", () => {
     expect(assignmentIncomplete(selection())).toBe(true);
+  });
+});
+
+function formData(overrides: Partial<AssignmentFormData> = {}): AssignmentFormData {
+  return {
+    carrier: "carrier-1",
+    carrierExternalId: "375",
+    carrierAccreditation: null,
+    driver: "driver-1",
+    driverAccreditation: null,
+    secondDriver: "",
+    secondDriverAccreditation: null,
+    hasSecondDriver: false,
+    truck: "truck-1",
+    truckAccreditation: null,
+    trailer: "",
+    trailerAccreditation: null,
+    truckTrailerNeed: null,
+    ...overrides,
+  };
+}
+
+describe("assignmentOverrides", () => {
+  it("writes the filled slots", () => {
+    const out = assignmentOverrides(
+      formData({ trailer: "trailer-1", truckTrailerNeed: true })
+    );
+    expect(out.assignedCarrier).toBe("carrier-1");
+    expect(out.assignedDriver).toBe("driver-1");
+    expect(out.assignedTruck).toBe("truck-1");
+    expect(out.assignedTrailer).toBe("trailer-1");
+  });
+
+  it("explicitly clears the trailer of a trailerless truck", () => {
+    // The prod-job-2123fcea shape: previous assignment had a trailer, the new
+    // truck runs without one. Omitting the key would let the stale trailer
+    // ride the merged service state into the dispatch.
+    const out = assignmentOverrides(formData({ truckTrailerNeed: false }));
+    expect(out.assignedTrailer).toBe("");
+    expect(out.assignedTrailerAccreditation).toBeNull();
+  });
+
+  it("leaves a pending required trailer untouched", () => {
+    // Trailer-needing truck, trailer not picked yet: a partial fill, not a
+    // statement — don't wipe what a previous confirm saved.
+    const out = assignmentOverrides(formData({ truckTrailerNeed: true }));
+    expect(out).not.toHaveProperty("assignedTrailer");
+  });
+
+  it("leaves the trailer untouched while the flag is unknown", () => {
+    const out = assignmentOverrides(formData({ truckTrailerNeed: null }));
+    expect(out).not.toHaveProperty("assignedTrailer");
+  });
+
+  it("explicitly clears a closed second-driver section", () => {
+    const out = assignmentOverrides(formData({ hasSecondDriver: false }));
+    expect(out.assignedDriver2).toBe("");
+    expect(out.assignedDriver2Accreditation).toBeNull();
+  });
+
+  it("leaves an open-but-empty second-driver section untouched", () => {
+    const out = assignmentOverrides(
+      formData({ hasSecondDriver: true, secondDriver: "" })
+    );
+    expect(out).not.toHaveProperty("assignedDriver2");
+  });
+
+  it("writes a picked second driver", () => {
+    const out = assignmentOverrides(
+      formData({ hasSecondDriver: true, secondDriver: "driver-2" })
+    );
+    expect(out.assignedDriver2).toBe("driver-2");
+  });
+
+  it("preserves a null carrier external id as a real value", () => {
+    const out = assignmentOverrides(formData({ carrierExternalId: null }));
+    expect(out).toHaveProperty("assignedCarrierExternalId", null);
   });
 });

--- a/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
+++ b/turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts
@@ -1,4 +1,5 @@
 import type { AssignmentFormData } from "./assignment-form";
+import type { SelectedService } from "../../planning-selection-types";
 import type { AccreditedResource } from "@/features/calendar/services/accredited-resources.service";
 
 /**
@@ -30,6 +31,65 @@ export function trailerRequired(
   data: Pick<AssignmentFormData, "truck" | "truckTrailerNeed">
 ): boolean {
   return Boolean(data.truck) && data.truckTrailerNeed !== false;
+}
+
+/**
+ * Build the service-override patch that travels with `confirmService` so the
+ * booking payload reflects the user's current selections. A slot the user
+ * filled is written; a slot that is merely *not yet* filled (trailer still
+ * pending on a trailer-needing truck, second-driver section open but empty)
+ * is left untouched — partial assignments shouldn't wipe previously-saved
+ * fields.
+ *
+ * Two empties are statements, not partial fills, and are written as explicit
+ * `""` clears (ECM's `strVar` reads `""` as absent, so the process variable
+ * and the outbound `trailer_id`/`driver2_id` become null end-to-end):
+ *
+ * - a picked truck whose `trailer_need` says it runs trailerless — otherwise
+ *   the previous assignment's trailer rides the merged service state into the
+ *   dispatch, and the partner rejects a transport-type truck that indicates a
+ *   remolque (prod job 2123fcea);
+ * - a closed second-driver section — otherwise a removed conductor2 keeps
+ *   being re-sent.
+ */
+export function assignmentOverrides(
+  data: AssignmentFormData
+): Partial<SelectedService> {
+  const out: Partial<SelectedService> = {};
+  if (data.carrier) {
+    out.assignedCarrier = data.carrier;
+    // Carry the upstream prve_codigo alongside the UUID so the binding
+    // extractor can ship `carrier_external_id` for the partner's `proveedor`.
+    // `null` is a real value (carrier with no upstream code on file) and
+    // must be preserved — don't gate this on truthiness.
+    out.assignedCarrierExternalId = data.carrierExternalId;
+    // Same lifecycle for the accreditation level the calendar card renders:
+    // `null` (unknown) is a real value too.
+    out.assignedCarrierAccreditation = data.carrierAccreditation;
+  }
+  if (data.driver) {
+    out.assignedDriver = data.driver;
+    out.assignedDriverAccreditation = data.driverAccreditation;
+  }
+  if (data.hasSecondDriver && data.secondDriver) {
+    out.assignedDriver2 = data.secondDriver;
+    out.assignedDriver2Accreditation = data.secondDriverAccreditation;
+  } else if (!data.hasSecondDriver) {
+    out.assignedDriver2 = "";
+    out.assignedDriver2Accreditation = null;
+  }
+  if (data.truck) {
+    out.assignedTruck = data.truck;
+    out.assignedTruckAccreditation = data.truckAccreditation;
+  }
+  if (data.trailer) {
+    out.assignedTrailer = data.trailer;
+    out.assignedTrailerAccreditation = data.trailerAccreditation;
+  } else if (data.truck && !trailerRequired(data)) {
+    out.assignedTrailer = "";
+    out.assignedTrailerAccreditation = null;
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
Closes #1099

## Problem (prod job `2123fcea`, service 1611553)

A trailer-less truck (FFZC81, `trailer_need=0`) was assigned; the dispatch still sent the previous trailer `PWSC75` → Alerce `ERROR_ACCION: CAMIÓN CON TIPO DE TRANSPORTE, NO PUEDE INDICAR REMOLQUE`.

`assignmentOverrides` writes slots only when filled ("partial assignments shouldn't wipe"), so the trailer that #1091 hid/cleared never overwrote the merged `SelectedService` — and `buildAssignProcessVariables`, which is *designed* to send `trailer_id: null`, faithfully forwarded the stale UUID. The enrichment then resolved the old plate. Same latent gap for a removed second driver, which would keep re-sending the old **real** conductor2.

## FE fix

Two empties are statements, not partial fills — they now write explicit `""` clears (ECM `strVar` reads `""` as absent → the process var and the outbound `trailer_id`/`driver2_id` become null end-to-end):

| state | behavior |
|---|---|
| truck picked, `trailer_need` falsy | `assignedTrailer: ""` (clear) |
| truck picked, trailer required but not yet picked | untouched (partial) |
| `trailer_need` unknown (`null`) | untouched (submit is blocked anyway) |
| second-driver section closed | `assignedDriver2: ""` (clear) |
| section open but empty | untouched (partial) |

`assignmentOverrides` moves into `assignment-rules.ts` where the tuple logic already lives (and becomes testable). 19/19 vitest, `tsc` clean.

## Modulith: `calendar.resource_release`

Registers the new dispatch event (same template roots as the assignment event) so its binding is manageable via API/FE. The ECM placeholder legs (unassign/unplan chains) will emit it — companion ecm-coordinator PR — and its binding renders the clean shape via #1096/#1097 explicit-null defaults:

```json
{"camion": null, "remolque": null, "proveedor": "935", "conductor1": null, "conductor2": null, "tipo_servicio": "V", "numero_servicio": "…"}
```

Splitting the event is what lets the assignment binding drop its `PROCESO` stand-ins and gain `remolque: null` (the trailer dissociation) without the release flow losing its placeholder `proveedor`. Full miot-integrations suite: 443/443.

## Rollout order

1. Config: create the `calendar.resource_release` binding (inert until events name it) — staged.
2. Deploy modulith with #1097 + this PR.
3. Deploy ecm-coordinator (placeholder legs emit the release event).
4. Config stage 2 (only after 3): assignment binding defaults → `{remolque: null, conductor2: null, tipo_servicio: "V"}` (drop the PROCESO/935 stand-ins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)