### PR TITLE
chore(release): prepare MIOT stack v0.5.45

### DIFF
--- a/miot-harness/pyproject.toml
+++ b/miot-harness/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miot-harness"
-version = "0.1.5"
+version = "0.1.6"
 description = "ASK MIOT multi-agent backend harness pilot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/miot-harness/uv.lock
+++ b/miot-harness/uv.lock
@@ -1412,7 +1412,7 @@ wheels = [
 
 [[package]]
 name = "miot-harness"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-symptoms/pom.xml
+++ b/quarkus-srv/miot-symptoms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-symptoms</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.26</version>
+        <version>0.5.27</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.26</version>
+    <version>0.5.27</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.44.mdx
+++ b/releases/notes/v1.31.44.mdx
@@ -1,0 +1,79 @@
+# 🔔 Release Notes v1.31.44 — ModularIoT
+
+### Fecha: 27/08/2026
+
+**Objetivo**: Esta versión consolida la experiencia del asistente Harness, mejora el procesamiento de señales de activos con enriquecimiento configurable de datos de camiones, e incorpora correcciones críticas en la barra de filtros de Torre de Control. Se avanza además en la reducción de costos operativos mediante el dispatcher en proceso para síntomas IoT.
+
+---
+
+## 🚀 Evolutivos
+
+- **💬 Experiencia de chat del asistente Harness**
+  - **Implementado**: Interfaz de chat multi-sesión con historial de conversaciones, adjuntos, skills por slash-command y razonamiento expandible. Incluye prompts interactivos de respuesta simple, múltiple y texto libre.
+  - **Detalle técnico**: Se añadieron atajos de teclado para abrir el chat y disparar acciones, integración con Spotlight Search, y actualización del acento visual de Harness y Spotlight a amber/gold. *(Integración OSS — MIOT-0.5.45)*
+
+- **⚙️ Dispatcher RouteTable en proceso para síntomas IoT**
+  - **Implementado**: Componente `miot-symptoms` en `quarkus-srv` con suscripción compartida a Pulsar sobre `accumulated_states` y un `RouteTable` en proceso indexado por `rule_id`, con bootstrap JSON configurable.
+  - **Detalle técnico**: Contrato de skip compatible con el comportamiento actual (`forward:false` / `status:204`). Tabla vacía no inicia el consumidor; los pods Helm existentes retienen ownership de cada `rule_id` hasta migración explícita, evitando escrituras dobles en `symptoms`. *(Integración OSS — MIOT-0.5.45)*
+
+- **🚛 Enriquecimiento configurable de señales con datos de camiones (`rd_trucks`)**
+  - **Implementado**: Cada señal de activo validada se enriquece con atributos configurables de `ams.rd_trucks`, exponiendo por defecto el campo numérico `max_weight`.
+  - **Detalle técnico**: Resolución por `(client_id, asset_id)` con caché Redis tenant-aware (TTL positivo 8 h, negativo 15 min). La proyección es configurable vía `rd-truck.enrichment.fields`. El enriquecimiento nunca rechaza la señal ante fallos de Redis o PostgreSQL (fail-open). Los campos core de la señal no pueden ser sobreescritos.
+
+- **🎨 Marca Lynx como logo único de la plataforma**
+  - **Implementado**: Eliminación del logo ilustrado legacy (búho ilustrado) y todas sus variantes; consolidación en el símbolo Golden Owl "Lynx" generado por `apps/web/scripts/generate-logo.mjs`.
+  - **Detalle técnico**: Consumidores en `packages/ui/src/brand/` y `apps/web-admin` actualizados para renderizar únicamente la marca Lynx. README de marca documentado. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 🔧 Integraciones
+
+- **🔌 Renombrado de variable de entorno del modulith (`MIOT_MODULITH_URL`)**
+  - **Alcance**: `MIOT_HARNESS_URL` renombrada a `MIOT_MODULITH_URL` para reflejar que es el host base del gateway Quarkus modulith, no solo del harness. La lectura se centralizó en un único helper. Se mantiene fallback transitional a `MIOT_HARNESS_URL` con advertencia de deprecación para evitar interrupciones durante el despliegue escalonado. `MIOT_MODULITH_URL` y `ENABLE_DEV_TOOLS` declarados en `turbo.json` `globalEnv`. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 🐛 Correcciones
+
+- **🐛 Barra de filtros de Torre de Control — cuatro defectos en síntomas**
+  - **Impacto**: (1) Rangos de fecha predefinidos ("Hoy", "Ayer", "Últimos 7 días") emitían solo la fecha sin hora, perdiendo el rango completo del día. (2) El dropdown "Nombre del síntoma" mostraba checkboxes en blanco porque `SelectFilterBadge` recibía strings en lugar de objetos `{label, value}`. (3) La lista de opciones colapsaba a la selección activa, impidiendo cambiar de síntoma sin limpiar el filtro. (4) Seleccionar dos síntomas devolvía tabla vacía porque la función SQL espera un valor único.
+  - **Solución**: Corregida la emisión de fechas con hora completa (`00:00:00`→`23:59:59`); corregida la hidratación de opciones del selector de síntomas de forma reactiva; la lista de opciones se carga independientemente del filtro activo; los selectores del dashboard ganan `optionsSource` opcional para derivar opciones desde variables del Request Planner. *(Integración OSS — MIOT-0.5.45)*
+
+- **🐛 Favicon desactualizado en la aplicación principal**
+  - **Impacto**: `apps/app` mostraba el favicon anterior (arte pre-Lynx) en lugar del ícono adaptativo Lynx.
+  - **Solución**: `apps/app/src/app/icon.svg` y `favicon.ico` sincronizados con los generados por `apps/web`, mostrando la marca Lynx en superficies claras y oscuras. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 📊 Beneficios
+
+- **Reducción de costos operativos**: El dispatcher en proceso para síntomas elimina la dependencia de 16 pods Autopilot always-on, permitiendo drenar esa flota progresivamente por `rule_id`.
+- **Señales más ricas**: El enriquecimiento con `max_weight` de `rd_trucks` llega de forma consistente a ambas funciones SQL de procesamiento (`speed_process_signal` y `acumulate_process_signal`) sin impacto en la disponibilidad del pipeline.
+- **Experiencia de asistente madura**: El chat Harness multi-sesión con historial, adjuntos y skills por slash-command eleva significativamente las capacidades de interacción con el asistente ASK MIOT.
+- **Filtros de Torre de Control corregidos**: Los operadores pueden ahora filtrar síntomas por nombre con opciones visibles y rangos de fecha precisos, sin resultados vacíos inesperados.
+- **Identidad visual consolidada**: La marca Lynx es el único logo de la plataforma, eliminando inconsistencias visuales entre aplicaciones.
+- **Configuración de entorno más robusta**: La centralización de `MIOT_MODULITH_URL` con fallback transitional evita interrupciones y hace explícita la dependencia de todos los consumidores del modulith.
+- **Seguridad de caché mejorada**: Las claves Redis con `client_id` + `asset_id` garantizan aislamiento entre tenants en el enriquecimiento de camiones.
+
+---
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.45`
+- **App** (`app@v0.5.45`): actualizada en esta versión.
+- **Docs** (`docs@v0.5.45`): actualizada en esta versión.
+- **Web** (`web@v0.5.45`): actualizada en esta versión.
+- **Modulith** (`modulith@v0.5.27`): actualizado en esta versión.
+- **Harness** (`harness@v0.1.6`): actualizado en esta versión.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+---
+
+## 📌 Conclusión
+
+La versión 1.31.44 representa un avance sustancial en tres frentes simultáneos: la experiencia de usuario con el asistente Harness, la confiabilidad operativa del pipeline de síntomas IoT, y la calidad de los datos de señales de flota. La migración progresiva del dispatcher de síntomas al modulith sienta las bases para una reducción significativa de infraestructura dedicada sin riesgo de pérdida de datos.
+
+Las correcciones en la barra de filtros de Torre de Control y el favicon restauran la consistencia esperada por los operadores, mientras que el enriquecimiento configurable con datos de camiones abre una vía extensible para incorporar atributos adicionales de `rd_trucks` sin modificar el núcleo del pipeline. La arquitectura fail-open garantiza que ninguna dependencia externa pueda interrumpir el procesamiento de señales.
+
+El renombrado de `MIOT_HARNESS_URL` a `MIOT_MODULITH_URL`, con su fallback transitional, es un ejemplo del enfoque adoptado en esta versión: cambios que mejoran la claridad del sistema sin imponer ventanas de mantenimiento, permitiendo que cada entorno se actualice de forma independiente y segura.

--- a/releases/stacks/v0.5.45.plan.json
+++ b/releases/stacks/v0.5.45.plan.json
@@ -1,0 +1,258 @@
+{
+  "stack_version": "0.5.45",
+  "stack_tag": "miot-stack@v0.5.45",
+  "milestone": "MIOT-0.5.45",
+  "pull_requests": [
+    {
+      "number": 1111,
+      "title": "feat(symptoms): in-process RouteTable dispatcher in the modulith",
+      "source_issues": [
+        {
+          "number": 1110,
+          "title": "feat(symptoms): in-process RouteTable dispatcher in the modulith"
+        }
+      ]
+    },
+    {
+      "number": 1112,
+      "title": "Based/implementing assistant UI",
+      "source_issues": [
+        {
+          "number": 1124,
+          "title": "Add the Harness assistant chat experience"
+        }
+      ]
+    },
+    {
+      "number": 1122,
+      "title": "[web-admin] Replace legacy illustrated owl with Golden Owl brand assets (#1114)",
+      "source_issues": [
+        {
+          "number": 1114,
+          "title": "chore: remove legacy illustrated owl logo and variants — keep only Golden Owl mark"
+        }
+      ]
+    },
+    {
+      "number": 1127,
+      "title": "refactor(app): collapse MIOT_HARNESS_URL and MIOT_RESOURCE_URL into MIOT_MODULITH_URL",
+      "source_issues": [
+        {
+          "number": 1126,
+          "title": "refactor(app): rename MIOT_HARNESS_URL to MIOT_MODULITH_URL and centralise the read"
+        }
+      ]
+    },
+    {
+      "number": 1128,
+      "title": "[app] Replace stale favicon with the Lynx mark from apps/web (#1123)",
+      "source_issues": [
+        {
+          "number": 1123,
+          "title": "bug: apps/app favicon is stale — use the Lynx favicon from apps/web"
+        }
+      ]
+    },
+    {
+      "number": 1131,
+      "title": "fix(app): make control-tower filters usable",
+      "source_issues": [
+        {
+          "number": 1132,
+          "title": "bug: control-tower filter bar — blank symptom options, collapsing option list, day-only date ranges, empty results on multi-select"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "miot-harness/tests/context_skills/test_miot_search_pages_parity.py",
+    "quarkus-srv/.env.sample",
+    "quarkus-srv/README.md",
+    "quarkus-srv/miot-cli/pom.xml",
+    "quarkus-srv/miot-cli/src/main/resources/application.properties",
+    "quarkus-srv/miot-symptoms/README.md",
+    "quarkus-srv/miot-symptoms/pom.xml",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/SymptomsComponent.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/consumer/SymptomsCdcConsumer.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/metrics/SymptomMetrics.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/FunctionInvoker.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/ProcessOutcome.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/ResultForwarder.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/RouteBulkhead.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/StreamhubSymptomsGpsClient.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/SymptomProcessor.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/process/WebhookForwarder.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/BootstrapRouteTableSource.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/RouteTable.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/RouteTableHolder.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/RouteTableParser.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/RouteTableSource.java",
+    "quarkus-srv/miot-symptoms/src/main/java/com/microboxlabs/miot/symptoms/route/SymptomRoute.java",
+    "quarkus-srv/miot-symptoms/src/main/resources/symptoms-routes.example.json",
+    "quarkus-srv/miot-symptoms/src/test/java/com/microboxlabs/miot/symptoms/process/ResultForwarderTest.java",
+    "quarkus-srv/miot-symptoms/src/test/java/com/microboxlabs/miot/symptoms/process/StreamhubSymptomsGpsClientTest.java",
+    "quarkus-srv/miot-symptoms/src/test/java/com/microboxlabs/miot/symptoms/process/SymptomProcessorTest.java",
+    "quarkus-srv/miot-symptoms/src/test/java/com/microboxlabs/miot/symptoms/route/RouteTableParserTest.java",
+    "quarkus-srv/miot-symptoms/src/test/java/com/microboxlabs/miot/symptoms/route/RouteTableTest.java",
+    "quarkus-srv/pom.xml",
+    "quarkus-srv/start.sh",
+    "turbo-repo/apps/app/.env.example",
+    "turbo-repo/apps/app/package.json",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/components/components-view.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/components/extension-preview.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/components/page.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/harness-extensions/harness-extensions-view.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/harness-extensions/json-highlight.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/dev/harness-extensions/page.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/harness-chat-mount.tsx",
+    "turbo-repo/apps/app/src/app/[lang]/(secured)/layout.tsx",
+    "turbo-repo/apps/app/src/app/api/admin/orgs/[orgId]/integrations/gps-webhooks/route.ts",
+    "turbo-repo/apps/app/src/app/api/harness/chat/stream/route.ts",
+    "turbo-repo/apps/app/src/app/api/harness/search/route.ts",
+    "turbo-repo/apps/app/src/app/api/harness/search/stream/route.test.ts",
+    "turbo-repo/apps/app/src/app/api/harness/search/stream/route.ts",
+    "turbo-repo/apps/app/src/app/api/harness/skills/route.ts",
+    "turbo-repo/apps/app/src/app/api/interactions/episodes/record-episode.test.ts",
+    "turbo-repo/apps/app/src/app/api/interactions/episodes/record-episode.ts",
+    "turbo-repo/apps/app/src/app/api/knowledge/candidates/candidates-client.test.ts",
+    "turbo-repo/apps/app/src/app/api/knowledge/candidates/candidates-client.ts",
+    "turbo-repo/apps/app/src/app/api/runtime-config/route.test.ts",
+    "turbo-repo/apps/app/src/app/api/utils/miot-resource-api-client.ts",
+    "turbo-repo/apps/app/src/app/api/utils/quarkus-proxy.ts",
+    "turbo-repo/apps/app/src/app/api/utils/streamhub-modulith-proxy.ts",
+    "turbo-repo/apps/app/src/app/api/utils/tenant-scope.ts",
+    "turbo-repo/apps/app/src/app/favicon.ico",
+    "turbo-repo/apps/app/src/app/icon.svg",
+    "turbo-repo/apps/app/src/features/common/components/keyboard-shortcut-trigger/index.ts",
+    "turbo-repo/apps/app/src/features/common/components/keyboard-shortcut-trigger/keyboard-shortcut-trigger.tsx",
+    "turbo-repo/apps/app/src/features/common/hooks/use-keyboard-shortcut.ts",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filter-bar/time-range-picker.test.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filter-bar/time-range-picker.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/date-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/select-filter-badge.test.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-filters-card/select-filter-badge.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/components/dashboard-settings-dropdown/dashboard-settings-dropdown.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/context/dashboard-context.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/context/standalone-dictionary-context.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/batch_import/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/chart/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/chart/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/chart_v2/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/common/column-filter-popover.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/common/column-filter-toolbar.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/common/use-planner-data.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/container/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/container/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/dashlet-preview.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/data_list/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/data_table/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/data_table_v2/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/file_upload/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/file_upload/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/flex_container/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/flex_container/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/geographic_map/dashlet.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/info_card/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/stat_expandable/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/text_card/index.ts",
+    "turbo-repo/apps/app/src/features/dashboard/dashlets/types.ts",
+    "turbo-repo/apps/app/src/features/dashboard/hooks/use-effective-refresh-interval.ts",
+    "turbo-repo/apps/app/src/features/dashboard/hooks/use-filter-options.test.tsx",
+    "turbo-repo/apps/app/src/features/dashboard/hooks/use-filter-options.ts",
+    "turbo-repo/apps/app/src/features/dashboard/types/dashboard.types.ts",
+    "turbo-repo/apps/app/src/features/dashboard/utils/date-param.test.ts",
+    "turbo-repo/apps/app/src/features/dashboard/utils/date-param.ts",
+    "turbo-repo/apps/app/src/features/geographic-view/components/filters.tsx",
+    "turbo-repo/apps/app/src/features/geographic-view/components/map-style-selector.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/attachments.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/composer.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/history-list.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/image-lightbox.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/initial-message-sender.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/session-title-watcher.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/components/thread-messages.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/context/harness-chat-context.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/context/harness-chat-i18n-context.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/context/run-cancel-context.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/extensions/ask-user-question.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/extensions/components/ask-user-question-card.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/extensions/components/show-dashlet-card.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/extensions/index.ts",
+    "turbo-repo/apps/app/src/features/harness-chat/extensions/show-dashlet.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/harness-chat-attachments.ts",
+    "turbo-repo/apps/app/src/features/harness-chat/harness-chat-toggle-button.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/harness-chat-types.ts",
+    "turbo-repo/apps/app/src/features/harness-chat/harness-chat.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/harness-extension.tsx",
+    "turbo-repo/apps/app/src/features/harness-chat/hooks/use-harness-skills.ts",
+    "turbo-repo/apps/app/src/features/harness-chat/hooks/use-resizable-panel-width.ts",
+    "turbo-repo/apps/app/src/features/harness-chat/thread.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-layout.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/navegation_params.ts",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-filter-bar.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/searchbar/parametrized-searchbar.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/secured-navbar.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/navigate-actions.ts",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-harness-progress.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-input.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-results.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-row.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/spotlight-search.tsx",
+    "turbo-repo/apps/app/src/features/layout/components/secured-navbar/spotlight-search/use-spotlight-state.ts",
+    "turbo-repo/apps/app/src/features/layout/context/sidebar-navigation-context.test.tsx",
+    "turbo-repo/apps/app/src/features/layout/context/sidebar-navigation-context.tsx",
+    "turbo-repo/apps/app/src/features/layout/hooks/use-visible-pages.ts",
+    "turbo-repo/apps/app/src/features/layout/models/pages-config.json",
+    "turbo-repo/apps/app/src/features/layout/models/pages.ts",
+    "turbo-repo/apps/app/src/features/layout/utils/utils.ts",
+    "turbo-repo/apps/app/src/features/runtime-config/runtime-config.constants.ts",
+    "turbo-repo/apps/app/src/features/runtime-config/runtime-config.types.ts",
+    "turbo-repo/apps/app/src/features/symptoms/components/condition-icon.tsx",
+    "turbo-repo/apps/app/src/features/symptoms/components/table-component.tsx",
+    "turbo-repo/apps/app/src/features/symptoms/hooks/use-symptom-names.test.tsx",
+    "turbo-repo/apps/app/src/features/symptoms/hooks/use-symptom-names.ts",
+    "turbo-repo/apps/app/src/lang/en.json",
+    "turbo-repo/apps/app/src/lang/es.json",
+    "turbo-repo/apps/app/src/lib/modulith-host.test.ts",
+    "turbo-repo/apps/app/src/lib/modulith-host.ts",
+    "turbo-repo/apps/web-admin/public/headlogo-dark.svg",
+    "turbo-repo/apps/web-admin/public/headlogo.svg",
+    "turbo-repo/apps/web-admin/public/logo.svg",
+    "turbo-repo/apps/web/public/brand/README.md",
+    "turbo-repo/package-lock.json",
+    "turbo-repo/turbo.json"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.45",
+      "tag": "app@v0.5.45"
+    },
+    "docs": {
+      "changed": true,
+      "changed_since": "docs@v0.5.44",
+      "version": "0.5.45",
+      "tag": "docs@v0.5.45"
+    },
+    "web": {
+      "changed": true,
+      "changed_since": "web@v0.5.44",
+      "version": "0.5.45",
+      "tag": "web@v0.5.45"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.26",
+      "version": "0.5.27",
+      "tag": "modulith@v0.5.27"
+    },
+    "harness": {
+      "changed": true,
+      "changed_since": "harness@v0.1.5",
+      "version": "0.1.6",
+      "tag": "harness@v0.1.6"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.44.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.44.mdx
@@ -1,0 +1,79 @@
+# 🔔 Release Notes v1.31.44 — ModularIoT
+
+### Fecha: 27/08/2026
+
+**Objetivo**: Esta versión consolida la experiencia del asistente Harness, mejora el procesamiento de señales de activos con enriquecimiento configurable de datos de camiones, e incorpora correcciones críticas en la barra de filtros de Torre de Control. Se avanza además en la reducción de costos operativos mediante el dispatcher en proceso para síntomas IoT.
+
+---
+
+## 🚀 Evolutivos
+
+- **💬 Experiencia de chat del asistente Harness**
+  - **Implementado**: Interfaz de chat multi-sesión con historial de conversaciones, adjuntos, skills por slash-command y razonamiento expandible. Incluye prompts interactivos de respuesta simple, múltiple y texto libre.
+  - **Detalle técnico**: Se añadieron atajos de teclado para abrir el chat y disparar acciones, integración con Spotlight Search, y actualización del acento visual de Harness y Spotlight a amber/gold. *(Integración OSS — MIOT-0.5.45)*
+
+- **⚙️ Dispatcher RouteTable en proceso para síntomas IoT**
+  - **Implementado**: Componente `miot-symptoms` en `quarkus-srv` con suscripción compartida a Pulsar sobre `accumulated_states` y un `RouteTable` en proceso indexado por `rule_id`, con bootstrap JSON configurable.
+  - **Detalle técnico**: Contrato de skip compatible con el comportamiento actual (`forward:false` / `status:204`). Tabla vacía no inicia el consumidor; los pods Helm existentes retienen ownership de cada `rule_id` hasta migración explícita, evitando escrituras dobles en `symptoms`. *(Integración OSS — MIOT-0.5.45)*
+
+- **🚛 Enriquecimiento configurable de señales con datos de camiones (`rd_trucks`)**
+  - **Implementado**: Cada señal de activo validada se enriquece con atributos configurables de `ams.rd_trucks`, exponiendo por defecto el campo numérico `max_weight`.
+  - **Detalle técnico**: Resolución por `(client_id, asset_id)` con caché Redis tenant-aware (TTL positivo 8 h, negativo 15 min). La proyección es configurable vía `rd-truck.enrichment.fields`. El enriquecimiento nunca rechaza la señal ante fallos de Redis o PostgreSQL (fail-open). Los campos core de la señal no pueden ser sobreescritos.
+
+- **🎨 Marca Lynx como logo único de la plataforma**
+  - **Implementado**: Eliminación del logo ilustrado legacy (búho ilustrado) y todas sus variantes; consolidación en el símbolo Golden Owl "Lynx" generado por `apps/web/scripts/generate-logo.mjs`.
+  - **Detalle técnico**: Consumidores en `packages/ui/src/brand/` y `apps/web-admin` actualizados para renderizar únicamente la marca Lynx. README de marca documentado. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 🔧 Integraciones
+
+- **🔌 Renombrado de variable de entorno del modulith (`MIOT_MODULITH_URL`)**
+  - **Alcance**: `MIOT_HARNESS_URL` renombrada a `MIOT_MODULITH_URL` para reflejar que es el host base del gateway Quarkus modulith, no solo del harness. La lectura se centralizó en un único helper. Se mantiene fallback transitional a `MIOT_HARNESS_URL` con advertencia de deprecación para evitar interrupciones durante el despliegue escalonado. `MIOT_MODULITH_URL` y `ENABLE_DEV_TOOLS` declarados en `turbo.json` `globalEnv`. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 🐛 Correcciones
+
+- **🐛 Barra de filtros de Torre de Control — cuatro defectos en síntomas**
+  - **Impacto**: (1) Rangos de fecha predefinidos ("Hoy", "Ayer", "Últimos 7 días") emitían solo la fecha sin hora, perdiendo el rango completo del día. (2) El dropdown "Nombre del síntoma" mostraba checkboxes en blanco porque `SelectFilterBadge` recibía strings en lugar de objetos `{label, value}`. (3) La lista de opciones colapsaba a la selección activa, impidiendo cambiar de síntoma sin limpiar el filtro. (4) Seleccionar dos síntomas devolvía tabla vacía porque la función SQL espera un valor único.
+  - **Solución**: Corregida la emisión de fechas con hora completa (`00:00:00`→`23:59:59`); corregida la hidratación de opciones del selector de síntomas de forma reactiva; la lista de opciones se carga independientemente del filtro activo; los selectores del dashboard ganan `optionsSource` opcional para derivar opciones desde variables del Request Planner. *(Integración OSS — MIOT-0.5.45)*
+
+- **🐛 Favicon desactualizado en la aplicación principal**
+  - **Impacto**: `apps/app` mostraba el favicon anterior (arte pre-Lynx) en lugar del ícono adaptativo Lynx.
+  - **Solución**: `apps/app/src/app/icon.svg` y `favicon.ico` sincronizados con los generados por `apps/web`, mostrando la marca Lynx en superficies claras y oscuras. *(Integración OSS — MIOT-0.5.45)*
+
+---
+
+## 📊 Beneficios
+
+- **Reducción de costos operativos**: El dispatcher en proceso para síntomas elimina la dependencia de 16 pods Autopilot always-on, permitiendo drenar esa flota progresivamente por `rule_id`.
+- **Señales más ricas**: El enriquecimiento con `max_weight` de `rd_trucks` llega de forma consistente a ambas funciones SQL de procesamiento (`speed_process_signal` y `acumulate_process_signal`) sin impacto en la disponibilidad del pipeline.
+- **Experiencia de asistente madura**: El chat Harness multi-sesión con historial, adjuntos y skills por slash-command eleva significativamente las capacidades de interacción con el asistente ASK MIOT.
+- **Filtros de Torre de Control corregidos**: Los operadores pueden ahora filtrar síntomas por nombre con opciones visibles y rangos de fecha precisos, sin resultados vacíos inesperados.
+- **Identidad visual consolidada**: La marca Lynx es el único logo de la plataforma, eliminando inconsistencias visuales entre aplicaciones.
+- **Configuración de entorno más robusta**: La centralización de `MIOT_MODULITH_URL` con fallback transitional evita interrupciones y hace explícita la dependencia de todos los consumidores del modulith.
+- **Seguridad de caché mejorada**: Las claves Redis con `client_id` + `asset_id` garantizan aislamiento entre tenants en el enriquecimiento de camiones.
+
+---
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.45`
+- **App** (`app@v0.5.45`): actualizada en esta versión.
+- **Docs** (`docs@v0.5.45`): actualizada en esta versión.
+- **Web** (`web@v0.5.45`): actualizada en esta versión.
+- **Modulith** (`modulith@v0.5.27`): actualizado en esta versión.
+- **Harness** (`harness@v0.1.6`): actualizado en esta versión.
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+---
+
+## 📌 Conclusión
+
+La versión 1.31.44 representa un avance sustancial en tres frentes simultáneos: la experiencia de usuario con el asistente Harness, la confiabilidad operativa del pipeline de síntomas IoT, y la calidad de los datos de señales de flota. La migración progresiva del dispatcher de síntomas al modulith sienta las bases para una reducción significativa de infraestructura dedicada sin riesgo de pérdida de datos.
+
+Las correcciones en la barra de filtros de Torre de Control y el favicon restauran la consistencia esperada por los operadores, mientras que el enriquecimiento configurable con datos de camiones abre una vía extensible para incorporar atributos adicionales de `rd_trucks` sin modificar el núcleo del pipeline. La arquitectura fail-open garantiza que ninguna dependencia externa pueda interrumpir el procesamiento de señales.
+
+El renombrado de `MIOT_HARNESS_URL` a `MIOT_MODULITH_URL`, con su fallback transitional, es un ejemplo del enfoque adoptado en esta versión: cambios que mejoran la claridad del sistema sin imponer ventanas de mantenimiento, permitiendo que cada entorno se actualice de forma independiente y segura.

--- a/turbo-repo/apps/docs/package.json
+++ b/turbo-repo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/docs",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo-repo/apps/web/package.json
+++ b/turbo-repo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/web",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3041",

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.44",
+      "version": "0.5.45",
       "dependencies": {
         "@ag-ui/client": "^0.0.57",
         "@alfresco/js-api": "^9.0.0",
@@ -610,7 +610,7 @@
     },
     "apps/docs": {
       "name": "@modulariot/docs",
-      "version": "0.5.44",
+      "version": "0.5.45",
       "dependencies": {
         "@modulariot/ui": "*",
         "next": "16.2.11",
@@ -710,7 +710,7 @@
     },
     "apps/web": {
       "name": "@modulariot/web",
-      "version": "0.5.44",
+      "version": "0.5.45",
       "dependencies": {
         "@modulariot/ui": "*",
         "flowbite-icons": "^1.5.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.45 from milestone MIOT-0.5.45, with release notes v1.31.44.

Components:
- App: app@v0.5.45 (changed: true)
- Docs: docs@v0.5.45 (changed: true since docs@v0.5.44)
- Web: web@v0.5.45 (changed: true since web@v0.5.44)
- Modulith: modulith@v0.5.27 (changed: true since modulith@v0.5.26)
- Harness: harness@v0.1.6 (changed: true since harness@v0.1.5)

Milestones: Release 1.31.44, MIOT-0.5.45.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
