### PR TITLE
fix(kanban): stop hard-coding the `v` service type in the task filters

### DIFF
--- a/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
+++ b/turbo-repo/apps/app/src/app/api/task/mytasks/route.ts
@@ -43,14 +43,12 @@ export async function GET(req: NextRequest) {
   const date_range_to = url.searchParams.get("date_range_to");
   const calendarId = url.searchParams.get("calendarId");
   const rawQ = url.searchParams.get("q");
-  // Mintral service IDs are stored as `v<digits>`; a purely numeric typed
-  // query won't prefix-match that column otherwise. Mirrors the `service=`
-  // normalization a few lines down so the autocomplete and the structured
-  // chip filter behave the same way for digit-only input.
-  let q: string | undefined;
-  if (rawQ) {
-    q = /^\d+$/.test(rawQ) ? `v${rawQ}` : rawQ;
-  }
+  // Pass the typed query through as-is. The coordinator matches it against both
+  // `mintral_key` — the Alerce key, `<serviceType><code>`: `v1457216`,
+  // `otr1152392` — and `mintral_serviceCode`, the bare number, so a digit-only
+  // query finds the trip whatever its service type. Prefixing `v` here, as this
+  // did, hid every `otr` and `ote` trip behind an empty result.
+  const q = rawQ ?? undefined;
 
   let data: Record<string, KanbanBoard> = {};
   let total = 0;
@@ -59,7 +57,7 @@ export async function GET(req: NextRequest) {
     from: from ? Number.parseInt(from) : 0,
     size: size ? Number.parseInt(size) : 10,
     filter: {
-      mintralKey: serviceCode ? `v${serviceCode}` : undefined,
+      mintralKey: serviceCode || undefined,
       licensePlate: licensePlate ? licensePlate.toUpperCase() : undefined,
       driverId: driverId ? driverId : undefined,
       carrierId: carrierId ? carrierId : undefined,
@@ -87,7 +85,7 @@ export async function GET(req: NextRequest) {
             size: size ? Number.parseInt(size) : 10,
             definitionKey: column,
             filter: {
-              mintralKey: serviceCode ? `v${serviceCode}` : undefined,
+              mintralKey: serviceCode || undefined,
               licensePlate: licensePlate
                 ? licensePlate.toUpperCase()
                 : undefined,

--- a/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
+++ b/turbo-repo/apps/app/src/features/common/providers/client-api.provider.ts
@@ -222,7 +222,7 @@ export function useSearchTasks(searchTerm: string | null) {
     FetcherError
   >(
     searchTerm
-      ? `/app/api/task/search?filter=mintral_key:v${searchTerm}`
+      ? `/app/api/task/search?filter=mintral_key:${searchTerm}`
       : null,
     fetcher
   );


### PR DESCRIPTION
Pairs with microboxlabs/ecm-coordinator#376. Refs microboxlabs/ecm-coordinator#373.

The service filter, the typeahead and the search box all rebuilt the coordinator's `mintral_key` by prefixing the typed number with `v`. That key is the Alerce key verbatim — `<serviceType><code>` — so `v1152392` never matches the `otr` trip whose key is `otr1152392`. Every `otr` and `ote` trip came back empty, indistinguishable from "no such trip".

Alerce carries three types today. Of 1,868,028 rows in `services`: **1,709,768 `v`, 114,103 `otr`, 44,157 `ote`**.

## What changed

| file | change |
| --- | --- |
| `api/task/mytasks/route.ts:52` | the digit-only typed query is passed through instead of being rewritten to `` `v${rawQ}` `` |
| `api/task/mytasks/route.ts:62` | `mintralKey` from the `service=` chip filter, un-prefixed |
| `api/task/mytasks/route.ts:90` | same, in the finished-workflows branch |
| `features/common/providers/client-api.provider.ts:224` | `?filter=mintral_key:${searchTerm}`, un-prefixed |

```diff
-  let q: string | undefined;
-  if (rawQ) {
-    q = /^\d+$/.test(rawQ) ? `v${rawQ}` : rawQ;
-  }
+  const q = rawQ ?? undefined;
```

`tsc --noEmit` reports no errors in either file.

## Deploy order doesn't matter

microboxlabs/ecm-coordinator#376 makes the coordinator match the typed value against **both** `mintral_serviceCode` (the bare number) and `mintral_key` (the composite). So:

- **this ships first** — an old coordinator still only matches `mintral_key`, and a bare `1457216` finds nothing. Regression for the `v` majority until the coordinator lands. **Prefer shipping the coordinator first.**
- **the coordinator ships first** — an old web client keeps sending `v<code>`, which still matches `mintral_key`. No change in behaviour, and `otr`/`ote` stay hidden until this lands.

Neither breaks, but the coordinator side is the safe one to lead with.

## Verified

Against dev (278 live processes, one already `otr` — proc `2988801`, key `otr1152392`):

| typed | before | after |
| --- | ---: | ---: |
| `1152392` (the `otr` trip) | 0 | **1** |
| `1457216` (a `v` trip) | 1 | 1 |
| `14572` (typeahead prefix) | 2 | 2 |

## Not covered here

There is still no way to filter the board *by* service type — `Filter` has no field for it. Worth adding once more than one type is flowing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task search so free-text queries and service-code filters are passed through accurately.
  * Removed an unintended prefix from task search terms, delivering more relevant results.
  * Applied consistent filtering for both active and completed tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->