### PR TITLE
chore(quarkus): upgrade platform to 3.33.3.1 LTS

### DIFF
--- a/quarkus-srv/miot-symptoms/pom.xml
+++ b/quarkus-srv/miot-symptoms/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>quarkus-messaging-pulsar</artifactId>
             <exclusions>
                 <!-- Pulsar 3.3.0 packages bcprov-ext 1.78 alongside Bouncy Castle
-                     1.83, which causes a native-image linkage error. -->
+                     1.84, which causes a native-image linkage error. -->
                 <exclusion>
                     <groupId>org.apache.pulsar</groupId>
                     <artifactId>bouncy-castle-bc</artifactId>
@@ -55,7 +55,6 @@
             <!-- Replace Pulsar's mixed-version aggregate with the matching provider set. -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-srv/pom.xml
+++ b/quarkus-srv/pom.xml
@@ -34,7 +34,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.4</quarkus.platform.version>
+        <quarkus.platform.version>3.33.3.1</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>


### PR DESCRIPTION
## Summary

Follow-up to #1138 (`CVE-2026-5588` / `GHSA-wg6q-6289-32hp`). Merging the Dependabot pin of `bcpkix-jdk18on` to `1.84` on Quarkus `3.32.4` left a mixed Bouncy Castle set:

```text
bcpkix-jdk18on 1.84
└── bcutil-jdk18on 1.83 (managed from 1.84)
    └── bcprov-jdk18on 1.83
```

That contradicts the `miot-symptoms` native-image design from #1136: replace Pulsar's mixed aggregate with a matching provider set.

Quarkus `3.32` is EOL. `3.33` is the current LTS and the direct continuation of `3.32` ([Quarkus 3.33 LTS](https://quarkus.io/blog/quarkus-3-33-released/), [releases](https://quarkus.io/releases/)). The `3.33.3.1` platform BOM manages `bcpkix`, `bcutil`, and `bcprov` at `1.84`.

This PR:

- Bumps `quarkus.platform.version` from `3.32.4` to `3.33.3.1`.
- Keeps the direct `bcpkix-jdk18on` dependency in `miot-symptoms` but drops the explicit `<version>` so the LTS BOM owns the whole provider set.
- Keeps the Pulsar `bouncy-castle-bc` exclusion. Pulsar stays at `3.3.0`.

Resolved after the upgrade:

```text
bcpkix-jdk18on 1.84
└── bcutil-jdk18on 1.84 (version managed from 1.84)
    └── bcprov-jdk18on 1.84 (version managed from 1.84)
```

## Related issues

Follows #1138. Addresses Dependabot alert #399 (`CVE-2026-5588`) by aligning the remaining Bouncy Castle modules, not just `bcpkix`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / tech debt
- [ ] Documentation
- [ ] CI / tooling

Also a platform security upgrade (Quarkus 3.33.3 / 3.33.3.1 LTS maintenance).

## Affected workspace(s)

- [x] `quarkus-srv/` (Integration)
- [ ] `ecm-srv/` (Coordinator)
- [ ] `turbo-repo/` (Frontend)
- [ ] `miot-harness/` (AI harness)

## Notable BOM changes (`3.32.4` → `3.33.3.1`)

`3.33` LTS is a continuation of `3.32`; there is no application migration step ([Migration Guide 3.33](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.33)). Meaningful managed-version moves:

| Component | 3.32.4 | 3.33.3.1 |
|---|---|---|
| Quarkus core / platform | 3.32.4 | 3.33.3.1 |
| Bouncy Castle `jdk18on` | 1.83 | 1.84 |
| Apache Pulsar | 3.3.0 | 3.3.0 (unchanged) |
| Netty | 4.1.130.Final | 4.1.136.Final |
| Vert.x | 4.5.25 | 4.5.31 |
| Jackson | 2.21.1 | 2.21.5 |
| PostgreSQL JDBC | 42.7.10 | 42.7.13 |
| Hibernate ORM | 7.2.6.Final | 7.2.19.Final |
| Agroal | 3.0 | 3.0.1 |

`3.33.3.1` also includes the native-image Netty `SslContext` fix and a Quarkus REST multipart bound ([3.33.3.1 changelog](https://github.com/quarkusio/quarkus/releases/tag/3.33.3.1)). `3.33.3` itself pulled in Vert.x, pgjdbc, Jackson, Jansi, and Netty security fixes ([3.33.3 announcement](https://quarkus.io/blog/quarkus-3-33-3-released/)).

## How was this tested?

```bash
cd quarkus-srv
./mvnw -pl miot-symptoms dependency:tree -Dincludes='org.bouncycastle:*' -Dverbose
./mvnw -pl miot-symptoms dependency:tree -Dincludes='org.apache.pulsar:*' -Dverbose
./mvnw clean verify \
  -Dmiot.component.fleet.enabled=true \
  -Dmiot.component.driver.enabled=true \
  -Dmiot.component.tracking.enabled=true \
  -Dmiot.component.gateway.enabled=true \
  -Dmiot.component.integrations.enabled=true \
  -Dmiot.component.conversational.enabled=true
```

- Bouncy Castle: `bcpkix` / `bcutil` / `bcprov` all `1.84`.
- Pulsar client artifacts remain `3.3.0`.
- JVM verify: **598 tests, 0 failures** (gps-model 2, core 52, integrations 443, conversational 65, fleet 7, tracking 3, symptoms 26).
- Native image was not built locally (no Mandrel/`native-image`). Quarkus CI's **Build Native** job (`./mvnw package -Pnative -DskipTests`) is the remaining gate.

## Checklist

- [x] PR title follows Conventional Commits (e.g. `feat(app): ...`, `fix(bff): ...`)
- [x] Lint and tests pass locally
- [x] Documentation updated where needed
- [x] I have read the [Contributing guidelines](../CONTRIBUTING.md)
