### PR TITLE
ci: update harness actions to Node.js 24

### DIFF
--- a/.github/workflows/app-release-train.yml
+++ b/.github/workflows/app-release-train.yml
@@ -1097,9 +1097,9 @@ jobs:
     outputs:
       image: ${{ steps.image.outputs.image }}
     steps:
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

Updates the Docker Buildx and registry login actions in the **Resolve harness image** release-train job from v3 to v4. The v4 actions use Node.js 24 and remove the Node.js 20 deprecation warnings reported by GitHub Actions.

## Related issues

Closes #1140

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [x] CI / tooling

## Affected workspace(s)

- [ ] `quarkus-srv/` (Integration)
- [ ] `ecm-srv/` (Coordinator)
- [ ] `turbo-repo/` (Frontend)
- [x] `miot-harness/` (AI harness)

## How was this tested?

- `git diff --check`
- Parsed `.github/workflows/app-release-train.yml` with Ruby YAML parser

## Checklist

- [x] PR title follows Conventional Commits (e.g. `feat(app): ...`, `fix(bff): ...`)
- [x] Relevant validation passes locally
- [x] Documentation updated where needed (not required for this action-version update)
- [x] I have read the [Contributing guidelines](../CONTRIBUTING.md)