### PR TITLE
chore(release): prepare MIOT stack v0.5.42

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.25</version>
+        <version>0.5.26</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.25</version>
+    <version>0.5.26</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.41.mdx
+++ b/releases/notes/v1.31.41.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.41 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida ajustes clave de confiabilidad operativa y consistencia visual en la plataforma. El foco está en evitar datos residuales en asignaciones logísticas y mejorar la adaptación de la identidad visual en distintos modos de interfaz.
+
+## 🐛 Correcciones
+
+- **🐛 Corrección de favicon adaptable para modos claro y oscuro**
+  - **Impacto**: La iconografía de la aplicación no se adaptaba de forma óptima a superficies claras y oscuras, afectando legibilidad y consistencia visual.
+  - **Solución**: Se actualizó el ícono a SVG escalable, se incorporó arte transparente adaptable, se generó favicon ICO para mayor compatibilidad y se ajustó la metadata de la app para usar los nuevos assets. *(Integración OSS — MIOT-0.5.42)*
+
+- **🐛 Limpieza correcta de remolque y segundo conductor en asignaciones de calendario**
+  - **Impacto**: En ciertos escenarios se reenviaban valores previos (por ejemplo, remolque o conductor2) aunque ya se hubieran retirado en la asignación actual, generando inconsistencias en despacho.
+  - **Solución**: Se trató la asignación como declaración completa del estado operativo: se limpian explícitamente los campos cuando corresponde y, además, se registró el evento `calendar.resource_release` para separar mejor los flujos de asignación y liberación de recursos. *(Integración OSS — MIOT-0.5.42)*
+
+## 📊 Beneficios
+
+- Mayor precisión en la coordinación de viajes al evitar reenvío de datos obsoletos.
+- Reducción de errores operativos en integraciones de despacho asociadas a recursos.
+- Mejor trazabilidad funcional entre eventos de asignación y liberación.
+- Experiencia visual más consistente de la aplicación en modo claro y oscuro.
+- Compatibilidad ampliada de favicon entre navegadores gracias al formato ICO.
+- Menor fricción para equipos de operación al reflejarse mejor el estado real de recursos.
+
+## 🧾 Versiones del stack
+
+- Versión de release ModularIoT: `1.31.41`
+- Versión de stack: `0.5.42`
+- Stack tag: `miot-stack@v0.5.42`
+- App tag: `app@v0.5.42` (con cambios)
+- Docs tag: `docs@v0.5.42` (con cambios)
+- Web tag: `web@v0.5.42` (con cambios)
+- Modulith tag: `modulith@v0.5.26` (con cambios)
+- Harness tag: `harness@v0.1.5` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.41` fortalece aspectos críticos de calidad en operación logística e interfaz, con impacto directo en la confiabilidad de asignaciones y en la consistencia de la experiencia de uso.
+
+En particular, la separación explícita entre asignación y liberación de recursos mejora el comportamiento de las integraciones en escenarios reales de despacho y reduce ambigüedades en datos enviados a sistemas externos.
+
+Con el stack `0.5.42`, esta entrega mantiene una evolución enfocada en robustez funcional, compatibilidad y mantenimiento predecible del entorno productivo.

--- a/releases/stacks/v0.5.42.plan.json
+++ b/releases/stacks/v0.5.42.plan.json
@@ -1,0 +1,71 @@
+{
+  "stack_version": "0.5.42",
+  "stack_tag": "miot-stack@v0.5.42",
+  "milestone": "MIOT-0.5.42",
+  "pull_requests": [
+    {
+      "number": 1094,
+      "title": "fixed favicon",
+      "source_issues": [
+        {
+          "number": 1101,
+          "title": "Fix adaptive favicon styling for light and dark modes"
+        }
+      ]
+    },
+    {
+      "number": 1100,
+      "title": "fix(calendar): an assignment is a complete statement — clear dropped slots; register calendar.resource_release",
+      "source_issues": [
+        {
+          "number": 1099,
+          "title": "fix(calendar): an assignment is a complete statement — clear dropped trailer/driver2 slots; register calendar.resource_release"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    ".claude/settings.json",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/calendar/CalendarSyncFeature.java",
+    "quarkus-srv/miot-integrations/src/main/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingService.java",
+    "quarkus-srv/miot-integrations/src/test/java/com/microboxlabs/miot/integrations/service/IntegrationEventBindingServiceTest.java",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/planning-sidebar-form.tsx",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.test.ts",
+    "turbo-repo/apps/app/src/features/calendar/components/planning/sidebar-tabs/assignment/assignment-rules.ts",
+    "turbo-repo/apps/web/app/favicon.ico",
+    "turbo-repo/apps/web/app/icon.svg",
+    "turbo-repo/apps/web/app/layout.tsx",
+    "turbo-repo/apps/web/scripts/generate-logo.mjs"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.42",
+      "tag": "app@v0.5.42"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.40",
+      "version": "0.5.42",
+      "tag": "docs@v0.5.42"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.40",
+      "version": "0.5.42",
+      "tag": "web@v0.5.42"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.25",
+      "version": "0.5.26",
+      "tag": "modulith@v0.5.26"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.41",
+  "version": "0.5.42",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.41.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.41.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.41 — ModularIoT
+
+### Fecha: 04/08/2026
+
+**Objetivo**: Esta versión consolida ajustes clave de confiabilidad operativa y consistencia visual en la plataforma. El foco está en evitar datos residuales en asignaciones logísticas y mejorar la adaptación de la identidad visual en distintos modos de interfaz.
+
+## 🐛 Correcciones
+
+- **🐛 Corrección de favicon adaptable para modos claro y oscuro**
+  - **Impacto**: La iconografía de la aplicación no se adaptaba de forma óptima a superficies claras y oscuras, afectando legibilidad y consistencia visual.
+  - **Solución**: Se actualizó el ícono a SVG escalable, se incorporó arte transparente adaptable, se generó favicon ICO para mayor compatibilidad y se ajustó la metadata de la app para usar los nuevos assets. *(Integración OSS — MIOT-0.5.42)*
+
+- **🐛 Limpieza correcta de remolque y segundo conductor en asignaciones de calendario**
+  - **Impacto**: En ciertos escenarios se reenviaban valores previos (por ejemplo, remolque o conductor2) aunque ya se hubieran retirado en la asignación actual, generando inconsistencias en despacho.
+  - **Solución**: Se trató la asignación como declaración completa del estado operativo: se limpian explícitamente los campos cuando corresponde y, además, se registró el evento `calendar.resource_release` para separar mejor los flujos de asignación y liberación de recursos. *(Integración OSS — MIOT-0.5.42)*
+
+## 📊 Beneficios
+
+- Mayor precisión en la coordinación de viajes al evitar reenvío de datos obsoletos.
+- Reducción de errores operativos en integraciones de despacho asociadas a recursos.
+- Mejor trazabilidad funcional entre eventos de asignación y liberación.
+- Experiencia visual más consistente de la aplicación en modo claro y oscuro.
+- Compatibilidad ampliada de favicon entre navegadores gracias al formato ICO.
+- Menor fricción para equipos de operación al reflejarse mejor el estado real de recursos.
+
+## 🧾 Versiones del stack
+
+- Versión de release ModularIoT: `1.31.41`
+- Versión de stack: `0.5.42`
+- Stack tag: `miot-stack@v0.5.42`
+- App tag: `app@v0.5.42` (con cambios)
+- Docs tag: `docs@v0.5.42` (con cambios)
+- Web tag: `web@v0.5.42` (con cambios)
+- Modulith tag: `modulith@v0.5.26` (con cambios)
+- Harness tag: `harness@v0.1.5` (sin cambios)
+- Los digest exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset `stack-manifest.json` de la release.
+
+## 📌 Conclusión
+
+La release `1.31.41` fortalece aspectos críticos de calidad en operación logística e interfaz, con impacto directo en la confiabilidad de asignaciones y en la consistencia de la experiencia de uso.
+
+En particular, la separación explícita entre asignación y liberación de recursos mejora el comportamiento de las integraciones en escenarios reales de despacho y reduce ambigüedades en datos enviados a sistemas externos.
+
+Con el stack `0.5.42`, esta entrega mantiene una evolución enfocada en robustez funcional, compatibilidad y mantenimiento predecible del entorno productivo.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.40",
+  "version": "0.5.42",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.40",
+  "version": "0.5.42",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.41",
+      "version": "0.5.42",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.40",
+      "version": "0.5.42",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.40",
+      "version": "0.5.42",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.42 from milestone MIOT-0.5.42, with release notes v1.31.41.

Components:
- App: app@v0.5.42 (changed: true)
- Docs: docs@v0.5.42 (changed: true since docs@v0.5.40)
- Web: web@v0.5.42 (changed: true since web@v0.5.40)
- Modulith: modulith@v0.5.26 (changed: true since modulith@v0.5.25)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.41, MIOT-0.5.42.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
