### PR TITLE
chore(release): prepare MIOT stack v0.5.43

### DIFF
--- a/releases/notes/v1.31.42.mdx
+++ b/releases/notes/v1.31.42.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.42 — ModularIoT
+
+### Fecha: 05/08/2026
+
+**Objetivo**: Esta versión refuerza la confiabilidad operativa en flujos de asignación y mejora la experiencia del landing público con navegación localizada y destinos de autenticación configurables. El foco está en reducir errores de ejecución en operaciones logísticas y facilitar una entrada más clara para usuarios en distintos idiomas.
+
+## 🚀 Evolutivos
+
+- **📍 Navegación localizada y destinos de autenticación configurables**
+  - **Key point**: Se incorporó contenido de navegación localizado en inglés, español y portugués, incluyendo menús traducidos, selección de idioma/país, enlaces de contacto y acciones de autenticación en layouts desktop y mobile.
+  - **Technical detail**: Se configuraron destinos de login y signup por variables de entorno y se consolidó el contenido de navegación en datos compartidos para mantener consistencia entre vistas. *(Integración OSS — MIOT-0.5.43)*
+
+## 🐛 Correcciones
+
+- **🐛 Limpieza explícita de variables de proceso en tareas**
+  - **Impacto**: Cuando una variable llegaba explícitamente como `null`, podía mantenerse un valor previo en el proceso, provocando reutilización de datos obsoletos en asignaciones posteriores.
+  - **Solución**: El tratamiento de `null` pasa a considerarse retractación explícita y se elimina la variable de proceso correspondiente, mientras que claves ausentes conservan el comportamiento actual.
+
+## 📊 Beneficios
+
+- Menor riesgo de despachos o asignaciones con datos residuales en flujos de tareas.
+- Mayor coherencia entre la intención del cliente y el estado real de variables de proceso.
+- Experiencia de landing más clara para usuarios multilingües.
+- Configuración más flexible de accesos de autenticación según entorno de despliegue.
+- Menor acoplamiento de contenido de navegación al centralizar datos localizados.
+- Mejor continuidad operativa entre frontend y servicios de coordinación de procesos.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.43`
+- App: `app@v0.5.43` (actualizado)
+- Docs: `docs@v0.5.42` (sin cambios)
+- Web: `web@v0.5.43` (actualizado)
+- Modulith: `modulith@v0.5.26` (sin cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.42 combina una corrección crítica de comportamiento en ejecución de tareas con una mejora visible en la experiencia de acceso y navegación del sitio público. Esto fortalece tanto la operación logística como la capa de entrada de usuarios.
+
+En términos técnicos, se reduce la posibilidad de arrastre de estado en procesos y se alinea mejor el contrato de datos cuando se envían valores nulos explícitos. A la vez, la navegación localizada y configurable mejora mantenibilidad y adaptación por entorno.
+
+Con el stack en `0.5.43`, esta entrega consolida estabilidad operativa y prepara una base más consistente para siguientes iteraciones funcionales y de integración.

--- a/releases/stacks/v0.5.43.plan.json
+++ b/releases/stacks/v0.5.43.plan.json
@@ -1,0 +1,63 @@
+{
+  "stack_version": "0.5.43",
+  "stack_tag": "miot-stack@v0.5.43",
+  "milestone": "MIOT-0.5.43",
+  "pull_requests": [
+    {
+      "number": 1042,
+      "title": "Based/landing page",
+      "source_issues": [
+        {
+          "number": 1103,
+          "title": "Localize landing-page navigation and configure auth destinations"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    ".github/workflows/ci.yaml",
+    ".github/workflows/web.yml",
+    "turbo-repo/apps/web/.env.example",
+    "turbo-repo/apps/web/components/v2/DetailPage.tsx",
+    "turbo-repo/apps/web/components/v2/Nav.tsx",
+    "turbo-repo/apps/web/components/v2/content.en.ts",
+    "turbo-repo/apps/web/components/v2/content.pt.ts",
+    "turbo-repo/apps/web/components/v2/content.ts",
+    "turbo-repo/apps/web/components/v2/nav-data.ts",
+    "turbo-repo/apps/web/messages/br.json",
+    "turbo-repo/apps/web/messages/en.json",
+    "turbo-repo/apps/web/messages/es.json",
+    "turbo-repo/apps/web/next.config.ts"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.43",
+      "tag": "app@v0.5.43"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.42",
+      "version": "0.5.42",
+      "tag": "docs@v0.5.42"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.42",
+      "version": "0.5.43",
+      "tag": "web@v0.5.43"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.26",
+      "version": "0.5.26",
+      "tag": "modulith@v0.5.26"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.42.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.42.mdx
@@ -1,0 +1,44 @@
+# 🔔 Release Notes v1.31.42 — ModularIoT
+
+### Fecha: 05/08/2026
+
+**Objetivo**: Esta versión refuerza la confiabilidad operativa en flujos de asignación y mejora la experiencia del landing público con navegación localizada y destinos de autenticación configurables. El foco está en reducir errores de ejecución en operaciones logísticas y facilitar una entrada más clara para usuarios en distintos idiomas.
+
+## 🚀 Evolutivos
+
+- **📍 Navegación localizada y destinos de autenticación configurables**
+  - **Key point**: Se incorporó contenido de navegación localizado en inglés, español y portugués, incluyendo menús traducidos, selección de idioma/país, enlaces de contacto y acciones de autenticación en layouts desktop y mobile.
+  - **Technical detail**: Se configuraron destinos de login y signup por variables de entorno y se consolidó el contenido de navegación en datos compartidos para mantener consistencia entre vistas. *(Integración OSS — MIOT-0.5.43)*
+
+## 🐛 Correcciones
+
+- **🐛 Limpieza explícita de variables de proceso en tareas**
+  - **Impacto**: Cuando una variable llegaba explícitamente como `null`, podía mantenerse un valor previo en el proceso, provocando reutilización de datos obsoletos en asignaciones posteriores.
+  - **Solución**: El tratamiento de `null` pasa a considerarse retractación explícita y se elimina la variable de proceso correspondiente, mientras que claves ausentes conservan el comportamiento actual.
+
+## 📊 Beneficios
+
+- Menor riesgo de despachos o asignaciones con datos residuales en flujos de tareas.
+- Mayor coherencia entre la intención del cliente y el estado real de variables de proceso.
+- Experiencia de landing más clara para usuarios multilingües.
+- Configuración más flexible de accesos de autenticación según entorno de despliegue.
+- Menor acoplamiento de contenido de navegación al centralizar datos localizados.
+- Mejor continuidad operativa entre frontend y servicios de coordinación de procesos.
+
+## 🧾 Versiones del stack
+
+- Stack: `miot-stack@v0.5.43`
+- App: `app@v0.5.43` (actualizado)
+- Docs: `docs@v0.5.42` (sin cambios)
+- Web: `web@v0.5.43` (actualizado)
+- Modulith: `modulith@v0.5.26` (sin cambios)
+- Harness: `harness@v0.1.5` (sin cambios)
+- Los digests exactos de imágenes desplegadas están disponibles en el diálogo de información de build dentro de la app y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.42 combina una corrección crítica de comportamiento en ejecución de tareas con una mejora visible en la experiencia de acceso y navegación del sitio público. Esto fortalece tanto la operación logística como la capa de entrada de usuarios.
+
+En términos técnicos, se reduce la posibilidad de arrastre de estado en procesos y se alinea mejor el contrato de datos cuando se envían valores nulos explícitos. A la vez, la navegación localizada y configurable mejora mantenibilidad y adaptación por entorno.
+
+Con el stack en `0.5.43`, esta entrega consolida estabilidad operativa y prepara una base más consistente para siguientes iteraciones funcionales y de integración.

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.42",
+      "version": "0.5.43",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.42",
+      "version": "0.5.43",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.43 from milestone MIOT-0.5.43, with release notes v1.31.42.

Components:
- App: app@v0.5.43 (changed: true)
- Docs: docs@v0.5.42 (changed: false since docs@v0.5.42)
- Web: web@v0.5.43 (changed: true since web@v0.5.42)
- Modulith: modulith@v0.5.26 (changed: false since modulith@v0.5.26)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.42, MIOT-0.5.43.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
