### PR TITLE
chore(release): prepare MIOT stack v0.5.46

### DIFF
--- a/quarkus-srv/miot-cli/pom.xml
+++ b/quarkus-srv/miot-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-cli</artifactId>

--- a/quarkus-srv/miot-conversational/pom.xml
+++ b/quarkus-srv/miot-conversational/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-conversational</artifactId>

--- a/quarkus-srv/miot-core/pom.xml
+++ b/quarkus-srv/miot-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-core</artifactId>

--- a/quarkus-srv/miot-driver/pom.xml
+++ b/quarkus-srv/miot-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-driver</artifactId>

--- a/quarkus-srv/miot-fleet/pom.xml
+++ b/quarkus-srv/miot-fleet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-fleet</artifactId>

--- a/quarkus-srv/miot-gateway/pom.xml
+++ b/quarkus-srv/miot-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-gateway</artifactId>

--- a/quarkus-srv/miot-gps-model/pom.xml
+++ b/quarkus-srv/miot-gps-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-gps-model</artifactId>

--- a/quarkus-srv/miot-integrations/pom.xml
+++ b/quarkus-srv/miot-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-integrations</artifactId>

--- a/quarkus-srv/miot-resource-core/pom.xml
+++ b/quarkus-srv/miot-resource-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-resource-core</artifactId>

--- a/quarkus-srv/miot-symptoms/pom.xml
+++ b/quarkus-srv/miot-symptoms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-symptoms</artifactId>

--- a/quarkus-srv/miot-tracking/pom.xml
+++ b/quarkus-srv/miot-tracking/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microboxlabs.miot</groupId>
         <artifactId>miot-parent</artifactId>
-        <version>0.5.27</version>
+        <version>0.5.28</version>
     </parent>
 
     <artifactId>miot-tracking</artifactId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microboxlabs.miot</groupId>
     <artifactId>miot-parent</artifactId>
-    <version>0.5.27</version>
+    <version>0.5.28</version>
     <packaging>pom</packaging>
 
     <name>ModularIoT — Parent</name>

--- a/releases/notes/v1.31.45.mdx
+++ b/releases/notes/v1.31.45.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.45 — ModularIoT
+
+### Fecha: 27/08/2026
+
+**Objetivo**: Esta versión estabiliza el proceso de compilación nativa del CLI de ModularIoT, resolviendo un conflicto de dependencias de Bouncy Castle que impedía generar imágenes nativas con Mandrel/GraalVM. Se consolida la base técnica para entregas continuas más confiables.
+
+## 🐛 Correcciones
+
+- **🐛 Fallo en la generación de imagen nativa por dependencias mixtas de Bouncy Castle en Pulsar**
+  - **Impacto**: El proceso de compilación nativa del CLI con Mandrel/GraalVM fallaba durante el análisis de `native-image` debido a que el bundle agregado `bouncy-castle-bc` de Pulsar 3.3.0 combinaba Bouncy Castle 1.83 con `bcprov-ext` 1.78, causando un `NoSuchFieldError` en `CMSObjectIdentifiers`. *(Integración OSS — MIOT-0.5.46)*
+  - **Solución**: Se excluyó el artefacto `bouncy-castle-bc` de Pulsar 3.3.0, se agregó la dependencia `bcpkix-jdk18on` 1.83 para mantener los proveedores estándar de Pulsar, y se configuró la inicialización de `SecurityUtility` en tiempo de ejecución durante las compilaciones nativas.
+
+## 📊 Beneficios
+
+- El CLI de ModularIoT puede compilarse como imagen nativa con Mandrel sin errores de análisis de dependencias.
+- Se elimina la ambigüedad de versiones de Bouncy Castle en el árbol de dependencias, resolviendo únicamente artefactos 1.83.
+- La cadena de CI/CD en GitHub Actions valida automáticamente las compilaciones nativas en cada pull request.
+- Se reduce el riesgo de regresiones criptográficas al garantizar una única versión coherente de la librería Bouncy Castle.
+- La estabilización del proceso de build nativo sienta las bases para distribuciones del CLI más ligeras y de inicio más rápido.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.46`
+- **App**: `app@v0.5.46` *(actualizado)*
+- **Modulith**: `modulith@v0.5.28` *(actualizado)*
+- **Docs**: `docs@v0.5.45` *(sin cambios)*
+- **Web**: `web@v0.5.45` *(sin cambios)*
+- **Harness**: `harness@v0.1.6` *(sin cambios)*
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.45 se centra en la solidez del proceso de construcción del CLI nativo, un componente crítico para la distribución y despliegue de ModularIoT en entornos industriales. La resolución del conflicto de Bouncy Castle elimina una barrera técnica que afectaba la generación de binarios optimizados con GraalVM/Mandrel.
+
+Este ajuste refuerza la confiabilidad del pipeline de integración continua y garantiza que futuros cambios en el CLI puedan validarse mediante compilación nativa sin intervención manual. La alineación con las versiones correctas de las librerías criptográficas también mejora la postura de seguridad del componente.
+
+Con los componentes `app` y `modulith` actualizados en este ciclo, la plataforma avanza hacia el stack `v0.5.46` con una base de build más estable, lista para soportar los próximos evolutivos de integración y funcionalidad industrial.

--- a/releases/stacks/v0.5.46.plan.json
+++ b/releases/stacks/v0.5.46.plan.json
@@ -1,0 +1,52 @@
+{
+  "stack_version": "0.5.46",
+  "stack_tag": "miot-stack@v0.5.46",
+  "milestone": "MIOT-0.5.46",
+  "pull_requests": [
+    {
+      "number": 1136,
+      "title": "fix(native): exclude Pulsar Bouncy Castle bundle",
+      "source_issues": [
+        {
+          "number": 1137,
+          "title": "Fix Mandrel native-image failure caused by Pulsar Bouncy Castle dependencies"
+        }
+      ]
+    }
+  ],
+  "milestone_changed_files": [
+    "quarkus-srv/miot-cli/src/main/resources/application.properties",
+    "quarkus-srv/miot-symptoms/pom.xml"
+  ],
+  "components": {
+    "app": {
+      "changed": true,
+      "version": "0.5.46",
+      "tag": "app@v0.5.46"
+    },
+    "docs": {
+      "changed": false,
+      "changed_since": "docs@v0.5.45",
+      "version": "0.5.45",
+      "tag": "docs@v0.5.45"
+    },
+    "web": {
+      "changed": false,
+      "changed_since": "web@v0.5.45",
+      "version": "0.5.45",
+      "tag": "web@v0.5.45"
+    },
+    "modulith": {
+      "changed": true,
+      "changed_since": "modulith@v0.5.27",
+      "version": "0.5.28",
+      "tag": "modulith@v0.5.28"
+    },
+    "harness": {
+      "changed": false,
+      "changed_since": "harness@v0.1.6",
+      "version": "0.1.6",
+      "tag": "harness@v0.1.6"
+    }
+  }
+}

--- a/turbo-repo/apps/app/package.json
+++ b/turbo-repo/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modulariot/app",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3050",

--- a/turbo-repo/apps/app/src/releases/v1.31.45.mdx
+++ b/turbo-repo/apps/app/src/releases/v1.31.45.mdx
@@ -1,0 +1,38 @@
+# 🔔 Release Notes v1.31.45 — ModularIoT
+
+### Fecha: 27/08/2026
+
+**Objetivo**: Esta versión estabiliza el proceso de compilación nativa del CLI de ModularIoT, resolviendo un conflicto de dependencias de Bouncy Castle que impedía generar imágenes nativas con Mandrel/GraalVM. Se consolida la base técnica para entregas continuas más confiables.
+
+## 🐛 Correcciones
+
+- **🐛 Fallo en la generación de imagen nativa por dependencias mixtas de Bouncy Castle en Pulsar**
+  - **Impacto**: El proceso de compilación nativa del CLI con Mandrel/GraalVM fallaba durante el análisis de `native-image` debido a que el bundle agregado `bouncy-castle-bc` de Pulsar 3.3.0 combinaba Bouncy Castle 1.83 con `bcprov-ext` 1.78, causando un `NoSuchFieldError` en `CMSObjectIdentifiers`. *(Integración OSS — MIOT-0.5.46)*
+  - **Solución**: Se excluyó el artefacto `bouncy-castle-bc` de Pulsar 3.3.0, se agregó la dependencia `bcpkix-jdk18on` 1.83 para mantener los proveedores estándar de Pulsar, y se configuró la inicialización de `SecurityUtility` en tiempo de ejecución durante las compilaciones nativas.
+
+## 📊 Beneficios
+
+- El CLI de ModularIoT puede compilarse como imagen nativa con Mandrel sin errores de análisis de dependencias.
+- Se elimina la ambigüedad de versiones de Bouncy Castle en el árbol de dependencias, resolviendo únicamente artefactos 1.83.
+- La cadena de CI/CD en GitHub Actions valida automáticamente las compilaciones nativas en cada pull request.
+- Se reduce el riesgo de regresiones criptográficas al garantizar una única versión coherente de la librería Bouncy Castle.
+- La estabilización del proceso de build nativo sienta las bases para distribuciones del CLI más ligeras y de inicio más rápido.
+
+## 🧾 Versiones del stack
+
+- **Stack**: `miot-stack@v0.5.46`
+- **App**: `app@v0.5.46` *(actualizado)*
+- **Modulith**: `modulith@v0.5.28` *(actualizado)*
+- **Docs**: `docs@v0.5.45` *(sin cambios)*
+- **Web**: `web@v0.5.45` *(sin cambios)*
+- **Harness**: `harness@v0.1.6` *(sin cambios)*
+
+Los digests exactos de las imágenes desplegadas están disponibles en el diálogo de información de build dentro de la aplicación y en el artefacto de release `stack-manifest.json`.
+
+## 📌 Conclusión
+
+La versión 1.31.45 se centra en la solidez del proceso de construcción del CLI nativo, un componente crítico para la distribución y despliegue de ModularIoT en entornos industriales. La resolución del conflicto de Bouncy Castle elimina una barrera técnica que afectaba la generación de binarios optimizados con GraalVM/Mandrel.
+
+Este ajuste refuerza la confiabilidad del pipeline de integración continua y garantiza que futuros cambios en el CLI puedan validarse mediante compilación nativa sin intervención manual. La alineación con las versiones correctas de las librerías criptográficas también mejora la postura de seguridad del componente.
+
+Con los componentes `app` y `modulith` actualizados en este ciclo, la plataforma avanza hacia el stack `v0.5.46` con una base de build más estable, lista para soportar los próximos evolutivos de integración y funcionalidad industrial.

--- a/turbo-repo/package-lock.json
+++ b/turbo-repo/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/app": {
       "name": "@modulariot/app",
-      "version": "0.5.45",
+      "version": "0.5.46",
       "dependencies": {
         "@ag-ui/client": "^0.0.57",
         "@alfresco/js-api": "^9.0.0",


### PR DESCRIPTION
Prepares miot-stack@v0.5.46 from milestone MIOT-0.5.46, with release notes v1.31.45.

Components:
- App: app@v0.5.46 (changed: true)
- Docs: docs@v0.5.45 (changed: false since docs@v0.5.45)
- Web: web@v0.5.45 (changed: false since web@v0.5.45)
- Modulith: modulith@v0.5.28 (changed: true since modulith@v0.5.27)
- Harness: harness@v0.1.6 (changed: false since harness@v0.1.6)

Milestones: Release 1.31.45, MIOT-0.5.46.

Approve and merge this PR, then approve the protected release job to tag changed components, resolve component images, and deploy the stack manifest.
