### PR TITLE
Fixed naming in dashboard

### DIFF
--- a/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
@@ -122,7 +122,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   return (
     <div className="flex justify-between items-center">
       <FlowbiteBreadcrumb aria-label="Breadcrumb">
-        {translatedPath.map(renderCrumb)}
+        {translatedPath.map((item, index) => renderCrumb(item, index))}
       </FlowbiteBreadcrumb>
       {rightContent.length > 0 && (
         <div className="flex items-center space-x-2">

--- a/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
@@ -1,10 +1,11 @@
 "use client";
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Breadcrumb as FlowbiteBreadcrumb,
   BreadcrumbItem,
 } from "flowbite-react";
 import { HiHome } from "react-icons/hi";
+import { HiPencilSquare } from "react-icons/hi2";
 import { trDynamic } from "@/features/i18n/tr.service";
 import { I18nRecord } from "@/features/i18n/i18n.service.types";
 
@@ -15,6 +16,9 @@ interface BreadcrumbProps {
   rightContent?: React.ReactNode[];
   dict: I18nRecord;
   disableLinks?: boolean;
+  /** When true, clicking the last crumb turns it into an editable text field. */
+  editableLast?: boolean;
+  onEditLast?: (value: string) => void;
 }
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({
@@ -24,8 +28,39 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   rightContent = [],
   dict,
   disableLinks = false,
+  editableLast = false,
+  onEditLast,
 }) => {
   const translatedPath = path.map((item) => trDynamic(item, dict));
+  const lastIndex = translatedPath.length - 1;
+  const lastValue = translatedPath[lastIndex] ?? "";
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(lastValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isEditing) setValue(lastValue);
+  }, [lastValue, isEditing]);
+
+  useEffect(() => {
+    if (isEditing) inputRef.current?.select();
+  }, [isEditing]);
+
+  const commitEdit = useCallback(() => {
+    const trimmed = value.trim();
+    if (trimmed && trimmed !== lastValue) {
+      onEditLast?.(trimmed);
+    } else {
+      setValue(lastValue);
+    }
+    setIsEditing(false);
+  }, [value, lastValue, onEditLast]);
+
+  const cancelEdit = useCallback(() => {
+    setValue(lastValue);
+    setIsEditing(false);
+  }, [lastValue]);
 
   return (
     <div className="flex justify-between items-center">
@@ -37,6 +72,33 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
               key={index}
             >
               {item}
+            </BreadcrumbItem>
+          ) : index === lastIndex && editableLast ? (
+            <BreadcrumbItem key={index}>
+              {isEditing ? (
+                <input
+                  ref={inputRef}
+                  autoFocus
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  onBlur={commitEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") commitEdit();
+                    else if (e.key === "Escape") cancelEdit();
+                  }}
+                  className="bg-transparent border-b border-gray-400 outline-none text-sm font-medium text-gray-700 dark:text-gray-300 focus:border-blue-500 dark:focus:border-blue-500"
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setIsEditing(true)}
+                  title="Rename dashboard"
+                  className="group flex items-center gap-1.5 cursor-text hover:underline decoration-dashed underline-offset-2"
+                >
+                  {item}
+                  <HiPencilSquare className="h-3.5 w-3.5 text-gray-400 group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" />
+                </button>
+              )}
             </BreadcrumbItem>
           ) : (
             <BreadcrumbItem

--- a/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
+++ b/turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx
@@ -34,6 +34,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   const translatedPath = path.map((item) => trDynamic(item, dict));
   const lastIndex = translatedPath.length - 1;
   const lastValue = translatedPath[lastIndex] ?? "";
+  const renameLabel = trDynamic("renameDashboard", dict);
 
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(lastValue);
@@ -62,53 +63,66 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
     setIsEditing(false);
   }, [lastValue]);
 
+  const renderCrumb = (item: string, index: number) => {
+    // Derived from the path prefix up to this level — stable and unique per
+    // crumb, unlike the array index (see typescript:S6479).
+    const key = path.slice(0, index + 1).join("/");
+
+    if (index === 0) {
+      return (
+        <BreadcrumbItem icon={() => rootIcon} key={key}>
+          {item}
+        </BreadcrumbItem>
+      );
+    }
+
+    if (index === lastIndex && editableLast) {
+      return (
+        <BreadcrumbItem key={key}>
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              autoFocus
+              aria-label={renameLabel}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitEdit();
+                else if (e.key === "Escape") cancelEdit();
+              }}
+              className="bg-transparent border-b border-gray-400 outline-none text-sm font-medium text-gray-700 dark:text-gray-300 focus:border-blue-500 dark:focus:border-blue-500"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              aria-label={renameLabel}
+              title={renameLabel}
+              className="group flex items-center gap-1.5 cursor-text hover:underline decoration-dashed underline-offset-2"
+            >
+              {item}
+              <HiPencilSquare className="h-3.5 w-3.5 text-gray-400 group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" />
+            </button>
+          )}
+        </BreadcrumbItem>
+      );
+    }
+
+    return (
+      <BreadcrumbItem
+        key={key}
+        href={disableLinks ? undefined : `/app/${lang}/${path.slice(1, index + 1).join("/")}`}
+      >
+        {item}
+      </BreadcrumbItem>
+    );
+  };
+
   return (
     <div className="flex justify-between items-center">
       <FlowbiteBreadcrumb aria-label="Breadcrumb">
-        {translatedPath.map((item, index) =>
-          index === 0 ? (
-            <BreadcrumbItem
-              icon={() => rootIcon}
-              key={index}
-            >
-              {item}
-            </BreadcrumbItem>
-          ) : index === lastIndex && editableLast ? (
-            <BreadcrumbItem key={index}>
-              {isEditing ? (
-                <input
-                  ref={inputRef}
-                  autoFocus
-                  value={value}
-                  onChange={(e) => setValue(e.target.value)}
-                  onBlur={commitEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commitEdit();
-                    else if (e.key === "Escape") cancelEdit();
-                  }}
-                  className="bg-transparent border-b border-gray-400 outline-none text-sm font-medium text-gray-700 dark:text-gray-300 focus:border-blue-500 dark:focus:border-blue-500"
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setIsEditing(true)}
-                  title="Rename dashboard"
-                  className="group flex items-center gap-1.5 cursor-text hover:underline decoration-dashed underline-offset-2"
-                >
-                  {item}
-                  <HiPencilSquare className="h-3.5 w-3.5 text-gray-400 group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" />
-                </button>
-              )}
-            </BreadcrumbItem>
-          ) : (
-            <BreadcrumbItem
-              key={index}
-              href={disableLinks ? undefined : `/app/${lang}/${path.slice(1, index + 1).join("/")}`}
-            >
-              {item}
-            </BreadcrumbItem>
-          )
-        )}
+        {translatedPath.map(renderCrumb)}
       </FlowbiteBreadcrumb>
       {rightContent.length > 0 && (
         <div className="flex items-center space-x-2">

--- a/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx
@@ -86,6 +86,7 @@ export function DashboardView() {
     isKiosk,
     isLoaded,
     dashboardName,
+    setDashboardName,
     dictionary,
     siteId,
     toggleEditMode,
@@ -294,6 +295,8 @@ export function DashboardView() {
           }
           lang={params.lang}
           filterDict={dictionary}
+          editableLastCrumb={editMode}
+          onEditLastCrumb={setDashboardName}
           leftContent={
             isLoaded ? undefined : (
               <div className="h-7 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />

--- a/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
+++ b/turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   type PropsWithChildren,
 } from "react";
+import { mutate as mutateGlobal } from "swr";
 import { useDashboardStorage } from "../hooks/use-dashboard-storage";
 import {
   type Widget,
@@ -359,8 +360,28 @@ export function DashboardProvider({
   const setDashboardName = useCallback(
     (name: string) => {
       setDashboardNameStorage(name);
+
+      // The sidebar's dashboard list is a separate SWR cache
+      // (`/app/api/dashboard/configs`) — patch it optimistically so the
+      // renamed dashboard shows up there without waiting for its own
+      // revalidation.
+      if (siteId) {
+        void mutateGlobal(
+          `/app/api/dashboard/configs?site=${encodeURIComponent(siteId)}`,
+          (
+            current?: { data: { slug: string; name: string; order?: number }[] }
+          ) =>
+            current && {
+              ...current,
+              data: current.data.map((dashboard) =>
+                dashboard.slug === slug ? { ...dashboard, name } : dashboard
+              ),
+            },
+          { revalidate: false }
+        );
+      }
     },
-    [setDashboardNameStorage]
+    [setDashboardNameStorage, siteId, slug]
   );
 
   const setOrder = useCallback(

--- a/turbo-repo/apps/app/src/features/layout/components/section-header/section-header.tsx
+++ b/turbo-repo/apps/app/src/features/layout/components/section-header/section-header.tsx
@@ -13,6 +13,9 @@ interface SectionHeaderProps {
   lang?: string;
   rootIcon?: React.ReactNode;
   rightContent?: React.ReactNode;
+  /** When true, clicking the last breadcrumb crumb turns it into an editable text field. */
+  editableLastCrumb?: boolean;
+  onEditLastCrumb?: (value: string) => void;
 }
 
 export function SectionHeader({
@@ -23,6 +26,8 @@ export function SectionHeader({
   lang,
   rootIcon,
   rightContent,
+  editableLastCrumb,
+  onEditLastCrumb,
 }: Readonly<SectionHeaderProps>) {
   return (
     <div className="bg-white dark:bg-gray-900 w-full">
@@ -35,6 +40,8 @@ export function SectionHeader({
               rootIcon={rootIcon}
               dict={breadcrumbDict}
               disableLinks
+              editableLast={editableLastCrumb}
+              onEditLast={onEditLastCrumb}
             />
           ) : null
         )}

--- a/turbo-repo/apps/app/src/lang/en.json
+++ b/turbo-repo/apps/app/src/lang/en.json
@@ -2289,6 +2289,7 @@
       "sidebar": {
         "home": "Home",
         "dashboard": "Dashboard",
+        "renameDashboard": "Rename dashboard",
         "maintenanceStatus": "Maintenance Status",
         "vehicleTechnicalHealth": "Vehicle Technical Health",
         "devicesAndTelemetry": "Devices and Telemetry",

--- a/turbo-repo/apps/app/src/lang/es.json
+++ b/turbo-repo/apps/app/src/lang/es.json
@@ -2289,6 +2289,7 @@
       "sidebar": {
         "home": "Home",
         "dashboard": "Dashboard",
+        "renameDashboard": "Renombrar panel",
         "maintenanceStatus": "Estado de Mantención",
         "vehicleTechnicalHealth": "Salud Técnica del Vehículo",
         "devicesAndTelemetry": "Dispositivos y Telemetría",


### PR DESCRIPTION
Fixed naming system in dashboard header.

if the dasboard its in edit mode, clicking the name in the breadcrumbs will allow edit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard names can now be edited directly from the final breadcrumb in the section header.
  * Press Enter or click away to save changes; press Escape to cancel.
  * Empty or unchanged names are discarded, and updated names appear immediately in the dashboard sidebar.
  * Added localized rename actions in English and Spanish.
  * Breadcrumb paths remain stable during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1107