### PR TITLE
chore(release): prepare MIOT stack v0.5.44

### DIFF
--- a/releases/notes/v1.31.43.mdx
+++ b/releases/notes/v1.31.43.mdx
@@ -1,0 +1,47 @@
+# 🔔 Release Notes v1.31.43 — ModularIoT
+
+### Fecha: 06/08/2026
+
+**Objetivo**: Esta versión refuerza la experiencia de uso en la aplicación web con mejoras de búsqueda, edición contextual y navegación comercial del sitio público. Además, consolida el paquete OSS MIOT-0.5.44 con cambios orientados a usabilidad y adopción.
+
+## 🚀 Evolutivos
+
+- **📍 Spotlight con recomendaciones y recientes persistentes**
+  - **Key point**: Se incorporaron recomendaciones para preguntas de Harness y accesos de navegación, junto con secciones contextuales de sugerencias y elementos recientes persistentes.
+  - **Technical detail**: Se unificó el comportamiento de selección por teclado y hover en todas las sugerencias, y se mantuvo el modal abierto al elegir preguntas sugeridas de Harness para mejorar continuidad de flujo. *(Integración OSS — MIOT-0.5.44)*
+
+- **📍 Renombrado inline de dashboards desde breadcrumbs**
+  - **Key point**: Ahora es posible editar el nombre del dashboard directamente desde el último breadcrumb en modo edición.
+  - **Technical detail**: El guardado se ejecuta con Enter o pérdida de foco, Escape cancela, se ignoran nombres vacíos/sin cambios y el sidebar se actualiza inmediatamente tras renombrar. *(Integración OSS — MIOT-0.5.44)*
+
+- **📍 Renovación de landing orientada a demo y barra de confianza de integraciones**
+  - **Key point**: La landing prioriza la solicitud de demo como acción principal y actualiza contenidos, KPIs y terminología en ES/EN/PT.
+  - **Technical detail**: Se añadió una sección de Seguridad y Datos y una barra de confianza con carruseles de proveedores/plataformas y enlaces, manteniendo separados los testimonios y preservando contenido reutilizable fuera de la página principal. *(Integración OSS — MIOT-0.5.44)*
+
+## 📊 Beneficios
+
+- Mejora la descubribilidad funcional con búsqueda guiada y atajos relevantes.
+- Reduce fricción operativa al permitir renombrar dashboards sin salir del contexto actual.
+- Aumenta consistencia UX con interacciones homogéneas por teclado y puntero.
+- Refuerza confianza comercial/técnica con mensajes explícitos de seguridad, trazabilidad y SLA.
+- Mejora la localización multilingüe en flujos clave de producto y sitio público.
+- Favorece continuidad de uso en Harness al evitar cierres innecesarios del modal.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.44`
+- **App**: `app@v0.5.44` *(actualizado)*
+- **Docs**: `docs@v0.5.44` *(actualizado)*
+- **Web**: `web@v0.5.44` *(actualizado)*
+- **Modulith**: `modulith@v0.5.26` *(sin cambios)*
+- **Harness**: `harness@v0.1.5` *(sin cambios)*
+
+Los digest exactos de imágenes desplegadas están disponibles en el diálogo in-app de información de build y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.43 se centra en elevar la calidad de interacción diaria en el producto y en fortalecer la propuesta pública de ModularIoT para adopción comercial. Los cambios priorizan rapidez de uso, contexto y claridad en navegación.
+
+A nivel de plataforma, esta entrega alinea app, web y documentación con el stack 0.5.44, manteniendo estabilidad en componentes no modificados. El resultado es una versión más cohesionada entre experiencia de usuario, operación y posicionamiento.
+
+En conjunto, MIOT-0.5.44 aporta mejoras OSS concretas que se integran de forma directa en esta versión, con impacto positivo en productividad y percepción de confianza.

--- a/releases/stacks/v0.5.44.plan.json
+++ b/releases/stacks/v0.5.44.plan.json
@@ -1,0 +1,145 @@
+{
+  "stack_version": "0.5.44",
+  "stack_tag": "miot-stack@v0.5.44",
+  "milestone": "MIOT-0.5.44",
+  "pull_requests": [
+    {
+      "number": 1045,
+      "title": "feat(web): revisión RV + demo-led + trust bar de integraciones",
+      "source_issues": [
+        {
+          "number": 1104,
+          "title": "Refresh demo-led landing page and add integrations trust bar"
+        }
+      ]
+    },
+    {
+      "number": 1092,
+      "title": "Fixed recommendations on the spotlight search",
+      "source_issues": [
+        {
+          "number": 1108,
+          "title": "Add recommendations and persistent recent items to Spotlight search"
+        }
+      ]
+    },
+    {
+      "number": 1106,
+      "title": "Fixed naming in dashboard",
+      "source_issues": [
+        {
+          "number": 1107,
+          "title": "Enable inline dashboard renaming from breadcrumbs"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "turbo-repo/apps/app/src/features/common/components/Breadcrumb/Breadcrumb.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-view/dashboard-view.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/section-header/section-header.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-empty-state.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/apps/web/app/alpha-2506/[lang]/page.tsx",
+    "turbo-repo/apps/web/app/page.tsx",
+    "turbo-repo/apps/web/components/v2/GpsProviders.tsx",
+    "turbo-repo/apps/web/components/v2/ModuleTabs.tsx",
+    "turbo-repo/apps/web/components/v2/Nav.tsx",
+    "turbo-repo/apps/web/components/v2/StatsGrid.tsx",
+    "turbo-repo/apps/web/components/v2/StatsGrid.types.ts",
+    "turbo-repo/apps/web/components/v2/StepsInteractive.tsx",
+    "turbo-repo/apps/web/components/v2/TorreDeControl.tsx",
+    "turbo-repo/apps/web/components/v2/content.en.ts",
+    "turbo-repo/apps/web/components/v2/content.pt.ts",
+    "turbo-repo/apps/web/components/v2/content.ts",
+    "turbo-repo/apps/web/components/v2/partners-data.ts",
+    "turbo-repo/apps/web/components/v2/partners-data.types.ts",
+    "turbo-repo/apps/web/components/v2/sections/Partners.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Security.tsx",
+    "turbo-repo/apps/web/components/v2/sections/Security.types.ts",
+    "turbo-repo/apps/web/components/v2/sections/Stats.tsx",
+    "turbo-repo/apps/web/components/v2/sections/TresActos.tsx",
+    "turbo-repo/apps/web/components/v2/sections/TrustedBy.tsx",
+    "turbo-repo/apps/web/components/v2/sections/shared.tsx",
+    "turbo-repo/apps/web/components/v2/torre-data.en.ts",
+    "turbo-repo/apps/web/components/v2/torre-data.pt.ts",
+    "turbo-repo/apps/web/components/v2/torre-data.ts",
+    "turbo-repo/apps/web/components/v2/torre-modules-data.en.ts",
+    "turbo-repo/apps/web/components/v2/torre-modules-data.pt.ts",
+    "turbo-repo/apps/web/components/v2/torre-modules-data.ts",
+    "turbo-repo/apps/web/messages/br.json",
+    "turbo-repo/apps/web/messages/en.json",
+    "turbo-repo/apps/web/messages/es.json",
+    "turbo-repo/apps/web/public/partners/aws.svg",
+    "turbo-repo/apps/web/public/partners/azure.svg",
+    "turbo-repo/apps/web/public/partners/bermann.png",
+    "turbo-repo/apps/web/public/partners/controlposition.svg",
+    "turbo-repo/apps/web/public/partners/copiloto.png",
+    "turbo-repo/apps/web/public/partners/digiplus.png",
+    "turbo-repo/apps/web/public/partners/epol.png",
+    "turbo-repo/apps/web/public/partners/galileo.svg",
+    "turbo-repo/apps/web/public/partners/gcloud.svg",
+    "turbo-repo/apps/web/public/partners/geoaustral.png",
+    "turbo-repo/apps/web/public/partners/gotrack.png",
+    "turbo-repo/apps/web/public/partners/gpschile.png",
+    "turbo-repo/apps/web/public/partners/gpsglobal.png",
+    "turbo-repo/apps/web/public/partners/isanto.png",
+    "turbo-repo/apps/web/public/partners/kausana.svg",
+    "turbo-repo/apps/web/public/partners/laxgps.webp",
+    "turbo-repo/apps/web/public/partners/michelin.png",
+    "turbo-repo/apps/web/public/partners/n8n.svg",
+    "turbo-repo/apps/web/public/partners/onelogis.png",
+    "turbo-repo/apps/web/public/partners/onway.svg",
+    "turbo-repo/apps/web/public/partners/position.png",
+    "turbo-repo/apps/web/public/partners/postgresql.svg",
+    "turbo-repo/apps/web/public/partners/pulsar.svg",
+    "turbo-repo/apps/web/public/partners/rastreosat.png",
+    "turbo-repo/apps/web/public/partners/rolbox.png",
+    "turbo-repo/apps/web/public/partners/samtech.png",
+    "turbo-repo/apps/web/public/partners/sicom.png",
+    "turbo-repo/apps/web/public/partners/sitrack.svg",
+    "turbo-repo/apps/web/public/partners/targa.png",
+    "turbo-repo/apps/web/public/partners/teams.svg",
+    "turbo-repo/apps/web/public/partners/tracktec.png",
+    "turbo-repo/apps/web/public/partners/visionid.png",
+    "turbo-repo/apps/web/public/partners/waypoint.png",
+    "turbo-repo/apps/web/public/partners/webex.svg",
+    "turbo-repo/apps/web/public/partners/webfleet.svg",
+    "turbo-repo/apps/web/public/partners/whatsapp.svg",
+    "turbo-repo/apps/web/public/partners/wisetrack.png"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.44",
+      "tag": "app@v0.5.44"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.42",
+      "version": "0.5.44",
+      "tag": "docs@v0.5.44"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.43",
+      "version": "0.5.44",
+      "tag": "web@v0.5.44"
+    },
+    "modulith": {
+      "changed": false,
+      "changed_since": "modulith@v0.5.26",
+      "version": "0.5.26",
+      "tag": "modulith@v0.5.26"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.5",
+      "tag": "harness@v0.1.5"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.43.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.43.mdx
@@ -1,0 +1,47 @@
+# 🔔 Release Notes v1.31.43 — ModularIoT
+
+### Fecha: 06/08/2026
+
+**Objetivo**: Esta versión refuerza la experiencia de uso en la aplicación web con mejoras de búsqueda, edición contextual y navegación comercial del sitio público. Además, consolida el paquete OSS MIOT-0.5.44 con cambios orientados a usabilidad y adopción.
+
+## 🚀 Evolutivos
+
+- **📍 Spotlight con recomendaciones y recientes persistentes**
+  - **Key point**: Se incorporaron recomendaciones para preguntas de Harness y accesos de navegación, junto con secciones contextuales de sugerencias y elementos recientes persistentes.
+  - **Technical detail**: Se unificó el comportamiento de selección por teclado y hover en todas las sugerencias, y se mantuvo el modal abierto al elegir preguntas sugeridas de Harness para mejorar continuidad de flujo. *(Integración OSS — MIOT-0.5.44)*
+
+- **📍 Renombrado inline de dashboards desde breadcrumbs**
+  - **Key point**: Ahora es posible editar el nombre del dashboard directamente desde el último breadcrumb en modo edición.
+  - **Technical detail**: El guardado se ejecuta con Enter o pérdida de foco, Escape cancela, se ignoran nombres vacíos/sin cambios y el sidebar se actualiza inmediatamente tras renombrar. *(Integración OSS — MIOT-0.5.44)*
+
+- **📍 Renovación de landing orientada a demo y barra de confianza de integraciones**
+  - **Key point**: La landing prioriza la solicitud de demo como acción principal y actualiza contenidos, KPIs y terminología en ES/EN/PT.
+  - **Technical detail**: Se añadió una sección de Seguridad y Datos y una barra de confianza con carruseles de proveedores/plataformas y enlaces, manteniendo separados los testimonios y preservando contenido reutilizable fuera de la página principal. *(Integración OSS — MIOT-0.5.44)*
+
+## 📊 Beneficios
+
+- Mejora la descubribilidad funcional con búsqueda guiada y atajos relevantes.
+- Reduce fricción operativa al permitir renombrar dashboards sin salir del contexto actual.
+- Aumenta consistencia UX con interacciones homogéneas por teclado y puntero.
+- Refuerza confianza comercial/técnica con mensajes explícitos de seguridad, trazabilidad y SLA.
+- Mejora la localización multilingüe en flujos clave de producto y sitio público.
+- Favorece continuidad de uso en Harness al evitar cierres innecesarios del modal.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.44`
+- **App**: `app@v0.5.44` *(actualizado)*
+- **Docs**: `docs@v0.5.44` *(actualizado)*
+- **Web**: `web@v0.5.44` *(actualizado)*
+- **Modulith**: `modulith@v0.5.26` *(sin cambios)*
+- **Harness**: `harness@v0.1.5` *(sin cambios)*
+
+Los digest exactos de imágenes desplegadas están disponibles en el diálogo in-app de información de build y en el asset de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La release 1.31.43 se centra en elevar la calidad de interacción diaria en el producto y en fortalecer la propuesta pública de ModularIoT para adopción comercial. Los cambios priorizan rapidez de uso, contexto y claridad en navegación.
+
+A nivel de plataforma, esta entrega alinea app, web y documentación con el stack 0.5.44, manteniendo estabilidad en componentes no modificados. El resultado es una versión más cohesionada entre experiencia de usuario, operación y posicionamiento.
+
+En conjunto, MIOT-0.5.44 aporta mejoras OSS concretas que se integran de forma directa en esta versión, con impacto positivo en productividad y percepción de confianza.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.42",
+  "version": "0.5.44",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.43",
+      "version": "0.5.44",
       "dependencies": {
         "@alfresco/js-api": "^9.0.0",
         "@auth/core": "0.41.3",
@@ -619,7 +619,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.42",
+      "version": "0.5.44",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -719,7 +719,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.43",
+      "version": "0.5.44",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.44 from milestone MIOT-0.5.44, with release notes v1.31.43.

Components:
- App: app@v0.5.44 (changed: true)
- Docs: docs@v0.5.44 (changed: true since docs@v0.5.42)
- Web: web@v0.5.44 (changed: true since web@v0.5.43)
- Modulith: modulith@v0.5.26 (changed: false since modulith@v0.5.26)
- Harness: harness@v0.1.5 (changed: false since harness@v0.1.5)

Milestones: Release 1.31.43, MIOT-0.5.44.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spotlight recommendations and persistent recent items are now highlighted.
  * Dashboards support inline renaming.
  * The landing experience includes demo-focused content and integration trust information.
  * Added multilingual updates and clearer platform benefits.

* **Documentation**
  * Added release documentation covering the latest platform improvements, stack versions, and deployment details.

* **Chores**
  * Updated application, documentation, and web component versions to 0.5.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->